### PR TITLE
fix(chezmoi): use current checkout for apply, not stale config sourceDir

### DIFF
--- a/chezmoi/.sync
+++ b/chezmoi/.sync
@@ -32,21 +32,20 @@ EOF
     echo "  Wrote chezmoi.toml -> sourceDir=$script_dir"
 fi
 
-# Trigger chezmoi apply so the run_onchange skill installer runs whenever
-# the dotfiles/skills tree changes. Non-fatal — if chezmoi rejects
-# the user's sourceDir override or any other config edit, dots sync still
-# wires everything else.
+# Trigger chezmoi apply from this checkout so workspace syncs use the source
+# tree that launched dots sync, not a stale sourceDir preserved in
+# ~/.config/chezmoi/chezmoi.toml. Non-fatal — if chezmoi rejects the source or
+# any user config edit, dots sync still wires everything else.
 #
 # Stream output live (sed indent, set -o pipefail preserves chezmoi's exit
-# code). The skill installer runs serial `gh skill install` per
-# (source × skill × harness); without live output the user sees nothing
-# for the multi-minute install loop.
+# code). Some run_onchange scripts can take a while, so live output avoids an
+# apparently hung dots sync.
 if command -v chezmoi &>/dev/null; then
-    if chezmoi apply --force 2>&1 | sed 's/^/  /'; then
+    if chezmoi --source "$script_dir" apply --force 2>&1 | sed 's/^/  /'; then
         echo "  chezmoi apply complete"
     else
-        echo "  WARN: chezmoi apply failed (skills may be out of sync)" >&2
+        echo "  WARN: chezmoi apply failed (chezmoi-managed files may be out of sync)" >&2
     fi
 else
-    echo "  Skipping chezmoi apply (chezmoi not installed); skills will not sync"
+    echo "  Skipping chezmoi apply (chezmoi not installed); chezmoi-managed files will not sync"
 fi

--- a/tests/chezmoi-wiring.bats
+++ b/tests/chezmoi-wiring.bats
@@ -55,6 +55,32 @@ EOF
     grep -qF 'sourceDir = "/some/user/override"' "$config"
 }
 
+@test "chezmoi/.sync applies from current checkout even when config has an old sourceDir" {
+    local fake_bin="$TEST_HOME/fake-bin"
+    mkdir -p "$fake_bin"
+    cat > "$fake_bin/chezmoi" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$HOME/chezmoi-args.log"
+exit 0
+SH
+    chmod +x "$fake_bin/chezmoi"
+
+    local config="$HOME/.config/chezmoi/chezmoi.toml"
+    mkdir -p "$(dirname "$config")"
+    cat > "$config" <<'EOF'
+sourceDir = "/some/stale/checkout/chezmoi"
+EOF
+
+    PATH="$fake_bin:$PATH"
+    run bash "$CHEZMOI_SYNC"
+    assert_success
+    grep -qF 'sourceDir = "/some/stale/checkout/chezmoi"' "$config"
+
+    local args
+    args=$(tr '\n' ' ' < "$HOME/chezmoi-args.log")
+    [[ "$args" == "--source $REAL_DOTFILES_DIR/chezmoi apply --force " ]]
+}
+
 @test "chezmoi/.sync cleans up its mktemp scratch file" {
     run bash "$CHEZMOI_SYNC"
     assert_success


### PR DESCRIPTION
## Summary

Fix `chezmoi/.sync` to use the current checkout's chezmoi directory instead of relying on a potentially stale `sourceDir` from `~/.config/chezmoi/chezmoi.toml`.

**Problem**: When `dots sync` runs from a different checkout, chezmoi could apply from a stale sourceDir preserved in the user's config, causing chezmoi-managed files to get wired from the wrong location.

**Solution**: Pass `--source $script_dir` to chezmoi apply, ensuring it always uses the source tree that launched dots sync.

## Changes

- **chezmoi/.sync**: Added `--source "$script_dir"` flag to chezmoi apply
- Updated comments to clarify the purpose and improve accuracy
- **tests/chezmoi-wiring.bats**: Added test to verify chezmoi uses current checkout even when config has stale sourceDir

## Test Plan

- [x] New test verifies chezmoi uses `--source` flag when config has stale sourceDir
- [x] Existing chezmoi tests still pass
