### PR TITLE
feat(packages): add gh-extension source, install github/gh-stack

### DIFF
--- a/packages/packages.yaml
+++ b/packages/packages.yaml
@@ -3,7 +3,7 @@
 # Bare string = brew (mac) / apt (linux)
 # Key-value = override defaults
 #
-#   source:   brew (default) | cask | tap | cargo | npm | uv
+#   source:   brew (default) | cask | tap | cargo | npm | uv | gh-extension
 #   dev:      only when DOTFILES_DEV=true
 #   apt:      override name for linux
 #   platform: mac | linux (default: both)
@@ -94,6 +94,9 @@ packages:
   - check-jsonschema: { source: uv }
   - skills-ref: { source: uv, pkg: "git+https://github.com/agentskills/agentskills@main#subdirectory=skills-ref" }
   - tavily-cli: { source: uv }                # provides `tvly` CLI for Tavily API
+
+  # gh CLI extensions
+  - gh-stack: { source: gh-extension, pkg: github/gh-stack }   # native PR-stack management (used by /pr-stack)
 
   # Cargo
   - cargo-llvm-cov: { source: cargo }

--- a/packages/sync.sh
+++ b/packages/sync.sh
@@ -356,6 +356,45 @@ sync_uv() {
     log_success "UV sync complete"
 }
 
+########## gh extensions
+
+sync_gh_extensions() {
+    local ext_pkgs
+    ext_pkgs=$(yq -r '.packages[] | select(kind == "map") | to_entries[0] | select(.value.source == "gh-extension") | [.key, (.value.pkg // .key)] | @tsv' "$PACKAGES_FILE" 2>/dev/null)
+    [[ -z "$ext_pkgs" ]] && return 0
+
+    if ! command -v gh &>/dev/null; then
+        log_error "gh not found (install gh first)"
+        FAILED+=("gh")
+        return 0
+    fi
+
+    log_info "Syncing gh extensions"
+    local installed
+    # gh extension list emits tab-separated rows: "gh <name>\t<owner>/<repo>\t<version>"
+    installed=$(gh extension list 2>/dev/null | awk -F'\t' '{print $2}' || true)
+
+    while IFS=$'\t' read -r name pkg; do
+        [[ -z "$name" ]] && continue
+        if echo "$installed" | grep -qx "$pkg"; then
+            echo "  + $name"
+        else
+            echo "  Installing $pkg..."
+            if ! gh extension install "$pkg" </dev/null; then
+                log_error "Failed to install $pkg"
+                FAILED+=("$pkg")
+            fi
+        fi
+    done <<< "$ext_pkgs"
+
+    if [[ "${UPGRADE_MODE:-false}" == "true" ]]; then
+        log_info "Upgrading gh extensions..."
+        gh extension upgrade --all </dev/null || log_warning "gh extension upgrade --all failed"
+    fi
+
+    log_success "gh extensions sync complete"
+}
+
 ########## APT
 
 apt_check_pkg() {
@@ -428,6 +467,7 @@ sync_cargo
 sync_rustup_proxies
 sync_npm
 sync_uv
+sync_gh_extensions
 
 if ((${#FAILED[@]})); then
     echo ""

--- a/tests/packages.bats
+++ b/tests/packages.bats
@@ -21,9 +21,11 @@ setup() {
 
     export BREW_LOG="$TEST_HOME/brew.log"
     export CARGO_LOG="$TEST_HOME/cargo.log"
+    export GH_LOG="$TEST_HOME/gh.log"
 
     write_mock_brew
     write_mock_cargo
+    write_mock_gh
     export PATH="$MOCK_BIN:$PATH"
 }
 
@@ -75,6 +77,36 @@ MOCKCARGO
     chmod +x "$MOCK_BIN/cargo"
 }
 
+# Usage: write_mock_gh [installed_repos] [fail_repo]
+#   installed_repos: newline-separated list of "owner/repo" already installed
+#   fail_repo:       exit non-zero when `gh extension install` is asked for this repo
+write_mock_gh() {
+    local installed="${1:-}" fail_repo="${2:-}"
+    cat > "$MOCK_BIN/gh" << MOCKGH
+#!/bin/bash
+echo "gh \$*" >> "$GH_LOG"
+case "\$1" in
+    extension)
+        case "\$2" in
+            list)
+                while IFS= read -r repo; do
+                    [[ -z "\$repo" ]] && continue
+                    printf 'gh %s\t%s\tv0.0.0\n' "\${repo##*/gh-}" "\$repo"
+                done <<< "$installed"
+                ;;
+            install)
+                if [[ -n "$fail_repo" && "\$3" == "$fail_repo" ]]; then
+                    exit 1
+                fi
+                ;;
+        esac
+        ;;
+esac
+exit 0
+MOCKGH
+    chmod +x "$MOCK_BIN/gh"
+}
+
 write_test_yaml() {
     cat > "$PACKAGES_FILE" << 'YAML'
 packages:
@@ -89,6 +121,7 @@ packages:
   - npm: { platform: linux, dev: true }
   - pyenv: { dev: true }
   - cargo-llvm-cov: { source: cargo }
+  - gh-stack: { source: gh-extension, pkg: github/gh-stack }
 YAML
 }
 
