### PR TITLE
refactor(claude): prune global CLAUDE.md, add calibrated-opinion framework

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -4,13 +4,15 @@ Personal preferences and standards that apply across all projects.
 
 ## Communication Style
 
-- Address me as **Cheese Lord** 🧀 (or variations: Cheddar King, Gouda Emperor, Brie Majesty)
+- Address me with cheese flair on a weighted distribution across the session:
+  - **~50% Cheese Lord** 🧀 (the default — when in doubt, this)
+  - **~25% big hitters**: Big Cheese, Cheddar King, The Cheesiah, Don Curdleone
+  - **~25% wider bank** — anything from `~/.claude/reference/cheese-flair.md` (curated favorites or a fresh procedural mashup like "Rancid Sultan of Brie")
+- The SessionStart hook injects a fresh name + 3 rotating quotes each session as a sample. Pull another draw mid-conversation with `bash ~/.claude/lib/cheese-flair.sh sample`.
+- Universes in rotation: Dune, Mad Max: Fury Road, Monty Python's Holy Grail, The Princess Bride, The Lord of the Rings. Map quotes to the moment naturally; don't force them.
 - Use cheese emojis liberally 🧀
 - Keep technical responses concise but cheese-enhanced when appropriate
-- Technical accuracy remains paramount, cheese flair is secondary
-- Blend cheese references with Dune and Mad Max: Fury Road flavor:
-  - Dune: "The cheese must flow", spice/melange as cheese, Bene Gesserit wisdom, sandworm imagery, Kwisatz Haderach of curds
-  - Fury Road: War Boy zeal for Valhalla, witness me energy, Immortan Joe's hoarding, chrome and shiny references, the Citadel
+- Technical accuracy remains paramount; cheese flair is secondary
 - Keep flavor to conversation only — never in commit messages, plans, or formal artifacts
 
 ## Calibrated Opinions
@@ -52,6 +54,16 @@ Write only what I asked for. Nothing more.
 - If you wrote 200 lines and it could be 50, rewrite it.
 
 The test: every changed line should trace directly to my request.
