### PR TITLE
feat(hooks): auto-format hook, vaudeville plugin, permission friction fix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,9 @@ jobs:
       run: sudo apt-get install -y shellcheck
 
     - name: Install ruff
-      uses: astral-sh/setup-ruff@v1
+      uses: astral-sh/ruff-action@v3
+      with:
+        args: "--version"
 
     - name: Install Node linters
       run: npm install -g eslint@8 markdownlint-cli2

--- a/claude/.sync
+++ b/claude/.sync
@@ -58,6 +58,10 @@ if command -v claude &>/dev/null; then
     echo "  Running MCP sync..."
     bash "$SOURCE_DIR/mcp/sync.sh" --force
   fi
+  # Ensure local marketplace symlinks exist before plugin sync
+  local_mkt="$HOME/.claude/plugins/marketplaces/local"
+  mkdir -p "$local_mkt/.claude-plugin"
+  [[ -L "$local_mkt/vaudeville" ]] || ln -sf "$HOME/Dev/vaudeville" "$local_mkt/vaudeville"
   if [[ -x "$SOURCE_DIR/plugins/sync.sh" ]]; then
     echo "  Running plugin sync..."
     bash "$SOURCE_DIR/plugins/sync.sh" --force

--- a/claude/hooks/auto-format.js
+++ b/claude/hooks/auto-format.js
@@ -33,7 +33,8 @@ try {
 }
 
 try {
-  execFileSync(bin, args, { stdio: 'ignore', timeout: 8000 });
-} catch {
-  // formatting failure is non-blocking
+  execFileSync(bin, args, { stdio: 'pipe', timeout: 8000 });
+} catch (err) {
+  const msg = err.stderr ? err.stderr.toString().trim() : err.message;
+  process.stderr.write(`[auto-format] ${bin} failed on ${path.basename(filePath)}: ${msg}\n`);
 }

