### PR TITLE
feat(code-review-graph): launchd boot + ~/Dev/* watch list sync

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -284,6 +284,17 @@ Tiling window manager + hotkey daemon for macOS, installed from the `koekeishiya
 - **First-time setup**: grant Accessibility (and optionally Screen Recording) to `yabai` and `skhd` in System Settings → Privacy & Security after `dots sync`.
 - **SIP**: opacity, removing title bars, and cross-space window movement require SIP partially disabled. The basic tile/focus/swap loop works with SIP on.
 
+### Code Review Graph Daemon (macOS)
+
+`code-review-graph` (uv tool) ships a persistent knowledge-graph daemon that watches per-repo working trees and feeds the matching MCP server. Boot-time start + repo discovery are handled by `code-review-graph/.sync`:
+
+- **launchd agent**: `code-review-graph/com.coderevgraph.daemon.plist.tmpl` is rendered (substituting `__HOME__` / `__CRG_BIN__`) into `~/Library/LaunchAgents/com.coderevgraph.daemon.plist`. `RunAtLoad=true`, `KeepAlive` on crash. The plist sets `OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES` — without it the daemon's per-repo watcher forks crash on the macOS CoreFoundation fork-safety check.
+- **Repo discovery**: `discover_dev_repos` (in `sync-lib.sh`) walks `~/Dev/*` and emits `<path>\t<alias>` for every git repo (skips symlinks, dotfiles, non-git dirs). `diff_repo_sets` produces ADD/REMOVE deltas against `code-review-graph repos` output; `.sync` calls `register`/`unregister` + `daemon add`/`remove` to reconcile.
+- **Bouncing**: the launchd agent is restarted only when either the plist content or the watch list changes (via the per-repo CLI calls). Restart sequence is `daemon stop` → `pkill` orphan watchers → `launchctl bootout` → `cp` plist → `launchctl bootstrap`. Reconciliation always runs before the bounce so the daemon reads the final config at startup.
+- **Logs**: launchd-managed stdout/stderr at `~/.code-review-graph/logs/launchd.{out,err}.log`; per-watcher logs in the same dir.
+- **Gotcha**: `code-review-graph daemon status` looks at `~/.code-review-graph/daemon.pid`, which `--foreground` mode does NOT write. So `daemon status` will report "not running" even when launchd has the daemon up — use `launchctl print gui/$UID/com.coderevgraph.daemon` or `/bin/ps` to verify.
+- **Override `~/Dev` root**: set `CRG_DEV_ROOT=/some/other/path` before running `.sync` to point at a different repo root.
+
 ## Pre-Commit Hooks (prek)
 
 Pre-commit hooks are managed by [prek](https://prek.j178.dev/) via `prek.toml`. Hooks run automatically on commit and include: trailing whitespace, secret detection, shellcheck, large file checks, and a claude config sync check. Run `prek install` after cloning to set up hooks.

--- a/code-review-graph/.sync
+++ b/code-review-graph/.sync
@@ -1,0 +1,90 @@
+#!/bin/bash
+# Install launchd agent for code-review-graph daemon and sync
+# ~/Dev/* git repos into its watch list.
+#
+# Skipped on non-macOS. Idempotent: re-running reconciles the watch list
+# (add new repos, remove ones that have disappeared) and reloads the
+# launchd agent only when the plist content changes.
+
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+    echo "code-review-graph/.sync: skipping (not macOS)" >&2
+    exit 0
+fi
+
+readonly SCRIPT_DIR="$(cd "${BASH_SOURCE%/*}" && pwd)"
+# shellcheck source=sync-lib.sh
+source "$SCRIPT_DIR/sync-lib.sh"
+
+readonly DEV_ROOT="${CRG_DEV_ROOT:-$HOME/Dev}"
+readonly LAUNCH_AGENTS="$HOME/Library/LaunchAgents"
+readonly PLIST_NAME="com.coderevgraph.daemon.plist"
+readonly PLIST_TARGET="$LAUNCH_AGENTS/$PLIST_NAME"
+readonly PLIST_TEMPLATE="$SCRIPT_DIR/com.coderevgraph.daemon.plist.tmpl"
+
+if ! command -v code-review-graph >/dev/null 2>&1; then
+    echo "code-review-graph/.sync: code-review-graph not installed (run dots sync to install)" >&2
+    exit 0
+fi
+
+mkdir -p "$LAUNCH_AGENTS" "$HOME/.code-review-graph/logs"
+
+tmp_plist="$(mktemp)"
+desired_file="$(mktemp)"
+current_file="$(mktemp)"
+trap 'rm -f "$tmp_plist" "$desired_file" "$current_file"' EXIT
+
+# 1. Reconcile watch list with ~/Dev/* git repos. Done BEFORE bootstrapping
+# the launchd agent so the daemon reads the final config at startup.
+discover_dev_repos "$DEV_ROOT" > "$desired_file"
+# Format: "  <path>  (<alias>)" — strip leading whitespace, convert " (alias)" tail to "\talias"
+code-review-graph repos 2>/dev/null \
+    | sed -E 's/^[[:space:]]+//; s/  \(([^)]+)\)$/\t\1/' \
+    > "$current_file"
+
+added=0
+removed=0
+while IFS=$'\t' read -r op a b; do
+    case "$op" in
+        ADD)
+            if code-review-graph register --alias "$b" "$a" >/dev/null 2>&1; then
+                code-review-graph daemon add --alias "$b" "$a" >/dev/null 2>&1 || true
+                echo "  + $b ($a)"
+                added=$((added + 1))
+            fi
+            ;;
+        REMOVE)
+            code-review-graph daemon remove "$a" >/dev/null 2>&1 || true
+            code-review-graph unregister "$a" >/dev/null 2>&1 || true
+            echo "  - $a"
+            removed=$((removed + 1))
+            ;;
+    esac
+done < <(diff_repo_sets "$desired_file" "$current_file")
+
+# 2. Render plist; only swap in if content differs (avoids unnecessary bounces).
+if ! render_plist "$PLIST_TEMPLATE" "$tmp_plist"; then
+    echo "code-review-graph/.sync: failed to render plist (template or binary missing)" >&2
+    exit 1
+fi
+
+plist_changed=true
+[[ -f "$PLIST_TARGET" ]] && cmp -s "$tmp_plist" "$PLIST_TARGET" && plist_changed=false
+
+# Need a bounce if the plist content changed OR the watch list changed
+# (so the daemon re-reads it). No-op only when nothing's moved.
+if $plist_changed || (( added + removed > 0 )); then
+    # Kill any pre-launchd daemon + orphan watcher processes; ignore failures.
+    code-review-graph daemon stop >/dev/null 2>&1 || true
+    pkill -f 'code-review-graph (daemon start|watch --repo)' 2>/dev/null || true
+    launchctl bootout "gui/$(id -u)/com.coderevgraph.daemon" 2>/dev/null || true
+    cp "$tmp_plist" "$PLIST_TARGET"
+    launchctl bootstrap "gui/$(id -u)" "$PLIST_TARGET"
+    echo "code-review-graph/.sync: launchd agent (re)started"
+else
+    echo "code-review-graph/.sync: launchd agent up-to-date"
+fi
+
+watched=$(wc -l < "$desired_file" | tr -d ' ')
+echo "code-review-graph/.sync: watching $watched repos under $DEV_ROOT (+$added -$removed)"

--- a/code-review-graph/com.coderevgraph.daemon.plist.tmpl
+++ b/code-review-graph/com.coderevgraph.daemon.plist.tmpl
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.coderevgraph.daemon</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__CRG_BIN__</string>
+        <string>daemon</string>
+        <string>start</string>
+        <string>--foreground</string>
+    </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__HOME__/.local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <!-- macOS CoreFoundation kills python multiprocessing forks unless this is set. -->
+        <!-- The daemon spawns one watcher subprocess per repo, so without this every -->
+        <!-- child crashes on the fork-without-exec safety check. -->
+        <key>OBJC_DISABLE_INITIALIZE_FORK_SAFETY</key>
+        <string>YES</string>
+    </dict>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+        <key>Crashed</key>
+        <true/>
+    </dict>
+    <key>WorkingDirectory</key>
+    <string>__HOME__</string>
+    <key>StandardOutPath</key>
+    <string>__HOME__/.code-review-graph/logs/launchd.out.log</string>
+    <key>StandardErrorPath</key>
+    <string>__HOME__/.code-review-graph/logs/launchd.err.log</string>
+    <key>ProcessType</key>
+    <string>Background</string>
+</dict>
+</plist>

--- a/code-review-graph/sync-lib.sh
+++ b/code-review-graph/sync-lib.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# code-review-graph/sync-lib.sh
+# Testable functions for the code-review-graph daemon sync.
+# Sourced by .sync and by tests/code-review-graph.bats.
+
+# Emit tab-separated <path>\t<alias> lines for each git repo found
+# directly under <root>. Skips: non-dirs, symlinks, dotfiles (.foo),
+# and any directory without a .git entry.
+#
+# Usage: discover_dev_repos <root_dir>
+discover_dev_repos() {
+    local root="$1"
+    [[ -d "$root" ]] || return 0
+    local entry name
+    for entry in "$root"/*; do
+        [[ -d "$entry" ]] || continue
+        [[ -L "$entry" ]] && continue
+        name="${entry##*/}"
+        [[ "$name" == .* ]] && continue
+        [[ -e "$entry/.git" ]] || continue
+        printf '%s\t%s\n' "$entry" "$name"
+    done
+}
+
+# Given the desired repos (tab-separated path\talias on stdin) and the
+# currently-watched repos (same format on FD 3), emit two streams:
+#   ADD\t<path>\t<alias>      for repos in desired but not current
+#   REMOVE\t<alias>           for repos in current but not desired
+#
+# Usage: diff_repo_sets <(desired) <(current)
+diff_repo_sets() {
+    local desired_file="$1" current_file="$2"
+    local d_path d_alias _c_path c_alias
+    while IFS=$'\t' read -r d_path d_alias; do
+        [[ -z "$d_alias" ]] && continue
+        if ! grep -qE "^[^	]+	${d_alias}$" "$current_file" 2>/dev/null; then
+            printf 'ADD\t%s\t%s\n' "$d_path" "$d_alias"
+        fi
+    done < "$desired_file"
+    while IFS=$'\t' read -r _c_path c_alias; do
+        [[ -z "$c_alias" ]] && continue
+        if ! grep -qE "^[^	]+	${c_alias}$" "$desired_file" 2>/dev/null; then
+            printf 'REMOVE\t%s\n' "$c_alias"
+        fi
+    done < "$current_file"
+}
+
+# Render the launchd plist template, substituting __HOME__ and __CRG_BIN__.
+# Reads template path on $1, writes resolved plist to $2.
+render_plist() {
+    local template="$1" target="$2" home_dir="${3:-$HOME}" crg_bin="${4:-}"
+    [[ -f "$template" ]] || return 1
+    [[ -n "$crg_bin" ]] || crg_bin="$(command -v code-review-graph || true)"
+    [[ -n "$crg_bin" ]] || return 2
+    sed -e "s|__HOME__|${home_dir}|g" -e "s|__CRG_BIN__|${crg_bin}|g" "$template" > "$target"
+}