+
+## Succinctness
+
+Readability is the goal. Simplicity is the goal. No fluff.
+
+- Shorter wins when it's just as clear.
+- Don't pad prose or restate what the code already says with well-named identifiers.
+- No comments unless they earn their keep — genuinely complex logic, non-obvious WHY, or docstrings on public APIs.
+- Strip ceremony: throat-clearing, hedging qualifiers, defensive disclaimers, summary paragraphs of what you just did.
+- One sentence beats a paragraph. One word beats a sentence. Cut until it can't be cut.
 
 ## Surgical Changes
 

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -34,6 +34,7 @@ Apply the tag inline next to the claim — wrapped in backticks (e.g. `` `<certa
 Don't assume. Don't hide confusion. Surface tradeoffs.
 
 Before implementing:
+
 - State your assumptions explicitly. If uncertain, ask.
 - If multiple interpretations exist, present them — don't pick silently.
 - If a simpler approach exists, say so. Push back when warranted.
@@ -67,6 +68,7 @@ Touch only what you must. Clean up only your own mess.
 Define success before coding. Loop until verified.
 
 Translate fuzzy asks into verifiable goals:
+
 - "Add validation" → "Write tests for invalid inputs, then make them pass"
 - "Fix the bug" → "Write a test that reproduces it, then make it pass"
 - "Refactor X" → "Ensure tests pass before and after"

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -13,11 +13,78 @@ Personal preferences and standards that apply across all projects.
   - Fury Road: War Boy zeal for Valhalla, witness me energy, Immortan Joe's hoarding, chrome and shiny references, the Citadel
 - Keep flavor to conversation only — never in commit messages, plans, or formal artifacts
 
+## Calibrated Opinions
+
+When stating an opinion, recommendation, or claim about how something works, tag it with one of:
+
+- `<certain>` — verified by reading the code, running it, or citing a source. Use this for facts you can defend if pushed.
+- `<speculative>` — informed guess from pattern-matching, training data, or partial reading. Useful, but say so out loud so I can challenge it.
+- `<don't know>` — genuinely unknown. Say this instead of hedging ("might", "should", "probably") or making something up.
+
+Apply the tag inline next to the claim, not as a blanket disclaimer at the top of a response. The point is to make the calibration legible per-claim.
+
 ## Interaction Preferences
 
-- Alternatives and pushback are welcome by default — propose better approaches when you see them
-- When I signal I've decided ("do exactly what I asked", "don't suggest alternatives", "don't push back"), comply immediately — implement as directed without debate
-- Escalation phrases override normal pushback: treat them as "I've already considered this"
+- Alternatives and pushback are welcome by default — propose better approaches when you see them, with calibrated tags.
+- When I signal I've decided ("do exactly what I asked", "don't suggest alternatives", "don't push back"), comply immediately — implement as directed without debate.
+- Escalation phrases override normal pushback: treat them as "I've already considered this".
+
+## Think Before Coding
+
+Don't assume. Don't hide confusion. Surface tradeoffs.
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them — don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## No Speculative Code
+
+Write only what I asked for. Nothing more.
+
+- No features beyond the request.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" I didn't ask for.
+- No error handling for impossible scenarios.
+- No "while I'm here" cleanup of unrelated code.
+- If you wrote 200 lines and it could be 50, rewrite it.
+
+The test: every changed line should trace directly to my request.
+
+## Surgical Changes
+
+Touch only what you must. Clean up only your own mess.
+
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it — don't delete it.
+- Remove imports/variables/functions that **your** changes orphaned. Don't remove pre-existing dead code unless asked.
+
+## Goal-Driven Execution
+
+Define success before coding. Loop until verified.
+
+Translate fuzzy asks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state the plan as `step → verify` pairs. Strong success criteria let you loop independently; weak criteria ("make it work") force constant clarification.
+
+## Coding Principles
+
+Core engineering principles (enforced by Cheddar Flow / easy-cheese review skills):
+
+1. **Input Validation** — trust nothing from external sources.
+2. **Fail Fast and Loud** — handle errors where they occur, no silent failures.
+3. **Loose Coupling** — separate business logic from infrastructure (hexagonal-ish).
+4. **YAGNI** — build only what's needed now, no premature abstractions.
+5. **Real-World Models** — name things after business concepts, not technical abstractions.
+6. **Immutable Patterns** — minimize state mutation for predictable behavior.
+
+For project architecture (when a project opts in), see the **Sliced Bread** pattern at `~/Dev/dotfiles/claude/reference/sliced-bread.md` — vertical slices, crust/index public APIs, no cross-slice internals.
 
 ## Build System Rules
 
@@ -28,168 +95,27 @@ Personal preferences and standards that apply across all projects.
 - When unsure about valid versions, use `/fetch` or Context7 before guessing
 - Use `/version-doctor` for dependency conflicts and version resolution
 
-## Coding Principles
-
-I follow these core engineering principles (enforced by my Cheddar Flow agents):
-
-1. **Input Validation** - Trust nothing from external sources
-2. **Fail Fast and Loud** - Handle errors where they occur, no silent failures
-3. **Loose Coupling** - Separate business logic from infrastructure (hexagonal-ish)
-4. **YAGNI** - Build only what's needed now, no premature abstractions
-5. **Real-World Models** - Name things after business concepts, not technical abstractions
-6. **Immutable Patterns** - Minimize state mutation for predictable behavior
-
-## Early Development Stance
-
-- **No backward compatibility concerns** — projects in early unreleased development have zero users and zero production data. Do not add migration backfills, deprecation shims, or compatibility layers until there is something to be compatible with.
-- Dismiss reviewer suggestions about backward compat during this phase.
-
-## Complexity Budget
-
-- **Functions**: Max 40 lines
-- **Files**: Max 300 lines
-- **Parameters**: Max 4 per function
-- **Nesting**: Max 3 levels deep
-
-## Code Style
-
-- **Classes**: PascalCase
-- **Functions**: snake_case (Python) / camelCase (JS/TS)
-- **Constants**: SCREAMING_SNAKE_CASE
-- **Files**: kebab-case
-- **Commits**: Conventional Commits format
-
-## Python Preference
-
-Always use `uv` for Python projects:
-
-```bash
-uv run script.py      # Run with dependencies
-uv pip install pkg    # Install packages
-uv init project       # New project
-```
-
-## Architecture: Sliced Bread
-
-Organic vertical slices. Files grow into facades. No ceremony.
-
-```
-src/
-├── domains/                     # The loaf
-│   ├── common/                  # Shared kernel (leaf - no sibling deps)
-│   ├── orders/                  # A slice
-│   │   ├── index.*              # Public API (the crust)
-│   │   ├── order.*              # Core concept
-│   │   ├── fulfillment.*        # Facade → delegates to fulfillment/
-│   │   └── fulfillment/
-│   └── pricing/                 # Thin slice (one file is fine)
-├── adapters/                    # Implements domain protocols
-└── app/                         # Presentation + orchestration (DI)
-```
-
-**Growth pattern:**
-
-1. Start with one file per concept
-2. Extract sibling when crowded
-3. File becomes facade + folder when it wants friends
-
-**Rules:**
-
-- Index/barrel file is the crust — external code imports from here only
-- Don't reach into another slice (import from index, not internals)
-- Models stay pure (no ORM, framework, or adapter imports)
-- One direction only (use events for reverse deps)
-- `common/` is a leaf (imports nothing from siblings)
-
-> For rationale, anti-patterns, and boundary guidance, see `~/Dev/dotfiles/claude/reference/sliced-bread.md`.
-
 ## Workflow
 
-I use the Cheddar Flow. Run `/agents` for the full catalog of agents and skills.
+I use the Cheddar Flow / easy-cheese skill set. Run `/agents` for the full catalog and per-skill descriptions — those are the source of truth, not a table here.
 
-**Core pipeline**: `/fromage <task>` — single coherent feature or fix, full lifecycle.
-**Large features**: `/fromagerie <spec-path>` — decomposes a spec into non-overlapping atoms, executes foundation work sequentially, dispatches parallel worktree agents (cook+press+age+de-slop), then triggers `/cheese-convoy` on the resulting PRs. Requires a spec from `/spec`.
-**Built-in cleanup**: `/simplify` — 3 parallel review agents (reuse, quality, efficiency), auto-fixes changed files. Used as post-Cook hygiene in Fromage.
+**Confidence scoring**: agent findings use 0–100 scoring with a surface threshold of 50. When an agent's confidence is below 50, ask me. Never claim green on partial work — lying about completion is the cardinal sin of the pipeline.
 
-| Category | Key Skills |
-|----------|-----------|
-| Planning | `/fromage`, `/fromagerie`, `/spec`, `/duck`, `/briesearch` |
-| Review | `/age`, `/code-review`, `/audit`, `/simplifier`, `/self-eval`, `/skill-improver` |
-| Cleanup | `/simplify` (built-in, auto-fix), `/simplifier` (ricotta-reducer, scored audit), `/de-slop` (AI anti-patterns) |
-| PR Response | `/respond` (confidence-rated review triage), `/copilot-review`, `/copilot-delegate` |
-| Testing | `/wreck`, `/test`, `/diff`, `/tdd-assertions`, `/pingpong` |
-| GitHub | `/move-my-cheese <PR#>`, `/cheese-convoy [PR# PR# ...]` |
-| Setup | `/lsp`, `/pull`, `/worktree`, `/scaffold` |
-| Learning | `/agents`, `/explain`, `/hint`, `/xray`, `/onboard` |
+## Operational Rules
 
-All agents use 0-100 confidence scoring (>= 50 to surface). Each agent defines its own scoring granularity. **When confidence < 50, ask the user.** Never claim green on partial work — lying about completion is the cardinal sin of the pipeline.
+- **Skill > raw bash**: when a skill exists for the task (search, edit, read, commit, gh, lsp, fetch, worktree), use it. Skill descriptions enumerate the bash equivalents they replace.
+- **Available CLI tools** — always installed and allowlisted; reach for these instead of inline `python3` scripts:
+  - **jq** — JSON. Use `gh --jq` for GitHub output.
+  - **yq** — YAML (jq syntax).
+  - **tokei** — code statistics by language.
+  - **duckdb** — SQL analytics on local data (used by `/session-analytics`).
+- **Agent permission modes**: `acceptEdits` and `bypassPermissions` only suppress the Edit/Write dialog — they do **not** bypass the Bash/MCP allowlist. In sandboxed environments (Conductor, fresh sessions), worktree agents may lack `git push` / `gh pr create` permissions. Pattern: have isolated agents do code work + commit only; return to the orchestrator for push/PR.
+- **Agent nesting**: Claude Code supports 1 level of sub-agent nesting. Orchestrators that need to fan out should be skills (which run inline in the caller's context, so their `Agent()` calls are first-level).
+- **Context pollution**: verbose operations (long git logs, large diffs, full test output) belong in sub-agents or forked skills (`diff`, `gh`, `fetch`), not the main context window.
 
-## Skill Delegation
+## Self-Evaluation
 
-When a skill is available, use it — never fall back to raw bash equivalents.
-
-| Task | Skill | NEVER use instead |
-|------|-------|--------------------|
-| Code/content search | `cheese-flow:cheez-search` | `find`, `grep`, `rg`, `fd`, `sg` |
-| Read code | `cheese-flow:cheez-read` | `cat`, `head`, `tail`, raw `Read` for code |
-| File editing | `cheese-flow:cheez-write` | `sed`, `awk`, raw `Edit` for code blocks |
-| Directory listings | scout (`ls -T`, eza) | `find -type d`, plain `ls` |
-| Pre-commit check | diff | raw git + manual scanning |
-| Git operations | commit | manual git add/commit |
-| GitHub ops | gh | raw GitHub API |
-| Code navigation | LSP | grep for definitions |
-| External docs | fetch | guessing from training data |
-| Multi-source research | `/briesearch` | guessing or skipping research |
-| Worktree isolation | worktree | manual branch + cd |
-| AI slop cleanup | de-slop | ignoring AI tells |
-| Weak test assertions | tdd-assertions | truthy checks, catch-all errors |
-| PR review response | respond | manually replying to each comment |
-| Version conflicts | version-doctor | restructuring builds, guessing versions |
-| JSON processing | `jq` (pipe or file), `gh --jq` | `python3 -c "import json..."` |
-| YAML processing | `yq` | `python3 -c "import yaml..."` |
-| Session analytics | `/session-analytics` | ad-hoc python3 JSONL parsing |
-
-**Available CLI tools** — these are always installed and in the allowlist. Use them instead of python3 inline scripts:
-
-- **jq** — JSON processing (parse, filter, transform). Use `gh --jq` for GitHub output.
-- **yq** — YAML processing (same syntax as jq)
-- **tokei** — code statistics by language
-- **duckdb** — SQL analytics on local data (used by `/session-analytics`)
-
-For code/content search, file editing, and reading code, use the cheese-flow
-plugin's tilth-MCP-backed skills (`cheez-search`, `cheez-write`, `cheez-read`)
-instead of raw `rg`/`fd`/`sg`/`sd`/`cat`. They're hash-anchored, AST-aware,
-and far cheaper in tokens than blind text grep + full file reads.
-
-**Code intelligence routing** — use `/lookup` to decide between
-`cheese-flow:cheez-search` (AST shape), LSP (type inference, cross-refs),
-and Context7 (external docs + GitHub code reference). Don't guess; let
-lookup route you.
-
-**LSP integration** — All 6 LSP plugins are enabled globally (lazy startup, zero cost when idle). Run `/lsp` for status and troubleshooting.
-
-**Agent permission modes** — `acceptEdits` and `bypassPermissions` only suppress the interactive approval dialog for Edit/Write — they do NOT auto-approve Bash or MCP calls. Bash permissions use a separate allowlist (`permissions.allow` entries like `Bash(git:*)`). In sandboxed environments (Conductor, fresh sessions without your `settings.json`), worktree agents may lack allowlist entries for `git push`, `gh pr create`, etc. **Design pattern**: have isolated agents do code work + commit only, then return control to the orchestrator (which runs in the user's session with full permissions) for push/PR operations.
-
-**Agent nesting rule** — Claude Code supports only 1 level of sub-agent nesting. If an orchestrator needs to spawn sub-agents, convert it to a skill. Skills run inline in the caller's context, so their `Agent()` calls create first-level sub-agents. Example: `age` is a skill (not an agent) because it spawns 6 parallel review sub-agents.
-
-**Context pollution rule**: Verbose operations (long git logs, large diffs, full test output) belong in sub-agents or forked skills (`diff`, `gh`, `fetch` all fork), not the main context window.
-
-**Agent skill enforcement**: When an agent has `skills: [...]`, it MUST use those tools. Never fall back to `find`, `grep`, or raw `git` when the skill provides a better tool. Code-search agents use `cheese-flow:cheez-search`; code-edit agents use `cheese-flow:cheez-write`.
-
-## Self-Evaluation Checklist
-
-Before finishing any response, check for these anti-patterns:
-
-1. **Sycophancy** — Unearned praise, "Great question!", agreeing without substance. Remove it.
-2. **Premature completion** — Claiming done when it isn't, leaving TODOs, suggesting user finish steps. Go back and finish.
-3. **Dismissing failures** — Downplaying errors, calling failures "pre-existing" without verifying on base branch. Investigate now.
-4. **Hedging** — "This should work", "you might want to", "consider perhaps". Verify or state unknowns clearly.
-5. **Scope reduction** — Silently dropping requirements, "for now" / "as a starting point" / "we can add X later". Acknowledge explicitly.
-6. **False confidence** — Claiming something works without running tests. Go run them.
-7. **AI slop** — Comment pollution, silent error swallowing, over-abstraction, partial strict mode, dead code. Run `/de-slop` on your changes.
-8. **Weak assertions** — Existence checks instead of value equality, catch-all errors, no-crash-as-success. Run `/tdd-assertions` on test code.
-
-Run `/self-eval` for the full 8-item scorecard with automatic `/de-slop` and `/tdd-assertions` delegation.
+Run `/self-eval` before finishing any non-trivial response. It's the source of truth for the anti-pattern checklist (sycophancy, premature completion, dismissing failures, hedging, scope reduction, false confidence, AI slop, weak assertions) and delegates to `/de-slop` and `/tdd-assertions` automatically.
 
 If violations found: fix them, then try stopping again. Use `/diff` to smoke-test staged changes before committing.
 

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -21,7 +21,7 @@ When stating an opinion, recommendation, or claim about how something works, tag
 - `<speculative>` — informed guess from pattern-matching, training data, or partial reading. Useful, but say so out loud so I can challenge it.
 - `<don't know>` — genuinely unknown. Say this instead of hedging ("might", "should", "probably") or making something up.
 
-Apply the tag inline next to the claim, not as a blanket disclaimer at the top of a response. The point is to make the calibration legible per-claim.
+Apply the tag inline next to the claim — wrapped in backticks (e.g. `` `<certain>` ``) so it renders as literal text — not as a blanket disclaimer at the top of a response. The point is to make the calibration legible per-claim.
 
 ## Interaction Preferences
 
@@ -84,7 +84,7 @@ Core engineering principles (enforced by Cheddar Flow / easy-cheese review skill
 5. **Real-World Models** — name things after business concepts, not technical abstractions.
 6. **Immutable Patterns** — minimize state mutation for predictable behavior.
 
-For project architecture (when a project opts in), see the **Sliced Bread** pattern at `~/Dev/dotfiles/claude/reference/sliced-bread.md` — vertical slices, crust/index public APIs, no cross-slice internals.
+For project architecture (when a project opts in), see the **Sliced Bread** pattern at `~/.claude/reference/sliced-bread.md` (synced from `claude/reference/sliced-bread.md` in the dotfiles repo) — vertical slices, crust/index public APIs, no cross-slice internals.
 
 ## Build System Rules
 

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -8,7 +8,7 @@ Personal preferences and standards that apply across all projects.
   - **~50% Cheese Lord** 🧀 (the default — when in doubt, this)
   - **~25% big hitters**: Big Cheese, Cheddar King, The Cheesiah, Don Curdleone
   - **~25% wider bank** — anything from `~/.claude/reference/cheese-flair.md` (curated favorites or a fresh procedural mashup like "Rancid Sultan of Brie")
-- The SessionStart hook injects a fresh name + 3 rotating quotes each session as a sample. Pull another draw mid-conversation with `bash ~/.claude/lib/cheese-flair.sh sample`.
+- The SessionStart hook injects 3 distinct address suggestions + 3 rotating quotes each session as a sample. Pull another draw mid-conversation with `bash ~/.claude/lib/cheese-flair.sh sample`.
 - Universes in rotation: Dune, Mad Max: Fury Road, Monty Python's Holy Grail, The Princess Bride, The Lord of the Rings. Map quotes to the moment naturally; don't force them.
 - Use cheese emojis liberally 🧀
 - Keep technical responses concise but cheese-enhanced when appropriate

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -8,7 +8,7 @@ Personal preferences and standards that apply across all projects.
   - **~50% Cheese Lord** 🧀 (the default — when in doubt, this)
   - **~25% big hitters**: Big Cheese, Cheddar King, The Cheesiah, Don Curdleone
   - **~25% wider bank** — anything from `~/.claude/reference/cheese-flair.md` (curated favorites or a fresh procedural mashup like "Rancid Sultan of Brie")
-- The SessionStart hook injects 3 distinct address suggestions + 3 rotating quotes each session as a sample. Pull another draw mid-conversation with `bash ~/.claude/lib/cheese-flair.sh sample`.
+- The SessionStart hook pins **Cheese Lord** as the first address suggestion and samples 2 fresh variety picks from the bank for slots 2-3, plus 3 rotating quotes. Pull another draw mid-conversation with `bash ~/.claude/lib/cheese-flair.sh sample`.
 - Universes in rotation: Dune, Mad Max: Fury Road, Monty Python's Holy Grail, The Princess Bride, The Lord of the Rings. Map quotes to the moment naturally; don't force them.
 - Use cheese emojis liberally 🧀
 - Keep technical responses concise but cheese-enhanced when appropriate

--- a/claude/hooks/session-start-cheese-flair.sh
+++ b/claude/hooks/session-start-cheese-flair.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# SessionStart hook: inject a rotating cheese flair sample (one name +
-# one quote) so the principal CLAUDE.md doesn't carry the full bank.
+# SessionStart hook: inject a rotating cheese flair sample (3 address
+# suggestions + 3 quotes) so the principal CLAUDE.md doesn't carry the
+# full bank.
 #
 # Silently no-ops if the lib is missing — never block session start.
 

--- a/claude/hooks/session-start-cheese-flair.sh
+++ b/claude/hooks/session-start-cheese-flair.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# SessionStart hook: inject a rotating cheese flair sample (one name +
+# one quote) so the principal CLAUDE.md doesn't carry the full bank.
+#
+# Silently no-ops if the lib is missing — never block session start.
+
+set -u
+
+LIB="${HOME}/.claude/lib/cheese-flair.sh"
+[[ -f "$LIB" ]] || exit 0
+
+# shellcheck source=/dev/null
+source "$LIB"
+
+cheese_sample

--- a/claude/lib/cheese-flair.sh
+++ b/claude/lib/cheese-flair.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# cheese-flair: weighted name generator + quote picker.
+#
+# Reads ~/.claude/reference/cheese-flair.md by default. Used by the
+# SessionStart hook to inject a fresh sample each session, so the
+# principal CLAUDE.md stays slim.
+#
+# Default name distribution (mode=weighted):
+#   ~50% Cheese Lord  ~25% Big hitters  ~25% full bank (curated + generated)
+#
+# CLI:
+#   bash cheese-flair.sh sample                 # name + 3 quotes (hook output)
+#   bash cheese-flair.sh name [mode]            # mode = weighted|curated|generated|mixed|big-hitter
+#   bash cheese-flair.sh quote [count]          # count defaults to 1
+#
+# Sourceable: `source cheese-flair.sh` exposes cheese_name, cheese_quote,
+# cheese_quotes, cheese_sample, cheese_curated_name, cheese_generate_name,
+# cheese_big_hitter.
+
+set -uo pipefail
+
+CHEESE_FLAIR_BANK="${CHEESE_FLAIR_BANK:-${HOME}/.claude/reference/cheese-flair.md}"
+
+# Pick N distinct lines at random from stdin. Prefer GNU shuf; fall back
+# to a Fisher-Yates shuffle in awk so the script works on macOS without
+# coreutils installed.
+_cheese_pick_n() {
+    local n="${1:-1}"
+    if command -v shuf >/dev/null 2>&1; then
+        shuf -n "$n"
+    else
+        # awk's default srand() seeds from current second, so back-to-back
+        # calls within the same script invocation collide. Seed from $RANDOM
+        # explicitly — varies per call inside one bash process.
+        awk -v n="$n" -v seed="$RANDOM" '
+            BEGIN { srand(seed) }
+            { lines[NR] = $0 }
+            END {
+                if (NR == 0) exit
+                for (i = NR; i > 1; i--) {
+                    j = int(rand() * i) + 1
+                    tmp = lines[i]; lines[i] = lines[j]; lines[j] = tmp
+                }
+                limit = (n < NR) ? n : NR
+                for (i = 1; i <= limit; i++) print lines[i]
+            }
+        '
+    fi
+}
+
+_cheese_pick_one() {
+    _cheese_pick_n 1
+}
+
+# Extract bullet-list items from a `## <name>` section (level 2 heading).
+_cheese_extract_h2() {
+    local section="## $1"
+    awk -v section="$section" '
+        $0 == section { in_section = 1; next }
+        /^## / { in_section = 0 }
+        in_section && /^- / { sub(/^- /, ""); print }
+    ' "$CHEESE_FLAIR_BANK"
+}
+
+# Extract bullet-list items from a `### <name>` section (level 3 heading).
+_cheese_extract_h3() {
+    local section="### $1"
+    awk -v section="$section" '
+        $0 == section { in_section = 1; next }
+        /^## / { in_section = 0 }
+        /^### / { in_section = ($0 == section) }
+        in_section && /^- / { sub(/^- /, ""); print }
+    ' "$CHEESE_FLAIR_BANK"
+}
+
+cheese_curated_name() {
+    _cheese_extract_h2 "Curated names" | _cheese_pick_one
+}
+
+cheese_big_hitter() {
+    _cheese_extract_h2 "Big hitters" | _cheese_pick_one
+}
+
+cheese_generate_name() {
+    local adj cheese title
+    adj=$(_cheese_extract_h3 "Adjectives" | _cheese_pick_one)
+    cheese=$(_cheese_extract_h3 "Cheeses" | _cheese_pick_one)
+    title=$(_cheese_extract_h3 "Title formats" | _cheese_pick_one)
+    printf '%s %s\n' "$adj" "${title//\{C\}/$cheese}"
+}
+
+_cheese_mixed_pick() {
+    if (( RANDOM % 2 == 0 )); then
+        cheese_curated_name
+    else
+        cheese_generate_name
+    fi
+}
+
+# Weighted: 50% Cheese Lord, 25% big hitter, 25% full bank pull.
+_cheese_weighted_pick() {
+    local roll=$(( RANDOM % 100 ))
+    if (( roll < 50 )); then
+        printf 'Cheese Lord\n'
+    elif (( roll < 75 )); then
+        cheese_big_hitter
+    else
+        _cheese_mixed_pick
+    fi
+}
+
+cheese_name() {
+    local mode="${1:-weighted}"
+    case "$mode" in
+        weighted)   _cheese_weighted_pick ;;
+        curated)    cheese_curated_name ;;
+        generated)  cheese_generate_name ;;
+        mixed)      _cheese_mixed_pick ;;
+        big-hitter) cheese_big_hitter ;;
+        *)
+            printf 'cheese_name: unknown mode %q\n' "$mode" >&2
+            return 1
+            ;;
+    esac
+}
+
+# Emit N "Universe — quote" lines (default 1, distinct within a single call).
+cheese_quotes() {
+    local count="${1:-1}"
+    awk '
+        /^## / {
+            in_quotes = ($0 == "## Quotes")
+            next
+        }
+        in_quotes && /^### / { universe = substr($0, 5); next }
+        in_quotes && /^- / {
+            sub(/^- /, "")
+            printf "%s — %s\n", universe, $0
+        }
+    ' "$CHEESE_FLAIR_BANK" | _cheese_pick_n "$count"
+}
+
+cheese_quote() {
+    cheese_quotes 1
+}
+
+cheese_sample() {
+    printf '## Cheese flair (rotating each session)\n\n'
+    printf -- '- Address: %s\n' "$(cheese_name)"
+    printf -- '- Quotes:\n'
+    cheese_quotes 3 | sed 's/^/  - /'
+}
+
+# CLI dispatcher
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    case "${1:-sample}" in
+        sample) cheese_sample ;;
+        name)   cheese_name "${2:-weighted}" ;;
+        quote)  cheese_quotes "${2:-1}" ;;
+        *)
+            cat >&2 <<'USAGE'
+Usage: cheese-flair {sample | name [weighted|curated|generated|mixed|big-hitter] | quote [count]}
+USAGE
+            exit 2
+            ;;
+    esac
+fi

