### PR TITLE
feat(sync): auto-prune stale ~/.claude.json project entries

### DIFF
--- a/claude/.sync
+++ b/claude/.sync
@@ -119,4 +119,13 @@ else
   echo "  Skipping MCP/plugin sync (claude CLI not found)"
 fi
 
+# Drop stale per-project entries from ~/.claude.json (worktrees that no
+# longer exist on disk). The pruner takes a timestamped backup before
+# touching the file, so failures are recoverable.
+prune_script="$SOURCE_DIR/../bin/claude-json-prune"
+if [[ -x "$prune_script" && -f "$HOME/.claude.json" ]]; then
+  echo "  Pruning stale ~/.claude.json project entries..."
+  "$prune_script" --apply || echo "  WARN: claude-json-prune failed (non-fatal)" >&2
+fi
+
 echo "Claude config synced"


### PR DESCRIPTION
## Summary

\`dots sync\` now invokes \`bin/claude-json-prune --apply\` at the end of \`claude/.sync\`, dropping per-project entries whose directory no longer exists on disk.

## Why

After a typical week of multiplier worktree churn the file accumulates dead entries (e.g. \`gallant-poincare-5a9ca9\` that I noticed today). The pruner already exists and is well-tested (\`tests/claude-json-prune.bats\`) — just wire it into the sync flow so it runs automatically.

## Safety

- Pruner takes a timestamped backup to \`~/.local/state/dotfiles/backups/claude.json.<timestamp>\` before touching the file.
- Failure is non-fatal — sync prints a WARN and continues.
- Only acts on entries where the cwd path no longer exists (no heuristics, no false positives on temporarily-disconnected dirs unless their cwd was deleted).

## Test plan

- [ ] \`bash claude/.sync\` on a working dotfiles checkout still completes green
- [ ] \`~/.local/state/dotfiles/backups/claude.json.*\` appears after first run
- [ ] Stale worktree entries (cwd missing) get dropped on next \`dots sync\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)