### PR TITLE
fix(packages): pin rtk to master branch

### DIFF
--- a/packages.yaml
+++ b/packages.yaml
@@ -93,5 +93,6 @@ packages:
   # Install from Git because the crates.io `rtk` collides with the desired package.
   # If an unrelated `rtk` is already present from `cargo install rtk`, remove it first
   # so `dots sync` does not incorrectly treat the Git-sourced package as already satisfied.
-  - rtk: { source: cargo, git: "https://github.com/rtk-ai/rtk" }
+  # Pin to `master` (stable releases); the default branch `develop` lags behind.
+  - rtk: { source: cargo, git: "https://github.com/rtk-ai/rtk", branch: master }
   - qdrant: { source: cargo, dev: true }

--- a/packages/sync.sh
+++ b/packages/sync.sh
@@ -176,7 +176,7 @@ sync_brew() {
 
 sync_cargo() {
     local cargo_pkgs
-    cargo_pkgs=$(yq -r '.packages[] | select(kind == "map") | to_entries[0] | select(.value.source == "cargo") | [.key, (.value.git // "")] | @tsv' "$PACKAGES_FILE" 2>/dev/null)
+    cargo_pkgs=$(yq -r '.packages[] | select(kind == "map") | to_entries[0] | select(.value.source == "cargo") | [.key, (.value.git // ""), (.value.branch // "")] | @tsv' "$PACKAGES_FILE" 2>/dev/null)
     [[ -z "$cargo_pkgs" ]] && return 0
 
     if ! command -v cargo &>/dev/null; then
@@ -210,7 +210,7 @@ sync_cargo() {
     installed=$(cargo install --list 2>/dev/null | grep -E '^\S' | cut -d' ' -f1 || true)
     upgrade="${UPGRADE_MODE:-false}"
 
-    while IFS=$'\t' read -r name git_url; do
+    while IFS=$'\t' read -r name git_url branch; do
         [[ -z "$name" ]] && continue
         local already=false
         echo "$installed" | grep -qx "$name" && already=true
@@ -227,10 +227,13 @@ sync_cargo() {
             install_args+=(--force)
         fi
         [[ -n "$git_url" ]] && install_args+=(--git "$git_url")
+        [[ -n "$branch" ]] && install_args+=(--branch "$branch")
         install_args+=("$name")
 
         if [[ -n "$git_url" ]]; then
-            echo "  $action $name from $git_url..."
+            local source_desc="$git_url"
+            [[ -n "$branch" ]] && source_desc="$source_desc#$branch"
+            echo "  $action $name from $source_desc..."
         else
             echo "  $action $name..."
         fi

--- a/packages/sync.sh
+++ b/packages/sync.sh
@@ -226,6 +226,11 @@ sync_cargo() {
             action="Upgrading"
             install_args+=(--force)
         fi
+        if [[ -n "$branch" && -z "$git_url" ]]; then
+            log_error "Invalid cargo package config for $name: branch requires git_url"
+            FAILED+=("$name")
+            continue
+        fi
         [[ -n "$git_url" ]] && install_args+=(--git "$git_url")
         [[ -n "$branch" ]] && install_args+=(--branch "$branch")
         install_args+=("$name")


### PR DESCRIPTION
## Summary

`rtk-ai/rtk`'s default branch (`develop`) lags behind stable releases on `master`. Because `packages.yaml` only specified the git URL, cargo installed from the default branch — which silently regressed rtk from **0.38.0 → 0.34.3** during a recent `dots upgrade`.

This PR:
- Adds an optional `branch:` field to cargo entries in `packages.yaml` (yq query in `packages/sync.sh` now extracts a 3rd column and passes `--branch` to `cargo install` when present).
- Pins rtk to `branch: master`, which is currently at v0.39.0.
- Updates the log line to surface the branch as `<url>#<branch>` for visibility on subsequent upgrades.

## Why this matters

`cargo install --git <url>` without `--branch` checks out the default branch HEAD. For rtk-ai/rtk, default is `develop` (in-flight work at an older version number); stable releases live on `master`. The pin locks future `dots upgrade` runs to the stable line.

## Test plan

- [x] `shellcheck packages/sync.sh` — passed via prek hook
- [x] `bash packages/sync.sh` with `UPGRADE_MODE=true` — reinstalled rtk from `master`, log line shows `https://github.com/rtk-ai/rtk#master`
- [x] `rtk --version` post-install — reports `0.39.0`
- [x] Other cargo packages (`cargo-llvm-cov`, `tilth`, `qdrant`) without `branch:` field still install correctly — empty 3rd column path is exercised
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)