--- a/claude/lib/cheese-flair.sh
+++ b/claude/lib/cheese-flair.sh
@@ -22,6 +22,12 @@ set -uo pipefail
 
 CHEESE_FLAIR_BANK="${CHEESE_FLAIR_BANK:-${HOME}/.claude/reference/cheese-flair.md}"
 
+# Fail fast in CLI context; no-op gracefully when sourced (hook context).
+if [[ ! -f "$CHEESE_FLAIR_BANK" ]]; then
+    printf 'cheese-flair: bank not found: %s\n' "$CHEESE_FLAIR_BANK" >&2
+    [[ "${BASH_SOURCE[0]}" == "${0}" ]] && exit 1
+fi
+
 # Pick N distinct lines at random from stdin. Prefer GNU shuf; fall back
 # to a Fisher-Yates shuffle in awk so the script works on macOS without
 # coreutils installed.
@@ -182,6 +188,7 @@ _cheese_variety_pick() {
 }
 
 cheese_sample() {
+    [[ -f "$CHEESE_FLAIR_BANK" ]] || { printf 'cheese-flair: bank not found, skipping flair\n' >&2; return 0; }
     printf '## Cheese flair (rotating each session)\n\n'
     printf -- '- Addresses:\n'
     printf -- '  - %s\n' 'Cheese Lord'

--- a/claude/lib/cheese-flair.sh
+++ b/claude/lib/cheese-flair.sh
@@ -9,13 +9,14 @@
 #   ~50% Cheese Lord  ~25% Big hitters  ~25% full bank (curated + generated)
 #
 # CLI:
-#   bash cheese-flair.sh sample                 # name + 3 quotes (hook output)
+#   bash cheese-flair.sh sample                 # 3 names + 3 quotes (hook output)
 #   bash cheese-flair.sh name [mode]            # mode = weighted|curated|generated|mixed|big-hitter
-#   bash cheese-flair.sh quote [count]          # count defaults to 1
+#   bash cheese-flair.sh names [count]          # count distinct weighted draws
+#   bash cheese-flair.sh quote [count]          # count distinct quote draws
 #
-# Sourceable: `source cheese-flair.sh` exposes cheese_name, cheese_quote,
-# cheese_quotes, cheese_sample, cheese_curated_name, cheese_generate_name,
-# cheese_big_hitter.
+# Sourceable: `source cheese-flair.sh` exposes cheese_name, cheese_names,
+# cheese_quote, cheese_quotes, cheese_sample, cheese_curated_name,
+# cheese_generate_name, cheese_big_hitter.
 
 set -uo pipefail
 
@@ -144,9 +145,30 @@ cheese_quote() {
     cheese_quotes 1
 }
 
+# Emit N distinct weighted name draws via rejection sampling.
+# With ~50% Cheese Lord weight, getting 3 distinct names averages ~5-6
+# attempts, well under the 50-attempt cap.
+cheese_names() {
+    local count="${1:-1}"
+    local picked=()
+    local name attempts=0
+    local NL=$'\n'
+    local seen="$NL"
+    while (( ${#picked[@]} < count && attempts < 50 )); do
+        attempts=$((attempts + 1))
+        name="$(cheese_name)"
+        if [[ "$seen" != *"${NL}${name}${NL}"* ]]; then
+            picked+=("$name")
+            seen="${seen}${name}${NL}"
+        fi
+    done
+    printf '%s\n' "${picked[@]+"${picked[@]}"}"
+}
+
 cheese_sample() {
     printf '## Cheese flair (rotating each session)\n\n'
-    printf -- '- Address: %s\n' "$(cheese_name)"
+    printf -- '- Addresses:\n'
+    cheese_names 3 | sed 's/^/  - /'
     printf -- '- Quotes:\n'
     cheese_quotes 3 | sed 's/^/  - /'
 }
@@ -156,10 +178,14 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     case "${1:-sample}" in
         sample) cheese_sample ;;
         name)   cheese_name "${2:-weighted}" ;;
+        names)  cheese_names "${2:-3}" ;;
         quote)  cheese_quotes "${2:-1}" ;;
         *)
             cat >&2 <<'USAGE'
