### PR TITLE
feat(claude): gate cheese-flow, vaudeville, todoist plugins behind env flags

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,3 +29,17 @@ TODOIST_API_KEY=change-me
 # Set to true to install dev packages during `dots sync`
 # (pyenv, node, uv, rustup, docker — see brew/packages.yaml)
 DOTFILES_DEV=false
+
+# Optional Claude plugins — set to true to install during `dots sync`.
+# These are gated in claude/plugins/registry.yaml and stay out of
+# enabledPlugins / extraKnownMarketplaces unless explicitly opted in.
+# (Inline comments would leak into the exported value — keep them above.)
+
+# cheese-flow plugin (~/Dev/cheese-flow)
+CHEESE_FLOW=false
+
+# vaudeville plugin (~/Dev/vaudeville)
+VAUDEVILLE=false
+
+# todoist-flow plugin (claude/plugins/local/todoist-flow)
+TODOIST=false

--- a/claude/.sync
+++ b/claude/.sync
@@ -59,36 +59,51 @@ done
 # ~/.claude/settings.json on every invocation, clobbering our symlink.
 # Claude Code hook is tracked in settings.json above and needs no init.
 
+# Set up local-marketplace + cache symlinks for ~/Dev/vaudeville so plugin sync
+# can resolve it. Gate name is read from the registry to keep the gate field
+# as the single source of truth (rename `gate:` and this function follows).
+sync_vaudeville_cache() {
+  local registry="$SOURCE_DIR/plugins/registry.yaml"
+  [[ -f "$registry" ]] || return 0
+
+  local gate
+  gate=$(yq -r '.plugins."vaudeville@local".gate // ""' "$registry")
+  [[ -z "$gate" ]] || [[ "${!gate:-false}" == "true" ]] || return 0
+
+  local local_mkt="$HOME/.claude/plugins/marketplaces/local"
+  mkdir -p "$local_mkt/.claude-plugin"
+  [[ -L "$local_mkt/vaudeville" ]] || ln -sf "$HOME/Dev/vaudeville" "$local_mkt/vaudeville"
+
+  local plugin_json="$HOME/Dev/vaudeville/.claude-plugin/plugin.json"
+  [[ -f "$plugin_json" ]] || return 0
+
+  local vaud_ver vaud_cache
+  vaud_ver=$(jq -r '.version // "0.1.0"' "$plugin_json")
+  vaud_cache="$HOME/.claude/plugins/cache/local/vaudeville/$vaud_ver"
+  mkdir -p "$(dirname "$vaud_cache")"
+
+  if [[ ! -L "$vaud_cache" ]] || [[ "$(readlink "$vaud_cache")" != "$HOME/Dev/vaudeville" ]]; then
+    rm -rf "$vaud_cache"
+    ln -sf "$HOME/Dev/vaudeville" "$vaud_cache"
+    echo "  Linked vaudeville cache → ~/Dev/vaudeville (v$vaud_ver)"
+  fi
+
+  local old
+  for old in "$HOME/.claude/plugins/cache/local/vaudeville"/*; do
+    [[ -e "$old" ]] || continue
+    [[ "$(basename "$old")" == "$vaud_ver" ]] && continue
+    rm -rf "$old"
+    echo "  Pruned stale vaudeville cache: $(basename "$old")"
+  done
+}
+
 # Sync MCPs and plugins (requires claude CLI)
 if command -v claude &>/dev/null; then
   if [[ -x "$SOURCE_DIR/mcp/sync.sh" ]]; then
     echo "  Running MCP sync..."
     bash "$SOURCE_DIR/mcp/sync.sh" --force
   fi
-  # Ensure local marketplace symlinks exist before plugin sync
-  local_mkt="$HOME/.claude/plugins/marketplaces/local"
-  mkdir -p "$local_mkt/.claude-plugin"
-  [[ -L "$local_mkt/vaudeville" ]] || ln -sf "$HOME/Dev/vaudeville" "$local_mkt/vaudeville"
-
-  # Keep vaudeville plugin cache pointing at live source under ~/Dev/vaudeville
-  # so each `dots sync` picks up the latest commits without a reinstall dance.
-  if [[ -f "$HOME/Dev/vaudeville/.claude-plugin/plugin.json" ]]; then
-    vaud_ver=$(jq -r '.version // "0.1.0"' "$HOME/Dev/vaudeville/.claude-plugin/plugin.json")
-    vaud_cache="$HOME/.claude/plugins/cache/local/vaudeville/$vaud_ver"
-    mkdir -p "$(dirname "$vaud_cache")"
-    if [[ ! -L "$vaud_cache" ]] || [[ "$(readlink "$vaud_cache")" != "$HOME/Dev/vaudeville" ]]; then
-      rm -rf "$vaud_cache"
-      ln -sf "$HOME/Dev/vaudeville" "$vaud_cache"
-      echo "  Linked vaudeville cache → ~/Dev/vaudeville (v$vaud_ver)"
-    fi
-    # Prune orphan version dirs from previous vaudeville versions
-    for old in "$HOME/.claude/plugins/cache/local/vaudeville"/*; do
-      [[ -e "$old" ]] || continue
-      [[ "$(basename "$old")" == "$vaud_ver" ]] && continue
-      rm -rf "$old"
-      echo "  Pruned stale vaudeville cache: $(basename "$old")"
-    done
-  fi
+  sync_vaudeville_cache
   if [[ -x "$SOURCE_DIR/plugins/sync.sh" ]]; then
     echo "  Running plugin sync..."
     bash "$SOURCE_DIR/plugins/sync.sh" --force

--- a/claude/plugins/registry.yaml
+++ b/claude/plugins/registry.yaml
@@ -77,12 +77,14 @@ plugins:
     load: true
 
   # --- Local plugins (dotfiles) ---
+  # Gated entries are skipped unless the named env var is "true" (see .env.example).
 
   todoist-flow@todoist-flow:
     description: Todoist productivity suite — triage, organize, update, extract reference material
     scope: user
     load: true
     path: claude/plugins/local/todoist-flow
+    gate: TODOIST
 
   # --- Out-of-repo local plugins (path resolved at sync time) ---
   vaudeville@local:
@@ -90,9 +92,11 @@ plugins:
     scope: user
     load: true
     path: ~/Dev/vaudeville
+    gate: VAUDEVILLE
 
   cheese-flow@local:
     description: Opinionated coding harness plugin scaffold for portable agents and skills
     scope: user
     load: true
     path: ~/Dev/cheese-flow
+    gate: CHEESE_FLOW

--- a/claude/plugins/sync.sh
+++ b/claude/plugins/sync.sh
@@ -30,10 +30,15 @@ fi
 echo -e "${BLUE}Plugin Sync - Declarative Plugin Management${NC}"
 echo
 
+# Filter expression: keep plugins whose `gate` is unset or whose env var is "true".
+# `$g` is a jq variable, not a shell var — single quotes are intentional.
+# shellcheck disable=SC2016
+GATE_FILTER='select((.value.gate // "") as $g | $g == "" or (env[$g] // "false") == "true")'
+
 # Sync local plugin marketplaces — resolve relative paths to absolute
 sync_local_marketplaces() {
     local local_entries
-    local_entries=$(yq -o=json '.plugins' "$REGISTRY_FILE" | jq -c 'to_entries[] | select(.value.path) | {plugin: (.key | split("@") | .[0]), name: (.key | split("@") | .[1]), path: .value.path}' 2>/dev/null || true)
+    local_entries=$(yq -o=json '.plugins' "$REGISTRY_FILE" | jq -c "to_entries[] | $GATE_FILTER | select(.value.path) | {plugin: (.key | split(\"@\") | .[0]), name: (.key | split(\"@\") | .[1]), path: .value.path}" 2>/dev/null || true)
     [[ -z "$local_entries" ]] && return 0
 
     local changed=false
@@ -89,7 +94,7 @@ if [[ -f "$SETTINGS_FILE" ]]; then
 fi
 
 # shellcheck disable=SC2034  # used by sync-common.sh
-DESIRED_NAMES=$(yq '.plugins | keys | .[]' "$REGISTRY_FILE" | sort)
+DESIRED_NAMES=$(yq -o=json '.plugins' "$REGISTRY_FILE" | jq -r "to_entries[] | $GATE_FILTER | .key" | sort)
 
 # shellcheck disable=SC2034  # used by sync-common.sh
 if [[ -f "$SETTINGS_FILE" ]] && jq -e '.enabledPlugins' "$SETTINGS_FILE" &>/dev/null; then
@@ -130,7 +135,7 @@ sync_handle_removals "Plugins"
 if [[ -f "$SETTINGS_FILE" ]]; then
     echo -e "${BLUE}Syncing enabledPlugins in settings.json...${NC}"
 
-    ENABLED_JSON=$(yq -o=json '.plugins' "$REGISTRY_FILE" | jq 'to_entries | map({(.key): (.value.load // false)}) | add')
+    ENABLED_JSON=$(yq -o=json '.plugins' "$REGISTRY_FILE" | jq "to_entries | map($GATE_FILTER) | map({(.key): (.value.load // false)}) | add // {}")
 
     if $DRY_RUN; then
         echo -e "  ${BLUE}[dry-run]${NC} Would set enabledPlugins to:"

--- a/claude/plugins/sync.sh
+++ b/claude/plugins/sync.sh
@@ -88,9 +88,41 @@ sync_local_marketplaces() {
     echo
 }
 
+# Drop `extraKnownMarketplaces` entries for plugins whose gate is closed,
+# mirroring the safety constraint of the add path: only auto-managed entries
+# (mp_name == plugin_name) are touched. Shared marketplaces like `@local` may
+# host multiple plugins and stay registered.
+remove_gated_off_marketplaces() {
+    local stale_names
+    stale_names=$(yq -o=json '.plugins' "$REGISTRY_FILE" | jq -r '
+        to_entries[]
+        | select(.value.path) | select(.value.gate)
+        | select((env[.value.gate] // "false") != "true")
+        | (.key | split("@"))
+        | select(.[0] == .[1]) | .[0]
+    ' 2>/dev/null || true)
+    [[ -z "$stale_names" ]] && return 0
+
+    while IFS= read -r mp_name; do
+        [[ -z "$mp_name" ]] && continue
+        local has
+        has=$(jq --arg n "$mp_name" '.extraKnownMarketplaces // {} | has($n)' "$SETTINGS_FILE")
+        [[ "$has" == "true" ]] || continue
+
+        if $DRY_RUN; then
+            echo -e "  ${BLUE}[dry-run]${NC} Would remove $mp_name marketplace (gate closed)"
+        else
+            jq --arg n "$mp_name" 'del(.extraKnownMarketplaces[$n])' \
+                "$SETTINGS_FILE" > "${SETTINGS_FILE}.tmp" && mv "${SETTINGS_FILE}.tmp" "$SETTINGS_FILE"
+            echo -e "  ${GREEN}Removed $mp_name marketplace (gate closed)${NC}"
+        fi
+    done <<< "$stale_names"
+}
+
 if [[ -f "$SETTINGS_FILE" ]]; then
     echo -e "${BLUE}Syncing local marketplace paths...${NC}"
     sync_local_marketplaces
+    remove_gated_off_marketplaces
 fi
 
 # shellcheck disable=SC2034  # used by sync-common.sh

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -235,10 +235,7 @@
     "frontend-design@claude-plugins-official": true,
     "plugin-dev@claude-plugins-official": true,
     "skill-creator@claude-plugins-official": true,
-    "claude-hud@claude-hud": true,
-    "todoist-flow@todoist-flow": true,
-    "vaudeville@local": true,
-    "cheese-flow@local": true
+    "claude-hud@claude-hud": true
   },
   "extraKnownMarketplaces": {
     "claude-hud": {
@@ -251,12 +248,6 @@
       "source": {
         "source": "github",
         "repo": "boostvolt/claude-code-lsps"
-      }
-    },
-    "todoist-flow": {
-      "source": {
-        "source": "directory",
-        "path": "/Users/paul/Dev/dotfiles/claude/plugins/local/todoist-flow"
       }
     }
   },

--- a/tests/sync-claude.bats
+++ b/tests/sync-claude.bats
@@ -391,3 +391,71 @@ JSON
     assert_output_contains "linter@community"
     [ ! -f "$CLAUDE_LOG" ] || ! grep -q "claude plugin install" "$CLAUDE_LOG"
 }
+
+
+write_gated_plugin_fixtures() {
+    local dotfiles_root="$1"
+    local plugin_dir="$dotfiles_root/claude/plugins/local/gated-plugin"
+    mkdir -p "$plugin_dir/.claude-plugin"
+    echo '{"name": "gated-plugin"}' > "$plugin_dir/.claude-plugin/plugin.json"
+    cat > "$dotfiles_root/claude/plugins/registry.yaml" << 'YAML'
+plugins:
+  hookify@official:
+    description: Hook management
+    scope: user
+    load: true
+  gated-plugin@gated-plugin:
+    description: Gated test plugin
+    scope: user
+    load: true
+    path: claude/plugins/local/gated-plugin
+    gate: TEST_GATE
+YAML
+    cat > "$dotfiles_root/claude/settings.json" << 'JSON'
+{
+  "enabledPlugins": {},
+  "extraKnownMarketplaces": {}
+}
+JSON
+}
+
+setup_gated_sync_dir() {
+    local dotfiles_root="$1"
+    local claude_dir="$dotfiles_root/claude"
+    local mock_dir="$claude_dir/plugins"
+    mkdir -p "$mock_dir" "$claude_dir/lib"
+    cp "$SYNC_COMMON" "$claude_dir/lib/sync-common.sh"
+    cp "$PLUGIN_SYNC" "$mock_dir/sync.sh"
+    write_gated_plugin_fixtures "$dotfiles_root"
+}
+
+@test "plugin sync: gated plugin excluded from enabledPlugins when gate env var unset" {
+    local dotfiles_root
+    dotfiles_root="$(mkdir -p "$TEST_HOME/dotfiles-gate-off" && cd "$TEST_HOME/dotfiles-gate-off" && pwd -P)"
+    setup_gated_sync_dir "$dotfiles_root"
+
+    unset TEST_GATE
+    run bash "$dotfiles_root/claude/plugins/sync.sh" --force
+    assert_success
+    assert_output_not_contains "gated-plugin@gated-plugin"
+
+    local has_gated has_ungated
+    has_gated=$(jq '.enabledPlugins | has("gated-plugin@gated-plugin")' "$dotfiles_root/claude/settings.json")
+    has_ungated=$(jq '.enabledPlugins | has("hookify@official")' "$dotfiles_root/claude/settings.json")
+    [[ "$has_gated" == "false" ]]
+    [[ "$has_ungated" == "true" ]]
+}
+
+@test "plugin sync: gated plugin included in enabledPlugins when gate env var is true" {
+    local dotfiles_root
+    dotfiles_root="$(mkdir -p "$TEST_HOME/dotfiles-gate-on" && cd "$TEST_HOME/dotfiles-gate-on" && pwd -P)"
+    setup_gated_sync_dir "$dotfiles_root"
+
+    run env TEST_GATE=true bash "$dotfiles_root/claude/plugins/sync.sh" --force
+    assert_success
+    assert_output_contains "gated-plugin@gated-plugin"
+
+    local has_gated
+    has_gated=$(jq '.enabledPlugins | has("gated-plugin@gated-plugin")' "$dotfiles_root/claude/settings.json")
+    [[ "$has_gated" == "true" ]]
+}

--- a/tests/sync-claude.bats
+++ b/tests/sync-claude.bats
@@ -459,3 +459,24 @@ setup_gated_sync_dir() {
     has_gated=$(jq '.enabledPlugins | has("gated-plugin@gated-plugin")' "$dotfiles_root/claude/settings.json")
     [[ "$has_gated" == "true" ]]
 }
+
+@test "plugin sync: gated-off marketplace entry is removed from extraKnownMarketplaces" {
+    local dotfiles_root
+    dotfiles_root="$(mkdir -p "$TEST_HOME/dotfiles-gate-cleanup" && cd "$TEST_HOME/dotfiles-gate-cleanup" && pwd -P)"
+    setup_gated_sync_dir "$dotfiles_root"
+
+    # First sync with gate on, so the marketplace gets registered.
+    run env TEST_GATE=true bash "$dotfiles_root/claude/plugins/sync.sh" --force
+    assert_success
+    local has_mp
+    has_mp=$(jq '.extraKnownMarketplaces | has("gated-plugin")' "$dotfiles_root/claude/settings.json")
+    [[ "$has_mp" == "true" ]]
+
+    # Second sync with gate off should remove the stale marketplace entry.
+    unset TEST_GATE
+    run bash "$dotfiles_root/claude/plugins/sync.sh" --force
+    assert_success
+    assert_output_contains "Removed gated-plugin marketplace"
+    has_mp=$(jq '.extraKnownMarketplaces | has("gated-plugin")' "$dotfiles_root/claude/settings.json")
+    [[ "$has_mp" == "false" ]]
+}


### PR DESCRIPTION
## Summary

- Add `CHEESE_FLOW`, `VAUDEVILLE`, `TODOIST` env vars to `.env.example` (default `false`); plugins are skipped during `plugin-sync` unless the user opts in.
- Plugin gating is declared in `claude/plugins/registry.yaml` via a new `gate:` field; `plugin-sync.sh` honors it via a single `GATE_FILTER` jq expression applied to the desired-name list, marketplace resolution, and the `enabledPlugins` JSON.
- Vaudeville-specific marketplace+cache symlink setup in `claude/.sync` moves into a `sync_vaudeville_cache()` helper that reads its gate name from the registry — registry stays the single source of truth, and the helper drops the previous block from 4 levels of nesting back inside the budget.
- Removes the three opt-in plugins and the hardcoded `todoist-flow` path from `claude/settings.json`; `plugin-sync` re-adds them when the gates are on.

## Test plan

- [x] `bash claude/plugins/sync.sh --dry-run` with no env set → registry shows 12 plugins, all in sync, gated plugins absent.
- [x] `CHEESE_FLOW=true VAUDEVILLE=true TODOIST=true bash claude/plugins/sync.sh --dry-run` → registry shows 15 plugins, three queued for install, todoist-flow marketplace registration queued.
- [x] `CHEESE_FLOW=true bash claude/plugins/sync.sh --dry-run` → only cheese-flow added.
- [x] `sync_vaudeville_cache` returns early when `VAUDEVILLE` is unset, `false`, or any non-`true` value; proceeds when `VAUDEVILLE=true`.
- [x] `bash tests/run-tests.sh sync-claude.bats config-validation.bats worktree-settings.bats` → all pass.
- [x] `shellcheck claude/.sync claude/plugins/sync.sh` → clean.
- [x] `jq empty claude/settings.json` and `yq '.plugins' claude/plugins/registry.yaml` → valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)