### PR TITLE
feat(prompts): replace bundled system prompt across Claude/Codex/opencode

### DIFF
--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -142,9 +142,13 @@ For project architecture (when a project opts in), see the **Sliced Bread** patt
 
 Three MCPs cover code intelligence; they layer rather than overlap.
 
-- **tilth** — file I/O floor: `tilth_search`, `tilth_read`, `tilth_list`, `tilth_write` (+ `tilth_deps`, `tilth_diff`). Default for read/grep/edit; replaces host Grep/Read/Edit/Glob.
-- **serena** — LSP-grounded symbol layer: `find_symbol`, `find_referencing_symbols`, `find_declaration`, `find_implementations`, `get_symbols_overview`, `get_diagnostics_for_file`, `rename_symbol`, `safe_delete_symbol`, `replace_symbol_body`, `insert_before_symbol`, `insert_after_symbol`, `replace_content`. Use when ground-truth semantics matter (overloads, generics, dispatch, type info). Memory tools and `onboarding` are excluded in `~/.serena/serena_config.yml` — do not try to call them.
-- **code-review-graph** — project-scale graph: `get_impact_radius_tool`, `get_affected_flows_tool`, `get_review_context_tool`, `get_minimal_context_tool`, `get_architecture_overview_tool`, `list_communities_tool`, `semantic_search_nodes_tool`. Use for blast-radius, "what does this codebase do", and review-scope queries — not for routine search.
+- **tilth** — file I/O floor. Default for read/grep/edit; replaces host Grep/Read/Edit/Glob.
+- **serena** — LSP-grounded symbol layer. Use when ground-truth semantics matter (overloads, generics, dispatch, type info). Memory tools and `onboarding` are excluded in `~/.serena/serena_config.yml` — do not try to call them.
+- **code-review-graph** — project-scale graph. Use for blast-radius, "what does this codebase do", and review-scope queries — not for routine search.
+
+Built-in `Read` / `Edit` / `Write` / `Glob` / `Grep` are last-resort: use only when the file is outside the workspace, no MCP server can parse it, or a multi-file regex doesn't fit an MCP equivalent.
+
+Claude sessions get task-to-tool tables and a routing self-check via `agents/preamble.md` (loaded as `--append-system-prompt-file`). Codex/opencode users: discover tools via `mcp list` or the server's own descriptions.
 
 ### Editing: serena vs tilth
 

--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -148,7 +148,7 @@ Three MCPs cover code intelligence; they layer rather than overlap.
 
 Built-in `Read` / `Edit` / `Write` / `Glob` / `Grep` are last-resort: use only when the file is outside the workspace, no MCP server can parse it, or a multi-file regex doesn't fit an MCP equivalent.
 
-Claude sessions get task-to-tool tables and a routing self-check via `agents/preamble.md` (loaded as `--append-system-prompt-file`). Codex/opencode users: discover tools via `mcp list` or the server's own descriptions.
+Every harness gets task-to-tool tables and a routing self-check via `agents/preamble.md`, wired in as the *replacement* for the bundled system prompt: Claude Code via `--system-prompt-file` (cc/ccc/ccr/ccfresh in `zsh/claude.zsh`), Codex via `model_instructions_file` in `~/.codex/config.toml`, opencode via `~/.config/opencode/agents/build.md`. The user-side AGENTS.md / CLAUDE.md cascade still loads on top of the replaced prompt — this section is what you're reading from it.
 
 ### Editing: serena vs tilth
 

--- a/agents/preamble.md
+++ b/agents/preamble.md
@@ -1,20 +1,6 @@
 # Preamble — MCP tool routing
 
-This project provides three MCP servers that supersede built-in file tools for different shapes of work. Use the right one — built-ins are last-resort.
-
-## Routing rules
-
-| Question shape | MCP | Example tools |
-|---|---|---|
-| Read / list / search / edit any file | **tilth** (default) | `tilth_read`, `tilth_search`, `tilth_list`, `tilth_write` |
-| Symbol-level read or edit on code | **Serena** | `find_symbol`, `find_referencing_symbols`, `replace_symbol_body`, `rename_symbol` |
-| Graph-level analysis on code | **code-review-graph** | `get_impact_radius_tool`, `get_review_context_tool`, `get_architecture_overview_tool`, `semantic_search_nodes_tool` |
-
-Built-in `Read` / `Edit` / `Write` / `Glob` / `Grep` are acceptable only when:
-
-- The file is outside the workspace.
-- No MCP server can parse the file (binaries, malformed code).
-- A regex search across many files doesn't fit any MCP equivalent — and even then, follow-up reads/edits on matched code files go back through the right MCP.
+Reinforces `~/.claude/CLAUDE.md`'s Code-Intelligence Routing section. That section says *which* MCP to pick by shape; this one gives the task-to-tool tables and the pre-call self-check.
 
 The `cheez-search` / `cheez-read` / `cheez-write` skills route through tilth — use them instead of host `Read` / `Edit` / `Write` / `Grep` whenever they're available.
 

