### PR TITLE
fix(tests,worktree-settings): align with cheese-flow plugin migration

### DIFF
--- a/claude/skills/fetch/SKILL.md
+++ b/claude/skills/fetch/SKILL.md
@@ -145,6 +145,7 @@ Use when:
 - Searching for real-world usage examples of an API (`gh search code '<query>'`)
 - Inspecting a specific repo's README/structure (`gh repo view owner/repo`)
 - Finding popular implementations (`gh search repos '<topic>' --sort stars`)
+
 ### gh skill (GitHub ops)
 
 Use the `gh` skill for GitHub operations (PRs, issues, releases, CI checks). The

--- a/claude/worktree-settings.sh
+++ b/claude/worktree-settings.sh
@@ -37,29 +37,40 @@ if [[ -f "${MCP_REGISTRY}" ]]; then
 fi
 
 # Resolve a plugin's .mcp.json path. Prefer registry `path:` (for local plugins),
-# fall back to the marketplace cache. Always returns 0; emits empty string when
-# no .mcp.json is present (skill-only plugins).
+# fall back to the marketplace cache. Emits empty string when no .mcp.json is
+# present (skill-only plugins).
 locate_plugin_mcp() {
     local plugin="$1" marketplace="$2" path_field="$3"
     if [[ -n "${path_field}" && "${path_field}" != "null" ]]; then
         local expanded="${path_field/#\~/${HOME}}"
-        [[ "${expanded}" != /* ]] && expanded="${DOTFILES}/${expanded}"
+        if [[ "${expanded}" != /* ]]; then
+            expanded="${DOTFILES}/${expanded}"
+        fi
         if [[ -f "${expanded}/.mcp.json" ]]; then
             echo "${expanded}/.mcp.json"
             return 0
         fi
     fi
+    # Preserve caller's nullglob state so we don't leak the option globally.
+    local nullglob_was_set=0
+    if shopt -q nullglob; then
+        nullglob_was_set=1
+    fi
     shopt -s nullglob
     local candidates=("${PLUGIN_CACHE}/${marketplace}/${plugin}"/*/.mcp.json)
-    shopt -u nullglob
-    [[ ${#candidates[@]} -gt 0 ]] && echo "${candidates[0]}"
-    return 0
+    if [[ ${nullglob_was_set} -eq 0 ]]; then
+        shopt -u nullglob
+    fi
+    if [[ ${#candidates[@]} -gt 0 ]]; then
+        echo "${candidates[0]}"
+    fi
 }
 
 # Plugin .mcp.json may use either `{ "mcpServers": { name: ... } }` or a flat
-# `{ name: ... }` layout. Return server names, one per line.
+# `{ name: ... }` layout. Return server names, one per line. Errors from jq
+# (missing/invalid file) propagate so the script fails loudly under set -e.
 read_mcp_servers() {
-    jq -r 'if has("mcpServers") then .mcpServers | keys[] else keys[] end' "$1" 2>/dev/null
+    jq -r 'if has("mcpServers") then .mcpServers | keys[] else keys[] end' "$1"
 }
 
 if [[ -f "${PLUGIN_REGISTRY}" ]]; then
@@ -73,9 +84,11 @@ if [[ -f "${PLUGIN_REGISTRY}" ]]; then
         mcp_file="$(locate_plugin_mcp "${plugin}" "${marketplace}" "${path_field}")"
         [[ -z "${mcp_file}" ]] && continue
 
+        # Capture servers via command substitution so jq failures trip set -e.
+        servers="$(read_mcp_servers "${mcp_file}")"
         while IFS= read -r server; do
             [[ -n "${server}" ]] && perms+=("mcp__plugin_${plugin}_${server}__*")
-        done < <(read_mcp_servers "${mcp_file}")
+        done <<< "${servers}"
     done < <(yq -r '.plugins | keys[]' "${PLUGIN_REGISTRY}")
 fi
 

--- a/claude/worktree-settings.sh
+++ b/claude/worktree-settings.sh
@@ -2,10 +2,11 @@
 # Generate a worktree settings.local.json from dotfiles sources of truth.
 #
 # Sources:
-#   claude/skills/*/           → Skill(name) permissions
-#   claude/mcp/registry.yaml   → mcp__name__* permissions
-#   claude/plugins/registry.yaml → mcp__plugin_name_name__* (non-LSP only)
-#   claude/settings.json       → mcp__claude_ai_* entries (Claude.ai integrations)
+#   claude/skills/*/             → Skill(name) permissions
+#   claude/mcp/registry.yaml     → mcp__name__* permissions (user-scope MCPs)
+#   claude/plugins/registry.yaml → mcp__plugin_<plugin>_<server>__* per server
+#                                  declared in each plugin's .mcp.json
+#   claude/settings.json         → mcp__claude_ai_* entries (Claude.ai integrations)
 #
 # Usage: bash claude/worktree-settings.sh [dotfiles-root]
 # Output: JSON to stdout
@@ -17,6 +18,7 @@ SKILLS_DIR="${DOTFILES}/claude/skills"
 MCP_REGISTRY="${DOTFILES}/claude/mcp/registry.yaml"
 PLUGIN_REGISTRY="${DOTFILES}/claude/plugins/registry.yaml"
 SETTINGS_JSON="${DOTFILES}/claude/settings.json"
+PLUGIN_CACHE="${HOME}/.claude/plugins/cache"
 
 perms=()
 perms+=("Edit" "Write" "LSP" "WebSearch" "WebFetch")
@@ -34,16 +36,46 @@ if [[ -f "${MCP_REGISTRY}" ]]; then
     done < <(yq -r '.mcps | keys[]' "${MCP_REGISTRY}")
 fi
 
+# Resolve a plugin's .mcp.json path. Prefer registry `path:` (for local plugins),
+# fall back to the marketplace cache. Always returns 0; emits empty string when
+# no .mcp.json is present (skill-only plugins).
+locate_plugin_mcp() {
+    local plugin="$1" marketplace="$2" path_field="$3"
+    if [[ -n "${path_field}" && "${path_field}" != "null" ]]; then
+        local expanded="${path_field/#\~/${HOME}}"
+        [[ "${expanded}" != /* ]] && expanded="${DOTFILES}/${expanded}"
+        if [[ -f "${expanded}/.mcp.json" ]]; then
+            echo "${expanded}/.mcp.json"
+            return 0
+        fi
+    fi
+    shopt -s nullglob
+    local candidates=("${PLUGIN_CACHE}/${marketplace}/${plugin}"/*/.mcp.json)
+    shopt -u nullglob
+    [[ ${#candidates[@]} -gt 0 ]] && echo "${candidates[0]}"
+    return 0
+}
+
+# Plugin .mcp.json may use either `{ "mcpServers": { name: ... } }` or a flat
+# `{ name: ... }` layout. Return server names, one per line.
+read_mcp_servers() {
+    jq -r 'if has("mcpServers") then .mcpServers | keys[] else keys[] end' "$1" 2>/dev/null
+}
+
 if [[ -f "${PLUGIN_REGISTRY}" ]]; then
     while IFS= read -r key; do
         [[ -z "${key}" ]] && continue
         plugin="${key%%@*}"
         marketplace="${key#*@}"
-        # LSP plugins don't provide MCP tools
         [[ "${marketplace}" == "claude-code-lsps" ]] && continue
-        # Claude Code normalizes hyphens to underscores in tool names
-        normalized="${plugin//-/_}"
-        perms+=("mcp__plugin_${normalized}_${normalized}__*")
+
+        path_field="$(yq -r ".plugins[\"${key}\"].path // \"\"" "${PLUGIN_REGISTRY}")"
+        mcp_file="$(locate_plugin_mcp "${plugin}" "${marketplace}" "${path_field}")"
+        [[ -z "${mcp_file}" ]] && continue
+
+        while IFS= read -r server; do
+            [[ -n "${server}" ]] && perms+=("mcp__plugin_${plugin}_${server}__*")
+        done < <(read_mcp_servers "${mcp_file}")
     done < <(yq -r '.plugins | keys[]' "${PLUGIN_REGISTRY}")
 fi
 

--- a/tests/hooks-blockers.bats
+++ b/tests/hooks-blockers.bats
@@ -238,11 +238,11 @@ teardown() {
 
 # ── bash-guard: legacy tool blockers ────────────────────────────────
 
-@test "bash-guard: bare grep is blocked with /scout reference" {
+@test "bash-guard: bare grep is blocked with cheez-search reference" {
     run_hook "$HOOKS_DIR/bash-guard.js" Bash '{"command":"grep pattern file.txt"}'
     [ "$status" -eq 0 ]
     [[ "$output" == blocked:* ]]
-    [[ "$output" == *"/scout"* ]]
+    [[ "$output" == *"cheez-search"* ]]
 }
 
 @test "bash-guard: bare egrep is blocked" {
@@ -267,7 +267,7 @@ teardown() {
     run_hook "$HOOKS_DIR/bash-guard.js" Bash '{"command":"sed s/foo/bar/ file.txt"}'
     [ "$status" -eq 0 ]
     [[ "$output" == blocked:* ]]
-    [[ "$output" == *"/chisel"* ]]
+    [[ "$output" == *"cheez-write"* ]]
 }
 
 @test "bash-guard: awk with leading whitespace is blocked" {
@@ -282,11 +282,11 @@ teardown() {
     [[ "$output" == blocked:* ]]
 }
 
-@test "bash-guard: bare sed is blocked with /chisel reference" {
+@test "bash-guard: bare sed is blocked with cheez-write reference" {
     run_hook "$HOOKS_DIR/bash-guard.js" Bash '{"command":"sed -i s/foo/bar/ file.txt"}'
     [ "$status" -eq 0 ]
     [[ "$output" == blocked:* ]]
-    [[ "$output" == *"/chisel"* ]]
+    [[ "$output" == *"cheez-write"* ]]
 }
 
 @test "bash-guard: sed -i in pipeline is blocked" {
@@ -295,18 +295,18 @@ teardown() {
     [[ "$output" == blocked:* ]]
 }
 
-@test "bash-guard: bare find is blocked with /scout reference" {
+@test "bash-guard: bare find is blocked with cheez-search reference" {
     run_hook "$HOOKS_DIR/bash-guard.js" Bash '{"command":"find . -name *.ts"}'
     [ "$status" -eq 0 ]
     [[ "$output" == blocked:* ]]
-    [[ "$output" == *"/scout"* ]]
+    [[ "$output" == *"cheez-search"* ]]
 }
 
-@test "bash-guard: bare awk is blocked with /chisel reference" {
+@test "bash-guard: bare awk is blocked with cheez-write reference" {
     run_hook "$HOOKS_DIR/bash-guard.js" Bash '{"command":"awk -F, file.txt"}'
     [ "$status" -eq 0 ]
     [[ "$output" == blocked:* ]]
-    [[ "$output" == *"/chisel"* ]]
+    [[ "$output" == *"cheez-write"* ]]
 }
 
 @test "bash-guard: piped grep (ls | grep) is allowed" {

--- a/tests/worktree-settings.bats
+++ b/tests/worktree-settings.bats
@@ -4,7 +4,9 @@ DOTFILES_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME}")/.." && pwd)"
 GENERATOR="${DOTFILES_DIR}/claude/worktree-settings.sh"
 
 setup() {
-    TMPDIR_TEST="$(mktemp -d "${TMPDIR:-.}/wt-settings.XXXXXX")"
+    # Force absolute path. CI runners typically don't set $TMPDIR, and a
+    # relative TMPDIR_TEST breaks plugin path resolution in worktree-settings.sh.
+    TMPDIR_TEST="$(mktemp -d "${TMPDIR:-/tmp}/wt-settings.XXXXXX")"
     mkdir -p "${TMPDIR_TEST}/claude/skills/foo" \
              "${TMPDIR_TEST}/claude/skills/bar-baz" \
              "${TMPDIR_TEST}/claude/mcp" \
@@ -208,6 +210,8 @@ YAML
 
 @test "worktree-settings: real output includes known MCPs" {
     result="$(bash "$GENERATOR" "$DOTFILES_DIR")"
-    # tilth lives in the cheese-flow plugin's .mcp.json (not user-scope).
-    assert_has_entry "$result" "mcp__plugin_cheese-flow_tilth__*"
+    # serper is a deterministic user-scope entry in claude/mcp/registry.yaml.
+    # Plugin-sourced MCPs (e.g. cheese-flow's tilth) require an .mcp.json that
+    # may not exist in CI, so assert against the in-repo registry instead.
+    assert_has_entry "$result" "mcp__serper__*"
 }

--- a/tests/worktree-settings.bats
+++ b/tests/worktree-settings.bats
@@ -83,35 +83,71 @@ YAML
     [[ "$count" -eq 0 ]]
 }
 
-@test "worktree-settings: discovers non-LSP plugins" {
-    cat > "${TMPDIR_TEST}/claude/plugins/registry.yaml" <<'YAML'
+@test "worktree-settings: discovers non-LSP plugins via .mcp.json" {
+    # Local plugin with mcpServers wrapper exposing two distinct servers.
+    mkdir -p "${TMPDIR_TEST}/plugins/multi-srv"
+    cat > "${TMPDIR_TEST}/plugins/multi-srv/.mcp.json" <<'JSON'
+{
+  "mcpServers": {
+    "alpha": {"command": "alpha"},
+    "beta":  {"command": "beta"}
+  }
+}
+JSON
+    # Local plugin with flat layout (server name = top-level key).
+    mkdir -p "${TMPDIR_TEST}/plugins/single-flat"
+    cat > "${TMPDIR_TEST}/plugins/single-flat/.mcp.json" <<'JSON'
+{
+  "single-flat": {"command": "single"}
+}
+JSON
+    cat > "${TMPDIR_TEST}/claude/plugins/registry.yaml" <<YAML
 plugins:
   vtsls@claude-code-lsps:
     description: TypeScript LSP
     scope: user
-  github@claude-plugins-official:
-    description: GitHub MCP
+  multi-srv@local:
+    description: Multi-server plugin
     scope: user
-  claude-hud@claude-hud:
-    description: HUD
+    path: ${TMPDIR_TEST}/plugins/multi-srv
+  single-flat@local:
+    description: Flat-layout plugin
+    scope: user
+    path: ${TMPDIR_TEST}/plugins/single-flat
+  no-mcp@claude-plugins-official:
+    description: Skill-only plugin (no .mcp.json)
     scope: user
 YAML
     result="$(bash "$GENERATOR" "$TMPDIR_TEST")"
-    assert_has_entry "$result" "mcp__plugin_github_github__*"
-    assert_has_entry "$result" "mcp__plugin_claude_hud_claude_hud__*"
+    assert_has_entry "$result" "mcp__plugin_multi-srv_alpha__*"
+    assert_has_entry "$result" "mcp__plugin_multi-srv_beta__*"
+    assert_has_entry "$result" "mcp__plugin_single-flat_single-flat__*"
+    # LSP plugins never produce MCP entries.
     assert_no_entry "$result" "mcp__plugin_vtsls_vtsls__*"
+    # Skill-only plugins (no .mcp.json) produce no entries.
+    assert_no_entry "$result" "mcp__plugin_no-mcp_no-mcp__*"
 }
 
-@test "worktree-settings: normalizes hyphens to underscores in plugin names" {
-    cat > "${TMPDIR_TEST}/claude/plugins/registry.yaml" <<'YAML'
+@test "worktree-settings: preserves hyphens in plugin and server names" {
+    mkdir -p "${TMPDIR_TEST}/plugins/cheese-flow"
+    cat > "${TMPDIR_TEST}/plugins/cheese-flow/.mcp.json" <<'JSON'
+{
+  "mcpServers": {
+    "tilth-edit": {"command": "tilth"}
+  }
+}
+JSON
+    cat > "${TMPDIR_TEST}/claude/plugins/registry.yaml" <<YAML
 plugins:
-  ralph-loop@claude-plugins-official:
-    description: Ralph Loop
+  cheese-flow@local:
+    description: Hyphenated plugin
     scope: user
+    path: ${TMPDIR_TEST}/plugins/cheese-flow
 YAML
     result="$(bash "$GENERATOR" "$TMPDIR_TEST")"
-    assert_has_entry "$result" "mcp__plugin_ralph_loop_ralph_loop__*"
-    assert_no_entry "$result" "mcp__plugin_ralph-loop_ralph-loop__*"
+    assert_has_entry "$result" "mcp__plugin_cheese-flow_tilth-edit__*"
+    # Old (incorrect) hyphen-stripping behavior must not return.
+    assert_no_entry "$result" "mcp__plugin_cheese_flow_cheese_flow__*"
 }
 
 @test "worktree-settings: pulls claude_ai MCPs from settings.json" {
@@ -172,5 +208,6 @@ YAML
 
 @test "worktree-settings: real output includes known MCPs" {
     result="$(bash "$GENERATOR" "$DOTFILES_DIR")"
-    assert_has_entry "$result" "mcp__tilth__*"
+    # tilth lives in the cheese-flow plugin's .mcp.json (not user-scope).
+    assert_has_entry "$result" "mcp__plugin_cheese-flow_tilth__*"
 }


### PR DESCRIPTION
Two failures surfaced after f5af359 moved code-search/edit/research from in-repo skills to the cheese-flow plugin:

- bash-guard messages now reference cheese-flow:cheez-search / cheese-flow:cheez-write instead of /scout / /chisel; update the five hooks-blockers.bats assertions accordingly.

- worktree-settings.sh emitted mcp__plugin_<plugin>_<plugin>__* with hyphens stripped, which never matches Claude Code's actual permission format mcp__plugin_<plugin-name>_<server-name>__*. For cheese-flow this meant tilth/context7/tavily/milknado calls in ccw worktrees prompted on every invocation.

  Fix: parse each plugin's .mcp.json (registry path: field for local plugins, marketplace cache otherwise), discover real server names from either the {mcpServers: ...} wrapper or flat top-level layout, and emit one entry per server with hyphens preserved. Skill-only plugins without an .mcp.json now correctly emit nothing.

  Tests updated to fixture .mcp.json files; replaces the hyphen- stripping test with a hyphen-preserving one.