### PR TITLE
feat(macos,iterm2,claude): trackpad right-click, font update, skip permission prompt

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -295,5 +295,6 @@
   },
   "skipDangerousModePermissionPrompt": true,
   "theme": "dark-daltonized",
-  "editorMode": "vim"
+  "editorMode": "vim",
+  "skipAutoPermissionPrompt": true
 }

--- a/iterm2/iterm2.base.plist
+++ b/iterm2/iterm2.base.plist
@@ -1218,7 +1218,7 @@
 			<key>Name</key>
 			<string>Default</string>
 			<key>Non Ascii Font</key>
-			<string>Monaco 12</string>
+			<string>HackNFM-Regular 14</string>
 			<key>Non-ASCII Anti Aliased</key>
 			<true/>
 			<key>Normal Font</key>

--- a/macos/.sync
+++ b/macos/.sync
@@ -14,6 +14,11 @@ readonly LAUNCH_AGENTS_DIR="$HOME/Library/LaunchAgents"
 
 mkdir -p "$LAUNCH_AGENTS_DIR"
 
+# Enable two-finger right-click on trackpad
+defaults write com.apple.driver.AppleMultitouchTrackpad TrackpadRightClick -bool true
+defaults write com.apple.driver.AppleBluetoothMultitouch.trackpad TrackpadRightClick -bool true
+defaults write NSGlobalDomain com.apple.trackpad.enableSecondaryClick -bool true
+
 for plist in "$SCRIPT_DIR"/*.plist; do
     [[ -f "$plist" ]] || continue
     name="$(basename "$plist")"

--- a/packages.yaml
+++ b/packages.yaml
@@ -59,7 +59,7 @@ packages:
 
   # Dev (DOTFILES_DEV=true)
   - pyenv: { dev: true }
-  - uv: { dev: true }
+  - uv
   - rustup: { dev: true }
   - docker: { source: cask, dev: true, platform: mac }
   - npm: { platform: linux, dev: true }       # On mac, npm comes with `brew install node`
@@ -80,6 +80,7 @@ packages:
   # uv tools (Python)
   - ralphify: { source: uv }
   - code-review-graph: { source: uv }
+  - check-jsonschema: { source: uv }
 
   # Cargo
   - cargo-llvm-cov: { source: cargo }


### PR DESCRIPTION
## Summary

Configuration enhancements for macOS and Claude Code:

- **macOS trackpad**: Enable two-finger secondary click (right-click) support on built-in and Bluetooth trackpads via `defaults write`
- **iTerm2 font**: Update default terminal font to HackNFM-Regular at size 14 for improved readability
- **Claude Code**: Add `skipAutoPermissionPrompt` setting to reduce approval interruptions during development

## Files Changed

- `macos/.sync` — trackpad configuration
- `iterm2/iterm2.base.plist` — font settings
- `claude/settings.json` — permission handling
