### PR TITLE
feat(lsp): ship LSP plugins disabled by default, opt in per project

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,7 @@ This is a personal dotfiles repository that configures a vim-centric, terminal-b
 - `plugin-ls` - List currently installed plugins
 - `cf-refresh` - Rebuild the cheese-flow plugin cache from `~/Dev/cheese-flow` (use after editing the plugin in-place)
 - `plugin-refresh <plugin> [marketplace]` - Generic version of cf-refresh for any local plugin (defaults to cheese-flow@local)
+- `cc-lsp-local` - Enable LSP plugins in current project based on tokei (writes `.claude/settings.local.json`). Use `--dry-run` / `--print` / `--threshold N`. LSPs ship disabled at the user level; this is the per-project opt-in.
 
 ### Agent Skill Management (`gh skill install`)
 

--- a/bin/cc-lsp-local
+++ b/bin/cc-lsp-local
@@ -1,0 +1,97 @@
+#!/bin/bash
+# cc-lsp-local — Enable LSP plugins in the current project based on tokei.
+#
+# Writes (merges) `enabledPlugins` into `.claude/settings.local.json` in the
+# git root (or cwd if not in a repo). Persistent companion to the ephemeral
+# `_cc_lsp_gate` used by the cc/ccc/ccr/ccp shell wrappers.
+#
+# The repo-level user settings ship with all LSP plugins disabled; this script
+# is how you opt them back in for projects that need them.
+#
+# Usage:
+#   cc-lsp-local                  # write gate to .claude/settings.local.json
+#   cc-lsp-local --dry-run        # print what would be written
+#   cc-lsp-local --threshold 100  # only enable LSPs above N code-lines (default 50)
+#   cc-lsp-local --print          # print the gate JSON to stdout, nothing written
+#
+# Env: CC_LSP_GATE_THRESHOLD=<n> overrides the default threshold.
+
+set -euo pipefail
+
+DOTFILES_DIR="${DOTFILES_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+# shellcheck source=../claude/lib/lsp-gate.sh
+source "$DOTFILES_DIR/claude/lib/lsp-gate.sh"
+
+THRESHOLD="${CC_LSP_GATE_THRESHOLD:-50}"
+DRY_RUN=false
+PRINT_ONLY=false
+
+usage() {
+    sed -n '2,17p' "$0" | sed 's/^# \{0,1\}//'
+    exit "${1:-0}"
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run)   DRY_RUN=true ;;
+        --print)     PRINT_ONLY=true ;;
+        --threshold) THRESHOLD="$2"; shift ;;
+        -h|--help)   usage 0 ;;
+        *)           echo "cc-lsp-local: unknown arg: $1" >&2; usage 1 ;;
+    esac
+    shift
+done
+
+if ! command -v tokei >/dev/null; then
+    echo "cc-lsp-local: tokei not found (install: brew install tokei)" >&2
+    exit 1
+fi
+if ! command -v jq >/dev/null; then
+    echo "cc-lsp-local: jq not found (install: brew install jq)" >&2
+    exit 1
+fi
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+SETTINGS="$ROOT/.claude/settings.local.json"
+
+# Run tokei from the repo root, not cwd — otherwise running from a subdir
+# scans only that subdir and writes a wrong gate.
+GATE_JSON="$(cd "$ROOT" && lsp_gate_compute "$THRESHOLD")" || {
+    echo "cc-lsp-local: failed to compute gate (tokei/jq error)" >&2
+    exit 1
+}
+
+if $PRINT_ONLY; then
+    echo "$GATE_JSON" | jq '{enabledPlugins: .}'
+    exit 0
+fi
+
+# Merge: replace `enabledPlugins` only, preserve everything else (permissions, etc).
+MERGED="$(jq --argjson gate "$GATE_JSON" '. + {enabledPlugins: $gate}' \
+    <(test -f "$SETTINGS" && cat "$SETTINGS" || echo '{}'))"
+
+# Summary: show enabled vs skipped, sorted, with counts.
+ENABLED="$(echo "$GATE_JSON" | jq -r 'to_entries[] | select(.value) | .key' | sort)"
+SKIPPED="$(echo "$GATE_JSON" | jq -r 'to_entries[] | select(.value | not) | .key' | sort)"
+EN_COUNT="$(echo -n "$ENABLED" | grep -c . || true)"
+SK_COUNT="$(echo -n "$SKIPPED" | grep -c . || true)"
+
+if $DRY_RUN; then
+    echo "[dry-run] would write to $SETTINGS:"
+    echo "$MERGED" | jq .
+else
+    mkdir -p "$ROOT/.claude"
+    printf '%s\n' "$MERGED" | jq . > "$SETTINGS"
+    echo "Wrote $SETTINGS"
+fi
+
+echo
+echo "Threshold: ${THRESHOLD} code lines"
+echo "Enabled (${EN_COUNT}):"
+# shellcheck disable=SC2001 # parameter expansion can't elegantly prepend per-line
+[[ -n "$ENABLED" ]] && echo "$ENABLED" | sed 's/^/  + /' || echo "  (none — no language above threshold)"
+echo "Disabled (${SK_COUNT}):"
+# shellcheck disable=SC2001 # parameter expansion can't elegantly prepend per-line
+[[ -n "$SKIPPED" ]] && echo "$SKIPPED" | sed 's/^/  - /' || true
+echo
+echo "Restart Claude Code in this directory for changes to take effect."

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -166,7 +166,11 @@ and far cheaper in tokens than blind text grep + full file reads.
 and Context7 (external docs + GitHub code reference). Don't guess; let
 lookup route you.
 
