### PR TITLE
feat(profiles): add notion profile for opt-in Notion MCP

### DIFF
--- a/claude/profiles/notion/CLAUDE.md
+++ b/claude/profiles/notion/CLAUDE.md
@@ -1,0 +1,31 @@
+# Notion Profile
+
+This session adds the Notion MCP to the default dev environment.
+
+## Why this profile exists
+
+The Notion MCP is opt-in: it requires OAuth, injects a tool surface that
+isn't relevant to most coding sessions, and shouldn't auto-load. Launch
+this profile when the work involves reading or writing Notion pages —
+design docs, RFDs, project trackers, meeting notes.
+
+## MCPs in scope
+
+Defined in `mcp-add.json` (additive — user MCPs remain available):
+
+- **notion** — `mcp__notion__*` — read, search, create, and update pages,
+  databases, and blocks in the connected Notion workspace.
+
+## When to use
+
+- Pulling context from a Notion design doc into the working session.
+- Drafting / updating an RFD or tech spec via the `/rfd-coauthoring` or
+  `/generate-design-doc` skills.
+- Cross-referencing a Linear ticket against its linked Notion page.
+- Mirroring decisions made in chat back to a Notion record.
+
+## First-run authentication
+
+On the first tool call in a fresh `ccp notion` session, Claude Code will
+prompt for OAuth. Approve once; the token is stored by the Notion MCP
+server and reused on subsequent launches.

--- a/claude/profiles/notion/mcp-add.json
+++ b/claude/profiles/notion/mcp-add.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "notion": {
+      "type": "http",
+      "url": "https://mcp.notion.com/mcp"
+    }
+  }
+}

--- a/claude/profiles/notion/settings-merge.json
+++ b/claude/profiles/notion/settings-merge.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__notion__*"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Adds a scoped session profile (`ccp notion`) for sessions that need the
Notion MCP without auto-loading the OAuth-gated tool surface in default
dev sessions.

- `claude/profiles/notion/CLAUDE.md` — when-to-use guide + first-run OAuth note
- `claude/profiles/notion/mcp-add.json` — HTTP MCP at `https://mcp.notion.com/mcp`
- `claude/profiles/notion/settings-merge.json` — allow `mcp__notion__*`

User-level MCPs remain available (additive merge). Cherry-picked subset
of the WIP commit in #136 (closed); the rest of that PR (yabai, LSP
opt-in, vendored skills) is being triaged separately.

## Test plan

- [x] `ls claude/profiles/notion/` lists the three files
- [ ] `ccp notion` launches a session with `notion` MCP available
- [ ] First Notion tool call prompts OAuth; subsequent calls reuse the token

🤖 Generated with [Claude Code](https://claude.com/claude-code)