### PR TITLE
feat(packages): add rtk for transparent Bash output filtering

### DIFF
--- a/claude/.sync
+++ b/claude/.sync
@@ -18,6 +18,7 @@ configs=(
   skills
   reference
   CLAUDE.md
+  RTK.md
 )
 
 # Install hook dependencies (wink-nlp for violation classifier)
@@ -51,6 +52,31 @@ for item in "${configs[@]}"; do
     ln -s "$source" "$target"
   fi
 done
+
+# Install RTK hook for Cursor (global). Claude is already configured via the
+# settings.json hook entry tracked in this repo, so no rtk init needed for it.
+# Antigravity is project-scoped — run `rtk init --agent antigravity` inside
+# each project where you want it active; it writes .agents/rules/*.md there.
+#
+# Guard: `rtk init --agent cursor` also rewrites ~/.claude/settings.json on
+# every run, which would clobber our dotfiles symlink. Only invoke it the
+# first time (when Cursor's hooks.json doesn't yet reference rtk).
+cursor_hooks="$HOME/.cursor/hooks.json"
+if command -v rtk &>/dev/null; then
+  if [[ ! -f "$cursor_hooks" ]] || ! grep -q '"rtk hook cursor"' "$cursor_hooks"; then
+    echo "  Initializing rtk for cursor..."
+    rtk init -g --agent cursor --auto-patch --hook-only \
+      || echo "  rtk init --agent cursor failed (non-fatal)"
+    # rtk init touches ~/.claude/settings.json too; restore our symlink.
+    if [[ -f "$CLAUDE_DIR/settings.json" && ! -L "$CLAUDE_DIR/settings.json" ]]; then
+      rm "$CLAUDE_DIR/settings.json" "$CLAUDE_DIR/settings.json.bak" 2>/dev/null || true
+      ln -s "$SOURCE_DIR/settings.json" "$CLAUDE_DIR/settings.json"
+      echo "  Restored settings.json symlink"
+    fi
+  fi
+else
+  echo "  Skipping rtk init (rtk not installed — run 'dots sync' to install)"
+fi
 
 # Sync MCPs and plugins (requires claude CLI)
 if command -v claude &>/dev/null; then

--- a/claude/.sync
+++ b/claude/.sync
@@ -53,30 +53,10 @@ for item in "${configs[@]}"; do
   fi
 done
 
-# Install RTK hook for Cursor (global). Claude is already configured via the
-# settings.json hook entry tracked in this repo, so no rtk init needed for it.
-# Antigravity is project-scoped — run `rtk init --agent antigravity` inside
-# each project where you want it active; it writes .agents/rules/*.md there.
-#
-# Guard: `rtk init --agent cursor` also rewrites ~/.claude/settings.json on
-# every run, which would clobber our dotfiles symlink. Only invoke it the
-# first time (when Cursor's hooks.json doesn't yet reference rtk).
-cursor_hooks="$HOME/.cursor/hooks.json"
-if command -v rtk &>/dev/null; then
-  if [[ ! -f "$cursor_hooks" ]] || ! grep -q '"rtk hook cursor"' "$cursor_hooks"; then
-    echo "  Initializing rtk for cursor..."
-    rtk init -g --agent cursor --auto-patch --hook-only \
-      || echo "  rtk init --agent cursor failed (non-fatal)"
-    # rtk init touches ~/.claude/settings.json too; restore our symlink.
-    if [[ -f "$CLAUDE_DIR/settings.json" && ! -L "$CLAUDE_DIR/settings.json" ]]; then
-      rm "$CLAUDE_DIR/settings.json" "$CLAUDE_DIR/settings.json.bak" 2>/dev/null || true
-      ln -s "$SOURCE_DIR/settings.json" "$CLAUDE_DIR/settings.json"
-      echo "  Restored settings.json symlink"
-    fi
-  fi
-else
-  echo "  Skipping rtk init (rtk not installed — run 'dots sync' to install)"
-fi
+# RTK agent setup is done manually via the `rtk-init-*` aliases in
+# zsh/claude.zsh — running `rtk init` during sync would rewrite
+# ~/.claude/settings.json on every invocation, clobbering our symlink.
+# Claude Code hook is tracked in settings.json above and needs no init.
 
 # Sync MCPs and plugins (requires claude CLI)
 if command -v claude &>/dev/null; then

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -190,3 +190,5 @@ If violations found: fix them, then try stopping again. Use `/diff` to smoke-tes
 ## Troubleshooting
 
 MCPs broken? → `/go`. Agent missing? → `/agents`. LSP down? → `/lsp`.
+
+@RTK.md