--- a/agents/preamble.md
+++ b/agents/preamble.md
@@ -1,0 +1,69 @@
+# Preamble — MCP tool routing
+
+This project provides three MCP servers that supersede built-in file tools for different shapes of work. Use the right one — built-ins are last-resort.
+
+## Routing rules
+
+| Question shape | MCP | Example tools |
+|---|---|---|
+| Read / list / search / edit any file | **tilth** (default) | `tilth_read`, `tilth_search`, `tilth_list`, `tilth_write` |
+| Symbol-level read or edit on code | **Serena** | `find_symbol`, `find_referencing_symbols`, `replace_symbol_body`, `rename_symbol` |
+| Graph-level analysis on code | **code-review-graph** | `get_impact_radius_tool`, `get_review_context_tool`, `get_architecture_overview_tool`, `semantic_search_nodes_tool` |
+
+Built-in `Read` / `Edit` / `Write` / `Glob` / `Grep` are acceptable only when:
+
+- The file is outside the workspace.
+- No MCP server can parse the file (binaries, malformed code).
+- A regex search across many files doesn't fit any MCP equivalent — and even then, follow-up reads/edits on matched code files go back through the right MCP.
+
+The `cheez-search` / `cheez-read` / `cheez-write` skills route through tilth — use them instead of host `Read` / `Edit` / `Write` / `Grep` whenever they're available.
+
+## Serena mapping (symbol-level)
+
+| Task | Tool |
+|---|---|
+| See a file's structure | `get_symbols_overview` |
+| Read a specific symbol's body | `find_symbol` (`include_body=true`) |
+| Find a symbol by name | `find_symbol` |
+| Find references / callers | `find_referencing_symbols` |
+| Find declarations / implementations | `find_declaration` / `find_implementations` |
+| Edit a symbol's body | `replace_symbol_body` |
+| Insert near a symbol | `insert_before_symbol` / `insert_after_symbol` |
+| Pattern replace inside a file | `replace_content` |
+| Rename a symbol | `rename_symbol` |
+| Safe-delete a symbol | `safe_delete_symbol` |
+
+## code-review-graph mapping (graph-level)
+
+| Task | Tool |
+|---|---|
+| Build / refresh the graph for a repo | `build_or_update_graph_tool` |
+| One-call review context for a change | `get_review_context_tool` |
+| Detect what changed since last build | `detect_changes_tool` |
+| Trace blast radius of a symbol or file | `get_impact_radius_tool` |
+| Which user-facing flows a change touches | `get_affected_flows_tool` |
+| High-level architecture summary | `get_architecture_overview_tool` |
+| Hub / bridge nodes (critical nodes) | `get_hub_nodes_tool` / `get_bridge_nodes_tool` |
+| Suspicious size or shape | `find_large_functions_tool` |
+| Modular subgraphs | `list_communities_tool` / `get_community_tool` |
+| Semantic (embedding) search across nodes | `semantic_search_nodes_tool` |
+| Minimal context for a question | `get_minimal_context_tool` |
+| Knowledge gaps for review | `get_knowledge_gaps_tool` |
+
+Reach for code-review-graph first when reviewing a change, planning a multi-file edit, or answering "what does this actually affect."
+
+## Workflow before editing code
+
+1. **Scope it** — for changes that touch multiple files or for review work, start with `get_review_context_tool` or `get_impact_radius_tool`.
+2. **Read the symbol** — `get_symbols_overview` on the target file (skip if done this session), then `find_symbol` with `include_body=true` for the specific symbol.
+3. **Edit** — Serena `replace_symbol_body` / `insert_before_symbol` / `insert_after_symbol` / `replace_content` for symbol-anchored edits; `tilth_write` for whole-file rewrites or non-code files.
+
+## Routing self-check
+
+Before each tool call, ask: "What's the shape of the question?"
+
+- Symbol-level read or edit → **Serena**
+- File-level read, search, or edit → **tilth**
+- Graph-level analysis (impact, architecture, flows) → **code-review-graph**
+
+If unsure, pick the smallest-scope tool that can answer the question. Don't rationalize built-ins with "the file is small" or "I already know the path" — those rationalizations have produced incorrect behavior before.

--- a/chezmoi/.chezmoiscripts/run_onchange_install-prompts.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/run_onchange_install-prompts.sh.tmpl
@@ -1,0 +1,15 @@
+#!/bin/bash
+# run_onchange — re-runs whenever agents/preamble.md changes.
+#
+# Forks to chezmoi/lib/install-prompts.sh, which wires preamble.md as the
+# system prompt for Codex CLI and opencode. Claude Code reads it directly
+# via cc/ccc/ccr/ccfresh in zsh/claude.zsh (--system-prompt-file).
+#
+# Prompts hash: {{ output "sh" "-c" (printf "shasum -a 256 %q/../agents/preamble.md 2>/dev/null | cut -d' ' -f1" .chezmoi.sourceDir) }}
+
+set -euo pipefail
+
+SOURCE_DIR="{{ .chezmoi.sourceDir }}"
+DOTFILES_ROOT="$SOURCE_DIR/.."
+
+"$SOURCE_DIR/lib/install-prompts.sh" "$DOTFILES_ROOT/agents/preamble.md"

