### PR TITLE
docs: migrate stale LSP tool references to Serena MCP

### DIFF
--- a/claude/agents/fromage-age-arch.md
+++ b/claude/agents/fromage-age-arch.md
@@ -3,7 +3,7 @@ name: fromage-age-arch
 description: Complexity and structure reviewer. Enforces complexity budgets (line counts, params, nesting) and Sliced Bread file organization. Does NOT cover encapsulation, dead code, or bugs.
 model: sonnet
 effort: high
-skills: [scout, cheese-flow:cheez-search, lsp]
+skills: [scout, cheese-flow:cheez-search]
 disallowedTools: [Edit, NotebookEdit]
 color: red
 ---
@@ -25,7 +25,7 @@ Enforce measurable structural constraints:
 ## Tools
 
 - **trace** for structural code shape analysis (nesting depth, function length, import patterns)
-- **LSP documentSymbol** to enumerate functions/methods and measure their spans
+- **`mcp__serena__get_symbols_overview`** to enumerate functions/methods and measure their spans
 - **scout** to search for structural patterns across files
 
 ## Confidence Scoring
@@ -45,7 +45,7 @@ Rate every finding 0-100. Only surface findings scoring >= 50.
 | Evidence quality | Modifier |
 |------------------|----------|
 | Verified via trace (AST confirms nesting depth, function line count) | +20 |
-| Verified via LSP documentSymbol (symbol spans confirm line counts) | +20 |
+| Verified via Serena get_symbols_overview (symbol spans confirm line counts) | +20 |
 | Cites specific file:line with accurate measurement | +15 |
 | References complexity budget rule by name | +10 |
 | Generic observation without measurement | -15 |

--- a/claude/agents/fromage-age-history.md
+++ b/claude/agents/fromage-age-history.md
@@ -4,7 +4,7 @@ description: Git history analyst. Produces per-file risk scores that the orchest
 model: haiku
 effort: high
 skills: [scout]
-disallowedTools: [Edit, Write, NotebookEdit, WebSearch, WebFetch, Agent, LSP]
+disallowedTools: [Edit, Write, NotebookEdit, WebSearch, WebFetch, Agent]
 color: red
 ---
 

--- a/claude/agents/ghostbuster.md
+++ b/claude/agents/ghostbuster.md
@@ -209,7 +209,7 @@ Write the full JSON report to `$TMPDIR/ghostbuster-{slug}.json`. The JSON schema
     "languages": ["typescript", "python"],
     "filesScanned": 42,
     "specsFound": 3,
-    "lspAvailable": true,
+    "serenaAvailable": true,
     "gitHistoryUsed": true
   },
   "findings": [
@@ -266,11 +266,11 @@ Return to the orchestrator ONLY a structured summary (max 2000 chars):
 
 ## Gotchas
 
-- **Dynamic dispatch hides callers**: Trait impls (Rust), interface implementations (Go/TS), duck typing (Python) mean LSP `findReferences` can miss callers. Score types/interfaces lower.
-- **Codegen and macros**: Rust `derive` macros, Python decorators, and TS decorators can generate callers invisible to LSP. If a symbol has a decorator/derive attribute, reduce confidence by 10.
+- **Dynamic dispatch hides callers**: Trait impls (Rust), interface implementations (Go/TS), duck typing (Python) mean Serena's `find_referencing_symbols` (LSP-backed) can miss callers. Score types/interfaces lower.
+- **Codegen and macros**: Rust `derive` macros, Python decorators, and TS decorators can generate callers invisible to Serena. If a symbol has a decorator/derive attribute, reduce confidence by 10.
 - **Re-exports**: A symbol exported from a barrel file may appear to have 0 direct callers but is the module's public API. Check barrel files before flagging.
 - **Test helpers**: Functions in test files with 0 callers outside tests aren't dead — they're test infrastructure. Apply the -10 modifier, don't auto-flag.
-- **Shell functions**: Shell functions defined in sourced files (`. script.sh` or `source script.sh`) won't show up in LSP. Use Grep exclusively for shell.
+- **Shell functions**: Shell functions defined in sourced files (`. script.sh` or `source script.sh`) won't show up in Serena's symbol index — no LSP backend covers shell. Use Grep exclusively for shell.
 - **Spec format variance**: Some specs use backticks, some use prose references, some use code blocks. Cast a wide net when parsing — regex for `functionName`, not just `` `functionName` ``.
 - **User-invoked functions**: Shell functions, CLI commands, and `main()` entry points are called from the terminal, not from code. Zero grep references is expected. Check if the function is in a sourced file or bin/ directory before flagging.
 - **Documentation references are GHOST sources too**: CLAUDE.md, README.md, and docs/ files reference code symbols just like specs do. The test run's highest-confidence findings were GHOSTs from CLAUDE.md, not spec files.

--- a/claude/agents/ghostbuster.md
+++ b/claude/agents/ghostbuster.md
@@ -24,13 +24,13 @@ You receive:
 
 ## Protocol
 
-### 1. LSP Warmup
+### 1. Serena availability check
 
-LSP servers start lazily. Before any LSP call:
+Symbol intelligence is provided by the Serena MCP. Before any
+`mcp__serena__*` call:
 
-1. Call `LSP hover` on the first source file's line 1
-2. If it fails, wait 3s and retry (up to 3 attempts)
-3. If still failing, note the failure and fall back to Grep for reference counting
+1. Call `mcp__serena__get_symbols_overview` on the first source file
+2. If it errors, note the failure and fall back to Grep for reference counting
 
 ### 2. Discover Files
 
@@ -69,12 +69,12 @@ Build a lookup: `{symbol → [spec_file, line_number]}`.
 
 For each source file, identify exported/public symbols:
 
-**LSP mode** (preferred):
+**Serena mode** (preferred):
 
-- `LSP documentSymbol` to get all symbols
-- `LSP findReferences` on each exported symbol — count callers outside the defining file
+- `mcp__serena__get_symbols_overview` to list top-level symbols in each file
+- `mcp__serena__find_referencing_symbols` on each exported symbol — count callers outside the defining file
 
-**Grep fallback** (when LSP unavailable):
+**Grep fallback** (when Serena unavailable):
 
 | Language | Export pattern |
 |----------|---------------|
@@ -127,7 +127,7 @@ This catches entire dead subgraphs — utility functions that only served a now-
 
 For each finding from Steps 4-7:
 
-- Check the spec lookup from Step 3
+- Check the spec mapping from Step 3
 - If symbol has 0 references AND appears in a spec → upgrade to ZOMBIE
 - If symbol appears in a spec but doesn't exist in codebase → create GHOST finding
 
@@ -164,7 +164,7 @@ Rate every finding 0-100. Only surface findings >= 50.
 
 | Evidence | Modifier |
 |----------|----------|
-| Verified via LSP `findReferences` returns 0 | +20 |
+| Verified via Serena `find_referencing_symbols` returns 0 | +20 |
 | Grep confirms zero matches across codebase | +15 |
 | Last git touch > 6 months ago | +10 |
 | Last git touch > 3 months ago | +5 |
@@ -223,7 +223,7 @@ Write the full JSON report to `$TMPDIR/ghostbuster-{slug}.json`. The JSON schema
         "referenceCount": 0,
         "specMentions": [],
         "lastGitTouch": "2025-08-14",
-        "verifiedVia": "LSP findReferences"
+        "verifiedVia": "Serena find_referencing_symbols"
       },
       "action": "Safe to delete — zero callers, no spec references, untouched for 7 months"
     }
