### PR TITLE
feat(mcp): add Serena MCP with per-harness arg templating

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,9 @@ jobs:
     - name: Install bats
       run: sudo npm install -g bats
 
+    - name: Install chezmoi
+      run: sh -c "$(curl -fsLS get.chezmoi.io)" -- -b /usr/local/bin
+
     - name: Install hook dependencies
       run: cd claude/hooks && npm install
 

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,11 @@ claude/reference/cheese-flair.md
 # Harness-managed agent skill cache (written by `gh skill install`)
 .agents/
 
+# Serena's project-local data (memories, caches) — written when Serena's MCP
+# server runs against this directory. Our config + global state live under
+# ~/.serena/; this dir is per-project runtime state, not source.
+.serena/
+
 # Claude Code local state (settings.local.json, specs)
 .claude/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,14 +191,16 @@ mcps:
 - **codex** — native `codex mcp add/list/remove --json` (no scopes).
 - **opencode** — no non-interactive CLI; the sync jq-edits `~/.config/opencode/opencode.json` directly. Set `OPENCODE_CONFIG` to override the target path (used by tests). On first run the sync seeds a minimal `{"$schema": ".../config.json"}` file if absent.
 
-**Per-harness `args` via Go templates.** `agents/mcp/sync.sh` runs the registry through `chezmoi execute-template` once per harness with `HARNESS=<claude|codex>` exported, so a single entry can produce different argv per harness without adding new keys to the schema. Serena uses this:
+**Per-harness `args` via Go templates.** `agents/mcp/sync.sh` runs the registry through `chezmoi execute-template` once per harness with `HARNESS=<claude|codex>` exported. The registry preamble aliases that into `$h` so entries can branch inline without restating the env lookup. Default to `{{ $h }}` so new harnesses inherit their bare name without another schema edit. Serena uses this:
 
 ```yaml
+{{- $h := env "HARNESS" -}}
+...
 serena:
   command: serena
   args:
     - start-mcp-server
-    - --context={{ if eq (env "HARNESS") "claude" }}claude-code{{ else }}codex{{ end }}
+    - --context={{ if eq $h "claude" }}claude-code{{ else }}{{ $h }}{{ end }}
     - --project-from-cwd
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,6 +191,25 @@ mcps:
 - **codex** — native `codex mcp add/list/remove --json` (no scopes).
 - **opencode** — no non-interactive CLI; the sync jq-edits `~/.config/opencode/opencode.json` directly. Set `OPENCODE_CONFIG` to override the target path (used by tests). On first run the sync seeds a minimal `{"$schema": ".../config.json"}` file if absent.
 
+**Per-harness `args` via Go templates.** `agents/mcp/sync.sh` runs the registry through `chezmoi execute-template` once per harness with `HARNESS=<claude|codex>` exported, so a single entry can produce different argv per harness without adding new keys to the schema. Serena uses this:
+
+```yaml
+serena:
+  command: serena
+  args:
+    - start-mcp-server
+    - --context={{ if eq (env "HARNESS") "claude" }}claude-code{{ else }}codex{{ end }}
+    - --project-from-cwd
+```
+
+The bash-style `${VAR}` env substitution used by `env:` blocks runs in a later pass (`mcp_build_env_flags`) and is untouched by the templating step.
+
+**Filtering which tools an MCP exposes.** No MCP-spec-level mechanism exists; the practical answers are:
+
+- **Server-side (uniform across harnesses):** the cleanest path when supported by the server. Serena reads `~/.serena/serena_config.yml` — set `excluded_tools` (blacklist), `included_optional_tools` (whitelist additions), or `fixed_tools` (exact tool set, replaces defaults). Per-harness `--context=claude-code|codex` already excludes Read/Write/Bash duplicates upstream.
+- **Claude-side:** `mcp__<server>__<tool>` glob patterns in `permissions.allow` / `permissions.deny` (used by `claude/profiles/*/settings-merge.json`).
+- **Codex-side:** per-tool filtering is not exposed by `codex mcp` — only per-server enable/disable.
+
 **Workflow:**
 
 1. Edit registry: `mcp-edit`

--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -182,11 +182,11 @@ These have become tics. They either hedge, inflate, or substitute a cliché for 
 | non-trivial | hard, complex, involved |
 | deep dive | analysis, investigation, reading |
 | leverage (= use) | use, apply, build on |
-| let me _(opener)_ | _(just do it — no announcement needed)_ |
+| let me *(opener)* | *(just do it — no announcement needed)* |
 | surface (as verb) | mention, flag, call out, show |
 | ergonomic / ergonomics | readable, clean, easy to use |
-| guardrails _(abstract)_ | constraints, checks, limits |
-| not my changes / pre-existing _(unverified)_ | cite evidence: base-branch run ID, `git blame`, or commit hash — otherwise fix it |
+| guardrails *(abstract)* | constraints, checks, limits |
+| not my changes / pre-existing *(unverified)* | cite evidence: base-branch run ID, `git blame`, or commit hash — otherwise fix it |
 
 ## Rules
 

--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -138,6 +138,32 @@ For project architecture (when a project opts in), see the **Sliced Bread** patt
 - **Agent permission modes**: `acceptEdits` and `bypassPermissions` only suppress the Edit/Write dialog — they do **not** bypass the Bash/MCP allowlist. In sandboxed environments (Conductor, fresh sessions), worktree agents may lack `git push` / `gh pr create` permissions. Pattern: have isolated agents do code work + commit only; return to the orchestrator for push/PR.
 - **Agent nesting**: Claude Code supports 1 level of sub-agent nesting. Orchestrators that need to fan out should be skills (which run inline in the caller's context, so their `Agent()` calls are first-level).
 
+## Code-Intelligence Routing
+
+Three MCPs cover code intelligence; they layer rather than overlap.
+
+- **tilth** — file I/O floor: `tilth_search`, `tilth_read`, `tilth_list`, `tilth_write` (+ `tilth_deps`, `tilth_diff`). Default for read/grep/edit; replaces host Grep/Read/Edit/Glob.
+- **serena** — LSP-grounded symbol layer: `find_symbol`, `find_referencing_symbols`, `find_declaration`, `find_implementations`, `get_symbols_overview`, `get_diagnostics_for_file`, `rename_symbol`, `safe_delete_symbol`, `replace_symbol_body`, `insert_before_symbol`, `insert_after_symbol`, `replace_content`. Use when ground-truth semantics matter (overloads, generics, dispatch, type info). Memory tools and `onboarding` are excluded in `~/.serena/serena_config.yml` — do not try to call them.
+- **code-review-graph** — project-scale graph: `get_impact_radius_tool`, `get_affected_flows_tool`, `get_review_context_tool`, `get_minimal_context_tool`, `get_architecture_overview_tool`, `list_communities_tool`, `semantic_search_nodes_tool`. Use for blast-radius, "what does this codebase do", and review-scope queries — not for routine search.
+
+### Editing: serena vs tilth
+
+Pick by edit *shape*, not preference. Serena is more context-efficient for symbol-bounded edits (no need to re-ship the surrounding body); tilth wins for everything else, and for the read-step that precedes either.
+
+| Edit shape | Pick |
+|---|---|
+| Replace whole function / method / class body | `serena.replace_symbol_body` |
+| Insert relative to a known symbol | `serena.insert_before_symbol` / `insert_after_symbol` |
+| Rename a symbol across the codebase | `serena.rename_symbol` (one LSP call vs N text replaces, and correct under overloads) |
+| Safe-delete an unused symbol | `serena.safe_delete_symbol` |
+| Sub-symbol edit (slice inside a function) | `tilth_write` hash-anchor — serena would force shipping the whole body |
+| Imports, config (YAML/JSON/TOML), Markdown, shell | `tilth_write` |
+| Create new file | `tilth_write` overwrite — serena has no create-file tool |
+| Bulk pattern across files | `tilth_search` + `tilth_write` batch |
+| Language without LSP support here | `tilth_write` |
+
+Read-step matters too: serena's `get_symbols_overview` + `find_symbol(include_body=true)` pulls only the target symbol out of a large file. Reach for that when you only need one function from a long file — that's where the real context win is, not the write step.
+
 ## Self-Evaluation
 
 Run `/self-eval` before finishing any response that writes or changes code. It's the source of truth for the anti-pattern checklist (sycophancy, premature completion, dismissing failures, hedging, scope reduction, false confidence, AI slop, weak assertions) and delegates to `/de-slop` and `/tdd-assertions` automatically.

--- a/agents/mcp/registry.yaml
+++ b/agents/mcp/registry.yaml
@@ -1,14 +1,21 @@
 # MCP Registry - Source of truth for coding-agent MCP servers
+# (template var $h, set on the next line, is the active harness for this
+# render pass — sync.sh sets HARNESS=<name>. Entries may reference $h to
+# branch per-harness without restating the env lookup.)
+# {{ $h := env "HARNESS" }}
+#
 # Run `mcp-sync` (or `dots sync`) to apply this to every installed harness.
 #
 # Per-entry fields:
 #   command      — stdio launcher (required)
 #   args         — array of arg strings. Rendered through `chezmoi execute-template`
-#                  before YAML parsing, with HARNESS=<claude|codex> in the env,
-#                  so you can branch per-harness inline with Go-template syntax:
-#                      args: ["--context={{ if eq (env "HARNESS") "claude" }}claude-code{{ else }}codex{{ end }}"]
-#                  Existing ${VAR} bash-style env refs (resolved later in mcp_build_env_flags)
-#                  are untouched by the templating pass.
+#                  per harness; the active harness name is exposed as the
+#                  Go-template var $h. Branch inline only when an entry actually
+#                  diverges — see the `serena` entry below for a worked example.
+#                  Default to $h so future harnesses inherit their bare name
+#                  without another schema edit. Existing ${VAR} bash-style env
+#                  refs (resolved later in mcp_build_env_flags) are untouched
+#                  by the templating pass.
 #   env          — env vars; values can reference shell vars via "${VAR}"
 #   scope        — claude-only: user | project | local (default user)
 #   harnesses    — list of harness names to install into; default: [claude, codex, opencode]
@@ -81,7 +88,7 @@ mcps:
     command: serena
     args:
       - start-mcp-server
-      - --context={{ if eq (env "HARNESS") "claude" }}claude-code{{ else }}codex{{ end }}
+      - --context={{ if eq $h "claude" }}claude-code{{ else }}{{ $h }}{{ end }}
       - --project-from-cwd
     scope: user
     description: Semantic code intel via LSP (symbols, references, refactors). Tools tailored per harness via --context.

--- a/agents/mcp/registry.yaml
+++ b/agents/mcp/registry.yaml
@@ -3,7 +3,12 @@
 #
 # Per-entry fields:
 #   command      — stdio launcher (required)
-#   args         — array of arg strings
+#   args         — array of arg strings. Rendered through `chezmoi execute-template`
+#                  before YAML parsing, with HARNESS=<claude|codex> in the env,
+#                  so you can branch per-harness inline with Go-template syntax:
+#                      args: ["--context={{ if eq (env "HARNESS") "claude" }}claude-code{{ else }}codex{{ end }}"]
+#                  Existing ${VAR} bash-style env refs (resolved later in mcp_build_env_flags)
+#                  are untouched by the templating pass.
 #   env          — env vars; values can reference shell vars via "${VAR}"
 #   scope        — claude-only: user | project | local (default user)
 #   harnesses    — list of harness names to install into; default: [claude, codex, opencode]
@@ -67,3 +72,16 @@ mcps:
     args: ["--from", "code-review-graph[embeddings]", "code-review-graph", "serve"]
     scope: user
     description: Structural code knowledge graph via Tree-sitter — semantic search (sentence-transformers), call chains, impact radius, flows, communities
+
+  # Serena's per-harness contexts already strip tools that duplicate built-ins
+  # (Read/Write/Bash etc.). Server-wide further filtering lives in
+  # ~/.serena/serena_config.yml under `excluded_tools` / `included_optional_tools`
+  # / `fixed_tools` — applies to every harness uniformly.
+  serena:
+    command: serena
+    args:
+      - start-mcp-server
+      - --context={{ if eq (env "HARNESS") "claude" }}claude-code{{ else }}codex{{ end }}
+      - --project-from-cwd
+    scope: user
+    description: Semantic code intel via LSP (symbols, references, refactors). Tools tailored per harness via --context.

--- a/agents/mcp/sync.sh
+++ b/agents/mcp/sync.sh
@@ -61,7 +61,7 @@ done
 
 mcp_load_dotenv "$DOTFILES_DIR/.env"
 
-for cmd in yq jq; do
+for cmd in yq jq chezmoi; do
     command -v "$cmd" &>/dev/null \
         || { echo -e "${RED}Error: $cmd not found${NC}" >&2; exit 1; }
 done
@@ -69,15 +69,21 @@ done
 [[ -f "$REGISTRY_FILE" ]] \
     || { echo -e "${RED}Error: $REGISTRY_FILE not found${NC}" >&2; exit 1; }
 
-REGISTRY_JSON=$(yq -o=json '.mcps' "$REGISTRY_FILE")
-
 echo -e "${BLUE}MCP Sync - Declarative MCP Management${NC}"
 
+# Render the registry once per harness so `args` strings can branch on
+# `{{ env "HARNESS" }}`. mcp_sync_harness reads REGISTRY_JSON from its env.
+sync_for_harness() {
+    local h="$1"
+    REGISTRY_JSON=$(HARNESS="$h" chezmoi execute-template < "$REGISTRY_FILE" | yq -o=json '.mcps')
+    mcp_sync_harness "$h"
+}
+
 if [[ -n "$ONLY_HARNESS" ]]; then
-    mcp_sync_harness "$ONLY_HARNESS"
+    sync_for_harness "$ONLY_HARNESS"
 else
     for h in claude codex opencode; do
-        mcp_sync_harness "$h"
+        sync_for_harness "$h"
     done
 fi
 

--- a/chezmoi/dot_serena/modify_serena_config.yml
+++ b/chezmoi/dot_serena/modify_serena_config.yml
@@ -1,0 +1,41 @@
+#!/bin/sh
+# Patch a tiny subset of ~/.serena/serena_config.yml while preserving every
+# other key + Serena's inline documentation. Stdin is the current file
+# contents (empty on first install); stdout becomes the new file contents.
+#
+# Source-of-truth defaults are Serena's. We only override:
+#   web_dashboard                 → false  (no auto-browser tab)
+#   web_dashboard_open_on_launch  → false  (and no tray icon noise)
+#   excluded_tools                → []     (sentinel; populate as needed)
+
+set -eu
+
+if ! command -v yq >/dev/null 2>&1; then
+    # yq is in packages.yaml so this branch is for unusual environments
+    # (e.g. partial bootstrap). Pass the file through unchanged rather than
+    # corrupt it.
+    cat
+    exit 0
+fi
+
+existing=$(cat)
+
+# First-time install: Serena binary may be on PATH (uv tool install ran)
+# but `serena init` hasn't yet, so the target file is empty. Bootstrap.
+if [ -z "$existing" ] && command -v serena >/dev/null 2>&1; then
+    serena init >/dev/null 2>&1 || true
+    [ -f "$HOME/.serena/serena_config.yml" ] \
+        && existing=$(cat "$HOME/.serena/serena_config.yml")
+fi
+
+if [ -z "$existing" ]; then
+    # shellcheck disable=SC2016  # literal backticks in the message, not expansion
+    printf '# serena not initialized; run `serena init`, then `chezmoi apply` again\n'
+    exit 0
+fi
+
+printf '%s' "$existing" | yq '
+    .web_dashboard = false |
+    .web_dashboard_open_on_launch = false |
+    .excluded_tools = []
+'

--- a/chezmoi/dot_serena/modify_serena_config.yml
+++ b/chezmoi/dot_serena/modify_serena_config.yml
@@ -10,6 +10,9 @@
 
 set -eu
 
+# shellcheck disable=SC2016  # literal backticks in the message, not expansion
+PLACEHOLDER='# serena not initialized; run `serena init`, then `chezmoi apply` again'
+
 if ! command -v yq >/dev/null 2>&1; then
     # yq is in packages.yaml so this branch is for unusual environments
     # (e.g. partial bootstrap). Pass the file through unchanged rather than
@@ -20,17 +23,25 @@ fi
 
 existing=$(cat)
 
-# First-time install: Serena binary may be on PATH (uv tool install ran)
-# but `serena init` hasn't yet, so the target file is empty. Bootstrap.
+# Treat a previously-written placeholder as still-empty so the next apply
+# re-bootstraps once serena is on PATH. Without this, yq would later eat
+# the comment and emit a 3-key stub, permanently losing Serena's ~165
+# lines of inline-documented defaults.
+if [ "$existing" = "$PLACEHOLDER" ]; then
+    existing=
+fi
+
+# First-time install (or re-bootstrap after placeholder): adopt the live
+# ~/.serena/serena_config.yml if it exists, else run `serena init` to
+# create one. Either way, the resulting config is what we patch.
 if [ -z "$existing" ] && command -v serena >/dev/null 2>&1; then
-    serena init >/dev/null 2>&1 || true
+    [ -f "$HOME/.serena/serena_config.yml" ] || serena init >/dev/null 2>&1 || true
     [ -f "$HOME/.serena/serena_config.yml" ] \
         && existing=$(cat "$HOME/.serena/serena_config.yml")
 fi
 
 if [ -z "$existing" ]; then
-    # shellcheck disable=SC2016  # literal backticks in the message, not expansion
-    printf '# serena not initialized; run `serena init`, then `chezmoi apply` again\n'
+    printf '%s\n' "$PLACEHOLDER"
     exit 0
 fi
 

--- a/chezmoi/dot_serena/modify_serena_config.yml
+++ b/chezmoi/dot_serena/modify_serena_config.yml
@@ -33,11 +33,16 @@ fi
 
 # First-time install (or re-bootstrap after placeholder): adopt the live
 # ~/.serena/serena_config.yml if it exists, else run `serena init` to
-# create one. Either way, the resulting config is what we patch.
+# create one. Either way, the resulting config is what we patch. Apply the
+# same placeholder filter to the live-file read — chezmoi may have written
+# the placeholder to disk on a prior apply, so the live file is "ours" too
+# and round-tripping it into yq would emit the 3-key stub we're avoiding.
 if [ -z "$existing" ] && command -v serena >/dev/null 2>&1; then
     [ -f "$HOME/.serena/serena_config.yml" ] || serena init >/dev/null 2>&1 || true
-    [ -f "$HOME/.serena/serena_config.yml" ] \
-        && existing=$(cat "$HOME/.serena/serena_config.yml")
+    if [ -f "$HOME/.serena/serena_config.yml" ]; then
+        existing=$(cat "$HOME/.serena/serena_config.yml")
+        [ "$existing" = "$PLACEHOLDER" ] && existing=
+    fi
 fi
 
 if [ -z "$existing" ]; then

--- a/chezmoi/dot_serena/modify_serena_config.yml
+++ b/chezmoi/dot_serena/modify_serena_config.yml
@@ -6,7 +6,13 @@
 # Source-of-truth defaults are Serena's. We only override:
 #   web_dashboard                 → false  (no auto-browser tab)
 #   web_dashboard_open_on_launch  → false  (and no tray icon noise)
-#   excluded_tools                → []     (sentinel; populate as needed)
+#   excluded_tools                → memory + onboarding tools
+#       Rationale: Serena's parallel memory system (~/.serena/memories/)
+#       collides with our MEMORY.md auto-memory under
+#       ~/.claude/projects/-Users-paul-Dev-dotfiles/memory/. Scope serena
+#       to its LSP-grounded retrieval + symbol-edit surface only.
+#       `onboarding` exists solely to bootstrap memory files, so it goes
+#       with the rest.
 
 set -eu
 
@@ -53,5 +59,13 @@ fi
 printf '%s' "$existing" | yq '
     .web_dashboard = false |
     .web_dashboard_open_on_launch = false |
-    .excluded_tools = []
+    .excluded_tools = [
+        "write_memory",
+        "read_memory",
+        "list_memories",
+        "delete_memory",
+        "rename_memory",
+        "edit_memory",
+        "onboarding"
+    ]
 '

--- a/packages/packages.yaml
+++ b/packages/packages.yaml
@@ -7,6 +7,8 @@
 #   dev:      only when DOTFILES_DEV=true
 #   apt:      override name for linux
 #   platform: mac | linux (default: both)
+#   flags:    extra args spliced into the installer (uv source only;
+#             e.g. ["--python", "3.13", "--prerelease=allow"])
 
 packages:
   - tinted-theming/tinted: { source: tap }
@@ -98,6 +100,10 @@ packages:
   - check-jsonschema: { source: uv }
   - skills-ref: { source: uv, pkg: "git+https://github.com/agentskills/agentskills@main#subdirectory=skills-ref" }
   - tavily-cli: { source: uv }                # provides `tvly` CLI for Tavily API
+  # Serena pins Python 3.13 and ships pre-release builds on PyPI; the `flags`
+  # array is passed through to `uv tool install` verbatim. Exposes the `serena`
+  # binary, which the MCP registry invokes per harness via --context.
+  - serena-agent: { source: uv, flags: ["--python", "3.13", "--prerelease=allow"] }
 
   # gh CLI extensions
   - gh-stack: { source: gh-extension, pkg: github/gh-stack }   # native PR-stack management (used by /pr-stack)

--- a/packages/sync.sh
+++ b/packages/sync.sh
@@ -322,7 +322,9 @@ sync_npm() {
 
 sync_uv() {
     local uv_pkgs
-    uv_pkgs=$(yq -r '.packages[] | select(kind == "map") | to_entries[0] | select(.value.source == "uv") | [.key, (.value.pkg // .key)] | @tsv' "$PACKAGES_FILE" 2>/dev/null)
+    # `flags` is emitted as a space-joined string in the third TSV column.
+    # Empty / missing flags collapse to an empty field.
+    uv_pkgs=$(yq -r '.packages[] | select(kind == "map") | to_entries[0] | select(.value.source == "uv") | [.key, (.value.pkg // .key), ((.value.flags // []) | join(" "))] | @tsv' "$PACKAGES_FILE" 2>/dev/null)
     [[ -z "$uv_pkgs" ]] && return 0
 
     if ! command -v uv &>/dev/null; then
@@ -335,13 +337,15 @@ sync_uv() {
     local installed
     installed=$(uv tool list 2>/dev/null | awk '/^[a-zA-Z]/ {print $1}' || true)
 
-    while IFS=$'\t' read -r name pkg; do
+    while IFS=$'\t' read -r name pkg flags_str; do
         [[ -z "$name" ]] && continue
+        # shellcheck disable=SC2206  # word-splitting on flags_str is intentional
+        local flags_array=($flags_str)
         if echo "$installed" | grep -qx "$name"; then
             echo "  + $name"
         else
-            echo "  Installing $pkg..."
-            if ! uv tool install "$pkg" </dev/null; then
+            echo "  Installing $pkg${flags_str:+ ($flags_str)}..."
+            if ! uv tool install ${flags_array[@]+"${flags_array[@]}"} "$pkg" </dev/null; then
                 log_error "Failed to install $pkg"
                 FAILED+=("$pkg")
             fi

--- a/skills/serena-project-config/SKILL.md
+++ b/skills/serena-project-config/SKILL.md
@@ -119,9 +119,11 @@ This bypasses the blanket `.serena/` ignore for that one file. If many repos nee
 After editing, confirm the config took effect:
 
 1. **Render the rendered system prompt** — quickest sanity check that serena parsed the file:
+
    ```bash
    serena print-system-prompt "$(pwd)"
    ```
+
    Look for your project name, language list, and excluded tools in the output.
 
 2. **Probe a symbol** — exercise the LSP layer:

--- a/skills/serena-project-config/SKILL.md
+++ b/skills/serena-project-config/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: serena-project-config
+model: haiku
+description: >
+  Per-repo Serena MCP configuration. Use when the user wants to "configure
+  serena for this repo", "set up serena per repo", "serena project config",
+  "tune serena for this codebase", "monorepo serena", "serena wrong language",
+  "serena vendor/node_modules indexing", "review-only serena", or otherwise
+  wants the .serena/project.yml in a specific repo tuned. The skill recognizes
+  the four cases where the auto-bootstrap (--project-from-cwd) is not enough —
+  monorepos, wrong language detection, heavy generated dirs, LSP-specific
+  tuning — and walks through the edit + verification. Do NOT trigger on
+  general "use serena" routing requests; that lives in agents/AGENTS.md's
+  Code-Intelligence Routing section. Do NOT enable memory tools or onboarding
+  — they are intentionally disabled in ~/.serena/serena_config.yml.
+---
+
+# serena-project-config
+
+Tune `.serena/project.yml` when the auto-bootstrap is wrong.
+
+Serena is registered globally with `--project-from-cwd`, so on first activation in any repo it writes a sensible `.serena/project.yml` (language auto-detected, gitignore respected). For most repos that's the end of it. This skill is for the 20% of repos where the auto-bootstrap picks the wrong defaults or leaves performance on the table.
+
+## When to act (and when not to)
+
+Trigger an edit only if one of these is true:
+
+| Symptom | Root cause | Fix |
+|---|---|---|
+| LSP doesn't resolve symbols across package boundaries | Monorepo; serena only sees the active workspace folder | `additional_workspace_folders` |
+| `find_symbol` returns wrong language results, or LSP errors at startup | Auto-detect picked the wrong primary language | Edit `languages:` |
+| `find_symbol` is slow / floods results from `vendor/`, `node_modules/`, `dist/`, generated code | Those dirs aren't in `.gitignore` (or `ignore_all_files_in_gitignore` is off) | Add `ignored_paths:` |
+| Wrong Python venv, wrong PHP intelephense version, etc. | LSP needs language-specific tuning | `ls_specific_settings:` |
+| Repo is review-only and you don't want serena writing | — | `read_only: true` |
+| Want to lock down which serena tools work here | — | `excluded_tools:` (additive to global) |
+
+If none of these apply, leave `.serena/` alone. The bootstrap is fine.
+
+## The `.serena/` directory contract
+
+| File | Purpose | Git status (this dotfiles repo) |
+|---|---|---|
+| `project.yml` | Main config — committed in serena's intended workflow | gitignored by the top-level `.gitignore` |
+| `project.local.yml` | Local overrides; same schema as `project.yml` | always gitignored (serena's own `.serena/.gitignore`) |
+| `cache/` | Symbol cache; rebuilt on demand | always gitignored |
+| `memories/` | Memory store | inert — memory tools are globally disabled |
+| `.serena/.gitignore` | Excludes `cache/` + `project.local.yml` | committed by serena's intent |
+
+`<certain>` The top-level `.gitignore` in this dotfiles repo blanket-excludes `.serena/`, so by default every repo's serena config is per-machine. That's deliberate for single-author exploratory work but wrong for monorepos and shared-team repos — see [Committing decision](#committing-decision) below.
+
+## How to edit `project.yml`
+
+**Never create the directory from scratch.** Activate serena once (`find_symbol` against any file does it), let the bootstrap write the defaults, then edit. The auto-generated file has serena's inline documentation as comments — keep them.
+
+Key fields:
+
+```yaml
+# the project name shown in serena's UI / logs
+project_name: "my-repo"
+
+# LSP keys to start; choose from the 60-language enum in serena's docs.
+# First entry is the default/fallback. Multi-language repos list each.
+languages:
+  - typescript
+  - python
+
+# additive to .gitignore — gitignore syntax (*, **)
+ignored_paths:
+  - "vendor/**"
+  - "dist/**"
+  - "**/*.generated.ts"
+
+# TypeScript-only currently; cross-package symbol search in monorepos
+additional_workspace_folders:
+  - ../shared-lib
+  - packages/utils
+
+# per-language LSP knobs; keys vary per language server
+ls_specific_settings:
+  python:
+    python_interpreter: ".venv/bin/python"
+  php_phpactor:
+    ignore_vendor: true
+
+# disables all edit tools for this repo
+read_only: false
+
+# additive to ~/.serena/serena_config.yml excluded_tools
+excluded_tools:
+  - execute_shell_command  # example only — sandbox repos
+```
+
+`<speculative>` Exact `ls_specific_settings` keys are LSP-dependent. Check the [Configuration page](https://oraios.github.io/serena/02-usage/050_configuration.html) before guessing — Python and PHP are well-documented; others may have no knobs at all.
+
+## Committing decision
+
+| Repo shape | Recommendation |
+|---|---|
+| Single-author / exploratory | Leave gitignored — auto-bootstrap will recreate it on any machine |
+| Monorepo with non-trivial `additional_workspace_folders` | `git add -f .serena/project.yml` — the config encodes architectural intent that other contributors need |
+| Shared team repo with custom `ignored_paths` or `ls_specific_settings` | `git add -f .serena/project.yml` — saves every collaborator from re-discovering the same tuning |
+| Review-only fork (`read_only: true`) | Commit it — the read-only stance is policy, not preference |
+
+To commit selectively without un-gitignoring the whole dir, use the path-specific override pattern:
+
+```bash
+git add -f .serena/project.yml
+```
+
+This bypasses the blanket `.serena/` ignore for that one file. If many repos need this, consider editing the top-level `.gitignore` to unignore `.serena/project.yml` globally while keeping `cache/` and `project.local.yml` out:
+
+```gitignore
+.serena/
+!.serena/project.yml
+```
+
+## Verification
+
+After editing, confirm the config took effect:
+
+1. **Render the rendered system prompt** — quickest sanity check that serena parsed the file:
+   ```bash
+   serena print-system-prompt "$(pwd)"
+   ```
+   Look for your project name, language list, and excluded tools in the output.
+
+2. **Probe a symbol** — exercise the LSP layer:
+   - Call `find_symbol` with a known name from the repo, `include_body=true`.
+   - The result should be a clean symbol record, not an LSP startup error.
+
+3. **Check diagnostics** — `get_diagnostics_for_file` on any source file should return either real diagnostics or an empty list. If it returns LSP setup errors, the `languages:` or `ls_specific_settings:` are wrong.
+
+If verification fails, the fastest path forward is to delete `.serena/cache/` (forces a rebuild) and retry. If it still fails, your `languages:` entry probably doesn't match a key in [serena's Language enum](https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py).
+
+## What NOT to do
+
+- **Don't enable memory tools or `onboarding`.** They're globally excluded in `~/.serena/serena_config.yml` because they collide with the user's `MEMORY.md` auto-memory system. Re-enabling them per-project via `included_optional_tools` will split-brain the memory model.
+- **Don't hand-roll `.serena/` from scratch.** Let `--project-from-cwd` bootstrap, then edit. Manual creation skips serena's inline documentation comments and misses fields added by newer versions.
+- **Don't put secrets, large blobs, or long instructions in `initial_prompt`.** It's prepended to every session in this repo and inflates context unnecessarily. Use `agents/AGENTS.md` (committed) or `CLAUDE.md` (repo-local) for stable instructions.
+- **Don't toggle `ignore_all_files_in_gitignore: false` to "see more code".** It floods the symbol index with generated/vendor files and degrades every subsequent lookup. Use `included_optional_tools` or targeted `ignored_paths` overrides instead.
+
+## Gotchas
+
+- `<certain>` `additional_workspace_folders` is TypeScript-only at time of writing — Rust workspaces, Go modules, and Python monorepos won't benefit. For non-TS monorepos, the workaround is to start serena from the monorepo root and rely on the language server's own workspace detection.
+- `<certain>` `excluded_tools` in `project.yml` is *additive* to the global list. You cannot un-exclude a tool that the global config disables. If you need the memory tools back in one repo (you don't), they have to be re-enabled globally first.
+- `<speculative>` Some LSP servers (intelephense, rust-analyzer) cache aggressively. After editing `ls_specific_settings`, deleting `.serena/cache/` is sometimes not enough — restart the serena MCP server (in Claude Code: drop session, reopen) to fully reset.
+- `<certain>` `read_only: true` disables *every* editing tool — including `replace_symbol_body` and `insert_*_symbol`. It does not just block `replace_content`. Confirm that's the intent before setting it.
+- The auto-bootstrap picks `languages:` from the dominant file extension. In a polyglot repo where the dominant language is documentation (e.g. a docs-heavy monorepo with `.md` outnumbering `.ts`), it can pick `markdown` and leave you without a real LSP. Override explicitly.
+
+## References
+
+- Serena project config schema: [oraios.github.io/serena/02-usage/050_configuration.html](https://oraios.github.io/serena/02-usage/050_configuration.html)
+- Language enum (full list of LSP keys): [github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py](https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py)
+- Global serena config in this dotfiles repo: `chezmoi/dot_serena/modify_serena_config.yml`
+- The "use serena" routing (separate concern): `agents/AGENTS.md` § Code-Intelligence Routing

--- a/tests/chezmoi-wiring.bats
+++ b/tests/chezmoi-wiring.bats
@@ -658,7 +658,12 @@ YAML
 
     [[ "$(yq '.web_dashboard'                 "$HOME/.serena/serena_config.yml")" == "false" ]]
     [[ "$(yq '.web_dashboard_open_on_launch'  "$HOME/.serena/serena_config.yml")" == "false" ]]
-    [[ "$(yq '.excluded_tools | length'       "$HOME/.serena/serena_config.yml")" == "0" ]]
+    # excluded_tools is overridden with the managed memory + onboarding list,
+    # replacing whatever was there (here: ["some_tool"]).
+    [[ "$(yq '.excluded_tools | length'       "$HOME/.serena/serena_config.yml")" == "7" ]]
+    [[ "$(yq '.excluded_tools | .[0]'         "$HOME/.serena/serena_config.yml")" == "write_memory" ]]
+    [[ "$(yq '.excluded_tools | contains(["onboarding"])' "$HOME/.serena/serena_config.yml")" == "true" ]]
+    [[ "$(yq '.excluded_tools | contains(["some_tool"])'  "$HOME/.serena/serena_config.yml")" == "false" ]]
     # And keys we don't touch must survive intact.
     [[ "$(yq '.language_backend' "$HOME/.serena/serena_config.yml")" == "LSP" ]]
     [[ "$(yq '.tool_timeout'     "$HOME/.serena/serena_config.yml")" == "240" ]]

--- a/tests/chezmoi-wiring.bats
+++ b/tests/chezmoi-wiring.bats
@@ -606,3 +606,83 @@ TOML
     grep -qF 'ssh://code.uber.internal/' "$HOME/.gitconfig"
     grep -qF 'gopkg.uberinternal.com' "$HOME/.gitconfig"
 }
+
+# ── serena config (modify_ pattern) ────────────────────────────────────────
+# Serena ships ~165 lines of inline-documented defaults; we only want to
+# override three keys (web_dashboard, web_dashboard_open_on_launch,
+# excluded_tools). A full-content chezmoi template would freeze Serena's
+# defaults at the version we wrote against and strip the inline docs —
+# anything Serena adds in a future release would silently disappear. The
+# `modify_` pattern lets yq patch only the keys we care about while
+# preserving everything else.
+
+setup_serena_chezmoi_env() {
+    mkdir -p "$HOME/.config/chezmoi"
+    cat > "$HOME/.config/chezmoi/chezmoi.toml" <<TOML
+sourceDir = "$REAL_DOTFILES_DIR/chezmoi"
+
+[data]
+email = "test@example.com"
+work = false
+TOML
+    export CONTEXT7_API_KEY="test-context7-key"
+    export TAVILY_API_KEY="test-tavily-key"
+}
+
+@test "serena: chezmoi source has modify_ script (not a full-content template)" {
+    assert_file_exists "$REAL_DOTFILES_DIR/chezmoi/dot_serena/modify_serena_config.yml"
+    [[ ! -e "$REAL_DOTFILES_DIR/chezmoi/dot_serena/serena_config.yml.tmpl" ]] \
+        || { echo "stray full-content template — should be removed in favor of modify_" >&2; return 1; }
+}
+
+@test "serena: modify_ script flips the three managed overrides" {
+    command -v chezmoi >/dev/null 2>&1 || skip "chezmoi not installed"
+    command -v yq      >/dev/null 2>&1 || skip "yq not installed"
+    setup_serena_chezmoi_env
+
+    # Seed a representative existing config with non-default values for the
+    # three keys we override. The modify_ script must drive them to false / [].
+    mkdir -p "$HOME/.serena"
+    cat > "$HOME/.serena/serena_config.yml" <<YAML
+# Serena config (test fixture)
+language_backend: LSP
+web_dashboard: true
+web_dashboard_open_on_launch: true
+excluded_tools:
+  - some_tool
+tool_timeout: 240
+YAML
+
+    run chezmoi apply --force "$HOME/.serena/serena_config.yml"
+    assert_success
+
+    [[ "$(yq '.web_dashboard'                 "$HOME/.serena/serena_config.yml")" == "false" ]]
+    [[ "$(yq '.web_dashboard_open_on_launch'  "$HOME/.serena/serena_config.yml")" == "false" ]]
+    [[ "$(yq '.excluded_tools | length'       "$HOME/.serena/serena_config.yml")" == "0" ]]
+    # And keys we don't touch must survive intact.
+    [[ "$(yq '.language_backend' "$HOME/.serena/serena_config.yml")" == "LSP" ]]
+    [[ "$(yq '.tool_timeout'     "$HOME/.serena/serena_config.yml")" == "240" ]]
+}
+
+@test "serena: modify_ script preserves Serena's inline doc comments" {
+    command -v chezmoi >/dev/null 2>&1 || skip "chezmoi not installed"
+    command -v yq      >/dev/null 2>&1 || skip "yq not installed"
+    setup_serena_chezmoi_env
+
+    mkdir -p "$HOME/.serena"
+    cat > "$HOME/.serena/serena_config.yml" <<'YAML'
+# upstream Serena docs — must survive the modify_ pass
+# Possible values are:
+#  * LSP: Use the language server protocol (LSP)
+language_backend: LSP
+web_dashboard: true
+web_dashboard_open_on_launch: true
+excluded_tools: []
+YAML
+
+    run chezmoi apply --force "$HOME/.serena/serena_config.yml"
+    assert_success
+
+    grep -qF 'upstream Serena docs'           "$HOME/.serena/serena_config.yml"
+    grep -qF 'Use the language server protocol' "$HOME/.serena/serena_config.yml"
+}

--- a/tests/chezmoi-wiring.bats
+++ b/tests/chezmoi-wiring.bats
@@ -686,3 +686,41 @@ YAML
     grep -qF 'upstream Serena docs'           "$HOME/.serena/serena_config.yml"
     grep -qF 'Use the language server protocol' "$HOME/.serena/serena_config.yml"
 }
+
+# Regression: the placeholder we write when serena isn't on PATH must not
+# round-trip through yq on a subsequent apply. The bug it guards against:
+# stdin matches PLACEHOLDER → filter resets `existing=` → bootstrap branch
+# reads `~/.serena/serena_config.yml` (which IS the placeholder, since
+# chezmoi just wrote it last apply) → `existing` is re-populated with the
+# placeholder text → yq sees a non-empty input and emits a 3-key stub,
+# permanently destroying Serena's ~165 lines of inline-documented defaults.
+@test "serena: modify_ script does NOT round-trip the placeholder through yq" {
+    command -v chezmoi >/dev/null 2>&1 || skip "chezmoi not installed"
+    command -v yq      >/dev/null 2>&1 || skip "yq not installed"
+    setup_serena_chezmoi_env
+
+    mkdir -p "$HOME/.serena"
+    cat > "$HOME/.serena/serena_config.yml" <<'YAML'
+# serena not initialized; run `serena init`, then `chezmoi apply` again
+YAML
+
+    # Build a minimal PATH that has chezmoi + yq but not serena. The bug
+    # fires only when `command -v serena` succeeds AND the live config is
+    # the placeholder. To exercise the placeholder-loop protection honestly
+    # we need serena off PATH so the bootstrap branch's live-file read is
+    # the only contamination source.
+    local chezmoi_dir yq_dir minimal_path
+    chezmoi_dir=$(dirname "$(command -v chezmoi)")
+    yq_dir=$(dirname "$(command -v yq)")
+    minimal_path="/usr/bin:/bin:$chezmoi_dir:$yq_dir"
+    [ -z "$(PATH="$minimal_path" command -v serena 2>/dev/null)" ] \
+        || skip "serena found on minimal PATH; cannot isolate bootstrap branch"
+
+    PATH="$minimal_path" run chezmoi apply --force "$HOME/.serena/serena_config.yml"
+    assert_success
+
+    # Placeholder must survive — both as the comment AND as the *only*
+    # content. The bug would replace it with `web_dashboard: false\n...`.
+    grep -qF '# serena not initialized' "$HOME/.serena/serena_config.yml"
+    ! grep -qE '^web_dashboard:' "$HOME/.serena/serena_config.yml"
+}

--- a/tests/mcp-lib.bats
+++ b/tests/mcp-lib.bats
@@ -135,6 +135,7 @@ MOCK
 # execute-template` per harness, so the same entry can produce different
 # argv for Claude vs Codex (used by Serena's --context=claude-code|codex).
 @test "sync.sh --dry-run: per-harness templating swaps args based on HARNESS env" {
+    command -v chezmoi >/dev/null 2>&1 || skip "chezmoi not installed"
     write_claude_stub
     write_codex_stub
 

--- a/tests/mcp-lib.bats
+++ b/tests/mcp-lib.bats
@@ -131,6 +131,42 @@ MOCK
     [[ -z "$output" ]] || { echo "expected empty output, got: [$output]" >&2; return 1; }
 }
 