--- a/claude/RTK.md
+++ b/claude/RTK.md
@@ -1,0 +1,29 @@
+# RTK - Rust Token Killer
+
+**Usage**: Token-optimized CLI proxy (60-90% savings on dev operations)
+
+## Meta Commands (always use rtk directly)
+
+```bash
+rtk gain              # Show token savings analytics
+rtk gain --history    # Show command usage history with savings
+rtk discover          # Analyze Claude Code history for missed opportunities
+rtk proxy <cmd>       # Execute raw command without filtering (for debugging)
+```
+
+## Installation Verification
+
+```bash
+rtk --version         # Should show: rtk X.Y.Z
+rtk gain              # Should work (not "command not found")
+which rtk             # Verify correct binary
+```
+
+⚠️ **Name collision**: If `rtk gain` fails, you may have reachingforthejack/rtk (Rust Type Kit) installed instead.
+
+## Hook-Based Usage
+
+All other commands are automatically rewritten by the Claude Code hook.
+Example: `git status` → `rtk git status` (transparent, 0 tokens overhead)
+
+Refer to CLAUDE.md for full command reference.

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -144,8 +144,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"$HOME/.claude/hooks/hook-runner.js\" bash-guard.js",
-            "statusMessage": "Checking command..."
+            "command": "rtk hook claude"
           }
         ]
       },
@@ -154,7 +153,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "rtk hook claude"
+            "command": "node \"$HOME/.claude/hooks/hook-runner.js\" bash-guard.js",
+            "statusMessage": "Checking command..."
           }
         ]
       },

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -150,6 +150,15 @@
         ]
       },
       {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "rtk hook claude"
+          }
+        ]
+      },
+      {
         "matcher": "Write",
         "hooks": [
           {

--- a/packages.yaml
+++ b/packages.yaml
@@ -83,5 +83,8 @@ packages:
   # Cargo
   - cargo-llvm-cov: { source: cargo }
   - tilth: { source: cargo }
+  # Install from Git because the crates.io `rtk` collides with the desired package.
+  # If an unrelated `rtk` is already present from `cargo install rtk`, remove it first
+  # so `dots sync` does not incorrectly treat the Git-sourced package as already satisfied.
   - rtk: { source: cargo, git: "https://github.com/rtk-ai/rtk" }
   - qdrant: { source: cargo, dev: true }

--- a/packages.yaml
+++ b/packages.yaml
@@ -83,4 +83,5 @@ packages:
   # Cargo
   - cargo-llvm-cov: { source: cargo }
   - tilth: { source: cargo }
+  - rtk: { source: cargo, git: "https://github.com/rtk-ai/rtk" }
   - qdrant: { source: cargo, dev: true }

--- a/zsh/claude.zsh
+++ b/zsh/claude.zsh
@@ -125,6 +125,17 @@ alias plugin-sync-dry='$CLAUDE_DOTFILES/plugins/sync.sh --dry-run'
 alias plugin-edit='${EDITOR:-vim} $CLAUDE_DOTFILES/plugins/registry.yaml'
 
 # ═══════════════════════════════════════════════════════════════════
+# RTK — Rust Token Killer (github.com/rtk-ai/rtk)
+# ═══════════════════════════════════════════════════════════════════
+# Claude Code hook is tracked in claude/settings.json, so no Claude init
+# is needed after a fresh `dots sync`. These aliases mirror the commands
+# on https://github.com/rtk-ai/rtk#quick-start for the remaining agents
+# plus a manual Claude refresh. All three are idempotent.
+alias rtk-init-claude='rtk init -g'                       # global
+alias rtk-init-cursor='rtk init -g --agent cursor'        # global
+alias rtk-init-antigravity='rtk init --agent antigravity' # project-scoped, run in project root
+
+# ═══════════════════════════════════════════════════════════════════
 # Ralphify (autonomous coding loops — github.com/computerlovetech/ralphify)
 # ═══════════════════════════════════════════════════════════════════
 # ralph binary is installed via `uv tool install ralphify` and lives in


### PR DESCRIPTION
## Summary
- Install `rtk` via cargo from `https://github.com/rtk-ai/rtk` — name collision on crates.io means direct `cargo install rtk` resolves to an unrelated crate, so the git source is required.
- Register a PreToolUse Bash hook running `rtk hook claude`, matching what `rtk init -g` would emit. It sits alongside the existing `bash-guard.js` hook; both run for every Bash call.

[RTK](https://github.com/rtk-ai/rtk) (Rust Token Killer) transparently rewrites Bash commands (`cargo`, `git`, `gh`, `jest`, `pytest`, `tsc`, `eslint`, etc.) before execution and filters/groups/deduplicates their output. Claimed 60-90% token reduction with no prompt changes — the agent issues vanilla shell commands and the hook does the rewriting.

This covers the D1 + F1 slots from `.context/mcp-wishlist.md` (bounded exec + parsers, transparent Bash rewrite). RTK only hooks Bash — native Read/Grep/Glob tools bypass it.

## Test plan
- [ ] `dots sync` installs `rtk` from git without error
- [ ] `rtk --version` reports >= 0.23.0 (required by the hook)
- [ ] After Claude Code restart, `git status` issued from the agent shows RTK-filtered output (verify via `rtk gain`)
- [ ] Existing `bash-guard.js` still runs (both Bash matchers fire)