### PR TITLE
feat(yabai): unify chord ladder, switch mouse drag to cmd

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -275,12 +275,14 @@ Full agent/skill catalog is in `claude/CLAUDE.md` (auto-discovered). Key project
 
 Tiling window manager + hotkey daemon for macOS, installed from the `koekeishiya/formulae` brew tap and started as background services by `yabai/.sync`. Configs live at `yabai/yabairc` and `yabai/skhdrc` and are symlinked to `~/.yabairc` / `~/.skhdrc`.
 
-- **Modifier ladder**: `ctrl+alt` for focus/layout, `ctrl+alt+shift` for swap/move, `cmd+alt` for resize, `ctrl+cmd+alt` for SizeUp-style window/space ops.
-- **Vim navigation**: `ctrl+alt+hjkl` focus, `ctrl+alt+shift+hjkl` swap, `cmd+alt+hjkl` resize.
-- **Spaces**: `ctrl+alt+1..4` focus, `ctrl+alt+shift+1..4` move-and-follow. macOS spaces must be created manually in Mission Control first — yabai cannot create them with SIP enabled.
-- **Snap-to-grid for floating windows**: `ctrl+alt+arrows` for halves, `ctrl+alt+u/i/n/m` for quarters, `ctrl+alt+return` for fullscreen. Auto-floats a tiled window before snapping.
-- **SizeUp chords**: `ctrl+cmd+alt+m` toggles zoom-fullscreen (window covers display, others hide underneath), `ctrl+cmd+alt+n` rotates the BSP tree 90°.
-- **Reload**: `ctrl+alt+shift+r` restarts both services after config edits.
+- **Modifier ladder**: `ctrl+alt+cmd` for primary actions (snap, focus, layout); `shift+ctrl+alt+cmd` for destructive variants (swap, move-to-space, send-to-display, restart). Mouse drag uses `cmd` (set via `mouse_modifier=cmd` in `yabairc`).
+- **Vim navigation**: `ctrl+alt+cmd+hjkl` focus; `shift+ctrl+alt+cmd+hjkl` swap. Resize is mouse-drag only — no keyboard resize bindings.
+- **Spaces**: `shift+ctrl+alt+cmd+1..4` move-and-follow. Direct space focus is delegated to native macOS (`ctrl+1..4`, configurable in System Settings → Keyboard → Mission Control). macOS spaces must be created manually in Mission Control first — yabai cannot create them with SIP enabled.
+- **Snap-to-grid (auto-floats tiled windows)**: `ctrl+alt+cmd+arrows` for halves, `ctrl+alt+cmd+1..4` for quarters (clockwise from top-left: 1=TL, 2=TR, 3=BR, 4=BL), `ctrl+alt+cmd+m` for SizeUp-style maximize, `ctrl+alt+cmd+c` to center.
+- **Fullscreen / zoom**: `ctrl+alt+cmd+f` toggles native macOS fullscreen; `ctrl+alt+cmd+z` toggles BSP zoom-fullscreen (window covers display, others hide underneath).
+- **Layout**: `ctrl+alt+cmd+space` toggle float, `ctrl+alt+cmd+t` BSP layout, `ctrl+alt+cmd+s` stack layout, `ctrl+alt+cmd+0` balance, `ctrl+alt+cmd+r` rotate BSP tree 90°.
+- **Send to display**: `shift+ctrl+alt+cmd+left/right` moves the active window to the previous/next display and follows.
+- **Reload**: `shift+ctrl+alt+cmd+r` restarts both services after config edits.
 - **First-time setup**: grant Accessibility (and optionally Screen Recording) to `yabai` and `skhd` in System Settings → Privacy & Security after `dots sync`.
 - **SIP**: opacity, removing title bars, and cross-space window movement require SIP partially disabled. The basic tile/focus/swap loop works with SIP on.
 

--- a/yabai/skhdrc
+++ b/yabai/skhdrc
@@ -1,73 +1,60 @@
 # skhd hotkey daemon configuration
 #
