### PR TITLE
feat(jmux): complete install — bun runtime, attention hook, projectDirs

### DIFF
--- a/chezmoi/dot_config/jmux/create_config.json
+++ b/chezmoi/dot_config/jmux/create_config.json
@@ -3,9 +3,9 @@
   "infoPanelWidth": null,
   "claudeCommand": "claude",
   "cacheTimers": true,
-  "wtmIntegration": true,
+  "wtmIntegration": false,
   "pinnedSessions": [],
-  "projectDirs": [],
+  "projectDirs": ["~/Dev", "~/conductor/workspaces"],
   "diffPanel": {
     "splitRatio": 0.4,
     "hunkCommand": "hunk"

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -125,6 +125,17 @@
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "tmux set-option @jmux-attention 1 2>/dev/null || true",
+            "timeout": 5
+          }
+        ]
+      }
     ]
   },
   "enabledPlugins": {

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -131,7 +131,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "tmux set-option @jmux-attention 1 2>/dev/null || true",
+            "command": "if [ -n \"$TMUX\" ]; then tmux set-option -q @jmux-attention 1; fi",
             "timeout": 5
           }
         ]

--- a/packages/packages.yaml
+++ b/packages/packages.yaml
@@ -11,6 +11,7 @@
 packages:
   - tinted-theming/tinted: { source: tap }
   - koekeishiya/formulae: { source: tap }     # skhd
+  - oven-sh/bun: { source: tap }              # bun
 
   # Core CLI
   - jq
@@ -46,6 +47,7 @@ packages:
   - duckdb
   - watch
   - node: { apt: nodejs }
+  - bun                                       # JS/TS runtime required by jmux
   - sd
   - vhs
   - gettext

--- a/tmux.conf
+++ b/tmux.conf
@@ -106,7 +106,7 @@ echo "    r       reload config"; \
 echo "    ?       this cheatsheet"; \
 echo ""; \
 echo "  Popups"; \
-echo "    g       lazygit"; \
+echo "    G       lazygit"; \
 echo "    o       yazi (file manager)"; \
 echo "    t       scratch terminal"; \
 echo ""; \
@@ -115,7 +115,8 @@ read -n 1 -s -r -p "  Press any key to close"'
 # ---------------------------------------------------------------------------
 # Floating popups
 # ---------------------------------------------------------------------------
-bind g display-popup -E -xC -yC -w 80% -h 80% -d "#{pane_current_path}" "lazygit"
+# `g` is intercepted by jmux's input router (toggles diff panel); use `G` instead
+bind G display-popup -E -xC -yC -w 80% -h 80% -d "#{pane_current_path}" "lazygit"
 bind o display-popup -E -xC -yC -w 80% -h 80% -d "#{pane_current_path}" "yazi"
 bind t display-popup -E -xC -yC -w 60% -h 60% -d "#{pane_current_path}"
 


### PR DESCRIPTION
## Summary

Follow-up to #172. That PR landed jmux + emdash + hunkdiff but the install
wasn't fully usable. This finishes the wiring.

- **`bun` runtime via `oven-sh/bun` tap** — jmux's shebang is
  `#!/usr/bin/env bun` and bun wasn't installed; `jmux` errored with
  `bun: No such file or directory`.
- **Declarative Stop hook in `claude/settings.json`** — sets
  `@jmux-attention 1` so the orange `!` appears in the sidebar when
  Claude finishes a response. Functionally identical to running
  `jmux --install-agent-hooks`, but written directly because that command
  writes through the `~/.claude/settings.json` symlink into this repo —
  ergo it would bypass the declarative pattern.
- **chezmoi jmux seed + live config**:
  - `projectDirs` ← `["~/Dev", "~/conductor/workspaces"]` so the
    `Ctrl-a n` project picker has meaningful entries.
  - `wtmIntegration` → `false`. Existing `ccw` / `ccw-init` / `wt-git`
    tooling covers the worktree workflow; adding `@jx0/wtm` (separate
    binary by the same author as jmux) would create overlap.
- **tmux remap: lazygit `g` → `G`**. jmux's InputRouter
  (`src/input-router.ts:167`) intercepts `Ctrl-a g` for the diff-panel
  toggle before tmux sees it, so the existing `bind g display-popup
  lazygit` was silently dead inside jmux. Capital `G` is free in both
  jmux defaults and the router intercept list. Cheatsheet (`prefix + ?`)
  updated to match.

## Notes

- The chezmoi seed uses `create_` prefix so it only applies on first
  init — for this PR I also updated the existing `~/.config/jmux/config.json`
  out-of-tree so the changes take effect without manual cleanup.
- Research artifact: `.cheese/research/jmux-power-user/` has the
  source notes (input-router intercept evidence, repo age/activity,
  config schema). Not committed.

## Test plan

- [ ] `dots sync` applies cleanly (`oven-sh/bun` tap + `bun` install)
- [ ] `bun --version` returns 1.3.8+
- [ ] `jmux` launches (no `bun: No such file` error)
- [ ] `Ctrl-a n` shows `~/Dev` and `~/conductor/workspaces` in project picker
- [ ] `Ctrl-a g` toggles the diff panel inside jmux (jmux router wins)
- [ ] `prefix + G` (outside jmux) opens lazygit popup
- [ ] Stop hook fires: finishing a Claude response inside a jmux session
      surfaces the orange `!` in the sidebar
- [ ] `jq empty claude/settings.json` and chezmoi seed pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)