### PR TITLE
Fix CI suite lint, tests, and detached HEAD handling

### DIFF
--- a/bin/dots
+++ b/bin/dots
@@ -74,7 +74,12 @@ do_update() {
         exit 1
     }
 
-    # Check if we're behind
+    # Check if we're behind (skip cleanly if no upstream is configured)
+    if ! git rev-parse --abbrev-ref '@{u}' >/dev/null 2>&1; then
+        echo -e "${YELLOW}⚠️  No upstream configured for current branch, skipping update${NC}"
+        return 0
+    fi
+
     LOCAL=$(git rev-parse HEAD)
     REMOTE=$(git rev-parse '@{u}')
     BASE=$(git merge-base HEAD '@{u}')

--- a/justfile
+++ b/justfile
@@ -10,7 +10,7 @@ lint: lint-shell lint-python lint-js lint-markdown
 # shellcheck on shell scripts
 lint-shell:
     shellcheck -x -e SC1091 bin/* .sync .sync-with-rollback
-    shellcheck -x -e SC1091 -s bash claude/hooks/*.sh claude/mcp/sync.sh claude/plugins/sync.sh claude/lib/sync-common.sh
+    shellcheck -x -e SC1091 -s bash claude/mcp/sync.sh claude/plugins/sync.sh claude/lib/sync-common.sh
     shellcheck -x -e SC1091 -s bash tests/run-tests.sh tests/install-bats.sh
     @echo "shellcheck: ok"
 

--- a/tests/hooks-session.bats
+++ b/tests/hooks-session.bats
@@ -197,7 +197,7 @@ run_auto_format() {
     [ "$status" -eq 0 ]
 }
 
-@test "settings: worktree guard is wired for Edit and Write" {
-    run jq -e '.hooks.PreToolUse[] | select(.matcher == "Edit|Write") | .hooks[] | select(.command | contains("worktree-guard.js"))' "$REAL_DOTFILES_DIR/claude/settings.json"
-    [ "$status" -eq 0 ]
+@test "settings: worktree guard is NOT wired (disengaged)" {
+    run jq -e '.hooks.PreToolUse[]?.hooks[]? | select(.command | contains("worktree-guard.js"))' "$REAL_DOTFILES_DIR/claude/settings.json"
+    [ "$status" -ne 0 ]
 }

--- a/tests/packages.bats
+++ b/tests/packages.bats
@@ -119,7 +119,10 @@ run_sync() {
     assert_success
     while IFS= read -r source; do
         [[ -z "$source" ]] && continue
-        [[ "$source" == "brew" || "$source" == "cask" || "$source" == "tap" || "$source" == "cargo" || "$source" == "npm" || "$source" == "uv" ]]
+        if [[ "$source" != "brew" && "$source" != "cask" && "$source" != "tap" && "$source" != "cargo" && "$source" != "npm" && "$source" != "uv" ]]; then
+            echo "Invalid source value: $source" >&2
+            return 1
+        fi
     done <<< "$output"
 }
 

--- a/tests/packages.bats
+++ b/tests/packages.bats
@@ -113,13 +113,13 @@ run_sync() {
     done <<< "$output"
 }
 
-@test "all source values are brew, cask, tap, or cargo" {
+@test "all source values are brew, cask, tap, cargo, npm, or uv" {
     run yq -r '.packages[] | select(kind == "map") | to_entries[0] | select(.value.source != null) | .value.source' \
         "$REAL_DOTFILES_DIR/packages.yaml"
     assert_success
     while IFS= read -r source; do
         [[ -z "$source" ]] && continue
-        [[ "$source" == "brew" || "$source" == "cask" || "$source" == "tap" || "$source" == "cargo" || "$source" == "npm" ]]
+        [[ "$source" == "brew" || "$source" == "cask" || "$source" == "tap" || "$source" == "cargo" || "$source" == "npm" || "$source" == "uv" ]]
     done <<< "$output"
 }
 
@@ -140,6 +140,8 @@ run_sync() {
 # --- Integration: sync installs the right packages ---
 
 @test "sync installs bare-string formulae via brew" {
+    [[ "$(uname)" == "Darwin" ]] || skip "macOS only (sync_brew not invoked on Linux)"
+
     write_test_yaml
     run_sync
     assert_success
@@ -149,6 +151,8 @@ run_sync() {
 }
 
 @test "sync installs map formulae (fd, node) via brew" {
+    [[ "$(uname)" == "Darwin" ]] || skip "macOS only (sync_brew not invoked on Linux)"
+
     write_test_yaml
     run_sync
     assert_success
@@ -178,6 +182,8 @@ run_sync() {
 }
 
 @test "sync processes taps before formulae" {
+    [[ "$(uname)" == "Darwin" ]] || skip "macOS only (sync_brew not invoked on Linux)"
+
     write_test_yaml
     run_sync
     assert_success
@@ -221,6 +227,8 @@ run_sync() {
 }
 
 @test "sync skips already-installed packages" {
+    [[ "$(uname)" == "Darwin" ]] || skip "macOS only (sync_brew not invoked on Linux)"
+
     write_test_yaml
     write_mock_brew "curl"
 
@@ -264,6 +272,8 @@ run_sync() {
 }
 
 @test "FORCE_PACKAGES bypasses valid cache" {
+    [[ "$(uname)" == "Darwin" ]] || skip "macOS only (sync_brew not invoked on Linux)"
+
     write_test_yaml
     shasum -a 256 "$PACKAGES_FILE" | cut -d' ' -f1 > "$CACHE_FILE"
 
@@ -275,6 +285,8 @@ run_sync() {
 }
 
 @test "sync does NOT save cache when brew install fails" {
+    [[ "$(uname)" == "Darwin" ]] || skip "macOS only (sync_brew not invoked on Linux)"
+
     write_test_yaml
     write_mock_brew "" "" "jq"
 
@@ -286,6 +298,8 @@ run_sync() {
 }
 
 @test "sync retries after previous failure (no cache)" {
+    [[ "$(uname)" == "Darwin" ]] || skip "macOS only (sync_brew not invoked on Linux)"
+
     write_test_yaml
     write_mock_brew "" "" "jq"
 
@@ -388,6 +402,8 @@ MOCKRUSTUP
 }
 
 @test "UPGRADE_MODE runs brew upgrade after install loop" {
+    [[ "$(uname)" == "Darwin" ]] || skip "macOS only (sync_brew not invoked on Linux)"
+
     write_test_yaml
     UPGRADE_MODE=true run bash "$SYNC_SCRIPT"
     assert_success


### PR DESCRIPTION
Recent commits broke CI: removed .sh hook files leaving lint glob orphaned, disengaged worktree-guard but test expected it wired, added uv source but whitelist only allowed brew/cask/tap/cargo/npm, and pruned Darwin-only skip directives from brew-dependent tests.

## Changes

- Remove dead `claude/hooks/*.sh` from justfile (no .sh files exist after 06234bc)
- Invert worktree-guard test to assert it stays disengaged (ae3a99e)
- Add `uv` to source values whitelist in test 321 (0d45cf4)
- Restore `[[ "$(uname)" == "Darwin" ]] || skip` directives to 8 brew-dependent tests that fail on Linux CI
- Make `dots update` resilient to detached HEAD / missing upstream (exit cleanly instead of exit 128)

All 344 tests pass locally.