-# Modifier ladder:
-#   ctrl + alt          → focus / non-destructive
-#   ctrl + alt + shift  → swap / move (destructive)
-#   cmd  + alt          → resize
-#   ctrl + cmd + alt    → SizeUp-compatible window/space ops
+# Unified modifier ladder:
+#   ctrl + alt + cmd            → primary action (snap, focus, layout)
+#   shift + ctrl + alt + cmd    → destructive variant (swap, move, restart)
+#
+# Mouse drag with cmd held (yabairc mouse_modifier=cmd) covers move/resize.
+# Native macOS handles space focus via ctrl + 1..4.
 
-# focus
-ctrl + alt - h : yabai -m window --focus west
-ctrl + alt - j : yabai -m window --focus south
-ctrl + alt - k : yabai -m window --focus north
-ctrl + alt - l : yabai -m window --focus east
+# ---------- Snap (SizeUp-style window positioning) ----------
+# halves — toggle float first if window is tiled, then snap to grid
+ctrl + alt + cmd - left  : yabai -m query --windows --window | jq -er '."is-floating" == false' && yabai -m window --toggle float ; yabai -m window --grid 1:2:0:0:1:1
+ctrl + alt + cmd - right : yabai -m query --windows --window | jq -er '."is-floating" == false' && yabai -m window --toggle float ; yabai -m window --grid 1:2:1:0:1:1
+ctrl + alt + cmd - up    : yabai -m query --windows --window | jq -er '."is-floating" == false' && yabai -m window --toggle float ; yabai -m window --grid 2:1:0:0:1:1
+ctrl + alt + cmd - down  : yabai -m query --windows --window | jq -er '."is-floating" == false' && yabai -m window --toggle float ; yabai -m window --grid 2:1:0:1:1:1
 
-# swap
-ctrl + shift + alt - h : yabai -m window --swap west
-ctrl + shift + alt - j : yabai -m window --swap south
-ctrl + shift + alt - k : yabai -m window --swap north
-ctrl + shift + alt - l : yabai -m window --swap east
+# quarters (clockwise from top-left: 1=TL, 2=TR, 3=BR, 4=BL)
+ctrl + alt + cmd - 1 : yabai -m query --windows --window | jq -er '."is-floating" == false' && yabai -m window --toggle float ; yabai -m window --grid 2:2:0:0:1:1
+ctrl + alt + cmd - 2 : yabai -m query --windows --window | jq -er '."is-floating" == false' && yabai -m window --toggle float ; yabai -m window --grid 2:2:1:0:1:1
+ctrl + alt + cmd - 3 : yabai -m query --windows --window | jq -er '."is-floating" == false' && yabai -m window --toggle float ; yabai -m window --grid 2:2:1:1:1:1
+ctrl + alt + cmd - 4 : yabai -m query --windows --window | jq -er '."is-floating" == false' && yabai -m window --toggle float ; yabai -m window --grid 2:2:0:1:1:1
 
-# resize
-cmd + alt - h : yabai -m window --resize left:-50:0  ; yabai -m window --resize right:-50:0
-cmd + alt - l : yabai -m window --resize right:50:0  ; yabai -m window --resize left:50:0
-cmd + alt - j : yabai -m window --resize bottom:0:50 ; yabai -m window --resize top:0:50
-cmd + alt - k : yabai -m window --resize top:0:-50   ; yabai -m window --resize bottom:0:-50
+# center, maximize (SizeUp-style fills display), native fullscreen, BSP zoom
+ctrl + alt + cmd - c : yabai -m query --windows --window | jq -er '."is-floating" == false' && yabai -m window --toggle float ; yabai -m window --grid 4:4:1:1:2:2
+ctrl + alt + cmd - m : yabai -m query --windows --window | jq -er '."is-floating" == false' && yabai -m window --toggle float ; yabai -m window --grid 1:1:0:0:1:1
+ctrl + alt + cmd - f : yabai -m window --toggle native-fullscreen
+ctrl + alt + cmd - z : yabai -m window --toggle zoom-fullscreen
 
-# layout
-ctrl + alt - space : yabai -m window --toggle float
-ctrl + alt - t     : yabai -m space  --layout bsp
-ctrl + alt - s     : yabai -m space  --layout stack
-ctrl + alt - 0     : yabai -m space  --balance
+# ---------- Focus (BSP nav) ----------
+ctrl + alt + cmd - h : yabai -m window --focus west
+ctrl + alt + cmd - j : yabai -m window --focus south
+ctrl + alt + cmd - k : yabai -m window --focus north
+ctrl + alt + cmd - l : yabai -m window --focus east
 
