### PR TITLE
feat(dots): refresh remote skills on `dots upgrade`

### DIFF
--- a/bin/dots
+++ b/bin/dots
@@ -36,7 +36,7 @@ ${GREEN}Usage:${NC} dots [command] [args]
 ${BLUE}Commands:${NC}
   ${GREEN}update${NC}          Pull latest changes and run sync
   ${GREEN}sync${NC}            Run the sync script (with rollback support)
-  ${GREEN}upgrade${NC}         Upgrade installed packages (brew/cargo/npm/uv)
+  ${GREEN}upgrade${NC}         Upgrade installed packages and refresh remote skills
   ${GREEN}status${NC}          Show git status of dotfiles
   ${GREEN}rollback [id]${NC}   Rollback to a previous state
   ${GREEN}backups${NC}         List available backups
@@ -305,6 +305,13 @@ case "${1:-status}" in
         echo -e "${BLUE}⬆️  Upgrading packages...${NC}"
         cd_dotfiles
         UPGRADE_MODE=true bash "$DOTFILES_DIR/packages/sync.sh"
+
+        echo
+        echo -e "${BLUE}⬆️  Refreshing remote skills...${NC}"
+        if ! bash "$DOTFILES_DIR/chezmoi/lib/install-external.sh" \
+                "$DOTFILES_DIR/skills/_registry.yaml" --force; then
+            echo -e "${YELLOW}⚠️  Remote skills refresh failed (continuing)${NC}" >&2
+        fi
         ;;
     status|st)
         do_status

--- a/tests/dots.bats
+++ b/tests/dots.bats
@@ -54,6 +54,15 @@ STUB
     assert_output_contains "stub-sync UPGRADE_MODE=true"
     assert_output_contains "Refreshing remote skills"
     assert_output_contains "stub-skill-sync args=$stub_dir/skills/_registry.yaml --force"