+# End-to-end: registry `args` strings are rendered through `chezmoi
+# execute-template` per harness, so the same entry can produce different
+# argv for Claude vs Codex (used by Serena's --context=claude-code|codex).
+@test "sync.sh --dry-run: per-harness templating swaps args based on HARNESS env" {
+    write_claude_stub
+    write_codex_stub
+
+    cat > "$MOCK_BIN/claude" << 'MOCK'
+#!/bin/bash
+if [[ "$1" == mcp && "$2" == list ]]; then exit 0; fi
+exit 0
+MOCK
+    chmod +x "$MOCK_BIN/claude"
+    export CODEX_STUB_JSON='[]'
+
+    local fake_dotfiles="$TEST_HOME/fake-dotfiles"
+    mkdir -p "$fake_dotfiles/agents/mcp" "$fake_dotfiles/claude/lib"
+    cp "$REAL_DOTFILES_DIR/agents/mcp/sync.sh" "$fake_dotfiles/agents/mcp/sync.sh"
+    cp "$REAL_DOTFILES_DIR/agents/mcp/lib.sh"  "$fake_dotfiles/agents/mcp/lib.sh"
+    cp "$REAL_DOTFILES_DIR/claude/lib/sync-common.sh" "$fake_dotfiles/claude/lib/sync-common.sh"
+    cat > "$fake_dotfiles/agents/mcp/registry.yaml" << 'YAML'
+mcps:
+  picky:
+    command: picky
+    args:
+      - --mode={{ if eq (env "HARNESS") "claude" }}claude-mode{{ else }}codex-mode{{ end }}
+    scope: user
+    description: per-harness templating fixture
+YAML
+
+    run bash "$fake_dotfiles/agents/mcp/sync.sh" --dry-run
+    assert_success
+    assert_output_contains "picky --mode=claude-mode"
+    assert_output_contains "picky --mode=codex-mode"
+}
+
 # End-to-end: the exact failure mode chezmoi reported. Drives sync.sh in
 # dry-run with both harnesses in sync — pre-fix this hit exit 1 silently,
 # now it must print "Sync complete!" and exit 0.