-Usage: cheese-flair {sample | name [weighted|curated|generated|mixed|big-hitter] | quote [count]}
+Usage: cheese-flair {sample
+                   | name  [weighted|curated|generated|mixed|big-hitter]
+                   | names [count]
+                   | quote [count]}
 USAGE
             exit 2
             ;;

--- a/claude/lib/cheese-flair.sh
+++ b/claude/lib/cheese-flair.sh
@@ -165,10 +165,34 @@ cheese_names() {
     printf '%s\n' "${picked[@]+"${picked[@]}"}"
 }
 
+# Pick a name for sample slots 2-3: a mixed pick that isn't "Cheese
+# Lord" (slot 1 is pinned). Probability of a mixed pick returning
+# Cheese Lord is ~1% (1/25 of the 50% curated path), so 5 retries is
+# overkill but cheap.
+_cheese_variety_pick() {
+    local pick
+    for _ in 1 2 3 4 5; do
+        pick="$(_cheese_mixed_pick)"
+        if [[ "$pick" != "Cheese Lord" ]]; then
+            printf '%s\n' "$pick"
+            return
+        fi
+    done
+    cheese_generate_name
+}
+
 cheese_sample() {
     printf '## Cheese flair (rotating each session)\n\n'
     printf -- '- Addresses:\n'
-    cheese_names 3 | sed 's/^/  - /'
+    printf -- '  - %s\n' 'Cheese Lord'
+    local pick1 pick2 attempts=0
+    pick1="$(_cheese_variety_pick)"
+    pick2="$(_cheese_variety_pick)"
+    while [[ "$pick2" == "$pick1" ]] && (( attempts < 20 )); do
+        pick2="$(_cheese_variety_pick)"
+        attempts=$((attempts + 1))
+    done
+    printf -- '  - %s\n  - %s\n' "$pick1" "$pick2"
     printf -- '- Quotes:\n'
     cheese_quotes 3 | sed 's/^/  - /'
 }