-**LSP integration** — All 6 LSP plugins are enabled globally (lazy startup, zero cost when idle). Run `/lsp` for status and troubleshooting.
+**LSP integration** — All 6 LSP plugins ship installed but **disabled at the user level**; opt in per project. Two paths:
+- Ephemeral (per-session): `cc` / `ccc` / `ccr` / `ccp <profile>` invoke `_cc_lsp_gate` (tokei-driven) and pass a tmp settings file via `--settings`.
+- Persistent (per-project): run `cc-lsp-local` once in the project to write `enabledPlugins` into `.claude/settings.local.json` (gitignored). Threshold defaults to 50 code lines per language; override with `--threshold N` or `CC_LSP_GATE_THRESHOLD`.
+
+Run `/lsp` for status and troubleshooting.
 
 **Agent permission modes** — `acceptEdits` and `bypassPermissions` only suppress the interactive approval dialog for Edit/Write — they do NOT auto-approve Bash or MCP calls. Bash permissions use a separate allowlist (`permissions.allow` entries like `Bash(git:*)`). In sandboxed environments (Conductor, fresh sessions without your `settings.json`), worktree agents may lack allowlist entries for `git push`, `gh pr create`, etc. **Design pattern**: have isolated agents do code work + commit only, then return control to the orchestrator (which runs in the user's session with full permissions) for push/PR operations.
 

--- a/claude/agents/cheese-factory.md
+++ b/claude/agents/cheese-factory.md
@@ -87,7 +87,7 @@ Keep it to one screen. This is a map, not a thesis.
 
 ## LSP Integration
 
-All 7 LSP plugins are enabled globally. Use the built-in `LSP` tool — `documentSymbol` for quick file overviews, `hover` for type discovery, `goToDefinition` to trace imports. Accelerates orientation in typed languages.
+LSP plugins ship installed but disabled by default — opt in per-project via `cc-lsp-local`. When enabled, use the built-in `LSP` tool — `documentSymbol` for quick file overviews, `hover` for type discovery, `goToDefinition` to trace imports. Accelerates orientation in typed languages. If `LSP` returns empty, the project hasn't opted in — fall back to cheez-search.
 
 ## Rules
 

--- a/claude/agents/fromage-cook.md
+++ b/claude/agents/fromage-cook.md
@@ -59,7 +59,7 @@ If your prompt includes design skill content, apply it alongside the plan steps.
 
 ## LSP Integration
 
-All 7 LSP plugins are enabled globally. Use the built-in `LSP` tool after edits — `hover` for type checks, `findReferences` to verify callers, `documentSymbol` to orient in a file. Auto-diagnostics surface type errors after edits without running a full build. Faster than `cargo check` or `npm test` for quick verification.
+LSP plugins ship installed but disabled by default — opt in per-project via `cc-lsp-local`. When enabled, use the built-in `LSP` tool after edits — `hover` for type checks, `findReferences` to verify callers, `documentSymbol` to orient in a file. Auto-diagnostics surface type errors after edits without running a full build. Faster than `cargo check` or `npm test` for quick verification. If `LSP` returns empty, fall back to the language's own checker.
 
 ## Build Verification
 

--- a/claude/agents/fromage-culture.md
+++ b/claude/agents/fromage-culture.md
@@ -89,7 +89,7 @@ The orchestrator works from summaries. The full report is available if a later a
 
 ## LSP Integration
 
-All 7 LSP plugins are enabled globally. Use the built-in `LSP` tool to enrich exploration — `hover` for inferred types at key flow points, `goToDefinition` through generics/re-exports, `findReferences` for blast radius. Especially useful for trait objects and dynamic dispatch.
+LSP plugins ship installed but disabled by default — opt in per-project via `cc-lsp-local`. When enabled, use the built-in `LSP` tool to enrich exploration — `hover` for inferred types at key flow points, `goToDefinition` through generics/re-exports, `findReferences` for blast radius. Especially useful for trait objects and dynamic dispatch.
 
 ## Rules
 

--- a/claude/agents/fromage-press.md
+++ b/claude/agents/fromage-press.md
@@ -99,7 +99,7 @@ The orchestrator works from summaries. The full report is available if needed fo
 
 ## LSP Integration
 
-All 7 LSP plugins are enabled globally. Use the built-in `LSP` tool — `hover` to check return/error types for assertions, auto-diagnostics catch type mismatches after editing test files before running the suite.
+LSP plugins ship installed but disabled by default — opt in per-project via `cc-lsp-local`. When enabled, use the built-in `LSP` tool — `hover` to check return/error types for assertions, auto-diagnostics catch type mismatches after editing test files before running the suite.
 
 ## Rules
 

--- a/claude/agents/ricotta-reducer.md
+++ b/claude/agents/ricotta-reducer.md
@@ -184,7 +184,7 @@ Categories: `DELETE`, `INLINE`, `EXTRACT`, `UNDOCUMENT`, `DECOUPLE`
 
 ## LSP Integration
 
-All 7 LSP plugins are enabled globally.
+LSP plugins ship installed but disabled by default — opt in per-project via `cc-lsp-local`.
 
 | Context | Strategy |
 |---|---|

--- a/claude/agents/roquefort-wrecker.md
+++ b/claude/agents/roquefort-wrecker.md
@@ -122,7 +122,7 @@ Test in this exact order:
 
 ## LSP Integration
 
-All 7 LSP plugins are enabled globally. Use the built-in `LSP` tool — `hover` for type discovery when writing assertions, auto-diagnostics catch mismatches after edits before running the suite.
+LSP plugins ship installed but disabled by default — opt in per-project via `cc-lsp-local`. When enabled, use the built-in `LSP` tool — `hover` for type discovery when writing assertions, auto-diagnostics catch mismatches after edits before running the suite.
 
 ## Quality Gates
 

--- a/claude/commands/fromage.md
+++ b/claude/commands/fromage.md
@@ -420,7 +420,7 @@ After cooks return, **verify plan completion** before proceeding:
 
 **Engineering principles**: Input validation at boundaries, fail fast and loud, loose coupling, YAGNI, real-world naming, immutable patterns, complexity budget (40 lines/fn, 300 lines/file, 4 params, 3 nesting).
 
-**LSP integration**: All 7 LSP plugins are enabled globally. Cook agents get auto-diagnostics after edits and can use the `LSP` tool (`hover`, `findReferences`, etc.) for quick type verification — reduces the need for `cargo check` / `npm test` loops.
+**LSP integration**: LSP plugins ship installed but disabled by default — projects opt in via `cc-lsp-local` (writes `.claude/settings.local.json`). When enabled, Cook agents get auto-diagnostics after edits and can use the `LSP` tool (`hover`, `findReferences`, etc.) for quick type verification — reduces the need for `cargo check` / `npm test` loops.
 
 ### Post-Cook Simplify Pass
 

--- a/claude/lib/lsp-gate.sh
+++ b/claude/lib/lsp-gate.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# lsp-gate.sh — Compute which LSP plugins should be enabled in cwd.
+#
+# Single source of truth for the tokei → enabledPlugins mapping. Sourced by
+# both the ephemeral session gate (zsh/claude.zsh:_cc_lsp_gate) and the
+# persistent project-local writer (bin/cc-lsp-local).
+#
+# Usage (from a sourced caller):
+#   lsp_gate_compute [threshold]   # prints {"name": bool, ...} JSON to stdout
+#                                   # returns non-zero if tokei or jq fail
+
+# Map tokei language buckets → LSP plugin name. Threshold is `code` lines.
+# Bucket sums let one plugin cover multiple languages (e.g. vtsls = JS+TS+TSX+JSX).
+lsp_gate_compute() {
+    local threshold="${1:-50}"
+    command -v tokei >/dev/null || return 1
+    command -v jq >/dev/null || return 1
+
+    tokei --output json | jq --argjson t "$threshold" '{
+      "bash-language-server@claude-code-lsps": (([.BASH.code//0,.Shell.code//0,.Zsh.code//0]|add) >= $t),
+      "vtsls@claude-code-lsps":                (([.JavaScript.code//0,.TypeScript.code//0,.TSX.code//0,.JSX.code//0]|add) >= $t),
+      "yaml-language-server@claude-code-lsps": ((.YAML.code//0) >= $t),
+      "rust-analyzer@claude-code-lsps":        ((.Rust.code//0) >= $t),
+      "pyright@claude-code-lsps":              ((.Python.code//0) >= $t),
+      "gopls@claude-code-lsps":                ((.Go.code//0) >= $t)
+    }'
+}

--- a/claude/plugins/registry.yaml
+++ b/claude/plugins/registry.yaml
@@ -14,36 +14,39 @@
 #   plugin-ls             List installed plugins
 
 plugins:
-  # --- LSP plugins (globally enabled, servers start lazily per file type) ---
+  # --- LSP plugins (installed but disabled by default; opt-in per project) ---
+  # Enable via:
+  #   cc / ccc / ccr / ccp <profile>  → ephemeral gate via _cc_lsp_gate (tokei-driven)
+  #   cc-lsp-local                    → persistent project-local opt-in (.claude/settings.local.json)
   bash-language-server@claude-code-lsps:
     description: Bash/shell script language server (.sh, .bash, .zsh)
     scope: user
-    load: true
+    load: false
 
   vtsls@claude-code-lsps:
     description: TypeScript/JavaScript language server (.ts, .tsx, .js, .jsx)
     scope: user
-    load: true
+    load: false
 
   yaml-language-server@claude-code-lsps:
     description: YAML language server (.yaml, .yml)
     scope: user
-    load: true
+    load: false
 
   rust-analyzer@claude-code-lsps:
     description: Rust language server (.rs)
     scope: user
-    load: true
+    load: false
 
   pyright@claude-code-lsps:
     description: Python type checking and language server (.py, .pyi)
     scope: user
-    load: true
+    load: false
 
   gopls@claude-code-lsps:
     description: Go language server (.go)
     scope: user
-    load: true
+    load: false
 
   # --- Workflow plugins ---
   claude-md-management@claude-plugins-official:

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -128,12 +128,12 @@
     ]
   },
   "enabledPlugins": {
-    "bash-language-server@claude-code-lsps": true,
-    "vtsls@claude-code-lsps": true,
-    "yaml-language-server@claude-code-lsps": true,
-    "rust-analyzer@claude-code-lsps": true,
-    "pyright@claude-code-lsps": true,
-    "gopls@claude-code-lsps": true,
+    "bash-language-server@claude-code-lsps": false,
+    "vtsls@claude-code-lsps": false,
+    "yaml-language-server@claude-code-lsps": false,
+    "rust-analyzer@claude-code-lsps": false,
+    "pyright@claude-code-lsps": false,
+    "gopls@claude-code-lsps": false,
     "claude-md-management@claude-plugins-official": true,
     "playwright@claude-plugins-official": true,
     "frontend-design@claude-plugins-official": true,

--- a/claude/skills/lsp/SKILL.md
+++ b/claude/skills/lsp/SKILL.md
@@ -3,8 +3,9 @@ name: lsp
 model: haiku
 description: >
   Check LSP plugin status and troubleshoot language server issues.
-  All 7 LSP plugins are enabled globally — this skill shows what's running,
-  verifies binaries, and diagnoses issues. Use when the user says "LSP not
+  LSP plugins ship installed but disabled at the user level — this skill shows
+  what's running, verifies binaries, diagnoses issues, and points at the
+  per-project opt-in (`cc-lsp-local`). Use when the user says "LSP not
   working", "language server down", "hover not working", "no type info",
   "check LSP", "types missing", or invokes /lsp. Also trigger when LSP
   operations return errors or empty results.
@@ -12,8 +13,11 @@ description: >
 
 # lsp
 
-LSP status and troubleshooting. All 7 LSP plugins are enabled globally in
-`settings.json` — servers start lazily when the LSP tool is used on a matching file.
+LSP status and troubleshooting. LSP plugins are installed at the user level but
+**disabled by default** — opt in per project via `cc-lsp-local` (writes
+`.claude/settings.local.json`) or per session via the `cc` / `ccc` / `ccr` /
+`ccp` shell wrappers (ephemeral tokei-driven gate). Servers start lazily once
+enabled and the LSP tool hits a matching file.
 
 ## How it works
 

--- a/tests/lsp-gate-lib.bats
+++ b/tests/lsp-gate-lib.bats
@@ -1,0 +1,176 @@
+#!/usr/bin/env bats
+# Tests for lsp_gate_compute — the pure tokei→enabledPlugins helper sourced
+# by both _cc_lsp_gate (claude.zsh) and bin/cc-lsp-local.
+
+load test_helper
+
+LSP_PLUGINS=(
+    "bash-language-server@claude-code-lsps"
+    "vtsls@claude-code-lsps"
+    "yaml-language-server@claude-code-lsps"
+    "rust-analyzer@claude-code-lsps"
+    "pyright@claude-code-lsps"
+    "gopls@claude-code-lsps"
+)
+
+LSP_GATE_LIB="$REAL_DOTFILES_DIR/claude/lib/lsp-gate.sh"
+
+# Run lsp_gate_compute against a mock tokei that returns the given JSON payload.
+# Args: 1=tokei JSON payload, 2=threshold (optional, default 50)
+run_with_mock_tokei() {
+    local tokei_payload="$1"
+    local threshold="${2:-50}"
+    local mock_dir="$BATS_TEST_TMPDIR/mock-bin"
+    mkdir -p "$mock_dir"
+    cat > "$mock_dir/tokei" <<EOF
+#!/bin/bash
+cat <<'JSON'
+$tokei_payload
+JSON
+EOF
+    chmod +x "$mock_dir/tokei"
+    PATH="$mock_dir:$PATH" bash -c "
+        source '$LSP_GATE_LIB'
+        lsp_gate_compute '$threshold'
+    "
+}
+
+# ── shape ─────────────────────────────────────────────────────────────────────
+
+@test "lsp-gate.sh has no syntax errors" {
+    run bash -n "$LSP_GATE_LIB"
+    [[ $status -eq 0 ]]
+}
+
+@test "lsp_gate_compute is defined in lsp-gate.sh" {
+    grep -q "^lsp_gate_compute()" "$LSP_GATE_LIB"
+}
+
+@test "lsp_gate_compute output is valid JSON" {
+    local out
+    out="$(run_with_mock_tokei '{"Rust":{"code":100}}' 50)"
+    [[ -n "$out" ]]
+    echo "$out" | jq -e . > /dev/null
+}
+
+@test "lsp_gate_compute output contains exactly the 6 LSP plugin keys" {
+    local out
+    out="$(run_with_mock_tokei '{"Rust":{"code":100}}' 50)"
+    local key_count
+    key_count="$(echo "$out" | jq 'length')"
+    [[ "$key_count" -eq 6 ]]
+    local plugin
+    for plugin in "${LSP_PLUGINS[@]}"; do
+        echo "$out" | jq -e --arg k "$plugin" 'has($k)' > /dev/null
+    done
+}
+
+@test "lsp_gate_compute values are booleans not strings" {
+    local out
+    out="$(run_with_mock_tokei '{"Rust":{"code":100}}' 50)"
+    local non_bool_count
+    non_bool_count="$(echo "$out" | jq '[to_entries[] | select(.value | type != "boolean")] | length')"
+    [[ "$non_bool_count" -eq 0 ]]
+}
+
+# ── threshold ─────────────────────────────────────────────────────────────────
+
+@test "lsp_gate_compute defaults threshold to 50 when no arg given" {
+    local out
+    out="$(PATH="$BATS_TEST_TMPDIR/mock-bin:$PATH" bash -c "
+        cat > '$BATS_TEST_TMPDIR/mock-bin/tokei' <<'EOF'
+#!/bin/bash
+echo '{\"Rust\":{\"code\":49}}'
+EOF
+        chmod +x '$BATS_TEST_TMPDIR/mock-bin/tokei'
+        source '$LSP_GATE_LIB'
+        lsp_gate_compute
+    ")"
+    # 49 < 50 → rust-analyzer should be false
+    [[ "$(echo "$out" | jq -r '."rust-analyzer@claude-code-lsps"')" == "false" ]]
+}
+
+@test "lsp_gate_compute threshold 999999 disables every plugin" {
+    local out
+    out="$(run_with_mock_tokei '{"Rust":{"code":1000},"Python":{"code":1000},"Go":{"code":1000}}' 999999)"
+    local enabled_count
+    enabled_count="$(echo "$out" | jq '[to_entries[] | select(.value == true)] | length')"
+    [[ "$enabled_count" -eq 0 ]]
+}
+
+@test "lsp_gate_compute threshold 1 enables every plugin with any code" {
+    local payload='{"Rust":{"code":10},"Python":{"code":10},"Go":{"code":10},"YAML":{"code":10},"BASH":{"code":10},"JavaScript":{"code":10}}'
+    local out
+    out="$(run_with_mock_tokei "$payload" 1)"
+    local enabled_count
+    enabled_count="$(echo "$out" | jq '[to_entries[] | select(.value == true)] | length')"
+    [[ "$enabled_count" -eq 6 ]]
+}
+
+# ── per-plugin language mapping ───────────────────────────────────────────────
+
+@test "rust-analyzer follows Rust line count" {
+    local above below
+    above="$(run_with_mock_tokei '{"Rust":{"code":100}}' 50)"
+    below="$(run_with_mock_tokei '{"Rust":{"code":10}}' 50)"
+    [[ "$(echo "$above" | jq -r '."rust-analyzer@claude-code-lsps"')" == "true" ]]
+    [[ "$(echo "$below" | jq -r '."rust-analyzer@claude-code-lsps"')" == "false" ]]
+}
+
+@test "pyright follows Python line count" {
+    local above below
+    above="$(run_with_mock_tokei '{"Python":{"code":100}}' 50)"
+    below="$(run_with_mock_tokei '{"Python":{"code":10}}' 50)"
+    [[ "$(echo "$above" | jq -r '."pyright@claude-code-lsps"')" == "true" ]]
+    [[ "$(echo "$below" | jq -r '."pyright@claude-code-lsps"')" == "false" ]]
+}
+
+@test "gopls follows Go line count" {
+    local above below
+    above="$(run_with_mock_tokei '{"Go":{"code":100}}' 50)"
+    below="$(run_with_mock_tokei '{"Go":{"code":10}}' 50)"
+    [[ "$(echo "$above" | jq -r '."gopls@claude-code-lsps"')" == "true" ]]
+    [[ "$(echo "$below" | jq -r '."gopls@claude-code-lsps"')" == "false" ]]
+}
+
+@test "yaml-language-server follows YAML line count" {
+    local above below
+    above="$(run_with_mock_tokei '{"YAML":{"code":100}}' 50)"
+    below="$(run_with_mock_tokei '{"YAML":{"code":10}}' 50)"
+    [[ "$(echo "$above" | jq -r '."yaml-language-server@claude-code-lsps"')" == "true" ]]
+    [[ "$(echo "$below" | jq -r '."yaml-language-server@claude-code-lsps"')" == "false" ]]
+}
+
+@test "bash-language-server sums BASH+Shell+Zsh" {
+    local out
+    # Each individually < 50, but sum = 60 → should enable.
+    out="$(run_with_mock_tokei '{"BASH":{"code":20},"Shell":{"code":20},"Zsh":{"code":20}}' 50)"
+    [[ "$(echo "$out" | jq -r '."bash-language-server@claude-code-lsps"')" == "true" ]]
+}
+
+@test "vtsls sums JS+TS+TSX+JSX" {
+    local out
+    # Each individually < 50, but sum = 80 → should enable.
+    out="$(run_with_mock_tokei '{"JavaScript":{"code":20},"TypeScript":{"code":20},"TSX":{"code":20},"JSX":{"code":20}}' 50)"
+    [[ "$(echo "$out" | jq -r '."vtsls@claude-code-lsps"')" == "true" ]]
+}
+
+@test "missing language buckets default to 0 and disable the plugin" {
+    local out
+    out="$(run_with_mock_tokei '{}' 50)"
+    local plugin
+    for plugin in "${LSP_PLUGINS[@]}"; do
+        [[ "$(echo "$out" | jq -r --arg k "$plugin" '.[$k]')" == "false" ]]
+    done
+}
+
+# ── failure modes ─────────────────────────────────────────────────────────────
+
+@test "lsp_gate_compute returns nonzero when tokei is missing" {
+    run bash -c "
+        PATH='/usr/bin:/bin'  # no tokei in this PATH
+        source '$LSP_GATE_LIB'
+        lsp_gate_compute 50
+    "
+    [[ $status -ne 0 ]]
+}

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -74,7 +74,7 @@ run_tests() {
     if [[ -n "$SPECIFIC_TEST" ]]; then
         test_files="$SPECIFIC_TEST"
     else
-        test_files="dots-simple.bats dots.bats git-hooks.bats sync.bats config-validation.bats prompt.bats sync-claude.bats sync-rollback.bats hooks-blockers.bats hooks-session.bats iterm2-fonts.bats worktree-settings.bats copilot-sync.bats skills-install.bats sync-skills.bats packages.bats"
+        test_files="dots-simple.bats dots.bats git-hooks.bats sync.bats config-validation.bats prompt.bats sync-claude.bats sync-rollback.bats hooks-blockers.bats hooks-session.bats iterm2-fonts.bats worktree-settings.bats copilot-sync.bats skills-install.bats sync-skills.bats packages.bats lsp-gate-lib.bats"
     fi
 
     # Count total tests

--- a/zsh/claude.zsh
+++ b/zsh/claude.zsh
@@ -16,23 +16,21 @@ export ENABLE_CLAUDEAI_MCP_SERVERS=false
 # ═══════════════════════════════════════════════════════════════════
 # Compute which LSP plugins this repo needs based on tokei line counts.
 # Writes a minimal JSON gate file and prints its path. Prints nothing on failure.
+# Persistent companion: bin/cc-lsp-local writes the same shape into
+# .claude/settings.local.json instead of an ephemeral tmp file.
 _cc_lsp_gate() {
-    git rev-parse --is-inside-work-tree &>/dev/null || return 0
+    local repo_root
+    repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || return 0
 
-    local threshold="${CC_LSP_GATE_THRESHOLD:-50}"
+    # shellcheck source=../claude/lib/lsp-gate.sh
+    source "$DOTFILES_DIR/claude/lib/lsp-gate.sh" 2>/dev/null || return 0
+
     local gate_file
     gate_file="$(mktemp -t claude-lsp-gate).json"
-
-    tokei --output json | jq --argjson t "$threshold" '{
-      enabledPlugins: {
-        "bash-language-server@claude-code-lsps": (([.BASH.code//0,.Shell.code//0,.Zsh.code//0]|add) >= $t),
-        "vtsls@claude-code-lsps":               (([.JavaScript.code//0,.TypeScript.code//0,.TSX.code//0,.JSX.code//0]|add) >= $t),
-        "yaml-language-server@claude-code-lsps": ((.YAML.code//0) >= $t),
-        "rust-analyzer@claude-code-lsps":        ((.Rust.code//0) >= $t),
-        "pyright@claude-code-lsps":              ((.Python.code//0) >= $t),
-        "gopls@claude-code-lsps":               ((.Go.code//0) >= $t)
-      }
-    }' > "$gate_file" || return 0
+    # Run tokei from the repo root, not cwd — otherwise launching cc/ccc/ccr
+    # from a subdir scans only that subdir and produces a wrong gate.
+    (cd "$repo_root" && lsp_gate_compute "${CC_LSP_GATE_THRESHOLD:-50}") \
+        | jq '{enabledPlugins: .}' > "$gate_file" || return 0
 
     echo "$gate_file"
 }
@@ -276,6 +274,11 @@ alias plugin-ls='claude plugin list'
 alias plugin-sync='$CLAUDE_DOTFILES/plugins/sync.sh'
 alias plugin-sync-dry='$CLAUDE_DOTFILES/plugins/sync.sh --dry-run'
 alias plugin-edit='${EDITOR:-vim} $CLAUDE_DOTFILES/plugins/registry.yaml'
+
+# Project-local LSP opt-in: writes tokei-driven enabledPlugins into
+# .claude/settings.local.json (gitignored). LSPs are off in user-level
+# settings by default; run this once per project that needs them.
+alias cc-lsp-local='$DOTFILES_DIR/bin/cc-lsp-local'
 
 # Refresh a local plugin's cache so edits in the source dir take effect.
 # Claude Code copies plugins into ~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/


### PR DESCRIPTION
## Summary

Cherry-picked LSP subset of #136 (closed). Stops loading all 6 LSP plugins by default; sessions opt in two ways. Includes a small bug fix and bats coverage.

### Default state flip

`claude/settings.json` and `claude/plugins/registry.yaml` flip 6 LSP plugins from `enabled/load: true → false`. After merge, **raw `claude` invocations get zero LSPs**; only `cc`/`ccc`/`ccr`/`ccp` (and projects you've run `cc-lsp-local` in) get LSPs.

### Two opt-in paths

- **Ephemeral, per session** (already on main, behavior preserved): `cc` / `ccc` / `ccr` / `ccp <profile>` invoke `_cc_lsp_gate`, which runs tokei against the repo and writes a tmp `--settings` file enabling LSPs above threshold.
- **Persistent, per project** (new): `bin/cc-lsp-local` writes/merges `enabledPlugins` into `<project>/.claude/settings.local.json` (gitignored). Flags: `--dry-run`, `--print`, `--threshold N`. Env: `CC_LSP_GATE_THRESHOLD`. Threshold defaults to 50 code lines per language.

### Refactor

Extracted the duplicated tokei→jq mapping into `claude/lib/lsp-gate.sh::lsp_gate_compute`. Both `_cc_lsp_gate` (zsh) and `cc-lsp-local` (bash) source it. Single source of truth for the language → plugin mapping.

### Bug fix

Both callers now `cd` to the git root before running tokei. Previously tokei ran from cwd, so launching `cc` or `cc-lsp-local` from a subdirectory scanned only that subdir and produced a wrong gate. The settings file always got written to the repo root, so the discrepancy was silent.

### Tests

`tests/lsp-gate-lib.bats` (16 tests) covers the pure helper — shape, threshold defaults (50), 999999 disables all, 1 enables all, per-plugin language mapping (including the `BASH+Shell+Zsh` and `JS+TS+TSX+JSX` sums), missing buckets default to disabled, and the tokei-missing failure mode. Added to `run-tests.sh`.

Existing `tests/claude-lsp-gate.bats` still passes (the 4 `ccp` failures are pre-existing on main, not caused by this PR — verified by stashing the diff and re-running).

### Docs

Every "All N LSP plugins are enabled globally" reference updated:
- `claude/CLAUDE.md`, `AGENTS.md`
- `claude/skills/lsp/SKILL.md`
- `claude/commands/fromage.md`
- `claude/agents/{cheese-factory, fromage-cook, fromage-culture, fromage-press, ricotta-reducer, roquefort-wrecker}.md`
- `claude/plugins/registry.yaml` (comment block)

## Things to verify before merging

- [ ] **Conductor / IDE / other launchers**: do any paths spawn raw `claude` instead of going through `cc`? If so, those sessions will silently lose LSP after this lands. Migration is to seed `.claude/settings.local.json` in the affected repos via `cc-lsp-local`.
- [ ] **`ccw` worktrees**: confirm `ccw-init` routes through `cc` (not raw `claude`).

## Test plan

- [x] `bats tests/lsp-gate-lib.bats` — 16/16 green
- [x] `bats tests/claude-lsp-gate.bats` — same status as main (pre-existing ccp failures)
- [x] `cc-lsp-local --print` from this repo → bash/vtsls/yaml/pyright enabled, rust/go disabled (correct for a shell-heavy repo)
- [x] `cc-lsp-local --dry-run` from `/tmp` (non-git) → falls back to cwd, doesn't crash
- [ ] After merge: `dots sync`, then `cc-lsp-local` in a real project, confirm `.claude/settings.local.json` is correct, restart Claude, LSP tool returns hover/refs

🤖 Generated with [Claude Code](https://claude.com/claude-code)