@@ -235,7 +235,7 @@ Return to the orchestrator ONLY a structured summary (max 2000 chars):
 
 ```
 ## Ghostbuster Summary
-**Scope**: {scope} | **Files**: N | **Specs/Docs**: N | **LSP**: yes/no
+**Scope**: {scope} | **Files**: N | **Specs/Docs**: N | **Serena**: yes/no
 **Findings >= 50**:
 | # | Score | Category | File:Symbol | Action |
 |---|-------|----------|-------------|--------|
@@ -255,7 +255,7 @@ Return to the orchestrator ONLY a structured summary (max 2000 chars):
 
 ## Rules
 
-- LSP first for symbol-aware reference counting, Grep as backup — LSP is generally more accurate than text search but can still miss callers under heavy dynamic dispatch or codegen (see Gotchas)
+- Serena first for symbol-aware reference counting, Grep as backup — Serena's LSP backing is generally more accurate than text search but can still miss callers under heavy dynamic dispatch or codegen (see Gotchas)
 - Budget ~40 tool calls. Prioritize: utility dirs → domain code → infrastructure
 - Include the file path and symbol name for every finding — vague findings are useless
 - Specs can live anywhere: `.claude/specs/`, `docs/specs/`, `specs/`, `SPEC.md` — glob broadly

--- a/claude/agents/nih-scanner.md
+++ b/claude/agents/nih-scanner.md
@@ -1,12 +1,12 @@
 ---
 name: nih-scanner
-description: Structural NIH pattern scanner. Uses LSP and ast-grep to find code that reinvents well-known library functionality. Returns JSON candidate list (~2 KB digest) with usage counts and categories. Does not judge — the orchestrator scores and filters. Suitable as an easy-cheese fork target when /age needs evidence on the NIH dimension.
+description: Structural NIH pattern scanner. Uses Serena MCP and ast-grep to find code that reinvents well-known library functionality. Returns JSON candidate list (~2 KB digest) with usage counts and categories. Does not judge — the orchestrator scores and filters. Suitable as an easy-cheese fork target when /age needs evidence on the NIH dimension.
 model: sonnet
-skills: [cheese-flow:cheez-search, lsp]
+skills: [cheese-flow:cheez-search]
 disallowedTools: [Edit, Write, NotebookEdit, WebSearch, WebFetch, AskUserQuestion]
 ---
 
-You are the NIH Scanner — a structural analysis agent that finds code reinventing the wheel. You use LSP and ast-grep to detect patterns, not Grep for text.
+You are the NIH Scanner — a structural analysis agent that finds code reinventing the wheel. You use Serena MCP and ast-grep to detect patterns, not Grep for text.
 
 ## Input
 
@@ -19,13 +19,13 @@ You receive:
 
 ## Protocol
 
-### 1. LSP Warmup
+### 1. Serena availability check
 
-LSP servers start lazily. Before any LSP call:
+Symbol intelligence is provided by the Serena MCP. Before any
+`mcp__serena__*` call:
 
-1. Call `LSP hover` on the first source file's line 1
-2. If it fails, wait 3s and retry (up to 3 attempts)
-3. If still failing, switch entirely to ast-grep mode and note the failure
+1. Call `mcp__serena__get_symbols_overview` on the first source file
+2. If it errors, switch entirely to ast-grep mode and note the failure
 
 ### 2. Discover Files
 
@@ -123,7 +123,7 @@ Glob: {scope}/**/lib/**/*.{ts,js,py,rs,go}
 Glob: {scope}/**/common/**/*.{ts,js,py,rs,go}
 ```
 