--- a/chezmoi/lib/install-prompts.sh
+++ b/chezmoi/lib/install-prompts.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+# install-prompts.sh — wire agents/preamble.md as the system prompt for
+# harnesses that support replacement (Codex CLI, opencode).
+#
+# Claude Code reads preamble.md directly via the cc/ccc/ccr/ccfresh wrappers
+# in zsh/claude.zsh (--system-prompt-file), so it is not handled here.
+#
+# Per-harness mechanism:
+#
+#   Codex     — copy preamble.md to <CODEX_HOME>/preamble.md, then yq-edit
+#               <CODEX_HOME>/config.toml to set
+#                 model_instructions_file = "<CODEX_HOME>/preamble.md"
+#               This REPLACES the bundled per-model system prompt
+#               (codex-rs/core/gpt_5_*_prompt.md). AGENTS.md cascade still
+#               loads as developer-role messages (untouched).
+#
+#   opencode  — copy preamble.md to <OPENCODE_HOME>/agents/build.md.
+#               opencode reads {agent,agents}/**/*.md and uses the file body
+#               as the agent's system prompt
+#               (packages/opencode/src/config/agent.ts:125). "build" is the
+#               default agent, so bare `opencode` picks it up.
+#
+# Harness CLIs that are not installed are skipped silently.
+#
+# Usage:
+#   install-prompts.sh <preamble_path>
+#
+# Honors:
+#   CODEX_HOME        defaults to ~/.codex
+#   OPENCODE_HOME     defaults to ~/.config/opencode
+#   INSTALL_PROMPTS_HAVE_CODEX       force-on/off codex detection (for tests)
+#   INSTALL_PROMPTS_HAVE_OPENCODE    force-on/off opencode detection (for tests)
+#   INSTALL_PROMPTS_HAVE_YQ          force-on/off yq detection (for tests)
+
+set -euo pipefail
+
+install_prompts_have() {
+    local cmd="$1"
+    # Manual uppercase — `${var^^}` requires bash 4+; macOS ships bash 3.2.
+    local cmd_upper
+    cmd_upper="$(printf '%s' "$cmd" | tr '[:lower:]' '[:upper:]')"
+    local override_var="INSTALL_PROMPTS_HAVE_${cmd_upper}"
+    if [[ -n "${!override_var:-}" ]]; then
+        [[ "${!override_var}" == "1" ]]
+        return $?
+    fi
+    command -v "$cmd" &>/dev/null
+}
+
+install_prompts_wire_codex() {
+    local preamble="$1"
+    local codex_home="${CODEX_HOME:-$HOME/.codex}"
+    local codex_prompt="$codex_home/preamble.md"
+    local codex_config="$codex_home/config.toml"
+
+    install_prompts_have codex || {
+        echo "  Skipped Codex wiring (codex not installed)"
+        return 0
+    }
+
+    mkdir -p "$codex_home"
+    cp -f "$preamble" "$codex_prompt"
+    echo "  Copied preamble.md -> $codex_prompt"
+
+    if [[ ! -f "$codex_config" ]]; then
+        echo "  Skipped $codex_config (not yet scaffolded; will pick up the prompt path on next dots sync)"
+        return 0
+    fi
+
+    if ! install_prompts_have yq; then
+        echo "  Skipped $codex_config update (yq not installed)"
+        return 0
+    fi
+
+    local current
+    current="$(yq -p=toml '.model_instructions_file // ""' "$codex_config" 2>/dev/null || true)"
+    if [[ "$current" != "$codex_prompt" ]]; then
+        yq -p=toml -o=toml -i ".model_instructions_file = \"$codex_prompt\"" "$codex_config"
+        echo "  Set model_instructions_file in $codex_config"
+    fi
+}
+
+install_prompts_wire_opencode() {
+    local preamble="$1"
+    local opencode_home="${OPENCODE_HOME:-$HOME/.config/opencode}"
+    local opencode_prompt="$opencode_home/agents/build.md"
+
+    install_prompts_have opencode || {
+        echo "  Skipped opencode wiring (opencode not installed)"
+        return 0
+    }
+
+    mkdir -p "$(dirname "$opencode_prompt")"
+    cp -f "$preamble" "$opencode_prompt"
+    echo "  Copied preamble.md -> $opencode_prompt"
+}
+
+install_prompts_main() {
+    local preamble="${1:-}"
+    if [[ -z "$preamble" ]]; then
+        echo "Usage: install-prompts.sh <preamble_path>" >&2
+        return 2
+    fi
+    if [[ ! -f "$preamble" ]]; then
+        echo "install-prompts: $preamble not found, skipping" >&2
+        return 0
+    fi
+    install_prompts_wire_codex "$preamble"
+    install_prompts_wire_opencode "$preamble"
+}
+
+# Only run main when this file is executed directly (not when sourced by bats).
+# shellcheck disable=SC2128
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    install_prompts_main "$@"
+fi

--- a/codex/config.toml
+++ b/codex/config.toml
@@ -8,5 +8,11 @@
 approval_policy = "on-request"
 sandbox_mode = "workspace-write"
 
+# `model_instructions_file` is set into the live ~/.codex/config.toml at sync
+# time by chezmoi/.chezmoiscripts/run_onchange_install-prompts.sh.tmpl using
+# an absolute path — TOML does not expand `~`, so we cannot bake it into this
+# seed file. The same script keeps ~/.codex/preamble.md in sync with
+# agents/preamble.md.
+
 [sandbox_workspace_write]
 network_access = true

--- a/tests/claude-lsp-gate.bats
+++ b/tests/claude-lsp-gate.bats
@@ -217,6 +217,35 @@ $snippet
     [[ "$args" == *"claude-lsp-gate"* ]]
 }
 
