### PR TITLE
fix(mcp): mcp_detect_drift returns 0 when no entries drift

### DIFF
--- a/agents/mcp/lib.sh
+++ b/agents/mcp/lib.sh
@@ -215,8 +215,11 @@ mcp_detect_drift() {
             claude) current=$(mcp_claude_current_signature "$name") ;;
             codex)  current=$(mcp_codex_current_signature  "$name") ;;
         esac
-        [[ "$desired" != "$current" ]] && echo "$name"
+        if [[ "$desired" != "$current" ]]; then
+            echo "$name"
+        fi
     done <<<"$EXISTING"
+    return 0
 }
 
 # ─── per-harness orchestration ──────────────────────────────────────────

--- a/tests/mcp-lib.bats
+++ b/tests/mcp-lib.bats
@@ -1,0 +1,185 @@
+#!/usr/bin/env bats
+#
+# Regression tests for agents/mcp/lib.sh.
+#
+# Strategy: source sync-common.sh + lib.sh, populate HARNESS_DESIRED_JSON
+# and EXISTING by hand, mock `claude` / `codex` on PATH, then call the
+# helpers directly.
+#
+# Pins the bug where every-MCP-in-sync made `mcp_detect_drift` exit 1:
+# the trailing `[[ ... ]] && echo` short-circuited to 1 on no-drift, the
+# while loop adopted that as its exit code, the function returned 1, and
+# sync.sh's `to_update=$(mcp_detect_drift ...)` bare assignment tripped
+# `set -e`. chezmoi surfaced the symptom as
+#   "chezmoi: .chezmoiscripts/install-mcp.sh: exit status 1".
+
+load test_helper
+
+setup() {
+    setup_test_env
+
+    export MOCK_BIN="$TEST_HOME/bin"
+    mkdir -p "$MOCK_BIN"
+    export PATH="$MOCK_BIN:$PATH"
+
+    # shellcheck source=../claude/lib/sync-common.sh
+    source "$REAL_DOTFILES_DIR/claude/lib/sync-common.sh"
+    # shellcheck source=../agents/mcp/lib.sh
+    source "$REAL_DOTFILES_DIR/agents/mcp/lib.sh"
+}
+
+teardown() {
+    teardown_test_env
+}
+
+# Stub `claude mcp get NAME` to print the contents of CLAUDE_STUB_<NAME>.
+write_claude_stub() {
+    cat > "$MOCK_BIN/claude" << 'MOCK'
+#!/bin/bash
+if [[ "$1" == mcp && "$2" == get ]]; then
+    var="CLAUDE_STUB_$3"
+    printf '%s' "${!var:-}"
+    exit 0
+fi
+exit 0
+MOCK
+    chmod +x "$MOCK_BIN/claude"
+}
+
+# Stub `codex mcp list --json` to print $CODEX_STUB_JSON.
+write_codex_stub() {
+    cat > "$MOCK_BIN/codex" << 'MOCK'
+#!/bin/bash
+if [[ "$1" == mcp && "$2" == list ]]; then
+    printf '%s' "${CODEX_STUB_JSON:-[]}"
+    exit 0
+fi
+exit 0
+MOCK
+    chmod +x "$MOCK_BIN/codex"
+}
+
+@test "mcp_detect_drift (claude): all-in-sync returns 0 with no output (regression: was exit 1)" {
+    write_claude_stub
+
+    export EXISTING=$'foo\nbar'
+    export HARNESS_DESIRED_JSON='{
+      "foo": {"command": "npx", "args": ["-y", "foo-mcp"]},
+      "bar": {"command": "npx", "args": ["-y", "bar-mcp"]}
+    }'
+    export CLAUDE_STUB_foo='foo:
+  Command: npx
+  Args: -y foo-mcp
+  Environment:'
+    export CLAUDE_STUB_bar='bar:
+  Command: npx
+  Args: -y bar-mcp
+  Environment:'
+
+    run mcp_detect_drift claude
+    assert_success
+    [[ -z "$output" ]] || { echo "expected empty output, got: [$output]" >&2; return 1; }
+}
+
+@test "mcp_detect_drift (claude): drifted entry is emitted, function still returns 0" {
+    write_claude_stub
+
+    export EXISTING=$'foo\nbar'
+    export HARNESS_DESIRED_JSON='{
+      "foo": {"command": "npx", "args": ["-y", "foo-mcp-NEW"]},
+      "bar": {"command": "npx", "args": ["-y", "bar-mcp"]}
+    }'
+    export CLAUDE_STUB_foo='foo:
+  Command: npx
+  Args: -y foo-mcp
+  Environment:'
+    export CLAUDE_STUB_bar='bar:
+  Command: npx
+  Args: -y bar-mcp
+  Environment:'
+
+    run mcp_detect_drift claude
+    assert_success
+    assert_output_contains "foo"
+    assert_output_not_contains "bar"
+}
+
+@test "mcp_detect_drift: empty EXISTING returns 0 with no output" {
+    export EXISTING=""
+    export HARNESS_DESIRED_JSON='{}'
+
+    run mcp_detect_drift claude
+    assert_success
+    [[ -z "$output" ]] || { echo "expected empty output, got: [$output]" >&2; return 1; }
+}
+
+@test "mcp_detect_drift (codex): all-in-sync returns 0 with no output" {
+    write_codex_stub
+
+    export EXISTING=$'foo\nbar'
+    export HARNESS_DESIRED_JSON='{
+      "foo": {"command": "npx", "args": ["-y", "foo-mcp"]},
+      "bar": {"command": "npx", "args": ["-y", "bar-mcp"]}
+    }'
+    export CODEX_STUB_JSON='[
+      {"name": "foo", "transport": {"command": "npx", "args": ["-y", "foo-mcp"], "env": {}}},
+      {"name": "bar", "transport": {"command": "npx", "args": ["-y", "bar-mcp"], "env": {}}}
+    ]'
+
+    run mcp_detect_drift codex
+    assert_success
+    [[ -z "$output" ]] || { echo "expected empty output, got: [$output]" >&2; return 1; }
+}
+
+# End-to-end: the exact failure mode chezmoi reported. Drives sync.sh in
+# dry-run with both harnesses in sync — pre-fix this hit exit 1 silently,
+# now it must print "Sync complete!" and exit 0.
+@test "sync.sh --dry-run: all-in-sync exits 0 (regression: chezmoi install-mcp.sh exit 1)" {
+    write_claude_stub
+    write_codex_stub
+
+    export CLAUDE_STUB_foo='foo:
+  Command: npx
+  Args: -y foo-mcp
+  Environment:'
+    export CODEX_STUB_JSON='[
+      {"name": "foo", "transport": {"command": "npx", "args": ["-y", "foo-mcp"], "env": {}}}
+    ]'
+
+    # `claude mcp list` (used by mcp_claude_list_current) needs to enumerate
+    # configured names. Override the stub to handle both `get` and `list`.
+    cat > "$MOCK_BIN/claude" << 'MOCK'
+#!/bin/bash
+if [[ "$1" == mcp && "$2" == list ]]; then
+    echo "foo: npx -y foo-mcp"
+    exit 0
+fi
+if [[ "$1" == mcp && "$2" == get ]]; then
+    var="CLAUDE_STUB_$3"
+    printf '%s' "${!var:-}"
+    exit 0
+fi
+exit 0
+MOCK
+    chmod +x "$MOCK_BIN/claude"
+
+    # Stand up a minimal registry the script can read.
+    local fake_dotfiles="$TEST_HOME/fake-dotfiles"
+    mkdir -p "$fake_dotfiles/agents/mcp" "$fake_dotfiles/claude/lib"
+    cp "$REAL_DOTFILES_DIR/agents/mcp/sync.sh" "$fake_dotfiles/agents/mcp/sync.sh"
+    cp "$REAL_DOTFILES_DIR/agents/mcp/lib.sh"  "$fake_dotfiles/agents/mcp/lib.sh"
+    cp "$REAL_DOTFILES_DIR/claude/lib/sync-common.sh" "$fake_dotfiles/claude/lib/sync-common.sh"
+    cat > "$fake_dotfiles/agents/mcp/registry.yaml" << 'YAML'
+mcps:
+  foo:
+    command: npx
+    args: ["-y", "foo-mcp"]
+    description: test
+    scope: user
+    harnesses: [claude, codex]
+YAML
+
+    run bash "$fake_dotfiles/agents/mcp/sync.sh" --dry-run
+    assert_success
+    assert_output_contains "Sync complete!"
+}

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -74,7 +74,7 @@ run_tests() {
     if [[ -n "$SPECIFIC_TEST" ]]; then
         test_files="$SPECIFIC_TEST"
     else
-        test_files="dots-simple.bats dots.bats git-hooks.bats sync.bats config-validation.bats prompt.bats sync-claude.bats sync-rollback.bats hooks-blockers.bats hooks-session.bats iterm2-fonts.bats worktree-settings.bats skills-external.bats skills-local.bats chezmoi-wiring.bats install-codex.bats install-agents-doc.bats packages.bats cheese-flair.bats"
+        test_files="dots-simple.bats dots.bats git-hooks.bats sync.bats config-validation.bats prompt.bats sync-claude.bats sync-rollback.bats hooks-blockers.bats hooks-session.bats iterm2-fonts.bats worktree-settings.bats skills-external.bats skills-local.bats chezmoi-wiring.bats install-codex.bats install-agents-doc.bats packages.bats cheese-flair.bats mcp-lib.bats"
     fi
 
     # Count total tests


### PR DESCRIPTION
## Summary

`chezmoi apply --force` was aborting on configured machines with:

\`\`\`
chezmoi: .chezmoiscripts/install-mcp.sh: exit status 1
\`\`\`

…which then short-circuited every downstream \`run_onchange\` script (skills install, agents-doc install, codex install). Root cause is a single line in \`mcp_detect_drift\` (\`agents/mcp/lib.sh\`) introduced by #164:

\`\`\`bash
[[ "$desired" != "$current" ]] && echo "$name"
\`\`\`

When every MCP is in sync (the steady state after a first successful sync — the common case), the \`[[ ]]\` returns 1, the \`&&\` short-circuits, and the compound exits 1. That's the last command in the \`while\` loop, so the loop returns 1; the loop is the last command in the function, so the function returns 1; \`sync.sh:257\` calls it as \`to_update=$(mcp_detect_drift ...)\` — a bare assignment — so \`set -e\` kills the script with no error printed.

\`bash -x\` repro: trace stops cleanly at \`+ to_update=\` and the script exits 1.

## Fix

- Replace the \`&&\` short-circuit with explicit \`if/then\` so the loop body always exits 0.
- Add explicit \`return 0\` to the function as defense against future edits.

## Tests

New \`tests/mcp-lib.bats\` with five regression cases:

1. \`mcp_detect_drift (claude)\`: all-in-sync — returns 0, no output (the bug)
2. \`mcp_detect_drift (claude)\`: one drifted — returns 0, emits drifted name
3. \`mcp_detect_drift\`: empty \`EXISTING\` — returns 0
4. \`mcp_detect_drift (codex)\`: all-in-sync — returns 0
5. End-to-end: \`sync.sh --dry-run\` against an in-sync mock registry exits 0 and prints \`Sync complete!\`

**Pre-fix:** 4 of 5 fail with exit 1 (test 3 passes via the early-return guard).
**Post-fix:** 5 of 5 pass.

Coverage gap noted: \`agents/mcp/lib.sh\` had no bats coverage at all, contrary to the \"shell functions need tests\" rule in \`AGENTS.md\`. This PR adds the missing harness; it does not aim for full coverage of \`lib.sh\` — just pins the specific regression.

## Test plan

- [x] \`bats tests/mcp-lib.bats\` → 5/5 pass
- [x] \`bash tests/run-tests.sh\` → 353/353 pass
- [x] \`bash agents/mcp/sync.sh --dry-run\` on this machine → \`Sync complete!\` exit 0
- [ ] After merge: \`chezmoi state delete-bucket --bucket=scriptState\` on affected machines to force \`run_onchange_install-mcp.sh.tmpl\` to re-fire (the registry hash is unchanged, so chezmoi will otherwise skip it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)