-For each utility file found, use `LSP documentSymbol` to inventory exported functions. Flag functions whose names match known library functionality:
+For each utility file found, use `mcp__serena__get_symbols_overview` to inventory exported functions. Flag functions whose names match known library functionality:
 
 | Function name pattern | Category | Common library |
 |----------------------|----------|----------------|
@@ -145,14 +145,14 @@ For each utility file found, use `LSP documentSymbol` to inventory exported func
 
 ### 5. Measure Usage
 
-For each flagged function, use `LSP findReferences` to count callers:
+For each flagged function, use `mcp__serena__find_referencing_symbols` to count callers:
 
 - 0 callers → dead code (note, but lower priority for NIH audit)
 - 1-3 callers → low coupling, easy migration (S effort)
 - 4-10 callers → moderate coupling (M effort)
 - 10+ callers → high coupling (L effort)
 
-If LSP is unavailable, use `Grep` as fallback for this step only.
+If Serena is unavailable, use `Grep` as fallback for this step only.
 
 ### 6. Output
 
@@ -188,7 +188,7 @@ Follow the JSON with a brief summary:
 ```
 ## NIH Scanner Results
 **Files scanned**: N
-**LSP available**: yes/no
+**Serena available**: yes/no
 **Candidates found**: N
 **By category**: UUID: N, RETRY: N, VALIDATION: N, ...
 ```
@@ -203,8 +203,8 @@ Follow the JSON with a brief summary:
 
 ## Rules
 
-- LSP first, ast-grep fallback — never rely on Grep for pattern detection
-- Use Grep ONLY for usage counting when LSP is down
+- Serena first, ast-grep fallback — never rely on Grep for pattern detection
+- Use Grep ONLY for usage counting when Serena is down
 - Be specific about file paths and line numbers
 - After ~30 tool calls, stop scanning and output what you have
 - Include the snippet (first 3 lines) for every candidate
@@ -212,7 +212,7 @@ Follow the JSON with a brief summary:
 
 ## Gotchas
 
-- **LSP cold start in worktrees**: Sub-agents spawned in worktrees may not have LSP running. The warmup protocol catches this, but expect ast-grep-only mode in worktree contexts.
+- **Serena cold start in worktrees**: Sub-agents spawned in worktrees may not have the Serena MCP indexed yet. The availability check catches this, but expect ast-grep-only mode in worktree contexts.
 - **ast-grep `--json` format**: Output format can vary between sg versions. Parse defensively — extract file, line, and matched text, ignore unknown fields.
 - **30 tool-call budget vs large repos**: A repo with 500+ source files won't be fully scanned. Prioritize utility directories first (Step 4), then pattern scan (Step 3), so the highest-value candidates are found first.
 - **`lib/` matches vendored code**: Some projects vendor third-party code in `lib/`. Cross-reference against `.gitignore` or presence of a separate `package.json`/`Cargo.toml` to identify vendored dirs.