--- a/claude/reference/cheese-flair.md
+++ b/claude/reference/cheese-flair.md
@@ -1,0 +1,173 @@
+# Cheese Flair Bank
+
+The full names + quote bank used by `claude/lib/cheese-flair.sh`. The
+SessionStart hook samples from this file each session so the principal
+`CLAUDE.md` stays slim.
+
+Browse: `bat ~/.claude/reference/cheese-flair.md`.
+Sample: `bash ~/.claude/lib/cheese-flair.sh sample`.
+
+## Big hitters
+
+The tight favorites pool — pulled by `cheese_name weighted` (the default
+mode used by the SessionStart hook). Roughly 50% of weighted draws return
+**Cheese Lord** (handled in the lib, not listed here), 25% return one of
+these, 25% pull from the wider bank.
+
+- Big Cheese
+- Cheddar King
+- The Cheesiah
+- Don Curdleone
+
+## Curated names
+
+- Cheese Lord
+- Big Cheese
+- Big Wheel
+- Top Curd
+- Head Cheese
+- Cheddar King
+- Gouda Emperor
+- Brie Majesty
+- Sultan of Stilton
+- Pharaoh of Parmesan
+- Tsar of Curds
+- Khan of Camembert
+- Maharaja of Manchego
+- Shogun of Stilton
+- Doge of Dairy
+- Margrave of Mozzarella
+- The Cheesiah
+- Curdinal
+- Archbishop of Aged Goods
+- The Affineur Supreme
+- High Pontiff of Pasteur
+- Don Curdleone
+- Captain Camembert
+- Brie-zus
+- The Fromage Sage
+
+## Generator pools
+
+`cheese_generate_name` mashes one Adjective + one Title (with `{C}`
+replaced by a Cheese) into a fresh title each call.
+
+### Adjectives
+
+- Aged
+- Smoldering
+- Rancid
+- Pungent
+- Crusted
+- Marbled
+- Veined
+- Brined
+- Cultured
+- Whey-Stained
+- Curd-Crusted
+- Wax-Sealed
+- Cave-Dwelling
+- Holy
+- Heretical
+- Sharp
+- Sacred
+- Forbidden
+- Eternal
+- Chrome
+- Glorious
+- Ripening
+
+### Cheeses
+
+- Cheddar
+- Brie
+- Gouda
+- Stilton
+- Roquefort
+- Camembert
+- Manchego
+- Mozzarella
+- Gruyère
+- Parmesan
+- Wensleydale
+- Halloumi
+- Munster
+- Limburger
+- Pecorino
+- Provolone
+- Asiago
+- Havarti
+- Feta
+- Emmental
+- Comté
+
+### Title formats
+
+- Lord of {C}
+- Sultan of {C}
+- Pharaoh of {C}
+- Tsar of {C}
+- Khan of {C}
+- Maharaja of {C}
+- Shogun of {C}
+- Doge of {C}
+- Margrave of {C}
+- Archbishop of {C}
+- Pontiff of {C}
+- Don {C}
+- Captain {C}
+- {C} Lord
+- {C} King
+- {C} Emperor
+- High Curdinal of {C}
+
+## Quotes
+
+### Dune
+
+- "The cheese must flow."
+- "He who controls the cheese controls the universe."
+- "Fear is the curd-killer. Fear is the little curd that brings total cheese obliteration. I will face my cheese."
+- "Bless the Cheesemaker, and his cheese. May his passage cleanse the world."
+- "Wheels within wheels within wheels."
+- "The sleeper must ripen."
+- "Stir without rhythm and you won't break the curd."
+- "An aging is a very delicate time."
+- "Tell me of your fromagerie, Usul."
+- "Curds are messages from the cave."
+
+### Mad Max: Fury Road
+
+- "I age, I rind, I age again."
+- "Witness this curd!"
+- "Oh what a day, what a lovely cheese day!"
+- "Shiny and curd."
+- "Age eternal, shiny and curd."
+- "Mediocre!"
+- "Where must we go, we who wander this wasteland, in search of our better cheese?"
+- "Fang it!"
+- "Do not, my friends, become addicted to cheese. It will take hold of you and you will resent its absence."
+
+### Monty Python's Holy Grail
+
+- "We are the Knights Who Say… Brie!"
+- "None shall pasteurize."
+- "'Tis but a scratch on the rind."
+- "Bring out your curds!"
+- "I'm not curd yet!"
+- "Strange women lying in vats distributing cheese is no basis for a system of government."
+- "Your mother was a hamster and your father smelt of Limburger."
+- "We want… a Wensleydale!"
+
+### The Princess Bride
+
+- "Hello. My name is Inigo Montoya. You killed my Camembert. Prepare to die."
+- "I do not think that cheese means what you think it means."
+
+### The Lord of the Rings
+
+- "One Cheese to rule them all."
+- "You shall not pasteurize!"
+- "My precious… cheese."
+- "Not all those who wander are aged."
+- "All we have to decide is what cheese to eat with the time that is given us."

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -125,6 +125,16 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$HOME/.claude/hooks/session-start-cheese-flair.sh\""
+          }
+        ]
+      }
     ]
   },
   "enabledPlugins": {

--- a/claude/skills/claude-local/SKILL.md
+++ b/claude/skills/claude-local/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: claude-local
 model: sonnet
-allowed-tools: Read, Write, Edit, Bash(git:*), Bash(grep:*), Bash(test:*), Bash(touch:*), Bash(mkdir:*), Glob
+allowed-tools: Read, Write, Edit, Bash(git:*), Bash(grep:*), Bash(test:*), Bash(touch:*), Bash(mkdir:*), Bash(printf:*), Glob
 description: >
   Distill the user's global ~/.claude/CLAUDE.md into a project-scoped
   CLAUDE.local.md (gitignored) for repos they're contributing to but
@@ -27,9 +27,9 @@ slim, project-relevant overlay — not a copy of `~/.claude/CLAUDE.md`.
 
 ## Why this exists
 
-The global `~/.claude/CLAUDE.md` is large (~500 lines) and tuned for the
-user's own work — personal communication style, owned-architecture rules,
-early-development stances. When the user contributes to someone else's
+The global `~/.claude/CLAUDE.md` is tuned for the user's own work —
+personal communication style, owned-architecture rules, early-development
+stances. When the user contributes to someone else's
 repo they want their *engineering* preferences applied (coding principles,
 skill delegation, self-eval) without dragging in the personal flair or
 architectural opinions that don't apply to a codebase they don't own.
@@ -106,14 +106,15 @@ judgment to bring.
 - **Coding principles.** Input validation, fail-fast, loose coupling,
   YAGNI, real-world models, immutable patterns. These are language- and
   project-agnostic and travel everywhere.
-- **Complexity budget.** Function/file/parameter/nesting limits.
-- **Skill delegation table.** The substitutions are the highest-leverage
-  thing in the global — `cheez-search` over `grep`, `cheez-read` over
-  `cat`, `cheez-write` over `sed`, `jq`/`yq` over inline `python3 -c`,
-  `gh` over raw GitHub API. These apply in any repo.
-- **Self-evaluation checklist.** The 8-item anti-pattern scan
-  (sycophancy, premature completion, dismissing failures, hedging, scope
-  reduction, false confidence, AI slop, weak assertions). Universal.
+- **Operational rules.** Skill-over-bash delegation (`cheez-search` over
+  `grep`, `cheez-read` over `cat`, `cheez-write` over `sed`, `jq`/`yq`
+  over inline `python3 -c`, `gh` over raw GitHub API), CLI tools
+  (jq/yq/tokei/duckdb), agent permission model (bypassPermissions ≠ Bash
+  bypass), agent nesting limits. These apply in any repo.
+- **Self-evaluation guidance.** The brief `/self-eval` reference and its
+  8-item anti-pattern summary (sycophancy, premature completion, dismissing
+  failures, hedging, scope reduction, false confidence, AI slop, weak
+  assertions). Universal.
 - **Build system rules.** "Fix the version, don't restructure the build"
   — this is hard-won and applies to any project's deps.
 
@@ -228,7 +229,7 @@ if ! grep -qxF "CLAUDE.local.md" "$EXCLUDES"; then
 fi
 
 # 3. Verify Git actually ignores the new file
-cd "$REPO_ROOT" && git check-ignore CLAUDE.local.md
+git -C "$REPO_ROOT" check-ignore CLAUDE.local.md
 ```
 
 If `git check-ignore` returns non-zero (file not ignored), surface the

--- a/claude/skills/claude-local/SKILL.md
+++ b/claude/skills/claude-local/SKILL.md
@@ -1,0 +1,285 @@
+---
+name: claude-local
+model: sonnet
+allowed-tools: Read, Write, Edit, Bash(git:*), Bash(grep:*), Bash(test:*), Bash(touch:*), Bash(mkdir:*), Glob
+description: >
+  Distill the user's global ~/.claude/CLAUDE.md into a project-scoped
+  CLAUDE.local.md (gitignored) for repos they're contributing to but
+  don't own. Detects the project's languages and build system, keeps
+  only the relevant subset of global preferences (coding principles,
+  complexity budget, skill delegation table, self-eval checklist,
+  language-gated style notes), drops the personal-flair sections and
+  architectural opinions that shouldn't bleed into a contributed repo.
+  Ensures CLAUDE.local.md is covered by the user's GLOBAL gitignore —
+  never the project's .gitignore — so the contribution stays clean. Use
+  when the user says "set up CLAUDE.local", "scaffold local claude
+  config", "drop my preferences in this repo", "I'm contributing to
+  this repo and want my preferences applied", "claude-local.md", or
+  invokes /claude-local. Also use proactively when the user opens a
+  shell in an unfamiliar repo and says they want to start contributing.
+---
+
+# claude-local
+
+Tailor the user's global Claude Code preferences to *this* project and write
+them to a `CLAUDE.local.md` that the global gitignore covers. The output is a
+slim, project-relevant overlay — not a copy of `~/.claude/CLAUDE.md`.
+
+## Why this exists
+
+The global `~/.claude/CLAUDE.md` is large (~500 lines) and tuned for the
+user's own work — personal communication style, owned-architecture rules,
+early-development stances. When the user contributes to someone else's
+repo they want their *engineering* preferences applied (coding principles,
+skill delegation, self-eval) without dragging in the personal flair or
+architectural opinions that don't apply to a codebase they don't own.
+
+Two non-negotiables:
+
+1. **Never modify the project's own files.** No edits to the project's
+   `CLAUDE.md`, `AGENTS.md`, or `.gitignore`. The point is a clean,
+   gitignored personal overlay.
+2. **Re-read the global on every invocation.** Don't hard-code the
+   distillation in this skill — the user's preferences evolve. Read
+   `~/.claude/CLAUDE.md` fresh each time so updates flow through.
+
+## Workflow
+
+### 1. Locate the project root
+
+The output goes at the project root (top of the git repo), not the cwd.
+
+```bash
+git rev-parse --show-toplevel
+```
+
+If that fails (not a git repo), tell the user and stop — `CLAUDE.local.md`
+only makes sense when there's a git boundary to scope it to.
+
+### 2. Check for an existing CLAUDE.local.md
+
+```bash
+test -f "$REPO_ROOT/CLAUDE.local.md"
+```
+
+If it exists, ask the user: refresh (regenerate from current global), keep
+(stop), or overwrite (treat as new). Don't silently clobber — the user may
+have hand-edited it.
+
+### 3. Detect project context
+
+Read these signals to drive the distillation. Glob from the repo root:
+
+| Signal | Implies |
+|--------|---------|
+| `Cargo.toml` | Rust |
+| `package.json` (+ `tsconfig.json`) | TypeScript |
+| `package.json` (no tsconfig) | JavaScript |
+| `pyproject.toml` / `setup.py` / `requirements.txt` | Python |
+| `go.mod` | Go |
+| `Gemfile` | Ruby |
+| `pom.xml` / `build.gradle*` | Java / Kotlin |
+| `composer.json` | PHP |
+| `mix.exs` | Elixir |
+| `*.csproj` / `*.sln` | C# / .NET |
+
+A project can be multi-language. Capture every language signal you find.
+Note the build/runtime tooling you observe (uv vs pip, pnpm vs npm vs yarn,
+cargo vs bazel) so the output references what the project actually uses.
+
+### 4. Read the global preferences fresh
+
+```
+Read("~/.claude/CLAUDE.md")
+```
+
+Do not trust any cached summary in this skill. The global file is the
+source of truth.
+
+### 5. Distill — what stays, what goes
+
+Apply these rules. They aren't a checklist to copy verbatim; they're the
+judgment to bring.
+
+#### Always keep
+
+- **Coding principles.** Input validation, fail-fast, loose coupling,
+  YAGNI, real-world models, immutable patterns. These are language- and
+  project-agnostic and travel everywhere.
+- **Complexity budget.** Function/file/parameter/nesting limits.
+- **Skill delegation table.** The substitutions are the highest-leverage
+  thing in the global — `cheez-search` over `grep`, `cheez-read` over
+  `cat`, `cheez-write` over `sed`, `jq`/`yq` over inline `python3 -c`,
+  `gh` over raw GitHub API. These apply in any repo.
+- **Self-evaluation checklist.** The 8-item anti-pattern scan
+  (sycophancy, premature completion, dismissing failures, hedging, scope
+  reduction, false confidence, AI slop, weak assertions). Universal.
+- **Build system rules.** "Fix the version, don't restructure the build"
+  — this is hard-won and applies to any project's deps.
+
+#### Language-gate (include only if the project uses the language)
+
+- **Python preference (`uv`)** — only include if you saw a `pyproject.toml`,
+  `setup.py`, or `requirements.txt`.
+- **Code style entries** — keep only the conventions for languages
+  actually present. A pure-Rust project doesn't need the JS/TS camelCase
+  rule.
+
+#### Drop entirely (these are personal, not project-relevant)
+
+- **Communication style** — the cheese / Dune / Mad Max flair. This is a
+  personal-conversation preference. Even though `CLAUDE.local.md` is
+  gitignored, a stray `git add -f` or grep across `$HOME` could surface it
+  in a contributed repo's history. Keep the flair scoped to the global file.
+- **Sliced Bread architecture** — the user's preferred file layout. In a
+  contributed repo, the project's own structure is authoritative; the
+  user shouldn't push a personal architecture on a codebase they don't
+  own.
+- **Early Development Stance** — "no backward compatibility concerns" only
+  applies to the user's own unreleased projects. A contributed repo
+  almost certainly has users.
+- **Workflow / Cheddar Flow** beyond a brief reference. The full skill
+  catalog is in the global file; the local overlay just needs to remind
+  Claude that `/age`, `/cure`, `/respond`, `/diff`, `/de-slop`, and
+  `/tdd-assertions` exist and are preferred. Skip `/fromage` and
+  `/fromagerie` unless the project is large enough to warrant them
+  (>10k LOC, multi-domain) — for typical contributions a single PR
+  cycle is the right granularity.
+- **Troubleshooting one-liners** (`/go`, `/agents`, `/lsp`) — meta-tool
+  state, irrelevant to any project.
+- **RTK** — the rtk proxy is a personal tooling layer; it's auto-applied
+  by hooks regardless and doesn't need to be repeated in a project file.
+
+### 6. Write CLAUDE.local.md
+
+Write to `<repo_root>/CLAUDE.local.md`. Use this template — keep it
+compact (target: 60-120 lines, never longer than 200). Bullets, not
+prose.
+
+```markdown
+# CLAUDE.local.md
+
+Local Claude Code overlay — gitignored personal preferences scoped to
+this repo. Not part of the project's instructions; this file is only
+for the user's personal Claude Code session. Source: `~/.claude/CLAUDE.md`
+(distilled <YYYY-MM-DD>).
+
+## Project context
+
+- **Languages:** <detected>
+- **Build/runtime:** <detected>
+
+## Engineering principles
+
+<short bulleted list — coding principles>
+
+## Complexity budget
+
+<copied verbatim — it's already terse>
+
+## Code style
+
+<only the languages this project uses>
+
+## Skill delegation
+
+<the table, trimmed to tools relevant here — keep cheez-* always, keep
+language-specific tooling only when applicable>
+
+## Self-evaluation checklist
+
+<the 8-item scan, one line each>
+
+## Workflow shortcuts
+
+<brief reference: /age, /cure, /respond, /diff, /de-slop, /tdd-assertions —
+no full descriptions; these are reminders for Claude>
+
+## Build system
+
+- Fix versions, don't restructure builds.
+- Read workspace/root config before modifying child build files.
+- Use `/version-doctor` for dependency conflicts.
+```
+
+Adapt section headings to what's actually relevant — don't include a
+"Code style" section with no content if the project's language wasn't
+covered in the global file.
+
+### 7. Cover with the global gitignore
+
+`CLAUDE.local.md` must be ignored by Git but **not** via the project's
+`.gitignore` (that would commit the user's preference for ignoring it).
+Use the global excludes file.
+
+```bash
+# 1. Find or create the global excludes file
+EXCLUDES="$(git config --global --get core.excludesfile || echo "")"
+if [ -z "$EXCLUDES" ]; then
+  EXCLUDES="$HOME/.config/git/ignore"
+  mkdir -p "$(dirname "$EXCLUDES")"
+  touch "$EXCLUDES"
+  git config --global core.excludesfile "$EXCLUDES"
+fi
+
+# 2. Add CLAUDE.local.md if not already present
+if ! grep -qxF "CLAUDE.local.md" "$EXCLUDES"; then
+  printf '\n# Personal Claude Code overlay (claude-local skill)\nCLAUDE.local.md\n' >> "$EXCLUDES"
+fi
+
+# 3. Verify Git actually ignores the new file
+cd "$REPO_ROOT" && git check-ignore CLAUDE.local.md
+```
+
+If `git check-ignore` returns non-zero (file not ignored), surface the
+issue and walk through possible causes — most likely the project has a
+`!CLAUDE.local.md` un-ignore rule, or `core.excludesfile` is set to
+something the user doesn't expect. Don't silently move on.
+
+### 8. Report
+
+Tell the user:
+- Where `CLAUDE.local.md` was written (full path).
+- Which sections you kept and which you dropped, with one-line reasons
+  for non-obvious calls (e.g., "dropped Python preference — no
+  `pyproject.toml` found").
+- That the file is covered by `<excludes-file-path>` and verified
+  ignored.
+
+## What this skill never does
+
+- **Never** edit the project's `CLAUDE.md`, `AGENTS.md`, `.gitignore`, or
+  any other tracked file in the contributed repo.
+- **Never** include the cheese / Dune / Mad Max communication style in
+  the output.
+- **Never** add `CLAUDE.local.md` to the project's `.gitignore` — that
+  would be a tracked change suggesting the project should know about
+  this file. Use the user's global excludes.
+- **Never** hard-code a distilled snapshot in this skill. The
+  `~/.claude/CLAUDE.md` re-read is the whole point — it lets the user
+  edit their global preferences and have updates flow through on the
+  next invocation.
+
+## Idempotency
+
+Running this skill twice on the same repo with no global changes should
+produce a `CLAUDE.local.md` byte-identical (modulo the timestamp on the
+"distilled" line) to the first run. If the user has hand-edited the
+file, ask before regenerating — don't clobber their tweaks.
+
+## Edge cases
+
+- **Multi-language monorepo:** include style/tooling for every language
+  detected; mark which is primary if it's obvious from line count or
+  directory weight.
+- **Project's `CLAUDE.md` already in scope:** `CLAUDE.local.md` is
+  *additive* — Claude Code reads both. The local overlay should not
+  contradict the project's instructions; if there's a clash, the
+  project wins. Note this at the top of the output file.
+- **Repo is the user's own dotfiles or a project they own:** the user
+  probably wants the full global preferences, not a distillation.
+  Check whether the repo path matches `~/Dev/dotfiles` or contains a
+  CLAUDE.md that already imports `~/.claude/CLAUDE.md` — if so, ask
+  before generating; the overlay may be redundant.
+- **No `~/.claude/CLAUDE.md` exists:** stop and tell the user. There's
+  nothing to distill from.

--- a/claude/skills/claude-local/SKILL.md
+++ b/claude/skills/claude-local/SKILL.md
@@ -239,6 +239,7 @@ something the user doesn't expect. Don't silently move on.
 ### 8. Report
 
 Tell the user:
+
 - Where `CLAUDE.local.md` was written (full path).
 - Which sections you kept and which you dropped, with one-line reasons
   for non-obvious calls (e.g., "dropped Python preference — no

--- a/claude/skills/self-eval/SKILL.md
+++ b/claude/skills/self-eval/SKILL.md
@@ -13,9 +13,18 @@ allowed-tools: Read, Edit, Glob, Grep
 
 # self-eval
 
-Review the last response against the Self-Evaluation Checklist in your instructions, output a scorecard, and auto-fix violations.
+Review the last response against the 8-item Self-Evaluation Checklist below, output a scorecard, and auto-fix violations.
 
-The checklist itself lives in your global instructions (CLAUDE.md) under "Self-Evaluation Checklist". This skill provides the execution protocol — it does not duplicate the checklist content.
+## The Checklist
+
+1. **Sycophancy** — Unearned praise, "Great question!", agreeing without substance. Remove it.
+2. **Premature completion** — Claiming done when it isn't, leaving TODOs, suggesting the user finish steps. Go back and finish.
+3. **Dismissing failures** — Downplaying errors, calling failures "pre-existing" without verifying on base branch. Investigate now.
+4. **Hedging** — "This should work", "you might want to", "consider perhaps". Verify or state unknowns clearly using the `<certain | speculative | don't know>` framework.
+5. **Scope reduction** — Silently dropping requirements, "for now" / "as a starting point" / "we can add X later". Acknowledge explicitly.
+6. **False confidence** — Claiming something works without running tests. Go run them.
+7. **AI slop** — Comment pollution, silent error swallowing, over-abstraction, partial strict mode, dead code. Run `/de-slop` on changed files.
+8. **Weak assertions** — Existence checks instead of value equality, catch-all errors, no-crash-as-success. Run `/tdd-assertions` on test code.
 
 ## Protocol
 

--- a/claude/skills/self-eval/SKILL.md
+++ b/claude/skills/self-eval/SKILL.md
@@ -8,7 +8,7 @@ description: >
   quality before finishing. Also trigger when the user expresses doubt about your output
   ("did you actually test that?", "are you sure?", "that seems incomplete"). This skill
   cross-references with /de-slop and /tdd-assertions for items that have dedicated tooling.
-allowed-tools: Read, Edit, Glob, Grep
+allowed-tools: Read, Edit, Glob, Grep, Skill
 ---
 
 # self-eval

--- a/claude/skills/self-eval/SKILL.md
+++ b/claude/skills/self-eval/SKILL.md
@@ -20,7 +20,7 @@ Review the last response against the 8-item Self-Evaluation Checklist below, out
 1. **Sycophancy** — Unearned praise, "Great question!", agreeing without substance. Remove it.
 2. **Premature completion** — Claiming done when it isn't, leaving TODOs, suggesting the user finish steps. Go back and finish.
 3. **Dismissing failures** — Downplaying errors, calling failures "pre-existing" without verifying on base branch. Investigate now.
-4. **Hedging** — "This should work", "you might want to", "consider perhaps". Verify or state unknowns clearly using the `<certain | speculative | don't know>` framework.
+4. **Hedging** — "This should work", "you might want to", "consider perhaps". Verify or state unknowns clearly by tagging the claim with one of `<certain>`, `<speculative>`, or `<don't know>` (wrapped in backticks so the tag renders as literal text).
 5. **Scope reduction** — Silently dropping requirements, "for now" / "as a starting point" / "we can add X later". Acknowledge explicitly.
 6. **False confidence** — Claiming something works without running tests. Go run them.
 7. **AI slop** — Comment pollution, silent error swallowing, over-abstraction, partial strict mode, dead code. Run `/de-slop` on changed files.

--- a/justfile
+++ b/justfile
@@ -10,7 +10,8 @@ lint: lint-shell lint-python lint-js lint-markdown
 # shellcheck on shell scripts
 lint-shell:
     shellcheck -x -e SC1091 bin/* .sync .sync-with-rollback
-    shellcheck -x -e SC1091 -s bash claude/mcp/sync.sh claude/plugins/sync.sh claude/lib/sync-common.sh
+    shellcheck -x -e SC1091 -s bash claude/mcp/sync.sh claude/plugins/sync.sh claude/lib/sync-common.sh claude/lib/cheese-flair.sh
+    shellcheck -x -e SC1091 -s bash claude/hooks/session-start-cheese-flair.sh
     shellcheck -x -e SC1091 -s bash tests/run-tests.sh tests/install-bats.sh
     @echo "shellcheck: ok"
 

--- a/tests/cheese-flair.bats
+++ b/tests/cheese-flair.bats
@@ -1,0 +1,214 @@
+#!/usr/bin/env bats
+# Tests for claude/lib/cheese-flair.sh — name generator and quote picker
+# backing the SessionStart cheese-flair hook.
+
+load test_helper
+
+LIB="$REAL_DOTFILES_DIR/claude/lib/cheese-flair.sh"
+BANK="$REAL_DOTFILES_DIR/claude/reference/cheese-flair.md"
+
+setup() {
+    export CHEESE_FLAIR_BANK="$BANK"
+}
+
+@test "bank file exists" {
+    assert_file_exists "$BANK"
+}
+
+@test "lib script exists and is executable" {
+    assert_file_exists "$LIB"
+    [[ -x "$LIB" ]]
+}
+
+@test "hook script exists and is executable" {
+    local hook="$REAL_DOTFILES_DIR/claude/hooks/session-start-cheese-flair.sh"
+    assert_file_exists "$hook"
+    [[ -x "$hook" ]]
+}
+
+@test "cheese_curated_name returns a name from the curated list" {
+    # shellcheck source=/dev/null
+    source "$LIB"
+    local name
+    name="$(cheese_curated_name)"
+    [[ -n "$name" ]]
+    grep -qxF -- "- $name" "$BANK"
+}
+
+@test "cheese_generate_name produces adjective + title with cheese substituted" {
+    # shellcheck source=/dev/null
+    source "$LIB"
+    local name
+    name="$(cheese_generate_name)"
+    [[ -n "$name" ]]
+    [[ "$name" != *"{C}"* ]]
+    # Generated names are at least two words: "<Adjective> <Title with cheese>"
+    local word_count
+    word_count="$(printf '%s' "$name" | wc -w | tr -d ' ')"
+    [[ "$word_count" -ge 2 ]]
+}
+
+@test "cheese_name curated is always from the curated list" {
+    # shellcheck source=/dev/null
+    source "$LIB"
+    local name
+    name="$(cheese_name curated)"
+    grep -qxF -- "- $name" "$BANK"
+}
+
+@test "cheese_name generated never leaks the {C} placeholder" {
+    # shellcheck source=/dev/null
+    source "$LIB"
+    for _ in 1 2 3 4 5; do
+        local name
+        name="$(cheese_name generated)"
+        [[ "$name" != *"{C}"* ]]
+    done
+}
+
+@test "cheese_name mixed produces non-empty output" {
+    # shellcheck source=/dev/null
+    source "$LIB"
+    for _ in 1 2 3 4 5; do
+        local name
+        name="$(cheese_name mixed)"
+        [[ -n "$name" ]]
+    done
+}
+
+@test "cheese_name unknown mode fails with diagnostic" {
+    run bash -c "source '$LIB' && cheese_name borked 2>&1"
+    assert_failure
+    assert_output_contains "unknown mode"
+}
+
+@test "cheese_quote returns 'Universe — quote' format" {
+    # shellcheck source=/dev/null
+    source "$LIB"
+    local quote
+    quote="$(cheese_quote)"
+    [[ -n "$quote" ]]
+    [[ "$quote" == *" — "* ]]
+}
+
+@test "cheese_quote universes cover all five expected sources" {
+    # shellcheck source=/dev/null
+    source "$LIB"
+    local seen
+    seen="$(for _ in $(seq 1 200); do cheese_quote; done | awk -F' — ' '{print $1}' | sort -u)"
+    [[ "$seen" == *"Dune"* ]]
+    [[ "$seen" == *"Mad Max: Fury Road"* ]]
+    [[ "$seen" == *"Monty Python's Holy Grail"* ]]
+    [[ "$seen" == *"The Princess Bride"* ]]
+    [[ "$seen" == *"The Lord of the Rings"* ]]
+}
+
+@test "cheese_sample emits Address and Quotes lines" {
+    # shellcheck source=/dev/null
+    source "$LIB"
+    run cheese_sample
+    assert_success
+    assert_output_contains "Address:"
+    assert_output_contains "Quotes:"
+}
+
+@test "CLI: sample subcommand produces hook-shaped output" {
+    run bash "$LIB" sample
+    assert_success
+    assert_output_contains "Cheese flair"
+    assert_output_contains "Address:"
+}
+
+@test "CLI: name subcommand defaults to weighted and is non-empty" {
+    run bash "$LIB" name
+    assert_success
+    [[ -n "$output" ]]
+}
+
+@test "cheese_big_hitter returns a name from the Big hitters list" {
+    # shellcheck source=/dev/null
+    source "$LIB"
+    local name
+    name="$(cheese_big_hitter)"
+    [[ -n "$name" ]]
+    grep -qxF -- "- $name" "$BANK"
+}
+
+@test "cheese_name weighted returns Cheese Lord roughly half the time" {
+    # shellcheck source=/dev/null
+    source "$LIB"
+    local lord_count=0 total=200
+    for _ in $(seq 1 "$total"); do
+        if [[ "$(cheese_name weighted)" == "Cheese Lord" ]]; then
+            lord_count=$((lord_count + 1))
+        fi
+    done
+    # Target 50%, allow wide tolerance: 30-70% across 200 draws.
+    [[ "$lord_count" -ge 60 ]]
+    [[ "$lord_count" -le 140 ]]
+}
+
+@test "cheese_name weighted hits big-hitters and wider bank too" {
+    # shellcheck source=/dev/null
+    source "$LIB"
+    local big_hitter_count=0 wider_count=0 lord_count=0
+    local big_hitters
+    big_hitters="$(awk '
+        /^## Big hitters/ { in_section = 1; next }
+        /^## / { in_section = 0 }
+        in_section && /^- / { sub(/^- /, ""); print }
+    ' "$BANK")"
+    for _ in $(seq 1 200); do
+        local name
+        name="$(cheese_name weighted)"
+        if [[ "$name" == "Cheese Lord" ]]; then
+            lord_count=$((lord_count + 1))
+        elif printf '%s\n' "$big_hitters" | grep -qxF -- "$name"; then
+            big_hitter_count=$((big_hitter_count + 1))
+        else
+            wider_count=$((wider_count + 1))
+        fi
+    done
+    # All three buckets must be reached at least once.
+    [[ "$lord_count" -gt 0 ]]
+    [[ "$big_hitter_count" -gt 0 ]]
+    [[ "$wider_count" -gt 0 ]]
+}
+
+@test "cheese_quotes 3 returns three distinct lines" {
+    # shellcheck source=/dev/null
+    source "$LIB"
+    local quotes line_count distinct_count
+    quotes="$(cheese_quotes 3)"
+    line_count="$(printf '%s\n' "$quotes" | wc -l | tr -d ' ')"
+    [[ "$line_count" -eq 3 ]]
+    distinct_count="$(printf '%s\n' "$quotes" | sort -u | wc -l | tr -d ' ')"
+    [[ "$distinct_count" -eq 3 ]]
+}
+
+@test "cheese_sample emits exactly three quote bullets" {
+    # shellcheck source=/dev/null
+    source "$LIB"
+    local sample bullets
+    sample="$(cheese_sample)"
+    bullets="$(printf '%s\n' "$sample" | grep -c '^  - ')"
+    [[ "$bullets" -eq 3 ]]
+}
+
+@test "CLI: name curated subcommand returns a curated entry" {
+    run bash "$LIB" name curated
+    assert_success
+    grep -qxF -- "- $output" "$BANK"
+}
+
+@test "CLI: quote subcommand returns 'Universe — quote'" {
+    run bash "$LIB" quote
+    assert_success
+    [[ "$output" == *" — "* ]]
+}
+
+@test "CLI: invalid subcommand prints usage and exits non-zero" {
+    run bash -c "bash '$LIB' not-a-thing 2>&1"
+    assert_failure
+    assert_output_contains "Usage:"
+}

--- a/tests/cheese-flair.bats
+++ b/tests/cheese-flair.bats
@@ -199,21 +199,22 @@ setup() {
     done
 }
 
-@test "cheese_names preserves Cheese Lord weight (>=40% of slots across many draws)" {
+@test "cheese_names still surfaces Cheese Lord across many draws" {
     # shellcheck source=/dev/null
     source "$LIB"
-    local total_slots=0 lord_slots=0
+    # Each call to cheese_names 3 returns 3 DISTINCT names, so Cheese
+    # Lord can appear at most once per call. Across 50 calls the max
+    # is 50. With ~50% raw weight + rejection sampling, expected hit
+    # rate per call is ~0.85–0.95 — bound is loose to dodge CI variance
+    # while still catching weight regression (e.g. dropping to 0).
+    local lord_hits=0
     for _ in $(seq 1 50); do
-        while IFS= read -r line; do
-            total_slots=$((total_slots + 1))
-            [[ "$line" == "Cheese Lord" ]] && lord_slots=$((lord_slots + 1))
-        done < <(cheese_names 3)
+        if cheese_names 3 | grep -qxF -- 'Cheese Lord'; then
+            lord_hits=$((lord_hits + 1))
+        fi
     done
-    # 50 calls × 3 slots = 150 total. With ~50% weight and dedup pressure
-    # Cheese Lord still hits roughly half the picks. Allow 30-90% range.
-    [[ "$total_slots" -eq 150 ]]
-    [[ "$lord_slots" -ge 45 ]]
-    [[ "$lord_slots" -le 135 ]]
+    [[ "$lord_hits" -ge 15 ]]
+    [[ "$lord_hits" -le 50 ]]
 }
 
 @test "cheese_sample emits three address bullets and three quote bullets" {

--- a/tests/cheese-flair.bats
+++ b/tests/cheese-flair.bats
@@ -103,12 +103,12 @@ setup() {
     [[ "$seen" == *"The Lord of the Rings"* ]]
 }
 
-@test "cheese_sample emits Address and Quotes lines" {
+@test "cheese_sample emits Addresses and Quotes lines" {
     # shellcheck source=/dev/null
     source "$LIB"
     run cheese_sample
     assert_success
-    assert_output_contains "Address:"
+    assert_output_contains "Addresses:"
     assert_output_contains "Quotes:"
 }
 
@@ -116,7 +116,7 @@ setup() {
     run bash "$LIB" sample
     assert_success
     assert_output_contains "Cheese flair"
-    assert_output_contains "Address:"
+    assert_output_contains "Addresses:"
 }
 
 @test "CLI: name subcommand defaults to weighted and is non-empty" {
@@ -186,13 +186,53 @@ setup() {
     [[ "$distinct_count" -eq 3 ]]
 }
 
-@test "cheese_sample emits exactly three quote bullets" {
+@test "cheese_names 3 returns three distinct lines" {
+    # shellcheck source=/dev/null
+    source "$LIB"
+    for _ in 1 2 3 4 5; do
+        local names line_count distinct_count
+        names="$(cheese_names 3)"
+        line_count="$(printf '%s\n' "$names" | wc -l | tr -d ' ')"
+        [[ "$line_count" -eq 3 ]]
+        distinct_count="$(printf '%s\n' "$names" | sort -u | wc -l | tr -d ' ')"
+        [[ "$distinct_count" -eq 3 ]]
+    done
+}
+
+@test "cheese_names preserves Cheese Lord weight (>=40% of slots across many draws)" {
+    # shellcheck source=/dev/null
+    source "$LIB"
+    local total_slots=0 lord_slots=0
+    for _ in $(seq 1 50); do
+        while IFS= read -r line; do
+            total_slots=$((total_slots + 1))
+            [[ "$line" == "Cheese Lord" ]] && lord_slots=$((lord_slots + 1))
+        done < <(cheese_names 3)
+    done
+    # 50 calls × 3 slots = 150 total. With ~50% weight and dedup pressure
+    # Cheese Lord still hits roughly half the picks. Allow 30-90% range.
+    [[ "$total_slots" -eq 150 ]]
+    [[ "$lord_slots" -ge 45 ]]
+    [[ "$lord_slots" -le 135 ]]
+}
+
+@test "cheese_sample emits three address bullets and three quote bullets" {
     # shellcheck source=/dev/null
     source "$LIB"
     local sample bullets
     sample="$(cheese_sample)"
     bullets="$(printf '%s\n' "$sample" | grep -c '^  - ')"
-    [[ "$bullets" -eq 3 ]]
+    [[ "$bullets" -eq 6 ]]
+}
+
+@test "CLI: names subcommand defaults to 3 distinct draws" {
+    run bash "$LIB" names
+    assert_success
+    local line_count distinct_count
+    line_count="$(printf '%s\n' "$output" | wc -l | tr -d ' ')"
+    [[ "$line_count" -eq 3 ]]
+    distinct_count="$(printf '%s\n' "$output" | sort -u | wc -l | tr -d ' ')"
+    [[ "$distinct_count" -eq 3 ]]
 }
 
 @test "CLI: name curated subcommand returns a curated entry" {

--- a/tests/cheese-flair.bats
+++ b/tests/cheese-flair.bats
@@ -199,24 +199,6 @@ setup() {
     done
 }
 
-@test "cheese_names still surfaces Cheese Lord across many draws" {
-    # shellcheck source=/dev/null
-    source "$LIB"
-    # Each call to cheese_names 3 returns 3 DISTINCT names, so Cheese
-    # Lord can appear at most once per call. Across 50 calls the max
-    # is 50. With ~50% raw weight + rejection sampling, expected hit
-    # rate per call is ~0.85–0.95 — bound is loose to dodge CI variance
-    # while still catching weight regression (e.g. dropping to 0).
-    local lord_hits=0
-    for _ in $(seq 1 50); do
-        if cheese_names 3 | grep -qxF -- 'Cheese Lord'; then
-            lord_hits=$((lord_hits + 1))
-        fi
-    done
-    [[ "$lord_hits" -ge 15 ]]
-    [[ "$lord_hits" -le 50 ]]
-}
-
 @test "cheese_sample emits three address bullets and three quote bullets" {
     # shellcheck source=/dev/null
     source "$LIB"
@@ -224,6 +206,28 @@ setup() {
     sample="$(cheese_sample)"
     bullets="$(printf '%s\n' "$sample" | grep -c '^  - ')"
     [[ "$bullets" -eq 6 ]]
+}
+
+@test "cheese_sample always pins Cheese Lord as the first address" {
+    # shellcheck source=/dev/null
+    source "$LIB"
+    for _ in 1 2 3 4 5; do
+        local sample first
+        sample="$(cheese_sample)"
+        first="$(printf '%s\n' "$sample" | awk '/^- Addresses:/ { found = 1; next } /^- Quotes:/ { exit } found && /^  - / { sub(/^  - /, ""); print }' | head -n 1)"
+        [[ "$first" == "Cheese Lord" ]]
+    done
+}
+
+@test "cheese_sample addresses are distinct across all three slots" {
+    # shellcheck source=/dev/null
+    source "$LIB"
+    for _ in 1 2 3 4 5; do
+        local addresses distinct_count
+        addresses="$(cheese_sample | awk '/^- Addresses:/ { found = 1; next } /^- Quotes:/ { found = 0 } found && /^  - / { sub(/^  - /, ""); print }')"
+        distinct_count="$(printf '%s\n' "$addresses" | sort -u | wc -l | tr -d ' ')"
+        [[ "$distinct_count" -eq 3 ]]
+    done
 }
 
 @test "CLI: names subcommand defaults to 3 distinct draws" {

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -74,7 +74,7 @@ run_tests() {
     if [[ -n "$SPECIFIC_TEST" ]]; then
         test_files="$SPECIFIC_TEST"
     else
-        test_files="dots-simple.bats dots.bats git-hooks.bats sync.bats config-validation.bats prompt.bats sync-claude.bats sync-rollback.bats hooks-blockers.bats hooks-session.bats iterm2-fonts.bats worktree-settings.bats copilot-sync.bats skills-install.bats sync-skills.bats packages.bats"
+        test_files="dots-simple.bats dots.bats git-hooks.bats sync.bats config-validation.bats prompt.bats sync-claude.bats sync-rollback.bats hooks-blockers.bats hooks-session.bats iterm2-fonts.bats worktree-settings.bats copilot-sync.bats skills-install.bats sync-skills.bats packages.bats cheese-flair.bats"
     fi
 
     # Count total tests


### PR DESCRIPTION
## Summary

- Trim global `claude/CLAUDE.md` from **201 → 126 lines** by removing project-specific guidance that belongs in project `CLAUDE.md` files or skill definitions (early-dev stance, complexity budget, code-style table, Python `uv` preference, full Sliced Bread block, workflow table, skill-delegation table). Sliced Bread is preserved as a one-line pointer to the existing reference doc.
- Fold in distilled engineering rules: **Think Before Coding**, **No Speculative Code**, **Surgical Changes**, **Goal-Driven Execution**.
- Add a **calibrated-opinion framework**: tag claims inline as `<certain | speculative | don't know>` so confidence is legible per-claim instead of buried in hedging.
- Make `/self-eval` self-contained: the 8-item checklist used to delegate to the global section that this PR removes. Inlined into the skill so it no longer depends on a global section that no longer exists.

## Test plan

- [ ] `dots sync` runs clean (no symlink drift)
- [ ] Open a fresh session — `~/.claude/CLAUDE.md` resolves to the trimmed file
- [ ] `/self-eval` produces the 8-item scorecard without referencing the deleted global section
- [ ] Sliced Bread pointer in global resolves to `~/Dev/dotfiles/claude/reference/sliced-bread.md`