+
+    # Lock down ordering: package sync must run before skill refresh.
+    local pkg_line skill_line
+    pkg_line=$(printf '%s\n' "$output" | grep -n 'stub-sync UPGRADE_MODE=true' | head -1 | cut -d: -f1)
+    skill_line=$(printf '%s\n' "$output" | grep -n 'stub-skill-sync args=' | head -1 | cut -d: -f1)
+    [[ "$pkg_line" -lt "$skill_line" ]] || {
+        echo "Expected package sync before skill refresh; got pkg=$pkg_line skill=$skill_line" >&2
+        return 1
+    }
 }
 
 @test "dots up shorthand routes to upgrade (packages + skill refresh)" {

--- a/tests/dots.bats
+++ b/tests/dots.bats
@@ -25,33 +25,61 @@ teardown() {
     assert_output_contains "rollback"
 }
 
-@test "dots upgrade dispatches to packages/sync.sh with UPGRADE_MODE=true" {
-    local stub_dir="$TEST_HOME/stub-dotfiles"
-    mkdir -p "$stub_dir/packages" "$stub_dir/bin"
+# Stub a dotfiles tree wired for `dots upgrade`: packages/sync.sh prints its
+# UPGRADE_MODE, install-external.sh prints its args. Both must be invoked.
+stub_upgrade_dotfiles() {
+    local stub_dir="$1"
+    mkdir -p "$stub_dir/packages" "$stub_dir/bin" \
+             "$stub_dir/chezmoi/lib" "$stub_dir/skills"
     cp "$DOTFILES_DIR/bin/dots" "$stub_dir/bin/dots"
     cat > "$stub_dir/packages/sync.sh" <<'STUB'
 #!/bin/bash
 echo "stub-sync UPGRADE_MODE=${UPGRADE_MODE:-unset}"
 STUB
-    chmod +x "$stub_dir/packages/sync.sh"
+    cat > "$stub_dir/chezmoi/lib/install-external.sh" <<'STUB'
+#!/bin/bash
+echo "stub-skill-sync args=$*"
+STUB
+    : > "$stub_dir/skills/_registry.yaml"
+    chmod +x "$stub_dir/packages/sync.sh" \
+             "$stub_dir/chezmoi/lib/install-external.sh"
+}
+
+@test "dots upgrade runs packages/sync.sh with UPGRADE_MODE=true, then skill-sync --force" {
+    local stub_dir="$TEST_HOME/stub-dotfiles"
+    stub_upgrade_dotfiles "$stub_dir"
     DOTFILES_DIR="$stub_dir" run "$stub_dir/bin/dots" upgrade
     assert_success
     assert_output_contains "Upgrading packages"
     assert_output_contains "stub-sync UPGRADE_MODE=true"
+    assert_output_contains "Refreshing remote skills"
+    assert_output_contains "stub-skill-sync args=$stub_dir/skills/_registry.yaml --force"
 }
 
-@test "dots up shorthand routes to upgrade" {
+@test "dots up shorthand routes to upgrade (packages + skill refresh)" {
     local stub_dir="$TEST_HOME/stub-dotfiles"
-    mkdir -p "$stub_dir/packages" "$stub_dir/bin"
-    cp "$DOTFILES_DIR/bin/dots" "$stub_dir/bin/dots"
-    cat > "$stub_dir/packages/sync.sh" <<'STUB'
-#!/bin/bash
-echo "stub-sync UPGRADE_MODE=${UPGRADE_MODE:-unset}"
-STUB
-    chmod +x "$stub_dir/packages/sync.sh"
+    stub_upgrade_dotfiles "$stub_dir"
     DOTFILES_DIR="$stub_dir" run "$stub_dir/bin/dots" up
     assert_success
     assert_output_contains "stub-sync UPGRADE_MODE=true"
+    assert_output_contains "stub-skill-sync args=$stub_dir/skills/_registry.yaml --force"
+}
+
+@test "dots upgrade keeps going when skill-sync fails (warns but exits 0)" {
+    local stub_dir="$TEST_HOME/stub-dotfiles"
+    stub_upgrade_dotfiles "$stub_dir"
+    # Replace skill-sync stub with a failing one
+    cat > "$stub_dir/chezmoi/lib/install-external.sh" <<'STUB'
+#!/bin/bash
+echo "stub-skill-sync FAILING" >&2
+exit 1
+STUB
+    chmod +x "$stub_dir/chezmoi/lib/install-external.sh"
+
+    DOTFILES_DIR="$stub_dir" run "$stub_dir/bin/dots" upgrade
+    assert_success  # package upgrade is the primary action; skill failure shouldn't abort
+    assert_output_contains "stub-sync UPGRADE_MODE=true"
+    assert_output_contains "Remote skills refresh failed"
 }
 
 @test "dots with no arguments shows status" {

--- a/tests/skills-external.bats
+++ b/tests/skills-external.bats
@@ -494,6 +494,151 @@ MOCK
     assert_output_contains "cache not updated"
 }
 
+@test "skill sync: cache digest is sha256(sha256(registry) + LF + harnesses + LF)" {
+    # Locks down the exact digest formula. If a refactor changes the
+    # algorithm, this test fails and forces a conscious decision about
+    # cache invalidation across machines.
+    write_registry "acme/widgets" "    skills:
+      - alpha"
+    write_env "claude-code cursor"
+
+    run_sync
+    assert_success
+
+    local cache_file="$HOME/.local/state/dotfiles/skill-external-hash"
+    assert_file_exists "$cache_file"
+
+    local registry_digest combined_digest actual
+    registry_digest=$(shasum -a 256 "$MOCK_REGISTRY_FILE" | awk '{print $1}')
+    combined_digest=$(printf '%s\n%s\n' "$registry_digest" "claude-code cursor" \
+        | shasum -a 256 | awk '{print $1}')
+    actual=$(cat "$cache_file")
+
+    [[ "$actual" == "$combined_digest" ]] || {
+        echo "Cache digest mismatch" >&2
+        echo "  expected: $combined_digest" >&2
+        echo "  actual:   $actual" >&2
+        return 1
+    }
+}
+
+@test "skill sync: cache is blind to upstream skill-set changes (known gap)" {
+    # Regression test for the bug that hid /cheese-factory: when a source
+    # repo gains a new skill upstream but the local registry + harness
+    # list are unchanged, the cache short-circuits and the new skill is
+    # never installed. This is the design boundary documented in
+    # install-external.sh ("run 'gh skill update --all' to pull upstream
+    # changes"). If we ever fix the gap by, e.g., folding the discovered
+    # skill list into the digest or adding a TTL, flip this test to
+    # assert the new behavior.
+    write_registry "acme/widgets"  # auto-discovery, no explicit skills:
+    write_env "claude-code"
+
+    # First run: mock returns 3 skills.
+    run_sync
+    assert_success
+    run grep -c 'gh skill install acme/widgets' "$GH_LOG"
+    [[ "$output" == "3" ]]
+
+    # Upstream "adds" a new skill — swap the mock to return 4.
+    cat > "$MOCK_BIN/gh" << 'MOCK'
+#!/bin/bash
+printf 'gh %s\n' "$*" >> "${GH_LOG:-/dev/null}"
+case "$1" in
+    skill)
+        case "$2" in
+            --help|install) exit 0 ;;
+        esac
+        exit 0
+        ;;
+    api)
+        if [[ "$2" == repos/*/contents/skills ]]; then
+            cat <<'JSON'
+[
+  {"name": "alpha", "type": "dir"},
+  {"name": "bravo", "type": "dir"},
+  {"name": "charlie", "type": "dir"},
+  {"name": "delta",  "type": "dir"}
+]
+JSON
+            exit 0
+        fi
+        exit 0
+        ;;
+esac
+exit 0
+MOCK
+    chmod +x "$MOCK_BIN/gh"
+
+    : > "$GH_LOG"
+    run_sync
+    assert_success
+
+    # The gap: cache hit, no installs, new skill never reaches the harness.
+    assert_output_contains "unchanged since last sync"
+    run grep -c 'gh skill install' "$GH_LOG"
+    [[ "$output" == "0" ]] || {
+        echo "Expected 0 installs on cache hit, got $output" >&2
+        return 1
+    }
+    run grep -c 'gh skill install acme/widgets delta' "$GH_LOG"
+    [[ "$output" == "0" ]] || {
+        echo "delta was installed — upstream gap may be fixed; update this test" >&2
+        return 1
+    }
+}
+
+@test "skill sync: --force pulls in upstream skill additions (the documented workaround)" {
+    # Companion to the upstream-blindness test: confirms the user-facing
+    # escape hatch (skill-sync --force) actually works to pick up new
+    # skills when the registry hasn't changed.
+    write_registry "acme/widgets"
+    write_env "claude-code"
+
+    run_sync
+    assert_success
+
+    # Upstream gains a skill.
+    cat > "$MOCK_BIN/gh" << 'MOCK'
+#!/bin/bash
+printf 'gh %s\n' "$*" >> "${GH_LOG:-/dev/null}"
+case "$1" in
+    skill)
+        case "$2" in
+            --help|install) exit 0 ;;
+        esac
+        exit 0
+        ;;
+    api)
+        if [[ "$2" == repos/*/contents/skills ]]; then
+            cat <<'JSON'
+[
+  {"name": "alpha", "type": "dir"},
+  {"name": "bravo", "type": "dir"},
+  {"name": "charlie", "type": "dir"},
+  {"name": "delta",  "type": "dir"}
+]
+JSON
+            exit 0
+        fi
+        exit 0
+        ;;
+esac
+exit 0
+MOCK
+    chmod +x "$MOCK_BIN/gh"
+
+    : > "$GH_LOG"
+    run_sync --force
+    assert_success
+
+    run grep -c 'gh skill install acme/widgets delta --agent claude-code' "$GH_LOG"
+    [[ "$output" == "1" ]] || {
+        echo "delta install missing under --force" >&2
+        return 1
+    }
+}
+
 @test "registry.yaml: real registry parses cleanly with yq" {
     run yq '.sources | keys' "$REAL_DOTFILES_DIR/skills/_registry.yaml"
     assert_success


### PR DESCRIPTION
## Summary
- Wire `skill-sync --force` into `dots upgrade` so upstream skill additions (new tags, new skill dirs in remote registries) land without manual `skill-sync --force`. Failure is warned but non-fatal — package upgrades stay green.
- Add bats coverage that locks the cache digest formula (`sha256(sha256(registry) + LF + harnesses + LF)`), documents the upstream-blindness gap (the bug that hid `/cheese-factory`), and proves `--force` is the working escape hatch.

## Test plan
- [x] `bats tests/dots.bats tests/skills-external.bats tests/skills-local.bats` — 59/59 green
- [ ] `dots upgrade` on a real machine picks up a new remote skill without manual `skill-sync --force`

🤖 Generated with [Claude Code](https://claude.com/claude-code)