-# SizeUp-compatible chords
-ctrl + cmd + alt - m : yabai -m window --toggle zoom-fullscreen
-ctrl + cmd + alt - n : yabai -m space  --rotate 90
+# ---------- Layout state ----------
+ctrl + alt + cmd - space : yabai -m window --toggle float
+ctrl + alt + cmd - t     : yabai -m space  --layout bsp
+ctrl + alt + cmd - s     : yabai -m space  --layout stack
+ctrl + alt + cmd - 0     : yabai -m space  --balance
+ctrl + alt + cmd - r     : yabai -m space  --rotate 90
 
-# spaces — focus
-ctrl + alt - 1 : yabai -m space --focus 1
-ctrl + alt - 2 : yabai -m space --focus 2
-ctrl + alt - 3 : yabai -m space --focus 3
-ctrl + alt - 4 : yabai -m space --focus 4
+# ---------- Destructive / move (shift + ^⌥⌘) ----------
+# swap windows by direction
+shift + ctrl + alt + cmd - h : yabai -m window --swap west
+shift + ctrl + alt + cmd - j : yabai -m window --swap south
+shift + ctrl + alt + cmd - k : yabai -m window --swap north
+shift + ctrl + alt + cmd - l : yabai -m window --swap east
 
-# spaces — move active window + follow
-ctrl + shift + alt - 1 : yabai -m window --space 1 ; yabai -m space --focus 1
-ctrl + shift + alt - 2 : yabai -m window --space 2 ; yabai -m space --focus 2
-ctrl + shift + alt - 3 : yabai -m window --space 3 ; yabai -m space --focus 3
-ctrl + shift + alt - 4 : yabai -m window --space 4 ; yabai -m space --focus 4
+# send active window to prev/next display
+shift + ctrl + alt + cmd - left  : yabai -m window --display prev ; yabai -m display --focus prev
+shift + ctrl + alt + cmd - right : yabai -m window --display next ; yabai -m display --focus next
 
-# snap-to-grid (auto-float if currently tiled)
-ctrl + alt - left : yabai -m query --windows --window \
-    | jq -er ".\"is-floating\" == false" \
-    && yabai -m window --toggle float ; yabai -m window --grid 1:2:0:0:1:1
-ctrl + alt - right : yabai -m query --windows --window \
-    | jq -er ".\"is-floating\" == false" \
-    && yabai -m window --toggle float ; yabai -m window --grid 1:2:1:0:1:1
-ctrl + alt - up : yabai -m query --windows --window \
-    | jq -er ".\"is-floating\" == false" \
-    && yabai -m window --toggle float ; yabai -m window --grid 2:1:0:0:1:1
-ctrl + alt - down : yabai -m query --windows --window \
-    | jq -er ".\"is-floating\" == false" \
-    && yabai -m window --toggle float ; yabai -m window --grid 2:1:0:1:1:1
+# move active window to space N and follow
+shift + ctrl + alt + cmd - 1 : yabai -m window --space 1 ; yabai -m space --focus 1
+shift + ctrl + alt + cmd - 2 : yabai -m window --space 2 ; yabai -m space --focus 2
+shift + ctrl + alt + cmd - 3 : yabai -m window --space 3 ; yabai -m space --focus 3
+shift + ctrl + alt + cmd - 4 : yabai -m window --space 4 ; yabai -m space --focus 4
 
-# quarters (assume already floating)
-ctrl + alt - u : yabai -m window --grid 2:2:0:0:1:1
-ctrl + alt - i : yabai -m window --grid 2:2:1:0:1:1
-ctrl + alt - n : yabai -m window --grid 2:2:0:1:1:1
-ctrl + alt - m : yabai -m window --grid 2:2:1:1:1:1
-
-# floating fullscreen
-ctrl + alt - return : yabai -m window --grid 1:1:0:0:1:1
-
-# reload
-ctrl + shift + alt - r : yabai --restart-service ; skhd --restart-service
+# restart services
+shift + ctrl + alt + cmd - r : yabai --restart-service ; skhd --restart-service