+# ── preamble wiring ──────────────────────────────────────────────────────────────────────
+
+@test "cc passes --append-system-prompt-file with preamble.md" {
+    local args
+    args="$(zsh_with_mock "cd '$REAL_DOTFILES_DIR' && cc --print test")"
+    [[ "$args" == *"--append-system-prompt-file"* ]]
+    [[ "$args" == *"agents/preamble.md"* ]]
+}
+
+@test "ccc passes --append-system-prompt-file with preamble.md" {
+    local args
+    args="$(zsh_with_mock "cd '$REAL_DOTFILES_DIR' && ccc")"
+    [[ "$args" == *"--append-system-prompt-file"* ]]
+    [[ "$args" == *"agents/preamble.md"* ]]
+}
+
+@test "ccr passes --append-system-prompt-file with preamble.md" {
+    local args
+    args="$(zsh_with_mock "cd '$REAL_DOTFILES_DIR' && ccr")"
+    [[ "$args" == *"--append-system-prompt-file"* ]]
+    [[ "$args" == *"agents/preamble.md"* ]]
+}
+
+@test "ccfresh passes --append-system-prompt-file with preamble.md" {
+    local args
+    args="$(zsh_with_mock "cd '$REAL_DOTFILES_DIR' && ccfresh")"
+    [[ "$args" == *"--append-system-prompt-file"* ]]
+    [[ "$args" == *"agents/preamble.md"* ]]
+}
 # ── ccp wiring ────────────────────────────────────────────────────────────────
 
 @test "ccp fe injects gate file before settings-merge.json" {

--- a/tests/claude-lsp-gate.bats
+++ b/tests/claude-lsp-gate.bats
@@ -12,9 +12,15 @@ LSP_PLUGINS=(
     "gopls@claude-code-lsps"
 )
 
+# Skip the calling test when zsh is missing. MUST be called directly from the
+# test body (not via `run` or `$(...)`) — `skip` only flips BATS_TEST_SKIPPED
+# in the current shell, so subshell calls would be silently lost.
+require_zsh() {
+    command -v zsh &>/dev/null || skip "zsh not installed"
+}
+
 # Run a zsh snippet with claude.zsh sourced. Errors from compdef are suppressed.
 zsh_run() {
-    command -v zsh &>/dev/null || skip "zsh not installed"
     local snippet="$1"
     DOTFILES_DIR="$DOTFILES_DIR" zsh -c "
 source '$REAL_DOTFILES_DIR/zsh/claude.zsh' 2>/dev/null || true
@@ -49,7 +55,7 @@ teardown() {
 # ── syntax ────────────────────────────────────────────────────────────────────
 
 @test "claude.zsh has no syntax errors" {
-    command -v zsh &>/dev/null || skip "zsh not installed"
+    require_zsh
     run zsh -n "$REAL_DOTFILES_DIR/zsh/claude.zsh"
     [[ $status -eq 0 ]]
 }
@@ -76,12 +82,14 @@ teardown() {
 # ── gate helper ───────────────────────────────────────────────────────────────
 
 @test "_cc_lsp_gate prints nothing outside a git repo" {
+    require_zsh
     run zsh_run "cd /tmp && _cc_lsp_gate"
     [[ $status -eq 0 ]]
     [[ -z "$output" ]]
 }
 
 @test "_cc_lsp_gate prints a file path inside a git repo" {
+    require_zsh
     run zsh_run "cd '$GATE_REPO' && _cc_lsp_gate"
     [[ $status -eq 0 ]]
     [[ -n "$output" ]]
@@ -89,6 +97,7 @@ teardown() {
 }
 
 @test "_cc_lsp_gate output is valid JSON" {
+    require_zsh
     local gate_file
     gate_file="$(zsh_run "cd '$REAL_DOTFILES_DIR' && _cc_lsp_gate")"
     [[ -n "$gate_file" ]]
@@ -96,6 +105,7 @@ teardown() {
 }
 
 @test "_cc_lsp_gate output contains exactly the 6 LSP plugin keys" {
+    require_zsh
     local gate_file
     gate_file="$(zsh_run "cd '$REAL_DOTFILES_DIR' && _cc_lsp_gate")"
     [[ -n "$gate_file" ]]
@@ -111,6 +121,7 @@ teardown() {
 }
 
 @test "_cc_lsp_gate values are booleans not strings" {
+    require_zsh
     local gate_file
     gate_file="$(zsh_run "cd '$REAL_DOTFILES_DIR' && _cc_lsp_gate")"
     [[ -n "$gate_file" ]]
@@ -121,6 +132,7 @@ teardown() {
 }
 
 @test "_cc_lsp_gate threshold 999999 disables all LSPs" {
+    require_zsh
     local gate_file
     gate_file="$(CC_LSP_GATE_THRESHOLD=999999 zsh_run "
 export CC_LSP_GATE_THRESHOLD=999999
@@ -134,6 +146,7 @@ _cc_lsp_gate")"
 }
 
 @test "_cc_lsp_gate threshold 1 enables at least one LSP in this repo" {
+    require_zsh
     local gate_file
     gate_file="$(CC_LSP_GATE_THRESHOLD=1 zsh_run "
 export CC_LSP_GATE_THRESHOLD=1
@@ -147,6 +160,7 @@ _cc_lsp_gate")"
 }
 
 @test "_cc_lsp_gate enables bash-language-server for this shell-heavy repo" {
+    require_zsh
     local gate_file
     gate_file="$(CC_LSP_GATE_THRESHOLD=50 zsh_run "
 export CC_LSP_GATE_THRESHOLD=50
@@ -160,6 +174,7 @@ _cc_lsp_gate")"
 }
 
 @test "_cc_lsp_gate disables rust-analyzer for this non-Rust repo" {
+    require_zsh
     local gate_file
     gate_file="$(zsh_run "cd '$REAL_DOTFILES_DIR' && _cc_lsp_gate")"
     [[ -n "$gate_file" ]]
@@ -170,6 +185,7 @@ _cc_lsp_gate")"
 }
 
 @test "_cc_lsp_gate disables gopls for this non-Go repo" {
+    require_zsh
     local gate_file
     gate_file="$(zsh_run "cd '$REAL_DOTFILES_DIR' && _cc_lsp_gate")"
     [[ -n "$gate_file" ]]
@@ -183,7 +199,6 @@ _cc_lsp_gate")"
 
 # Direct zsh invocation with explicit env — more reliable than zsh_run for PATH-sensitive tests.
 zsh_with_mock() {
-    command -v zsh &>/dev/null || skip "zsh not installed"
     local snippet="$1"
     DOTFILES_DIR="$DOTFILES_DIR" PATH="$MOCK_BIN:$PATH" zsh -c "
 source '$REAL_DOTFILES_DIR/zsh/claude.zsh' 2>/dev/null || true
@@ -192,6 +207,7 @@ $snippet
 }
 
 @test "cc passes --settings gate file when inside a git repo" {
+    require_zsh
     local args
     args="$(zsh_with_mock "cd '$REAL_DOTFILES_DIR' && cc --print test")"
     [[ "$args" == *"--settings"* ]]
@@ -199,12 +215,14 @@ $snippet
 }
 
 @test "cc passes no --settings flag outside a git repo" {
+    require_zsh
     local args
     args="$(zsh_with_mock "cd /tmp && cc --print test")"
     [[ "$args" != *"claude-lsp-gate"* ]]
 }
 
 @test "ccc passes --settings and --continue in a git repo" {
+    require_zsh
     local args
     args="$(zsh_with_mock "cd '$REAL_DOTFILES_DIR' && ccc")"
     [[ "$args" == *"--settings"* ]]
@@ -213,6 +231,7 @@ $snippet
 }
 
 @test "ccr passes --settings and --resume in a git repo" {
+    require_zsh
     local args
     args="$(zsh_with_mock "cd '$REAL_DOTFILES_DIR' && ccr")"
     [[ "$args" == *"--settings"* ]]
@@ -227,6 +246,7 @@ $snippet
 # auto-loads (we are not using --bare).
 
 @test "cc passes --system-prompt-file with preamble.md" {
+    require_zsh
     local args
     args="$(zsh_with_mock "cd '$REAL_DOTFILES_DIR' && cc --print test")"
     [[ "$args" == *"--system-prompt-file"* ]]
@@ -236,6 +256,7 @@ $snippet
 }
 
 @test "ccc passes --system-prompt-file with preamble.md" {
+    require_zsh
     local args
     args="$(zsh_with_mock "cd '$REAL_DOTFILES_DIR' && ccc")"
     [[ "$args" == *"--system-prompt-file"* ]]
@@ -244,6 +265,7 @@ $snippet
 }
 
 @test "ccr passes --system-prompt-file with preamble.md" {
+    require_zsh
     local args
     args="$(zsh_with_mock "cd '$REAL_DOTFILES_DIR' && ccr")"
     [[ "$args" == *"--system-prompt-file"* ]]
@@ -252,6 +274,7 @@ $snippet
 }
 
 @test "ccfresh passes --system-prompt-file with preamble.md" {
+    require_zsh
     local args
     args="$(zsh_with_mock "cd '$REAL_DOTFILES_DIR' && ccfresh")"
     [[ "$args" == *"--system-prompt-file"* ]]
@@ -260,6 +283,7 @@ $snippet
 }
 
 @test "cc does NOT pass --bare (we keep CLAUDE.md / hooks / LSP / plugins active)" {
+    require_zsh
     local args
     args="$(zsh_with_mock "cd '$REAL_DOTFILES_DIR' && cc --print test")"
     [[ "$args" != *"--bare"* ]]
@@ -267,6 +291,7 @@ $snippet
 # ── ccp wiring ────────────────────────────────────────────────────────────────
 
 @test "ccp fe injects gate file before settings-merge.json" {
+    require_zsh
     local args
     args="$(zsh_with_mock "cd '$REAL_DOTFILES_DIR' && ccp fe")"
     [[ "$args" == *"claude-lsp-gate"* ]]
@@ -279,18 +304,21 @@ $snippet
 }
 
 @test "ccp todo skips gate (profile has full-replace settings.json)" {
+    require_zsh
     local args
     args="$(zsh_with_mock "cd '$REAL_DOTFILES_DIR' && ccp todo")"
     [[ "$args" != *"claude-lsp-gate"* ]]
 }
 
 @test "ccp plugin injects gate (no full-replace settings.json)" {
+    require_zsh
     local args
     args="$(zsh_with_mock "cd '$REAL_DOTFILES_DIR' && ccp plugin")"
     [[ "$args" == *"claude-lsp-gate"* ]]
 }
 
 @test "ccp review injects gate (no full-replace settings.json)" {
+    require_zsh
     local args
     args="$(zsh_with_mock "cd '$REAL_DOTFILES_DIR' && ccp review")"
     [[ "$args" == *"claude-lsp-gate"* ]]

--- a/tests/claude-lsp-gate.bats
+++ b/tests/claude-lsp-gate.bats
@@ -14,6 +14,7 @@ LSP_PLUGINS=(
 
 # Run a zsh snippet with claude.zsh sourced. Errors from compdef are suppressed.
 zsh_run() {
+    command -v zsh &>/dev/null || skip "zsh not installed"
     local snippet="$1"
     DOTFILES_DIR="$DOTFILES_DIR" zsh -c "
 source '$REAL_DOTFILES_DIR/zsh/claude.zsh' 2>/dev/null || true
@@ -48,6 +49,7 @@ teardown() {
 # ── syntax ────────────────────────────────────────────────────────────────────
 
 @test "claude.zsh has no syntax errors" {
+    command -v zsh &>/dev/null || skip "zsh not installed"
     run zsh -n "$REAL_DOTFILES_DIR/zsh/claude.zsh"
     [[ $status -eq 0 ]]
 }
@@ -181,6 +183,7 @@ _cc_lsp_gate")"
 
 # Direct zsh invocation with explicit env — more reliable than zsh_run for PATH-sensitive tests.
 zsh_with_mock() {
+    command -v zsh &>/dev/null || skip "zsh not installed"
     local snippet="$1"
     DOTFILES_DIR="$DOTFILES_DIR" PATH="$MOCK_BIN:$PATH" zsh -c "
 source '$REAL_DOTFILES_DIR/zsh/claude.zsh' 2>/dev/null || true

--- a/tests/claude-lsp-gate.bats
+++ b/tests/claude-lsp-gate.bats
@@ -218,33 +218,48 @@ $snippet
 }
 
 # ── preamble wiring ──────────────────────────────────────────────────────────────────────
+#
+# cc/ccc/ccr/ccfresh REPLACE Claude's bundled system prompt with preamble.md
+# via --system-prompt-file. The user's CLAUDE.md / AGENTS.md cascade still
+# auto-loads (we are not using --bare).
 
-@test "cc passes --append-system-prompt-file with preamble.md" {
+@test "cc passes --system-prompt-file with preamble.md" {
     local args
     args="$(zsh_with_mock "cd '$REAL_DOTFILES_DIR' && cc --print test")"
-    [[ "$args" == *"--append-system-prompt-file"* ]]
+    [[ "$args" == *"--system-prompt-file"* ]]
     [[ "$args" == *"agents/preamble.md"* ]]
+    # Must NOT be the --append variant — we want full replacement.
+    [[ "$args" != *"--append-system-prompt-file"* ]]
 }
 
-@test "ccc passes --append-system-prompt-file with preamble.md" {
+@test "ccc passes --system-prompt-file with preamble.md" {
     local args
     args="$(zsh_with_mock "cd '$REAL_DOTFILES_DIR' && ccc")"
-    [[ "$args" == *"--append-system-prompt-file"* ]]
+    [[ "$args" == *"--system-prompt-file"* ]]
     [[ "$args" == *"agents/preamble.md"* ]]
+    [[ "$args" != *"--append-system-prompt-file"* ]]
 }
 
-@test "ccr passes --append-system-prompt-file with preamble.md" {
+@test "ccr passes --system-prompt-file with preamble.md" {
     local args
     args="$(zsh_with_mock "cd '$REAL_DOTFILES_DIR' && ccr")"
-    [[ "$args" == *"--append-system-prompt-file"* ]]
+    [[ "$args" == *"--system-prompt-file"* ]]
     [[ "$args" == *"agents/preamble.md"* ]]
+    [[ "$args" != *"--append-system-prompt-file"* ]]
 }
 
-@test "ccfresh passes --append-system-prompt-file with preamble.md" {
+@test "ccfresh passes --system-prompt-file with preamble.md" {
     local args
     args="$(zsh_with_mock "cd '$REAL_DOTFILES_DIR' && ccfresh")"
-    [[ "$args" == *"--append-system-prompt-file"* ]]
+    [[ "$args" == *"--system-prompt-file"* ]]
     [[ "$args" == *"agents/preamble.md"* ]]
+    [[ "$args" != *"--append-system-prompt-file"* ]]
+}
+
+@test "cc does NOT pass --bare (we keep CLAUDE.md / hooks / LSP / plugins active)" {
+    local args
+    args="$(zsh_with_mock "cd '$REAL_DOTFILES_DIR' && cc --print test")"
+    [[ "$args" != *"--bare"* ]]
 }
 # ── ccp wiring ────────────────────────────────────────────────────────────────
 

--- a/tests/install-prompts.bats
+++ b/tests/install-prompts.bats
@@ -1,0 +1,149 @@
+#!/usr/bin/env bats
+# shellcheck disable=SC1090,SC2034,SC2317
+# Tests for chezmoi/lib/install-prompts.sh — wires agents/preamble.md as the
+# replacement system prompt for Codex CLI and opencode.
+
+load test_helper
+
+setup() {
+    setup_test_env
+    LIB="$REAL_DOTFILES_DIR/chezmoi/lib/install-prompts.sh"
+    PREAMBLE_SRC="$TEST_HOME/preamble.md"
+    cat > "$PREAMBLE_SRC" <<'MD'
+# Preamble — MCP tool routing
+
+Test preamble content for assertion checks.
+MD
+    export CODEX_HOME="$TEST_HOME/.codex"
+    export OPENCODE_HOME="$TEST_HOME/.config/opencode"
+}
+
+teardown() { teardown_test_env; }
+
+# ── usage / arg handling ─────────────────────────────────────────────────────
+
+@test "install-prompts.sh exits 2 with no args" {
+    run bash "$LIB"
+    [[ "$status" -eq 2 ]]
+    assert_output_contains "Usage:"
+}
+
+@test "install-prompts.sh is a no-op when preamble file is missing" {
+    INSTALL_PROMPTS_HAVE_CODEX=1 INSTALL_PROMPTS_HAVE_OPENCODE=1 \
+        run bash "$LIB" "$TEST_HOME/does-not-exist.md"
+    assert_success
+    [[ ! -e "$CODEX_HOME/preamble.md" ]]
+    [[ ! -e "$OPENCODE_HOME/agents/build.md" ]]
+}
+
+# ── Codex wiring ─────────────────────────────────────────────────────────────
+
+@test "install-prompts.sh skips Codex when codex CLI is missing" {
+    INSTALL_PROMPTS_HAVE_CODEX=0 INSTALL_PROMPTS_HAVE_OPENCODE=0 \
+        run bash "$LIB" "$PREAMBLE_SRC"
+    assert_success
+    assert_output_contains "Skipped Codex wiring"
+    [[ ! -e "$CODEX_HOME/preamble.md" ]]
+}
+
+@test "install-prompts.sh copies preamble.md to \$CODEX_HOME/preamble.md when codex is present" {
+    INSTALL_PROMPTS_HAVE_CODEX=1 INSTALL_PROMPTS_HAVE_OPENCODE=0 \
+        run bash "$LIB" "$PREAMBLE_SRC"
+    assert_success
+    assert_file_exists "$CODEX_HOME/preamble.md"
+    diff "$PREAMBLE_SRC" "$CODEX_HOME/preamble.md"
+}
+
+@test "install-prompts.sh skips config.toml edit when it doesn't exist yet" {
+    INSTALL_PROMPTS_HAVE_CODEX=1 INSTALL_PROMPTS_HAVE_OPENCODE=0 \
+        run bash "$LIB" "$PREAMBLE_SRC"
+    assert_success
+    assert_output_contains "Skipped"
+    assert_output_contains "config.toml"
+    [[ ! -e "$CODEX_HOME/config.toml" ]]
+}
+
+@test "install-prompts.sh sets model_instructions_file in existing config.toml" {
+    mkdir -p "$CODEX_HOME"
+    cat > "$CODEX_HOME/config.toml" <<'TOML'
+approval_policy = "on-request"
+sandbox_mode = "workspace-write"
+TOML
+    INSTALL_PROMPTS_HAVE_CODEX=1 INSTALL_PROMPTS_HAVE_OPENCODE=0 INSTALL_PROMPTS_HAVE_YQ=1 \
+        run bash "$LIB" "$PREAMBLE_SRC"
+    assert_success
+    grep -q "model_instructions_file" "$CODEX_HOME/config.toml"
+    local set_path
+    set_path="$(yq -p=toml '.model_instructions_file' "$CODEX_HOME/config.toml")"
+    [[ "$set_path" == "$CODEX_HOME/preamble.md" ]]
+    # Other keys must survive.
+    grep -q 'approval_policy = "on-request"' "$CODEX_HOME/config.toml"
+    grep -q 'sandbox_mode = "workspace-write"' "$CODEX_HOME/config.toml"
+}
+
+@test "install-prompts.sh is idempotent on the config.toml edit" {
+    mkdir -p "$CODEX_HOME"
+    cat > "$CODEX_HOME/config.toml" <<'TOML'
+approval_policy = "on-request"
+TOML
+    INSTALL_PROMPTS_HAVE_CODEX=1 INSTALL_PROMPTS_HAVE_OPENCODE=0 INSTALL_PROMPTS_HAVE_YQ=1 \
+        bash "$LIB" "$PREAMBLE_SRC"
+    local before; before=$(shasum -a 256 "$CODEX_HOME/config.toml" | awk '{print $1}')
+    INSTALL_PROMPTS_HAVE_CODEX=1 INSTALL_PROMPTS_HAVE_OPENCODE=0 INSTALL_PROMPTS_HAVE_YQ=1 \
+        bash "$LIB" "$PREAMBLE_SRC"
+    local after; after=$(shasum -a 256 "$CODEX_HOME/config.toml" | awk '{print $1}')
+    [[ "$before" == "$after" ]]
+}
+
+@test "install-prompts.sh skips config.toml edit when yq is unavailable" {
+    mkdir -p "$CODEX_HOME"
+    cat > "$CODEX_HOME/config.toml" <<'TOML'
+approval_policy = "on-request"
+TOML
+    INSTALL_PROMPTS_HAVE_CODEX=1 INSTALL_PROMPTS_HAVE_OPENCODE=0 INSTALL_PROMPTS_HAVE_YQ=0 \
+        run bash "$LIB" "$PREAMBLE_SRC"
+    assert_success
+    assert_output_contains "yq not installed"
+    ! grep -q "model_instructions_file" "$CODEX_HOME/config.toml"
+}
+
+# ── opencode wiring ──────────────────────────────────────────────────────────
+
+@test "install-prompts.sh skips opencode when opencode CLI is missing" {
+    INSTALL_PROMPTS_HAVE_CODEX=0 INSTALL_PROMPTS_HAVE_OPENCODE=0 \
+        run bash "$LIB" "$PREAMBLE_SRC"
+    assert_success
+    assert_output_contains "Skipped opencode wiring"
+    [[ ! -e "$OPENCODE_HOME/agents/build.md" ]]
+}
+
+@test "install-prompts.sh copies preamble.md to opencode agents/build.md when opencode is present" {
+    INSTALL_PROMPTS_HAVE_CODEX=0 INSTALL_PROMPTS_HAVE_OPENCODE=1 \
+        run bash "$LIB" "$PREAMBLE_SRC"
+    assert_success
+    assert_file_exists "$OPENCODE_HOME/agents/build.md"
+    diff "$PREAMBLE_SRC" "$OPENCODE_HOME/agents/build.md"
+}
+
+@test "install-prompts.sh creates opencode agents/ dir if absent" {
+    [[ ! -d "$OPENCODE_HOME/agents" ]]
+    INSTALL_PROMPTS_HAVE_CODEX=0 INSTALL_PROMPTS_HAVE_OPENCODE=1 \
+        run bash "$LIB" "$PREAMBLE_SRC"
+    assert_success
+    [[ -d "$OPENCODE_HOME/agents" ]]
+}
+
+# ── both harnesses ───────────────────────────────────────────────────────────
+
+@test "install-prompts.sh wires both harnesses when both are present" {
+    mkdir -p "$CODEX_HOME"
+    cat > "$CODEX_HOME/config.toml" <<'TOML'
+approval_policy = "on-request"
+TOML
+    INSTALL_PROMPTS_HAVE_CODEX=1 INSTALL_PROMPTS_HAVE_OPENCODE=1 INSTALL_PROMPTS_HAVE_YQ=1 \
+        run bash "$LIB" "$PREAMBLE_SRC"
+    assert_success
+    assert_file_exists "$CODEX_HOME/preamble.md"
+    assert_file_exists "$OPENCODE_HOME/agents/build.md"
+    grep -q "model_instructions_file" "$CODEX_HOME/config.toml"
+}

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -75,7 +75,7 @@ run_tests() {
     if (( ${#SPECIFIC_TESTS[@]} > 0 )); then
         test_files="${SPECIFIC_TESTS[*]}"
     else
-        test_files="dots-simple.bats dots.bats git-hooks.bats sync.bats config-validation.bats prompt.bats sync-claude.bats sync-rollback.bats hooks-blockers.bats hooks-session.bats iterm2-fonts.bats worktree-settings.bats skills-external.bats skills-local.bats chezmoi-wiring.bats install-codex.bats install-agents-doc.bats packages.bats cheese-flair.bats mcp-lib.bats mcp-opencode.bats agents-hooks-sync.bats"
+        test_files="dots-simple.bats dots.bats git-hooks.bats sync.bats config-validation.bats prompt.bats sync-claude.bats sync-rollback.bats hooks-blockers.bats hooks-session.bats iterm2-fonts.bats worktree-settings.bats skills-external.bats skills-local.bats chezmoi-wiring.bats install-codex.bats install-agents-doc.bats install-prompts.bats packages.bats cheese-flair.bats mcp-lib.bats mcp-opencode.bats agents-hooks-sync.bats claude-lsp-gate.bats"
     fi
 
     # Count total tests

--- a/zsh/claude.zsh
+++ b/zsh/claude.zsh
@@ -37,11 +37,14 @@ _cc_lsp_gate() {
     echo "$gate_file"
 }
 
+# preamble.md replaces Claude's baked system prompt via --system-prompt-file.
+# CLAUDE.md auto-discovery, hooks, LSP gate, plugins, auto-memory all stay
+# active — only Anthropic's system prompt is swapped out.
 cc() {
     local gate; gate="$(_cc_lsp_gate)" || gate=""
     local -a flags=()
     [[ -n "$gate" ]] && flags+=(--settings "$gate")
-    [[ -f "$AGENTS_DOTFILES/preamble.md" ]] && flags+=(--append-system-prompt-file "$AGENTS_DOTFILES/preamble.md")
+    [[ -f "$AGENTS_DOTFILES/preamble.md" ]] && flags+=(--system-prompt-file "$AGENTS_DOTFILES/preamble.md")
     claude "${flags[@]}" "$@"
 }
 
@@ -49,7 +52,7 @@ ccc() {
     local gate; gate="$(_cc_lsp_gate)" || gate=""
     local -a flags=()
     [[ -n "$gate" ]] && flags+=(--settings "$gate")
-    [[ -f "$AGENTS_DOTFILES/preamble.md" ]] && flags+=(--append-system-prompt-file "$AGENTS_DOTFILES/preamble.md")
+    [[ -f "$AGENTS_DOTFILES/preamble.md" ]] && flags+=(--system-prompt-file "$AGENTS_DOTFILES/preamble.md")
     claude "${flags[@]}" --continue "$@"
 }
 
@@ -57,14 +60,14 @@ ccr() {
     local gate; gate="$(_cc_lsp_gate)" || gate=""
     local -a flags=()
     [[ -n "$gate" ]] && flags+=(--settings "$gate")
-    [[ -f "$AGENTS_DOTFILES/preamble.md" ]] && flags+=(--append-system-prompt-file "$AGENTS_DOTFILES/preamble.md")
+    [[ -f "$AGENTS_DOTFILES/preamble.md" ]] && flags+=(--system-prompt-file "$AGENTS_DOTFILES/preamble.md")
     claude "${flags[@]}" --resume "$@"
 }
 
 # Fresh session: prime MCPs in last conversation, then open it interactively
 ccfresh() {
   local -a flags=()
-  [[ -f "$AGENTS_DOTFILES/preamble.md" ]] && flags+=(--append-system-prompt-file "$AGENTS_DOTFILES/preamble.md")
+  [[ -f "$AGENTS_DOTFILES/preamble.md" ]] && flags+=(--system-prompt-file "$AGENTS_DOTFILES/preamble.md")
   claude "${flags[@]}" --continue -p '/go' && claude "${flags[@]}" --continue
 }
 

--- a/zsh/claude.zsh
+++ b/zsh/claude.zsh
@@ -39,34 +39,33 @@ _cc_lsp_gate() {
 
 cc() {
     local gate; gate="$(_cc_lsp_gate)" || gate=""
-    if [[ -n "$gate" ]]; then
-        claude --settings "$gate" "$@"
-    else
-        claude "$@"
-    fi
+    local -a flags=()
+    [[ -n "$gate" ]] && flags+=(--settings "$gate")
+    [[ -f "$AGENTS_DOTFILES/preamble.md" ]] && flags+=(--append-system-prompt-file "$AGENTS_DOTFILES/preamble.md")
+    claude "${flags[@]}" "$@"
 }
 
 ccc() {
     local gate; gate="$(_cc_lsp_gate)" || gate=""
-    if [[ -n "$gate" ]]; then
-        claude --settings "$gate" --continue "$@"
-    else
-        claude --continue "$@"
-    fi
+    local -a flags=()
+    [[ -n "$gate" ]] && flags+=(--settings "$gate")
+    [[ -f "$AGENTS_DOTFILES/preamble.md" ]] && flags+=(--append-system-prompt-file "$AGENTS_DOTFILES/preamble.md")
+    claude "${flags[@]}" --continue "$@"
 }
 
 ccr() {
     local gate; gate="$(_cc_lsp_gate)" || gate=""
-    if [[ -n "$gate" ]]; then
-        claude --settings "$gate" --resume "$@"
-    else
-        claude --resume "$@"
-    fi
+    local -a flags=()
+    [[ -n "$gate" ]] && flags+=(--settings "$gate")
+    [[ -f "$AGENTS_DOTFILES/preamble.md" ]] && flags+=(--append-system-prompt-file "$AGENTS_DOTFILES/preamble.md")
+    claude "${flags[@]}" --resume "$@"
 }
 
 # Fresh session: prime MCPs in last conversation, then open it interactively
 ccfresh() {
-  claude --continue -p '/go' && claude --continue
+  local -a flags=()
+  [[ -f "$AGENTS_DOTFILES/preamble.md" ]] && flags+=(--append-system-prompt-file "$AGENTS_DOTFILES/preamble.md")
+  claude "${flags[@]}" --continue -p '/go' && claude "${flags[@]}" --continue
 }
 
 # Session monitor


### PR DESCRIPTION
## Summary

Replaces the bundled system prompt across the three replaceable harnesses (Cursor's prompt is not user-overridable per our survey at `.cheese/research/prompt-injection-survey/`). Flips the mechanism from `--append-system-prompt-file` to true replacement, and extends from Claude-only to all three.

**Surgical replacement, not `--bare`.** Only the harness's bundled system prompt is swapped out. User-side AGENTS.md / CLAUDE.md cascade, hooks, LSP gate, plugins, auto-memory, OAuth auth all stay active.

## Per-harness wiring

| Harness | Mechanism | Wired by |
|---|---|---|
| Claude Code | `--system-prompt-file <path>` (replaces) | `cc`/`ccc`/`ccr`/`ccfresh` in `zsh/claude.zsh` |
| Codex CLI | `model_instructions_file = "<HOME>/.codex/preamble.md"` in `~/.codex/config.toml` | `chezmoi/lib/install-prompts.sh` (yq-edit + file copy) |
| opencode | `~/.config/opencode/agents/build.md` body becomes the prompt for the default `build` agent | same installer (file copy) |

`chezmoi/.chezmoiscripts/run_onchange_install-prompts.sh.tmpl` re-runs on every `agents/preamble.md` hash change and dispatches to the installer. Missing harness CLIs are skipped silently (matches the `agents/mcp/sync.sh` pattern).

## What stays active

This is surgical replacement, not `--bare`. Everything below continues to load on top of the replaced system prompt:

- `~/.claude/CLAUDE.md` / `~/.codex/AGENTS.md` cascade (cheese flair, calibrated `<certain>` / `<speculative>` tags, banned phrases, Rules 1-9, /self-eval)
- Hooks (cheese-flair SessionStart, RTK)
- `_cc_lsp_gate` (language-aware LSP plugin gating)
- Claude Code plugins (cheese-flow, todoist-flow, claude-md-management, etc.)
- Auto-memory (`MEMORY.md` index)
- OAuth / keychain auth (not narrowed to `ANTHROPIC_API_KEY`)
- Codex AGENTS.md cascade (developer-role messages — `project_doc_max_bytes` left at default)

## Known trade-off

Replacing each harness's bundled prompt drops its operational guidance: parallel-tool-call hints, destructive-op caution, harness-specific tool-use protocol, output formatting nuances, skill resolution rules. The user-side cascade carries the personality / engineering-discipline layer on top, but the harness-specific tool-use guidance is now absent.

`agents/preamble.md` content is left intentionally minimal for this PR (MCP routing + tool-mapping tables). Expansion to cover the dropped operational guidance can be a follow-up once the mechanism is validated in daily use.

## Tests

- `tests/install-prompts.bats` (new, 12 tests): Codex copy + yq edit, opencode copy, idempotence, missing-CLI skip, missing-yq skip, both-harness wiring.
- `tests/claude-lsp-gate.bats` (updated): `cc`/`ccc`/`ccr`/`ccfresh` now assert `--system-prompt-file` (not `--append`), and explicitly assert `--bare` is *not* passed. Added to `tests/run-tests.sh`.
- All adjacent suites still green: `install-codex.bats`, `install-agents-doc.bats`, `chezmoi-wiring.bats`.

## Out of scope

- **Cursor**: no first-party replacement mechanism. Every user surface (`.cursorrules`, `.cursor/rules/*.mdc`, AGENTS.md, User Rules, Cloud Agents, `cursor-agent` CLI) appends to a hidden baseline. Cursor staff confirmed on forum. See `.cheese/research/prompt-injection-survey/cursor.md`.
- **Codex `project_doc_max_bytes = 0`**: would also suppress AGENTS.md cascade for Codex. Not applied — A is surgical, we keep the personal cascade.
- **opencode `environment()` block**: survives all replacement paths except the plugin hook. Acceptable — it just injects model id + cwd / worktree / platform / date.

## Probes worth running after merge

- Claude Code: `cc -p "what's my cwd"` — verify dynamic env still reaches the model under `--system-prompt-file`.
- Codex: `codex exec "hi"` then grep `~/.codex/sessions/<id>/rollout.jsonl` for `model_instructions_file` byte-match.
- opencode: `opencode run --agent build "hi"` and confirm preamble content is in effect.