### PR TITLE
feat(cargo): add performance tuning—sccache, cargo-nextest, CARGO_INC...

### DIFF
--- a/cargo/config.toml
+++ b/cargo/config.toml
@@ -1,2 +1,12 @@
 # Cargo global configuration
 # Managed by dotfiles — synced to ~/.cargo/config.toml via cargo/.sync
+
+# Wrap rustc with sccache for cross-project / cross-branch compile caching.
+# Requires CARGO_INCREMENTAL=0 (set in zsh/tools.zsh) — sccache cannot cache
+# incremental builds.
+[build]
+rustc-wrapper = "sccache"
+
+# Linker: leave at default. Apple's ld (Xcode 15+, currently ld-1267) is the
+# fast parallel rewrite and beats lld for Mach-O on Apple Silicon. Don't add
+# `-fuse-ld=lld` here unless benchmarks on this machine prove otherwise.

--- a/packages.yaml
+++ b/packages.yaml
@@ -51,6 +51,10 @@ packages:
   - gettext
   - taf2/tap/mdvi
 
+  # Rust build acceleration
+  - sccache                                   # rustc wrapper for compile caching
+  - cargo-nextest                             # faster, parallel test runner
+
   # macOS-only
   - mas: { platform: mac }                    # Mac App Store CLI
   - trash: { platform: mac }                  # Move to Trash (safer rm)

--- a/zsh/aliases.zsh
+++ b/zsh/aliases.zsh
@@ -157,6 +157,12 @@ if command -v tokei &>/dev/null; then
     alias loc='tokei'
 fi
 
+# cargo-nextest - faster parallel test runner
+if command -v cargo-nextest &>/dev/null; then
+    alias cn='cargo nextest run'
+    alias cnf='cargo nextest run --failure-output immediate-final'
+fi
+
 # =============================================================================
 # Agent Skills (`gh skill install` — harness-agnostic; targets each agent in
 # $SKILL_HARNESSES from .env: claude-code, cursor, codex, github-copilot, etc.)

--- a/zsh/tools.zsh
+++ b/zsh/tools.zsh
@@ -33,5 +33,15 @@ if [[ -d "$HOME/.bun" ]]; then
     [[ -s "$BUN_INSTALL/_bun" ]] && source "$BUN_INSTALL/_bun"
 fi
 
+# ─── sccache (Rust compile cache) ────────────────────────────────────────
+# RUSTC_WRAPPER lives in cargo/config.toml ([build] rustc-wrapper = "sccache")
+# so it applies to every cargo invocation, not just interactive shells.
+# sccache cannot wrap incremental builds, so we must disable them globally.
+# Tradeoff: net win for branch-switching / clean builds, net loss for small
+# in-place edits in a single project.
+if command -v sccache &>/dev/null; then
+    export CARGO_INCREMENTAL=0
+fi
+
 # ─── vaudeville (SLM hook enforcement for Claude Code) ───────────────────
 export VAUDEVILLE_DEBUG="${VAUDEVILLE_DEBUG:-0}"


### PR DESCRIPTION
## Summary

Add Rust build acceleration tools and configuration:
- **sccache**: Per-project rustc wrapper for compile-result caching across branches
- **cargo-nextest**: Parallel test runner (2-3x faster than `cargo test` on multi-core)

## Changes

- `cargo/config.toml`: Enable sccache as rustc wrapper; document linker choice
- `packages.yaml`: Add sccache and cargo-nextest to brew packages
- `zsh/aliases.zsh`: Add `cn` (nextest) and `cnf` (nextest with immediate failure output) aliases
- `zsh/tools.zsh`: Set `CARGO_INCREMENTAL=0` when sccache is available (required for sccache to work)

## Trade-offs

- **sccache**: Excellent for branch-switching and clean rebuilds; slightly slower for small in-place edits in a single project
- **CARGO_INCREMENTAL=0**: Required by sccache; trades incremental rebuild speed for cross-project cache hits

## Testing

Run `dots sync` to install and configure both tools, then:
```bash
cargo build              # uses sccache
cargo nextest run       # cn alias
cargo nextest run --failure-output immediate-final  # cnf alias
```