--- a/tests/sync-claude.bats
+++ b/tests/sync-claude.bats
@@ -555,7 +555,9 @@ MOCK
     local mock_dir; mock_dir=$(create_mock_mcp_sync_dir "mcp-codex-missing")
     cp "$TEST_HOME/registry.yaml" "$mock_dir/registry.yaml"
     # Isolate PATH so a real `codex` binary on the dev machine doesn't satisfy `command -v codex`.
-    PATH="$MOCK_BIN:/usr/bin:/bin:/opt/homebrew/bin" run bash "$mock_dir/sync.sh" --harness codex
+    # /usr/local/bin and /opt/homebrew/bin stay on PATH so chezmoi (a hard dep of sync.sh)
+    # is still resolvable — they're the canonical install dirs on Ubuntu / macOS respectively.
+    PATH="$MOCK_BIN:/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin" run bash "$mock_dir/sync.sh" --harness codex
     assert_success
     assert_output_contains "Skipping codex"
 }

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -29,12 +29,26 @@ setup_test_env() {
     # Backup original HOME
     export ORIGINAL_HOME="$HOME"
     export HOME="$TEST_HOME"
+
+    # Pin XDG_* under the sandbox. CI runners (notably ubuntu-latest) preset
+    # XDG_CONFIG_HOME etc. to paths outside $HOME, which makes chezmoi look
+    # for its config in the wrong place when tests write ~/.config/chezmoi/
+    # under $TEST_HOME. Save the originals so teardown can restore them.
+    export ORIGINAL_XDG_CONFIG_HOME="${XDG_CONFIG_HOME-__unset__}"
+    export ORIGINAL_XDG_DATA_HOME="${XDG_DATA_HOME-__unset__}"
+    export ORIGINAL_XDG_CACHE_HOME="${XDG_CACHE_HOME-__unset__}"
+    unset XDG_CONFIG_HOME XDG_DATA_HOME XDG_CACHE_HOME
 }
 
 # Teardown test environment
 teardown_test_env() {
     # Restore original HOME
     export HOME="$ORIGINAL_HOME"
+
+    # Restore XDG_* (sentinel means it was unset on entry)
+    [[ "$ORIGINAL_XDG_CONFIG_HOME" != "__unset__" ]] && export XDG_CONFIG_HOME="$ORIGINAL_XDG_CONFIG_HOME"
+    [[ "$ORIGINAL_XDG_DATA_HOME"   != "__unset__" ]] && export XDG_DATA_HOME="$ORIGINAL_XDG_DATA_HOME"
+    [[ "$ORIGINAL_XDG_CACHE_HOME"  != "__unset__" ]] && export XDG_CACHE_HOME="$ORIGINAL_XDG_CACHE_HOME"
 
     # Clean up test directory
     if [[ -d "$TEST_HOME" ]]; then


### PR DESCRIPTION
Adds the Serena MCP server to the registry, picked up by both Claude and Codex. Serena exposes a different built-in tool set per harness (`--context=claude-code` strips Read/Write/Bash duplicates; `--context=codex` keeps them), which required teaching `agents/mcp/sync.sh` to render the registry through `chezmoi execute-template` once per harness with `HARNESS` in the env — so a single entry can branch its `args` inline via Go-template syntax without growing the schema. `packages/sync.sh` gains a per-package `flags` field for uv entries (needed because `serena-agent` pins Python 3.13 and ships pre-release builds), and `chezmoi/dot_serena/modify_serena_config.yml` patches only three keys via `yq` while preserving Serena's ~165 lines of inline-documented defaults. New tests cover per-harness arg templating end-to-end (`tests/mcp-lib.bats`) and the `modify_` pattern (`tests/chezmoi-wiring.bats`); `AGENTS.md` documents the templating contract and the limited options for filtering which MCP tools a server exposes.