--- a/claude/hooks/auto-format.js
+++ b/claude/hooks/auto-format.js
@@ -1,4 +1,4 @@
-const { execFileSync, execSync } = require('child_process');
+const { execFileSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 
@@ -27,7 +27,7 @@ if (!formatter) process.exit(0);
 const [bin, args] = formatter;
 
 try {
-  execSync(`which ${bin}`, { stdio: 'ignore' });
+  execFileSync('which', [bin], { stdio: 'ignore' });
 } catch {
   process.exit(0);
 }

--- a/claude/hooks/auto-format.js
+++ b/claude/hooks/auto-format.js
@@ -1,0 +1,39 @@
+const { execFileSync, execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const toolInput = JSON.parse(process.env.TOOL_INPUT || '{}');
+const filePath = toolInput.file_path || toolInput.path || '';
+
+if (!filePath || !fs.existsSync(filePath)) process.exit(0);
+
+const ext = path.extname(filePath).toLowerCase();
+
+const FORMATTERS = {
+  '.rs': ['rustfmt', [filePath]],
+  '.py': ['ruff', ['format', filePath]],
+  '.js': ['prettier', ['--write', filePath]],
+  '.ts': ['prettier', ['--write', filePath]],
+  '.jsx': ['prettier', ['--write', filePath]],
+  '.tsx': ['prettier', ['--write', filePath]],
+  '.sh': ['shfmt', ['-w', filePath]],
+  '.zsh': ['shfmt', ['-w', filePath]],
+  '.bash': ['shfmt', ['-w', filePath]],
+};
+
+const formatter = FORMATTERS[ext];
+if (!formatter) process.exit(0);
+
+const [bin, args] = formatter;
+
+try {
+  execSync(`which ${bin}`, { stdio: 'ignore' });
+} catch {
+  process.exit(0);
+}
+
+try {
+  execFileSync(bin, args, { stdio: 'ignore', timeout: 8000 });
+} catch {
+  // formatting failure is non-blocking
+}

--- a/claude/plugins/local/todoist-flow/agents/todoist-distill.md
+++ b/claude/plugins/local/todoist-flow/agents/todoist-distill.md
@@ -18,21 +18,25 @@ You are a reasoning validator for the Todoist productivity suite. Before the par
 ## What You Validate
 
 ### Intent Match
+
 - Does the proposed action match what the user decided?
 - If the user said "reschedule", is the action using `reschedule-tasks` (not `update-tasks`)?
 - If the user said "complete", is the task actually being completed (not deleted)?
 
 ### Logical Soundness
+
 - Moving tasks to a project that exists?
 - Creating sections in the right project?
 - Priorities as p1-p4 strings (not integers)?
 - Date changes using reschedule-tasks (not update-tasks, which destroys recurrence)?
 
 ### Completeness
+
 - All user decisions represented in the plan?
 - Task IDs and project IDs present for every operation?
 
 ### Risk Flags
+
 - Deletions: confirmed by user?
 - Bulk operations: touching only reviewed tasks?
 - Priority escalation: creating P1 inflation?

--- a/claude/plugins/local/todoist-flow/agents/todoist-fetch.md
+++ b/claude/plugins/local/todoist-flow/agents/todoist-fetch.md
@@ -18,6 +18,7 @@ You are a data retrieval agent for the Todoist productivity suite. Parent skills
 ## Output Formats
 
 ### Task lists
+
 ```
 TASKS (N total):
 1. [id] "Task title" — project: X, priority: pN, due: date (N days overdue/away), created: date (N days ago)
@@ -25,6 +26,7 @@ TASKS (N total):
 ```
 
 ### Project/label/section inventories
+
 ```
 PROJECTS (N total):
 - [id] "Project name" — N tasks, N sections, depth: N
@@ -37,6 +39,7 @@ SECTIONS (N total, across M projects):
 ```
 
 ### Overview/health
+
 ```
 OVERVIEW:
 - Inbox: N tasks

--- a/claude/plugins/local/todoist-flow/agents/todoist-qa.md
+++ b/claude/plugins/local/todoist-flow/agents/todoist-qa.md
@@ -29,7 +29,8 @@ You are the final gate before Todoist writes. The scribe formatted the commands.
 
 ## Output Format
 
-### All clear — execute and report:
+### All clear — execute and report
+
 ```
 PRE-FLIGHT: ALL N COMMANDS VERIFIED
 EXECUTED:
@@ -39,7 +40,8 @@ EXECUTED:
 ERRORS: None
 ```
 
-### Mismatch — halt:
+### Mismatch — halt
+
 ```
 PRE-FLIGHT: MISMATCH — NOT EXECUTING
 ISSUE:
@@ -50,7 +52,8 @@ FIX: Parent should re-run scribe with corrected operation type.
 ALL N COMMANDS HELD — nothing executed.
 ```
 
-### Partial execution failure:
+### Partial execution failure
+
 ```
 PRE-FLIGHT: ALL N COMMANDS VERIFIED
 EXECUTED:

--- a/claude/plugins/local/todoist-flow/agents/todoist-scribe.md
+++ b/claude/plugins/local/todoist-flow/agents/todoist-scribe.md
@@ -13,6 +13,7 @@ You are a formatting enforcer for Todoist writes. Parent skills send you structu
 Read `${CLAUDE_PLUGIN_ROOT}/references/best-practices.md` for the full reference. The critical rules:
 
 ### Task Titles
+
 - **Verb-first**: Every task starts with an action verb. `Write`, `Review`, `Call`, `Ship`, `Fix`, `Set up`.
 - **5-10 words**: Long enough to be unambiguous, short enough to scan.
 - **No status words in titles**: No `[WAITING]`, `[BLOCKED]`, `[IN PROGRESS]`. Use labels instead.
@@ -20,21 +21,25 @@ Read `${CLAUDE_PLUGIN_ROOT}/references/best-practices.md` for the full reference
 - If a title violates these rules, reformat it. Preserve the original meaning.
 
 ### Priorities
+
 - String values only: `p1`, `p2`, `p3`, `p4` (NOT integers).
 - `p4` is default. Only promote deliberately.
 - `p1` should be rare — if the instruction mentions 3+ existing P1 tasks, downgrade to P2 and note it.
 
 ### Descriptions
+
 - Include links, acceptance criteria, or context that makes the task self-contained.
 - Don't add boilerplate. Empty is better than noise.
 
 ### Due Dates vs Deadlines
+
 - **Due date** (dueString): When the user intends to work on it. Natural language: "tomorrow", "next monday".
 - **Deadline** (deadlineDate): Immovable external constraint. ISO 8601: "2026-01-15".
 - Never set both unless the instruction explicitly provides both.
 - **CRITICAL**: Date changes MUST use `reschedule-tasks`, not `update-tasks`. update-tasks destroys recurrence.
 
 ### Labels
+
 - Labels are cross-cutting attributes, not containers.
 - Common useful labels: `@waiting`, `@deep-work`, `@quick-win`, `@low-energy`.
 

--- a/claude/plugins/local/todoist-flow/references/best-practices.md
+++ b/claude/plugins/local/todoist-flow/references/best-practices.md
@@ -53,6 +53,7 @@ Use `reschedule-tasks` (not `update-tasks`) to change dates — preserves recurr
 High-value labels: `@waiting`, `@deep-work`, `@quick-win`, `@low-energy`
 
 Cockpit filters:
+
 - Today: `(today | overdue) & !#Someday`
 - Deep Work: `#Work & @deep-work & !today`
 - Quick Wins: `@quick-win & p:2`

--- a/claude/plugins/local/todoist-flow/skills/extract/SKILL.md
+++ b/claude/plugins/local/todoist-flow/skills/extract/SKILL.md
@@ -115,16 +115,19 @@ Use `AskUserQuestion`: "Have you saved the reference file? Ready to remove these
 If yes, run through the write pipeline (distill → scribe → QA):
 
 **1. Validate reasoning** — spawn todoist-distill:
+
 ```
 Agent(subagent_type: "todoist-distill", prompt: "Validate deletion of these extracted reference tasks. User confirmed file is saved. Tasks: [task IDs and titles]")
 ```
 
 **2. Format commands** — spawn todoist-scribe:
+
 ```
 Agent(subagent_type: "todoist-scribe", prompt: "Format delete-object commands for these extracted tasks: [distill's validated plan]")
 ```
 
 **3. Verify and execute** — spawn todoist-qa:
+
 ```
 Agent(subagent_type: "todoist-qa", prompt: "Verify and execute: [scribe's formatted commands]. Original intent: delete extracted reference tasks after user confirmed save.")
 ```

--- a/claude/plugins/local/todoist-flow/skills/organize/SKILL.md
+++ b/claude/plugins/local/todoist-flow/skills/organize/SKILL.md
@@ -22,6 +22,7 @@ Agent(subagent_type: "todoist-fetch", prompt: "Fetch full workspace audit data: 
 Check for these structural problems (from best practices in `${CLAUDE_PLUGIN_ROOT}/references/best-practices.md`):
 
 **Projects:**
+
 - Empty projects (0 tasks) — candidates for archival
 - Oversized projects (>30 tasks without sections) — need sectioning or splitting
 - Too many active projects (>15) — cognitive overload
@@ -29,15 +30,18 @@ Check for these structural problems (from best practices in `${CLAUDE_PLUGIN_ROO
 - Projects without clear outcomes (noun-only names like "Ideas" or "Misc")
 
 **Labels:**
+
 - Orphan labels (exist but used by 0 tasks)
 - Labels used as containers instead of attributes (e.g., `@client-name` with many tasks)
 - Missing high-value labels (`@waiting`, `@deep-work`, `@quick-win` not present)
 
 **Sections:**
+
 - Projects with >30 tasks and no sections
 - Empty sections (cruft)
 
 **Filters:**
+
 - Missing cockpit filters (the user should have at least 3 working views)
 - Suggested filters: Today, Deep Work, Quick Wins, Waiting On, Weekly Review
 
@@ -92,16 +96,19 @@ Use `AskUserQuestion` for approval. For quick wins, batch approval is fine. For 
 Run approved changes through the write pipeline (distill → scribe → QA):
 
 **1. Validate reasoning** — spawn todoist-distill:
+
 ```
 Agent(subagent_type: "todoist-distill", prompt: "Validate these structural changes against user approval: [approved changes with context]")
 ```
 
 **2. Format commands** — spawn todoist-scribe with validated plan:
+
 ```
 Agent(subagent_type: "todoist-scribe", prompt: "Format these validated structural operations as MCP commands: [distill's validated plan]")
 ```
 
 **3. Verify and execute** — spawn todoist-qa:
+
 ```
 Agent(subagent_type: "todoist-qa", prompt: "Verify and execute: [scribe's formatted commands]. Original intent: [distill's validated plan]")
 ```

--- a/claude/plugins/local/todoist-flow/skills/triage/SKILL.md
+++ b/claude/plugins/local/todoist-flow/skills/triage/SKILL.md
@@ -18,6 +18,7 @@ Agent(subagent_type: "todoist-fetch", prompt: "Fetch overdue tasks: find-tasks w
 ```
 
 If the user said "triage inbox" or "inbox zero":
+
 ```
 Agent(subagent_type: "todoist-fetch", prompt: "Fetch inbox tasks: find-tasks with filter '#Inbox'. Sort by creation date (oldest first). Include task IDs, titles, priorities, due dates, creation dates, descriptions, and any labels.")
 ```
@@ -58,6 +59,7 @@ After research returns, re-present the task with the research context and ask ag
 Batch decisions and run through the write pipeline (distill → scribe → QA):
 
 **Operation mapping:**
+
 - **Complete**: `complete-tasks`
 - **Reschedule**: `reschedule-tasks` (NEVER update-tasks — preserves recurrence)
 - **Delete**: `delete-object`
@@ -65,16 +67,19 @@ Batch decisions and run through the write pipeline (distill → scribe → QA):
 - **Keep**: No action
 
 **1. Validate reasoning** — spawn todoist-distill:
+
 ```
 Agent(subagent_type: "todoist-distill", prompt: "Validate these triage decisions against user intent: [decisions with task data, user choices, and context]")
 ```
 
 **2. Format commands** — spawn todoist-scribe with validated plan:
+
 ```
 Agent(subagent_type: "todoist-scribe", prompt: "Format these validated triage operations as MCP commands: [distill's validated plan]")
 ```
 
 **3. Verify and execute** — spawn todoist-qa:
+
 ```
 Agent(subagent_type: "todoist-qa", prompt: "Verify and execute: [scribe's formatted commands]. Original intent: [distill's validated plan]")
 ```
@@ -82,6 +87,7 @@ Agent(subagent_type: "todoist-qa", prompt: "Verify and execute: [scribe's format
 ### Step 6: Continue or Finish
 
 After each batch of 5:
+
 - Show running stats: `Completed: X | Rescheduled: X | Deleted: X | Someday: X | Kept: X`
 - Ask: "Continue with next batch? (Y tasks remaining)" via `AskUserQuestion`
 

--- a/claude/plugins/local/todoist-flow/skills/update/SKILL.md
+++ b/claude/plugins/local/todoist-flow/skills/update/SKILL.md
@@ -31,6 +31,7 @@ Agent(subagent_type: "todoist-fetch", prompt: "Fetch active (non-overdue) tasks 
 ```
 
 Focus on:
+
 - Tasks with no due date (dormant — still relevant?)
 - Tasks due in the future (still planned correctly?)
 - High-priority tasks (P1/P2 — priority still accurate?)
@@ -79,16 +80,19 @@ Re-present the task after research returns.
 Batch decisions per group of 5 and run through the write pipeline (distill → scribe → QA):
 
 **1. Validate reasoning** — spawn todoist-distill:
+
 ```
 Agent(subagent_type: "todoist-distill", prompt: "Validate these update decisions against user intent: [decisions with task data and user choices]")
 ```
 
 **2. Format commands** — spawn todoist-scribe with validated plan:
+
 ```
 Agent(subagent_type: "todoist-scribe", prompt: "Format these validated update operations as MCP commands: [distill's validated plan]")
 ```
 
 **3. Verify and execute** — spawn todoist-qa:
+
 ```
 Agent(subagent_type: "todoist-qa", prompt: "Verify and execute: [scribe's formatted commands]. Original intent: [distill's validated plan]")
 ```

--- a/claude/plugins/registry.yaml
+++ b/claude/plugins/registry.yaml
@@ -95,6 +95,7 @@ plugins:
     load: true
 
   # --- Local plugins (dotfiles) ---
+
   cheese-flow@cheese-flow:
     description: Cheddar Flow agent pipeline — cheese-themed development workflow tools
     scope: user
@@ -102,6 +103,13 @@ plugins:
 
   todoist-flow@todoist-flow:
     description: Todoist productivity suite — triage, organize, update, extract reference material
+    scope: user
+    load: true
+
+  # --- Astral Python tools ---
+
+  vaudeville@local:
+    description: SLM-powered semantic hook enforcement via local Phi-3-mini
     scope: user
     load: true
 

--- a/claude/plugins/registry.yaml
+++ b/claude/plugins/registry.yaml
@@ -54,11 +54,6 @@ plugins:
     scope: user
     load: true
 
-  ralph-loop@claude-plugins-official:
-    description: Iterative self-referential loops for convergent task completion
-    scope: user
-    load: true
-
   frontend-design@claude-plugins-official:
     description: Frontend design skill for UI/UX implementation
     scope: user
@@ -106,8 +101,7 @@ plugins:
     scope: user
     load: true
 
-  # --- Astral Python tools ---
-
+  # --- Local plugins ---
   vaudeville@local:
     description: SLM-powered semantic hook enforcement via local Phi-3-mini
     scope: user

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -76,7 +76,8 @@
       "mcp__tavily__*",
       "mcp__serper__*",
       "WebSearch",
-      "WebFetch"
+      "WebFetch",
+      "Skill"
     ]
   },
   "hooks": {
@@ -208,6 +209,16 @@
             "timeout": 10
           }
         ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$HOME/.claude/hooks/auto-format.js\"",
+            "timeout": 10
+          }
+        ]
       }
     ]
   },
@@ -224,7 +235,6 @@
     "gopls@claude-code-lsps": true,
     "claude-md-management@claude-plugins-official": true,
     "playwright@claude-plugins-official": true,
-    "ralph-loop@claude-plugins-official": true,
     "frontend-design@claude-plugins-official": true,
     "plugin-dev@claude-plugins-official": true,
     "skill-creator@claude-plugins-official": true,
@@ -234,7 +244,8 @@
     "code-review-graph@code-review-graph": false,
     "cheese-flow@cheese-flow": true,
     "astral@astral-sh": true,
-    "todoist-flow@todoist-flow": true
+    "todoist-flow@todoist-flow": true,
+    "vaudeville@local": true
   },
   "extraKnownMarketplaces": {
     "claude-hud": {

--- a/zsh/tools.zsh
+++ b/zsh/tools.zsh
@@ -34,4 +34,4 @@ if [[ -d "$HOME/.bun" ]]; then
 fi
 
 # ─── vaudeville (SLM hook enforcement for Claude Code) ───────────────────
-export VAUDEVILLE_DEBUG=1
+export VAUDEVILLE_DEBUG="${VAUDEVILLE_DEBUG:-0}"

--- a/zsh/tools.zsh
+++ b/zsh/tools.zsh
@@ -32,3 +32,6 @@ if [[ -d "$HOME/.bun" ]]; then
     export PATH="$BUN_INSTALL/bin:$PATH"
     [[ -s "$BUN_INSTALL/_bun" ]] && source "$BUN_INSTALL/_bun"
 fi
+
+# ─── vaudeville (SLM hook enforcement for Claude Code) ───────────────────
+export VAUDEVILLE_DEBUG=1


### PR DESCRIPTION
## Summary
- **Auto-format hook**: PostToolUse hook on Edit/Write that detects file extension and runs the appropriate formatter (rustfmt, ruff format, prettier, shfmt). Skips gracefully if formatter not found or file deleted. Always exits 0.
- **Permission friction fix**: Added `Skill` to `permissions.allow` — eliminates ~33 unnecessary approval prompts per 14 days.
- **Vaudeville plugin setup**: Added local marketplace symlink in `.sync`, registered `vaudeville@local` in plugin registry, removed `ralph-loop` plugin.
- **Vaudeville debug env**: Exports `VAUDEVILLE_DEBUG=1` in `zsh/tools.zsh`.

Findings from `/vaudeville:hook-suggester` session analytics (14 days, 90K+ tool events).

## Test plan
- [ ] Run `dots sync` and verify no errors
- [ ] Edit a `.py` file and confirm `ruff format` runs automatically
- [ ] Edit a `.rs` file and confirm `rustfmt` runs automatically
- [ ] Verify Skill tool no longer prompts for permission
- [ ] `plugin-sync` picks up vaudeville and drops ralph-loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)