--- a/yabai/yabairc
+++ b/yabai/yabairc
@@ -10,16 +10,16 @@ yabai -m config right_padding               8
 yabai -m config window_gap                  8
 
 yabai -m config window_origin_display       default
-yabai -m config window_placement            second_child
+yabai -m config window_placement            first_child
 yabai -m config split_ratio                 0.50
 yabai -m config auto_balance                off
 
 # mouse
-yabai -m config mouse_modifier              alt
+yabai -m config mouse_modifier              cmd
 yabai -m config mouse_action1               move
 yabai -m config mouse_action2               resize
-yabai -m config mouse_drop_action           swap
-yabai -m config focus_follows_mouse         autoraise
+yabai -m config mouse_drop_action           stack
+yabai -m config focus_follows_mouse         autofocus
 yabai -m config mouse_follows_focus         off
 
 # visuals — uncomment if SIP is partially disabled


### PR DESCRIPTION
## Summary

Cherry-picked from #136 (closed). Collapses the four overlapping yabai/skhd modifier ladders into one consistent SizeUp-style ladder, fixes mouse-drag collisions, and updates `AGENTS.md` to match.

> [!WARNING]
> **This is a deliberate ergonomics change.** Review the binding diff and decide if you want to retrain muscle memory before merging. The brew-services fix from #136 is split out into #142 — that one is uncontroversial and can ship independently.

## Modifier ladder

| | Before | After |
|---|---|---|
| Primary | `ctrl+alt` (focus/layout) | `ctrl+alt+cmd` |
| Destructive | `ctrl+alt+shift` (swap/move) | `shift+ctrl+alt+cmd` |
| Resize | `cmd+alt+hjkl` | **dropped** (use cmd-drag instead) |
| SizeUp | `ctrl+cmd+alt` | folded into the unified ladder |

## Bindings dropped

- **Keyboard resize** (`cmd+alt+hjkl`) — replaced by mouse-drag (`mouse_modifier=cmd` in yabairc).
- **Direct space focus** (`ctrl+alt+1..4`) — delegated to native macOS (`ctrl+1..4`, configurable in System Settings → Keyboard → Mission Control). `shift+ctrl+alt+cmd+1..4` still works for move-and-follow.
- **Quarter mnemonic** (`ctrl+alt+u/i/n/m`) — replaced by `ctrl+alt+cmd+1..4` (clockwise from top-left).
- **Float fullscreen on enter** (`ctrl+alt+return`) — replaced by `ctrl+alt+cmd+m` (SizeUp-style maximize).

## Bindings added

- `ctrl+alt+cmd+c` — center window
- `ctrl+alt+cmd+f` — toggle native macOS fullscreen
- `ctrl+alt+cmd+z` — toggle BSP zoom-fullscreen (was previously on `ctrl+cmd+alt+m`)
- `shift+ctrl+alt+cmd+left/right` — send window to previous/next display

## yabairc tweaks

- `mouse_modifier alt → cmd` — alt was colliding with every hotkey ladder; cmd is more macOS-idiomatic.
- `focus_follows_mouse autoraise → autofocus` — focus tracks the cursor without re-raising the window.
- `mouse_drop_action swap → stack` — stack-on-drop is non-destructive for accidental drags.
- `window_placement second_child → first_child` — more predictable BSP splits.

## Test plan

- [ ] Reload services after merge (`shift+ctrl+alt+cmd+r`).
- [ ] Smoke-test the new ladder: focus (`ctrl+alt+cmd+hjkl`), swap (`shift+ctrl+alt+cmd+hjkl`), halves (`ctrl+alt+cmd+arrows`), quarters (`ctrl+alt+cmd+1..4`), maximize (`ctrl+alt+cmd+m`).
- [ ] Confirm `cmd`-drag moves/resizes a window without intercepting app-specific behaviors (text drag, link previews) in the apps you use.
- [ ] Confirm `ctrl+1..4` still focuses macOS spaces (or rebind in System Settings → Keyboard → Mission Control).

🤖 Generated with [Claude Code](https://claude.com/claude-code)