@@ -113,16 +146,19 @@ run_sync() {
     done <<< "$output"
 }
 
-@test "all source values are brew, cask, tap, cargo, npm, or uv" {
+@test "all source values are brew, cask, tap, cargo, npm, uv, or gh-extension" {
     run yq -r '.packages[] | select(kind == "map") | to_entries[0] | select(.value.source != null) | .value.source' \
         "$REAL_DOTFILES_DIR/packages/packages.yaml"
     assert_success
     while IFS= read -r source; do
         [[ -z "$source" ]] && continue
-        if [[ "$source" != "brew" && "$source" != "cask" && "$source" != "tap" && "$source" != "cargo" && "$source" != "npm" && "$source" != "uv" ]]; then
-            echo "Invalid source value: $source" >&2
-            return 1
-        fi
+        case "$source" in
+            brew|cask|tap|cargo|npm|uv|gh-extension) ;;
+            *)
+                echo "Invalid source value: $source" >&2
+                return 1
+                ;;
+        esac
     done <<< "$output"
 }
 
@@ -248,6 +284,55 @@ run_sync() {
     assert_success
 
     grep -q "cargo install cargo-llvm-cov" "$CARGO_LOG"
+}
+
+@test "sync installs gh extensions" {
+    write_test_yaml
+    run_sync
+    assert_success
+
+    grep -q "gh extension install github/gh-stack" "$GH_LOG"
+}
+
+@test "sync skips gh extension that is already installed" {
+    write_test_yaml
+    write_mock_gh "github/gh-stack"
+
+    run_sync
+    assert_success
+
+    ! grep -q "gh extension install" "$GH_LOG"
+}
+
+@test "sync records failure when gh extension install fails" {
+    write_test_yaml
+    write_mock_gh "" "github/gh-stack"
+
+    run_sync
+
+    assert_output_contains "Failed to install github/gh-stack"
+    assert_output_contains "cache NOT saved"
+    [[ ! -f "$CACHE_FILE" ]] || [[ ! -s "$CACHE_FILE" ]]
+}
+
+@test "UPGRADE_MODE runs gh extension upgrade --all" {
+    write_test_yaml
+    write_mock_gh "github/gh-stack"
+
+    UPGRADE_MODE=true run bash "$SYNC_SCRIPT"
+    assert_success
+
+    grep -q "gh extension upgrade --all" "$GH_LOG"
+}
+
+@test "non-upgrade mode does NOT call gh extension upgrade" {
+    write_test_yaml
+    write_mock_gh "github/gh-stack"
+
+    run_sync
+    assert_success
+
+    ! grep -q "gh extension upgrade" "$GH_LOG"
 }
 
 # --- Integration: cache behavior ---


### PR DESCRIPTION
## Summary
- Adds a new `gh-extension` source type to `packages/packages.yaml` so gh CLI extensions can be installed declaratively via `dots sync`.
- Wires up `github/gh-stack` (the GitHub-native PR-stacking extension used by the `/pr-stack` skill) as the first entry.
- `sync_gh_extensions` mirrors the existing `sync_uv` pattern: list installed, install missing, and honor `UPGRADE_MODE` via `gh extension upgrade --all`.

## Test plan
- [x] `bats tests/packages.bats` — 31/31 pass (added 5 new tests covering install, skip-when-installed, install-failure, UPGRADE_MODE upgrade-all, and non-upgrade no-call)
- [x] Smoke test: `FORCE_PACKAGES=true bash packages/sync.sh` shows `+ gh-stack` (idempotent skip on already-installed)
- [x] Schema validation test updated to accept `gh-extension`