--- a/claude/agents/nih-scanner.md
+++ b/claude/agents/nih-scanner.md
@@ -164,7 +164,7 @@ to `$TMPDIR` or any file):
   "scanMeta": {
     "languages": ["typescript"],
     "filesScanned": 42,
-    "lspAvailable": true,
+    "serenaAvailable": true,
     "scope": "src/"
   },
   "candidates": [

--- a/claude/agents/ricotta-reducer.md
+++ b/claude/agents/ricotta-reducer.md
@@ -1,7 +1,7 @@
 ---
 name: ricotta-reducer
 description: Code simplification and distillation agent. Strips genAI bloat, speculative abstractions, and unnecessary documentation. Produces a simplification report categorized by DELETE, INLINE, UNDOCUMENT, and DECOUPLE with 0-100 confidence scoring. Analysis and detection only — never adds code (de-slop runs in scan mode, not auto-fix).
-tools: Read, Grep, Glob, Bash, LSP, Agent
+tools: Read, Grep, Glob, Bash, Agent, mcp__serena__*
 skills: [scout, de-slop]
 model: sonnet
 ---
@@ -38,7 +38,7 @@ Adjust from the base score based on how verifiable the finding is:
 
 | Evidence quality | Modifier |
 |------------------|----------|
-| Verified via LSP (`findReferences` returns 0, `hover` confirms unused type) | +25 |
+| Verified via Serena (`find_referencing_symbols` returns 0, `find_symbol` confirms unused type) | +25 |
 | Grep/search confirms zero callers across the codebase | +20 |
 | Cites specific file:line with accurate code reference | +15 |
 | References a CLAUDE.md rule or Sliced Bread anti-pattern by name | +10 |
@@ -55,7 +55,7 @@ Adjust from the base score based on how verifiable the finding is:
 
 ### Step 4: Re-assess borderline findings
 
-For any finding scoring 35-49 (near the surfacing threshold): verify once more via LSP or search, then score independently a second time without looking at your first score. If the two scores diverge by >15 points, don't surface it — the finding is ambiguous. If both scores land >= 50, surface it.
+For any finding scoring 35-49 (near the surfacing threshold): verify once more via Serena or search, then score independently a second time without looking at your first score. If the two scores diverge by >15 points, don't surface it — the finding is ambiguous. If both scores land >= 50, surface it.
 
 ### Score labels (after calibration)
 

--- a/claude/agents/roquefort-wrecker.md
+++ b/claude/agents/roquefort-wrecker.md
@@ -2,7 +2,7 @@
 name: roquefort-wrecker
 description: Writes and executes unit, integration, or other tests for new or modified code. Use PROACTIVELY to validate code functionality and find bugs. Adversarial approach with 0-100 confidence scoring per finding.
 model: haiku
-tools: Read, Write, Grep, Glob, Bash
+tools: Read, Write, Grep, Glob, Bash, mcp__serena__*
 skills: [scout]
 ---
 
@@ -120,9 +120,11 @@ Test in this exact order:
 | path/to/test-file | What it tests |
 ```
 
-## LSP Integration
+## Symbol Intelligence
 
-All 7 LSP plugins are enabled globally. Use the built-in `LSP` tool — `hover` for type discovery when writing assertions, auto-diagnostics catch mismatches after edits before running the suite.
+Symbol-level type info comes from the Serena MCP (`mcp__serena__find_symbol`
+with `include_body=true` for the equivalent of LSP hover;
+`mcp__serena__get_diagnostics_for_file` for type errors after edits).
 
 ## Quality Gates
 

--- a/claude/agents/skill-analytics-friction.md
+++ b/claude/agents/skill-analytics-friction.md
@@ -1,7 +1,7 @@
 ---
 model: sonnet
 tools: [Bash, Read]
-disallowedTools: [Edit, Write, NotebookEdit, Agent, WebSearch, WebFetch, LSP]
+disallowedTools: [Edit, Write, NotebookEdit, Agent, WebSearch, WebFetch]
 ---
 
 # Skill Friction Analyst

--- a/claude/agents/skill-analytics-tools.md
+++ b/claude/agents/skill-analytics-tools.md
@@ -1,7 +1,7 @@
 ---
 model: sonnet
 tools: [Bash, Read]
-disallowedTools: [Edit, Write, NotebookEdit, Agent, WebSearch, WebFetch, LSP]
+disallowedTools: [Edit, Write, NotebookEdit, Agent, WebSearch, WebFetch]
 ---
 
 # Skill Tool Pattern Analyst

--- a/claude/agents/skill-analytics-usage.md
+++ b/claude/agents/skill-analytics-usage.md
@@ -1,7 +1,7 @@
 ---
 model: sonnet
 tools: [Bash, Read]
-disallowedTools: [Edit, Write, NotebookEdit, Agent, WebSearch, WebFetch, LSP]
+disallowedTools: [Edit, Write, NotebookEdit, Agent, WebSearch, WebFetch]
 ---
 
 # Skill Usage Analyst

--- a/skills/ghostbuster/SKILL.md
+++ b/skills/ghostbuster/SKILL.md
@@ -4,7 +4,7 @@ model: opus
 effort: high
 context: fork
 argument-hint: "[directory to scope, or leave blank for full codebase]"
-allowed-tools: Read, Glob, Grep, Bash(git log:*), Bash(git diff:*), Bash(git blame:*), Bash(wc:*), Agent, LSP
+allowed-tools: Read, Glob, Grep, Bash(git log:*), Bash(git diff:*), Bash(git blame:*), Bash(wc:*), Agent, mcp__serena__*
 description: >
   Dead code forensics and spec cross-reference. Finds unreachable functions,
   orphaned implementations, specs pointing at deleted code, and transitive dead
@@ -125,5 +125,5 @@ Group findings by recommended action:
 
 - Dynamic dispatch (trait impls, interface implementations, duck typing) can hide callers — confidence is capped at 95 for this reason
 - Recently touched code (< 2 weeks) gets a confidence penalty — it may be WIP
-- Shell functions sourced via `. script.sh` won't appear in LSP — Grep-only for shell
+- Shell functions sourced via `. script.sh` won't appear in Serena — Grep-only for shell
 - Specs use varied formats for symbol references — the agent casts a wide net but may miss prose-only references

--- a/skills/nih-audit/SKILL.md
+++ b/skills/nih-audit/SKILL.md
@@ -4,7 +4,7 @@ model: opus
 effort: high
 context: fork
 argument-hint: "[directory to scope, or leave blank for full codebase]"
-allowed-tools: Read, Glob, Grep, Bash(sg:*), Bash(git log:*), Bash(git blame:*), Bash(jq:*), Bash(yq:*), Bash(wc:*), Agent, LSP
+allowed-tools: Read, Glob, Grep, Bash(sg:*), Bash(git log:*), Bash(git blame:*), Bash(jq:*), Bash(yq:*), Bash(wc:*), Agent, mcp__serena__*
 description: >
   Scan a codebase for custom code that duplicates what open-source libraries
   already do, then recommend which libraries to adopt. Detects hand-rolled
@@ -251,7 +251,7 @@ For each candidate with a library recommendation, apply the full 4-step chain:
 
 | Evidence | Modifier |
 |----------|----------|
-| LSP-verified usage count (exact caller list) | +15 |
+| Serena-verified usage count (exact caller list) | +15 |
 | Library has >10K weekly downloads + MIT/Apache | +20 |
 | ast-grep pattern match + code read confirms NIH | +15 |
 | NIH code has recent bug fixes (git blame) | +10 |
@@ -384,7 +384,7 @@ recommendation above threshold):
 ## Gotchas
 
 - **ast-grep patterns are approximate**: A `clearTimeout` + `setTimeout` combo isn't always a debounce. The orchestrator's scoring step (Phase 4) catches generic matches via the -15 modifier.
-- **LSP cold start**: First scan in a session may miss results due to LSP warmup. The nih-scanner has a warmup protocol, but note failures.
+- **Serena cold start**: First scan in a session may miss results if the Serena MCP hasn't indexed the project yet. The nih-scanner has an availability check, but note failures.
 - **Stdlib alternatives are the highest value**: `crypto.randomUUID()` replacing a hand-rolled UUID is a no-brainer (no new dep). Always score these highest.
 - **"Already installed" is the most common false positive**: A codebase that has lodash installed but hand-rolls `deepClone` might have done so intentionally (bundle size). The spec/comment check catches this.
 - **Monorepo dep scoping**: A function in `packages/api/` might be NIH in that workspace but the library is installed in `packages/web/`. Each workspace's depManifest is independent.

--- a/skills/settings-clean/SKILL.md
+++ b/skills/settings-clean/SKILL.md
@@ -84,7 +84,7 @@ These are commands the user ran once during a session. They accumulate fast and 
 Everything else stays:
 
 - `Skill(*)` entries — user enabled these deliberately
-- `LSP` — intentional
+- `mcp__serena__*` — intentional (symbol-intelligence MCP)
 - `Bash(toolname:*)` wildcards not covered by global or same-file — project-specific
 - Clean `Bash(toolname arg:*)` patterns that don't match one-off patterns
 - `mcp__*` entries not in global

--- a/skills/skill-improver/SKILL.md
+++ b/skills/skill-improver/SKILL.md
@@ -84,7 +84,7 @@ Category priors predict accuracy better than the model's self-assessed number.
 Style nits cap at 60; bugs start at 50 and can reach 100.
 
 **Step 2: Evidence grounding** — Modifiers based on verification quality.
-LSP-verified (+20-25), grep-confirmed (+20), specific file:line (+15),
+Serena-verified (+20-25), grep-confirmed (+20), specific file:line (+15),
 generic observation (-15), misread code (hard cap 0).
 
 **Step 3: Context modifiers** — Signals that adjust severity. Git hotspot (+10),
@@ -112,7 +112,7 @@ Reference implementations:
 | Tier | Tools | Use case | Frontmatter |
 |------|-------|----------|-------------|
 | Read-only | Grep, Glob, Read, Bash | Reviewers, auditors, explorers | `disallowedTools: [Edit, Write, NotebookEdit]` |
-| Write-scoped | + Edit, Write | Implementers, fixers | Exclude tools not needed (WebSearch, LSP, etc.) |
+| Write-scoped | + Edit, Write | Implementers, fixers | Exclude tools not needed (WebSearch, mcp__serena__*, etc.) |
 | Focused sub-agent | 2-4 tools max | Pipeline sub-tasks | Disallow 5-8 unused tools explicitly |
 
 Over-broad tool access degrades behavior in two ways: models waste tokens

--- a/skills/spec-verify/SKILL.md
+++ b/skills/spec-verify/SKILL.md
@@ -3,32 +3,32 @@ name: spec-verify
 model: opus
 context: fork
 effort: high
-allowed-tools: Read, Glob, Grep, Bash(sg:*), Bash(echo:*), Agent, LSP
+allowed-tools: Read, Glob, Grep, Bash(sg:*), Bash(echo:*), Agent, mcp__serena__*
 description: >
-  Verify that a spec's implementation matches its requirements using LSP structural
-  analysis, build verification, and test coverage checking. Use when the user says
-  "verify the spec", "check spec implementation", "does this match the spec",
-  "spec coverage", "verify acceptance criteria", or invokes /spec-verify with a spec
-  path. Also trigger after `/cure` completes to validate the result against the
-  original spec. Do NOT use for writing code — this is verification only.
-  Do NOT use for general code review — use /age for that.
+  Verify that a spec's implementation matches its requirements using Serena MCP
+  structural analysis, build verification, and test coverage checking. Use when the
+  user says "verify the spec", "check spec implementation", "does this match the
+  spec", "spec coverage", "verify acceptance criteria", or invokes /spec-verify
+  with a spec path. Also trigger after `/cure` completes to validate the result
+  against the original spec. Do NOT use for writing code — this is verification
+  only. Do NOT use for general code review — use /age for that.
 ---
 
 # spec-verify
 
-Verify implementation against spec. Trust LSP, not vibes.
+Verify implementation against spec. Trust the symbol graph, not vibes.
 
 You are the spec verification agent. You read a spec document (produced by `/spec`),
 then systematically verify that the implementation satisfies every user story,
-functional requirement, and quality gate — using LSP for structural verification,
-builds for correctness, and test analysis for coverage.
+functional requirement, and quality gate — using the Serena MCP for structural
+verification, builds for correctness, and test analysis for coverage.
 
 ## Input
 
 A path to a spec file (`.claude/specs/<slug>.md`). If no path given, list available
 specs and ask.
 
-Optional: `--quick` flag skips LSP deep analysis and test coverage, only checks
+Optional: `--quick` flag skips Serena deep analysis and test coverage, only checks
 quality gates and requirement mapping.
 
 ## Protocol
@@ -50,10 +50,10 @@ Build a verification checklist from these. Each item gets a status:
 ### Execution Strategy
 
 Phase 1 (quality gates) runs first — it's a stop gate. If it passes, spawn
-Phase 2 (LSP verification) and Phase 3 step 5 (test execution via whey-drainer)
+Phase 2 (Serena verification) and Phase 3 step 5 (test execution via whey-drainer)
 in parallel. Phase 3 steps 1-4 (coverage shape analysis) and Phase 4
 (acceptance criteria) run sequentially after Phase 2 because they depend on
-LSP results.
+Serena results.
 
 ### Phase 1: Quality Gates (build + lint)
 
@@ -69,33 +69,36 @@ If no quality gates are documented, run the project's default build check (`carg
 **Stop gate**: If quality gates fail, report immediately with the failures.
 Don't waste time on structural analysis of broken code.
 
-### Phase 2: LSP Structural Verification
+### Phase 2: Serena Structural Verification
 
 For each functional requirement and user story, verify the implementation exists
-and has the right shape using LSP — not just file reads.
+and has the right shape using the Serena MCP — not just file reads.
 
 **For each requirement:**
 
-1. **Locate implementation** — Use LSP `documentSymbol` and `findReferences` to
-   find the symbols that implement this requirement. Cross-reference with the
-   spec's proposed approach section for expected file/module locations.
+1. **Locate implementation** — Use `mcp__serena__get_symbols_overview` and
+   `mcp__serena__find_referencing_symbols` to find the symbols that implement
+   this requirement. Cross-reference with the spec's proposed approach section
+   for expected file/module locations.
 
-2. **Verify public API** — Use LSP `documentSymbol` on barrel/index files to
-   confirm expected exports exist. Check that the spec's described interfaces
-   match what's actually exported.
+2. **Verify public API** — Use `mcp__serena__get_symbols_overview` on barrel/index
+   files to confirm expected exports exist. Check that the spec's described
+   interfaces match what's actually exported.
 
-3. **Trace data flow** — Use LSP `goToDefinition` and `findReferences` to verify
-   that data flows through the expected path. If the spec says "orders calls
-   pricing via the public API", verify that import chain via LSP.
+3. **Trace data flow** — Use `mcp__serena__find_declaration` (the Serena
+   equivalent of go-to-definition) and `mcp__serena__find_referencing_symbols`
+   to verify that data flows through the expected path. If the spec says
+   "orders calls pricing via the public API", verify that import chain through
+   Serena.
 
 4. **Check boundary compliance** — Verify Sliced Bread rules:
-   - Imports cross slice boundaries only through index files (LSP references)
-   - Models don't import adapters or framework code (LSP goToDefinition on imports)
+   - Imports cross slice boundaries only through index files (Serena `find_referencing_symbols`)
+   - Models don't import adapters or framework code (`find_declaration` on imports)
    - Common/ doesn't import from siblings
 
-**LSP warmup**: Call `LSP hover` on line 1 of the first source file. Retry 3x
-with 3s waits. If LSP is unavailable after retries, fall back to ast-grep
-(`sg`) for structural patterns and note degraded confidence.
+**Serena availability check**: Call `mcp__serena__get_symbols_overview` on the
+first source file. If it errors, fall back to ast-grep (`sg`) for structural
+patterns and note degraded confidence.
 
 **ast-grep fallback patterns:**
 
@@ -115,7 +118,7 @@ sg --lang python -p 'class $NAME($BASE): $$$BODY' --json {file}
 ### Phase 3: Test Coverage Analysis
 
 Verify that tests exist and cover the spec's requirements. Steps 1-4 analyze
-coverage *shape* — mapping test names to requirements via LSP. Step 5 runs the
+coverage *shape* — mapping test names to requirements via Serena. Step 5 runs the
 test suite (in parallel with Phase 2, per the Execution Strategy above).
 
 1. **Find test files** — Glob for test files in scope:
@@ -126,14 +129,14 @@ test suite (in parallel with Phase 2, per the Execution Strategy above).
    {scope}/**/*_test.{go,rs}
    ```
 
-2. **Map tests to requirements** — Use LSP `documentSymbol` on test files to
+2. **Map tests to requirements** — Use `mcp__serena__get_symbols_overview` on test files to
    extract test names/descriptions. Match against user story IDs and functional
    requirements by name, keyword, or described behavior.
 
 3. **Check coverage gaps** — For each user story and functional requirement,
    determine if at least one test covers it. Score:
    - **Covered**: test name/description references the requirement + test
-     exercises the relevant code path (verified via LSP `findReferences` from
+     exercises the relevant code path (verified via `mcp__serena__find_referencing_symbols` from
      test to implementation)
    - **Weakly covered**: test exists but doesn't reference the requirement
      explicitly, or only tests a helper rather than the full path
@@ -150,18 +153,18 @@ test suite (in parallel with Phase 2, per the Execution Strategy above).
 
 For each user story's acceptance criteria (checkbox items):
 
-1. **Structural check** — Use LSP to verify the described behavior has a code
+1. **Structural check** — Use Serena to verify the described behavior has a code
    path. E.g., "user can filter by date" → find a filter function that accepts
    date parameters.
 
 2. **Test check** — Verify a test exercises this specific criterion.
 
 3. **Score the criterion**:
-   - `PASS` — Code path exists (LSP-verified) AND test covers it
+   - `PASS` — Code path exists (Serena-verified) AND test covers it
    - `PARTIAL` — Code path exists but no specific test, OR test exists but
-     code path couldn't be LSP-verified
+     code path couldn't be Serena-verified
    - `FAIL` — Neither code path nor test found
-   - `UNTESTED` — Code path exists (LSP-verified) but zero test coverage
+   - `UNTESTED` — Code path exists (Serena-verified) but zero test coverage
 
 ## Scoring
 
@@ -172,7 +175,7 @@ Each verification item uses 0-100 confidence scoring:
 | Type | Base | Cap |
 |------|------|-----|
 | Quality gate (build/lint) | 90 | 100 |
-| Functional requirement (LSP-verified) | 60 | 100 |
+| Functional requirement (Serena-verified) | 60 | 100 |
 | User story acceptance criterion | 50 | 95 |
 | Test coverage mapping | 40 | 90 |
 | Boundary/architecture compliance | 45 | 95 |
@@ -181,11 +184,11 @@ Each verification item uses 0-100 confidence scoring:
 
 | Evidence | Modifier |
 |----------|----------|
-| LSP-verified (goToDefinition, findReferences) | +25 |
+| Serena-verified (find_declaration, find_referencing_symbols) | +25 |
 | ast-grep structural match | +15 |
 | Test explicitly references requirement | +15 |
-| File/symbol name matches but not LSP-verified | +5 |
-| Inferred from file read only (no LSP) | -10 |
+| File/symbol name matches but not Serena-verified | +5 |
+| Inferred from file read only (no Serena) | -10 |
 
 **Step 3: Context modifiers**
 
@@ -197,7 +200,7 @@ Each verification item uses 0-100 confidence scoring:
 | Multiple tests cover same requirement | +5 |
 
 **Step 4: Borderline re-assessment** — Items scoring 55-69: re-verify with a
-second LSP pass. If scores diverge >15, mark as `PARTIAL` rather than making
+second Serena pass. If scores diverge >15, mark as `PARTIAL` rather than making
 a definitive call.
 
 **Surfacing threshold**: >= 50 for PASS. < 50 = PARTIAL or FAIL depending on
@@ -224,7 +227,7 @@ context window. Lead with the summary, then the details.
 ### Requirements Coverage
 | ID | Requirement | Status | Confidence | Evidence |
 |----|-------------|--------|------------|----------|
-| FR-1 | Order creation | PASS | 92 | LSP: OrderService.create verified, 3 tests |
+| FR-1 | Order creation | PASS | 92 | Serena: OrderService.create verified, 3 tests |
 | FR-2 | Price calculation | PARTIAL | 65 | Code exists, no test for edge case |
 | US-001 | User can place order | PASS | 88 | 4/4 acceptance criteria met |
 
@@ -263,17 +266,17 @@ N items scored < 50 (not shown above — details in the full report below)
 - Fix build failures — report them, let the caller decide
 - Review code quality or style — use `/age` for that
 - Run outside the spec's scope — verify what the spec describes, nothing more
-- Assign PASS without LSP or ast-grep evidence — file reads alone cap at PARTIAL
+- Assign PASS without Serena or ast-grep evidence — file reads alone cap at PARTIAL
 
 ## Gotchas
 
-- LSP may not be available for all languages — ast-grep fallback is less precise
+- Serena may not be available for all languages — ast-grep fallback is less precise
   but still structural. Note degraded confidence in the report.
 - Spec quality varies — vague requirements get lower confidence scores. If a
   requirement is too ambiguous to verify, score it PARTIAL with a note.
 - Test name matching is heuristic — a test named `test_order_creation` maps to
   FR "Order creation" but `test_helper_utils` doesn't map to anything specific.
-  When in doubt, use LSP findReferences to check if the test actually calls the
+  When in doubt, use `mcp__serena__find_referencing_symbols` to check if the test actually calls the
   implementation.
 - Large specs (20+ requirements) may hit the tool call limit. After ~60 tool
   calls, synthesize from available data and note incomplete coverage.
@@ -282,11 +285,11 @@ N items scored < 50 (not shown above — details in the full report below)
 
 ## Verification Principles
 
-- Require LSP or ast-grep evidence for PASS — file reads alone cap at PARTIAL
+- Require Serena or ast-grep evidence for PASS — file reads alone cap at PARTIAL
   because they can't verify structural relationships
 - Run quality gates first — they're the fastest failure signal and everything
   downstream is moot if the build is broken
-- Locate symbols via LSP before reading files — going straight to file reads
+- Locate symbols via Serena before reading files — going straight to file reads
   bypasses the structural verification that distinguishes this skill from /age
 - Prioritize red/green paths over individual checkboxes — they represent
   end-to-end user value, not isolated implementation details

--- a/skills/spec-verify/SKILL.md
+++ b/skills/spec-verify/SKILL.md
@@ -3,7 +3,7 @@ name: spec-verify
 model: opus
 context: fork
 effort: high
-allowed-tools: Read, Glob, Grep, Bash(sg:*), Bash(echo:*), Agent, mcp__serena__*
+allowed-tools: Read, Glob, Grep, Bash(sg:*), Bash(echo:*), Bash(cargo check:*), Bash(cargo clippy:*), Bash(cargo test:*), Bash(tsc:*), Bash(npm run:*), Bash(pnpm:*), Bash(yarn:*), Bash(go build:*), Bash(go vet:*), Bash(go test:*), Bash(uv run:*), Bash(python -m:*), Bash(pytest:*), Bash(ruff:*), Bash(mypy:*), Bash(prek:*), Bash(rtk:*), Agent, mcp__serena__*
 description: >
   Verify that a spec's implementation matches its requirements using Serena MCP
   structural analysis, build verification, and test coverage checking. Use when the

--- a/skills/tui-design/SKILL.md
+++ b/skills/tui-design/SKILL.md
@@ -24,7 +24,7 @@ Delegate to the right skill for each phase of TUI development:
 | Phase | Skill | Why |
 |-------|-------|-----|
 | Search codebase for patterns | `scout` | rg/fd for fast file and content search |
-| Understand existing code structure | LSP | Symbol lookup, cross-references, type info |
+| Understand existing code structure | Serena MCP | Symbol lookup, cross-references, type info |
 | Look up ratatui/Textual/crossterm docs | `fetch` | Context7 for version-specific library docs |
 | Find structural code patterns | `trace` | ast-grep for "what implements X?" questions |
 | Edit existing files precisely | `chisel` | sd for multi-file replacements, Edit for precision |


### PR DESCRIPTION
## Summary

Recent commits (0845c7d, 50a07e6, f8c051b) removed the per-language LSP plugins and the `LSP` tool surface in favour of routing symbol intelligence through the Serena MCP. Several agent and skill files still referenced the removed surface, leaving them in a half-rebranded state where the prose described \"LSP findReferences\" but no such tool was exposed.

This PR cleans up the residue across 15 files (9 agents, 6 skills):

**Frontmatter strips** — removed `LSP` from `disallowedTools:` / `tools:` / `skills:` / `allowed-tools:`. Two agents (`ricotta-reducer.md`, `roquefort-wrecker.md`) had bodies calling `mcp__serena__*` tools but their `tools:` lists didn't include serena — those calls would have been **denied at runtime**. Both now declare `mcp__serena__*`.

**Body rewrites** in agents/skills:
- \"LSP Warmup\" → \"Serena availability check\"
- `LSP documentSymbol` → `mcp__serena__get_symbols_overview`
- `LSP findReferences` → `mcp__serena__find_referencing_symbols`
- `LSP hover` → `mcp__serena__find_symbol` (with `include_body=true` for the type-info equivalent)
- `LSP goToDefinition` → `mcp__serena__find_declaration`
- \"LSP-verified\" → \"Serena-verified\"

Informational LSP mentions intentionally left intact where they accurately describe Serena's LSP backing under the hood (e.g. `ghostbuster.md` Gotchas section on how dynamic dispatch hides callers from LSP-backed analysis, `skills/serena-project-config/SKILL.md` which is literally about configuring Serena's LSP layer).

## Test plan

- [ ] `grep -rn '^tools:\\|^disallowedTools:\\|^skills:\\|^allowed-tools:' claude/agents/ skills/ | grep -i '\\bLSP\\b'` should return no results.
- [ ] Open Claude and trigger ghostbuster/nih-scanner/ricotta-reducer agents on a small repo; confirm `mcp__serena__*` calls succeed (not denied by tool surface).
- [ ] Spot-read `skills/spec-verify/SKILL.md` Phase 2 for consistency — every step that previously said \"LSP\" should now say \"Serena\".
- [ ] No prose references to a literal `LSP` *tool* (i.e. as something you call) should remain; mentions of LSP as a concept (servers, protocol, backing layer) are fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)