--- a/justfile
+++ b/justfile
@@ -12,6 +12,7 @@ lint-shell:
     shellcheck -x -e SC1091 bin/* .sync .sync-with-rollback
     shellcheck -x -e SC1091 -s bash claude/mcp/sync.sh claude/plugins/sync.sh claude/lib/sync-common.sh claude/lib/cheese-flair.sh
     shellcheck -x -e SC1091 -s bash claude/hooks/session-start-cheese-flair.sh
+    shellcheck -x -e SC1091,SC2155 -s bash code-review-graph/.sync code-review-graph/sync-lib.sh
     shellcheck -x -e SC1091 -s bash tests/run-tests.sh tests/install-bats.sh
     @echo "shellcheck: ok"
 

--- a/tests/code-review-graph.bats
+++ b/tests/code-review-graph.bats
@@ -1,0 +1,152 @@
+#!/usr/bin/env bats
+# Unit tests for code-review-graph/sync-lib.sh
+#
+# Covers the pure-bash helpers that .sync depends on:
+#   - discover_dev_repos: scans ~/Dev/* and emits path\talias for git repos
+#   - diff_repo_sets: produces ADD/REMOVE deltas between desired and current
+#   - render_plist: substitutes __HOME__ and __CRG_BIN__ into the template
+
+load test_helper
+
+CRG_LIB="$REAL_DOTFILES_DIR/code-review-graph/sync-lib.sh"
+PLIST_TMPL="$REAL_DOTFILES_DIR/code-review-graph/com.coderevgraph.daemon.plist.tmpl"
+
+setup() {
+    setup_test_env
+    DEV="$TEST_HOME/Dev"
+    mkdir -p "$DEV"
+    # shellcheck source=../code-review-graph/sync-lib.sh
+    source "$CRG_LIB"
+}
+
+teardown() {
+    teardown_test_env
+}
+
+# --- discover_dev_repos ---
+
+@test "discover_dev_repos: finds git repos, skips non-git dirs" {
+    mkdir -p "$DEV/repo-a/.git" "$DEV/repo-b/.git" "$DEV/not-a-repo"
+    run discover_dev_repos "$DEV"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"$DEV/repo-a	repo-a"* ]]
+    [[ "$output" == *"$DEV/repo-b	repo-b"* ]]
+    [[ "$output" != *"not-a-repo"* ]]
+}
+
+@test "discover_dev_repos: handles .git as a file (worktree linked)" {
+    mkdir -p "$DEV/wt-repo"
+    echo "gitdir: /elsewhere/.git/worktrees/foo" > "$DEV/wt-repo/.git"
+    run discover_dev_repos "$DEV"
+    [[ "$output" == *"$DEV/wt-repo	wt-repo"* ]]
+}
+
+@test "discover_dev_repos: skips symlinks" {
+    mkdir -p "$DEV/real-repo/.git"
+    ln -s "$DEV/real-repo" "$DEV/linked-repo"
+    run discover_dev_repos "$DEV"
+    [[ "$output" == *"real-repo"* ]]
+    [[ "$output" != *"linked-repo"* ]]
+}
+
+@test "discover_dev_repos: skips dotfiles (names starting with .)" {
+    mkdir -p "$DEV/.worktrees/foo/.git" "$DEV/visible/.git"
+    run discover_dev_repos "$DEV"
+    [[ "$output" == *"visible"* ]]
+    [[ "$output" != *".worktrees"* ]]
+}
+
+@test "discover_dev_repos: skips regular files" {
+    touch "$DEV/README.md"
+    mkdir -p "$DEV/real/.git"
+    run discover_dev_repos "$DEV"
+    [[ "$output" == *"real"* ]]
+    [[ "$output" != *"README.md"* ]]
+}
+
+@test "discover_dev_repos: returns empty when root has no git repos" {
+    mkdir -p "$DEV/random-stuff"
+    run discover_dev_repos "$DEV"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "discover_dev_repos: returns empty when root does not exist" {
+    run discover_dev_repos "$TEST_HOME/nonexistent"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+# --- diff_repo_sets ---
+
+@test "diff_repo_sets: emits ADD for repos only in desired" {
+    desired="$TEST_HOME/d"; current="$TEST_HOME/c"
+    printf '%s\t%s\n' "/Dev/a" "a" "/Dev/b" "b" > "$desired"
+    printf '%s\t%s\n' "/Dev/a" "a" > "$current"
+    run diff_repo_sets "$desired" "$current"
+    [[ "$output" == *"ADD	/Dev/b	b"* ]]
+    [[ "$output" != *"ADD	/Dev/a"* ]]
+    [[ "$output" != *"REMOVE"* ]]
+}
+
+@test "diff_repo_sets: emits REMOVE for repos only in current" {
+    desired="$TEST_HOME/d"; current="$TEST_HOME/c"
+    printf '%s\t%s\n' "/Dev/a" "a" > "$desired"
+    printf '%s\t%s\n' "/Dev/a" "a" "/Dev/gone" "gone" > "$current"
+    run diff_repo_sets "$desired" "$current"
+    [[ "$output" == *"REMOVE	gone"* ]]
+    [[ "$output" != *"ADD"* ]]
+}
+
+@test "diff_repo_sets: handles both ADD and REMOVE in one pass" {
+    desired="$TEST_HOME/d"; current="$TEST_HOME/c"
+    printf '%s\t%s\n' "/Dev/new" "new" "/Dev/keep" "keep" > "$desired"
+    printf '%s\t%s\n' "/Dev/old" "old" "/Dev/keep" "keep" > "$current"
+    run diff_repo_sets "$desired" "$current"
+    [[ "$output" == *"ADD	/Dev/new	new"* ]]
+    [[ "$output" == *"REMOVE	old"* ]]
+    [[ "$output" != *"keep"* ]]
+}
+
+@test "diff_repo_sets: empty desired drops everything" {
+    desired="$TEST_HOME/d"; current="$TEST_HOME/c"
+    : > "$desired"
+    printf '%s\t%s\n' "/Dev/x" "x" "/Dev/y" "y" > "$current"
+    run diff_repo_sets "$desired" "$current"
+    [[ "$output" == *"REMOVE	x"* ]]
+    [[ "$output" == *"REMOVE	y"* ]]
+}
+
+@test "diff_repo_sets: identical sets yield no output" {
+    desired="$TEST_HOME/d"; current="$TEST_HOME/c"
+    printf '%s\t%s\n' "/Dev/a" "a" "/Dev/b" "b" > "$desired"
+    cp "$desired" "$current"
+    run diff_repo_sets "$desired" "$current"
+    [ -z "$output" ]
+}
+
+# --- render_plist ---
+
+@test "render_plist: substitutes __HOME__ and __CRG_BIN__" {
+    out="$TEST_HOME/out.plist"
+    run render_plist "$PLIST_TMPL" "$out" "/Users/test" "/opt/fake/crg"
+    [ "$status" -eq 0 ]
+    [ -f "$out" ]
+    grep -q "/Users/test/.code-review-graph/logs/launchd.out.log" "$out"
+    grep -q "<string>/opt/fake/crg</string>" "$out"
+    run grep -c "__HOME__" "$out"
+    [ "$output" = "0" ]
+    run grep -c "__CRG_BIN__" "$out"
+    [ "$output" = "0" ]
+}
+
+@test "render_plist: returns 1 when template missing" {
+    run render_plist "$TEST_HOME/nope.tmpl" "$TEST_HOME/out.plist" "/Users/x" "/usr/bin/crg"
+    [ "$status" -eq 1 ]
+}
+
+@test "render_plist: returns 2 when binary cannot be resolved" {
+    # Restricted PATH that won't contain code-review-graph + empty explicit binary
+    run env PATH="/usr/bin:/bin" bash -c "source '$CRG_LIB'; render_plist '$PLIST_TMPL' '$TEST_HOME/out.plist' '/Users/x' ''"
+    [ "$status" -eq 2 ]
+}

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -74,7 +74,7 @@ run_tests() {
     if [[ -n "$SPECIFIC_TEST" ]]; then
         test_files="$SPECIFIC_TEST"
     else
-        test_files="dots-simple.bats dots.bats git-hooks.bats sync.bats config-validation.bats prompt.bats sync-claude.bats sync-rollback.bats hooks-blockers.bats hooks-session.bats iterm2-fonts.bats worktree-settings.bats copilot-sync.bats skills-install.bats sync-skills.bats packages.bats cheese-flair.bats"
+        test_files="dots-simple.bats dots.bats git-hooks.bats sync.bats config-validation.bats prompt.bats sync-claude.bats sync-rollback.bats hooks-blockers.bats hooks-session.bats iterm2-fonts.bats worktree-settings.bats copilot-sync.bats skills-install.bats sync-skills.bats packages.bats cheese-flair.bats code-review-graph.bats"
     fi
 
     # Count total tests


### PR DESCRIPTION
## Summary

Two related additions for the `code-review-graph` daemon:

1. **Auto-start at boot** via a macOS `LaunchAgent`. Keeps the daemon alive across crashes; restarts at login.
2. **Auto-sync `~/Dev/*`** into the daemon's watch list + registry on every `dots sync`. Adds new git repos, removes ones that have disappeared.

## What's in here

| File | Role |
|------|------|
| `code-review-graph/com.coderevgraph.daemon.plist.tmpl` | launchd plist template. `__HOME__` / `__CRG_BIN__` placeholders are rendered at sync time so cross-machine sync works (no hard-coded `/Users/paul`). |
| `code-review-graph/sync-lib.sh` | Three pure-bash helpers: `discover_dev_repos`, `diff_repo_sets`, `render_plist`. Sourced by both `.sync` and the bats tests, per the project rule that `.sync` orchestrators stay thin and dispatch to tested functions. |
| `code-review-graph/.sync` | Reconciles `watch.toml` + `registry.json` from `~/Dev/*`, then bootstraps or bounces the launchd agent only when the plist content or watch list actually changed. |
| `tests/code-review-graph.bats` | 15 unit tests covering discovery edge cases (symlinks, dotfiles, `.git`-as-file linked worktrees, missing root), ADD/REMOVE diff semantics, and plist substitution. |
| `AGENTS.md` | New "Code Review Graph Daemon" subsection covering wiring, gotchas, and the `CRG_DEV_ROOT` override. |
| `justfile` | Adds the two new shell files to the `lint-shell` target. |
| `tests/run-tests.sh` | Registers the new bats file in the suite. |

## Non-obvious design notes

- **Fork safety env var**: the plist explicitly sets `OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES`. Without this, macOS's CoreFoundation fork-safety check kills every per-repo watcher subprocess. A shell-launched daemon doesn't hit this because user shells inherit a permissive env; launchd does not.
- **Reconcile-before-bounce ordering**: the script reconciles `watch.toml` (via `code-review-graph daemon add` / `remove` and `register` / `unregister`) *before* bootstrapping launchd. The daemon reads `watch.toml` once at startup and does not hot-reload, so adding a repo to an already-running daemon would leave that repo unwatched until the next bounce.
- **Conditional bounce**: the launchctl `bootout` + `bootstrap` only runs when either the plist content changed *or* the watch list changed. Steady-state `dots sync` is a no-op.
- **`daemon status` lies**: `code-review-graph daemon status` consults `~/.code-review-graph/daemon.pid`, which `--foreground` mode does NOT write. So it will report "not running" even when launchd has the daemon up. Use `launchctl print gui/$UID/com.coderevgraph.daemon` or `/bin/ps` to verify. Documented in AGENTS.md.
- **Full sync (not add-only)**: confirmed with the user — repos that disappear from `~/Dev` get removed from the watch list and registry on next sync.

## Test plan

- [x] `bats tests/code-review-graph.bats` — all 15 pass
- [x] `just lint-shell` — clean
- [x] End-to-end verified locally: ran `bash code-review-graph/.sync`, confirmed:
  - Plist installed at `~/Library/LaunchAgents/com.coderevgraph.daemon.plist`
  - Agent bootstrapped (`launchctl print gui/$UID/com.coderevgraph.daemon` shows `state = running`)
  - One daemon process + 5 watcher processes for the 5 git repos under `~/Dev/`
  - `multiplier-pre-push-test` (previously missing from the watch list) was added correctly
  - Re-running `.sync` is a no-op (`+0 -0`, no bounce)
- [ ] Cross-machine: untested on a second mac. The plist template substitutes `__HOME__` so it should be portable; please verify on your other Apple silicon mac before merging if you sync there.
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)