### PR TITLE
feat(skills-install): add lsp-client/lsp-skill source

### DIFF
--- a/skills-install/registry.yaml
+++ b/skills-install/registry.yaml
@@ -20,3 +20,5 @@
 sources:
   paulnsorensen/easy-cheese:
     description: Portable agent skills toolkit — mold, cook, press, age, cure, melt, plus cheez-* tilth-backed code intelligence
+  lsp-client/lsp-skill:
+    description: LSP integration skill


### PR DESCRIPTION
## Summary

Registers the lsp-client/lsp-skill package in the harness-agnostic skill install registry.

## Details

- Adds `lsp-client/lsp-skill` to `skills-install/registry.yaml` with description "LSP integration skill"
- Part of declarative skill management system (`skills-install/registry.yaml` synced via `dots sync`)

## Test Plan

- [ ] `dots sync` completes without errors
- [ ] `skill-sync-dry` shows the expected lsp-client/lsp-skill entry
- [ ] Run `skill-sync` to install across all configured harnesses (SKILL_HARNESSES in .env)
