### PR TITLE
fix(chezmoi): prelink ~/.claude/settings.json on fresh install

### DIFF
--- a/chezmoi/.sync
+++ b/chezmoi/.sync
@@ -114,19 +114,21 @@ fi
 # Pre-create the ~/.claude symlinks that chezmoi's run_onchange templates
 # write through. On a fresh install, claude/.sync runs *after* chezmoi/.sync
 # (alphabetical iteration in .sync-with-rollback), so without these links
-# chezmoi would create real ~/.claude/{hooks,reference}/ directories that
-# claude/.sync would then back up — orphaning anything chezmoi just wrote
-# (e.g. session-start-cheese-flair.sh). The claude/.sync pass later rebuilds
-# these symlinks idempotently. Codex has no symlink layer, so this is
-# claude-only.
+# chezmoi would create real ~/.claude/{hooks,reference}/ directories — or a
+# real ~/.claude/settings.json file the moment `claude mcp add` or
+# `claude plugin install` touches user-scope state — that claude/.sync would
+# then back up, orphaning anything chezmoi just wrote (e.g.
+# session-start-cheese-flair.sh, the freshly-installed MCP entries). The
+# claude/.sync pass later rebuilds these symlinks idempotently. Codex has no
+# symlink layer, so this is claude-only.
 prelink_claude_writethrough() {
     local claude_dir="$HOME/.claude"
     local item link source
     mkdir -p "$claude_dir"
-    for item in hooks reference; do
+    for item in hooks reference settings.json; do
         link="$claude_dir/$item"
         source="$dotfiles_dir/claude/$item"
-        [[ -d "$source" ]] || continue
+        [[ -e "$source" ]] || continue
         # Already a symlink, or a real path claude/.sync will own — leave alone.
         [[ -e "$link" || -L "$link" ]] && continue
         ln -s "$source" "$link"

--- a/tests/chezmoi-wiring.bats
+++ b/tests/chezmoi-wiring.bats
@@ -292,11 +292,13 @@ EOF
 #
 # Regression guard for the first-install race between chezmoi/.sync (runs
 # first alphabetically) and claude/.sync (creates the ~/.claude/{hooks,
-# reference} symlinks). Without the prelink, chezmoi's run_onchange
-# install-hooks template lands files inside a real ~/.claude/hooks/ dir
-# that claude/.sync later backs up — orphaning the deployed hook.
+# reference, settings.json} symlinks). Without the prelink, chezmoi's
+# run_onchange install-hooks template lands files inside a real
+# ~/.claude/hooks/ dir, and `claude mcp add`/`claude plugin install` land
+# a real ~/.claude/settings.json file — both of which claude/.sync later
+# backs up to .bak, orphaning everything chezmoi just wrote.
 
-@test "chezmoi/.sync pre-links ~/.claude/{hooks,reference} on a fresh install" {
+@test "chezmoi/.sync pre-links ~/.claude/{hooks,reference,settings.json} on a fresh install" {
     # No ~/.claude at all — fresh-box state.
     [[ ! -e "$HOME/.claude" ]]
 
@@ -320,12 +322,15 @@ EOF
     [[ "$(readlink "$HOME/.claude/hooks")"     == "$REAL_DOTFILES_DIR/claude/hooks"     ]]
     [[ -L "$HOME/.claude/reference" ]]
     [[ "$(readlink "$HOME/.claude/reference")" == "$REAL_DOTFILES_DIR/claude/reference" ]]
+    [[ -L "$HOME/.claude/settings.json" ]]
+    [[ "$(readlink "$HOME/.claude/settings.json")" == "$REAL_DOTFILES_DIR/claude/settings.json" ]]
 }
 
 @test "chezmoi/.sync prelink is idempotent (existing correct symlink preserved)" {
     mkdir -p "$HOME/.claude"
-    ln -s "$REAL_DOTFILES_DIR/claude/hooks"     "$HOME/.claude/hooks"
-    ln -s "$REAL_DOTFILES_DIR/claude/reference" "$HOME/.claude/reference"
+    ln -s "$REAL_DOTFILES_DIR/claude/hooks"         "$HOME/.claude/hooks"
+    ln -s "$REAL_DOTFILES_DIR/claude/reference"     "$HOME/.claude/reference"
+    ln -s "$REAL_DOTFILES_DIR/claude/settings.json" "$HOME/.claude/settings.json"
 
     mkdir -p "$HOME/.config/chezmoi"
     cat > "$HOME/.config/chezmoi/chezmoi.toml" <<EOF
@@ -343,8 +348,9 @@ EOF
     run bash "$CHEZMOI_SYNC"
     assert_success
     # Symlinks unchanged.
-    [[ "$(readlink "$HOME/.claude/hooks")"     == "$REAL_DOTFILES_DIR/claude/hooks"     ]]
-    [[ "$(readlink "$HOME/.claude/reference")" == "$REAL_DOTFILES_DIR/claude/reference" ]]
+    [[ "$(readlink "$HOME/.claude/hooks")"         == "$REAL_DOTFILES_DIR/claude/hooks"         ]]
+    [[ "$(readlink "$HOME/.claude/reference")"     == "$REAL_DOTFILES_DIR/claude/reference"     ]]
+    [[ "$(readlink "$HOME/.claude/settings.json")" == "$REAL_DOTFILES_DIR/claude/settings.json" ]]
     # Prelink message only fires when it actually creates a link.
     [[ "$output" != *"Pre-linked"* ]]
 }
@@ -374,6 +380,33 @@ EOF
     # Real dir + its contents preserved untouched.
     [[ -d "$HOME/.claude/hooks" && ! -L "$HOME/.claude/hooks" ]]
     [[ "$(cat "$HOME/.claude/hooks/sentinel")" == "user file" ]]
+}
+
+@test "chezmoi/.sync prelink does not clobber a pre-existing real settings.json" {
+    # If the user has a hand-rolled ~/.claude/settings.json before adopting
+    # dotfiles, prelink must leave it alone — claude/.sync's backup pass owns
+    # real files at that path.
+    mkdir -p "$HOME/.claude"
+    echo '{"user":"keep"}' > "$HOME/.claude/settings.json"
+
+    mkdir -p "$HOME/.config/chezmoi"
+    cat > "$HOME/.config/chezmoi/chezmoi.toml" <<EOF
+sourceDir = "$REAL_DOTFILES_DIR/chezmoi"
+
+[data]
+email = "user@example.com"
+work = false
+EOF
+
+    local fake_bin
+    fake_bin=$(make_fake_chezmoi)
+    PATH="$fake_bin:$PATH"
+
+    run bash "$CHEZMOI_SYNC"
+    assert_success
+    # Real file preserved untouched.
+    [[ -f "$HOME/.claude/settings.json" && ! -L "$HOME/.claude/settings.json" ]]
+    [[ "$(cat "$HOME/.claude/settings.json")" == '{"user":"keep"}' ]]
 }
 
 # ── source-tree scaffold ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fresh-box symlink ordering bug: cc/ccp couldn't find `~/.claude/settings.json` because chezmoi's run_onchange scripts wrote a real file at that path before `claude/.sync` got a chance to symlink it to the repo.

`chezmoi/.sync:prelink_claude_writethrough` already pre-linked `~/.claude/{hooks,reference}` for exactly this reason — `chezmoi/.sync` runs first alphabetically, and without those pre-links the install-hooks template would drop files into real `~/.claude/hooks/` dirs that `claude/.sync` then backs up to `.bak`. `settings.json` had the same gap: the moment `chezmoi apply` ran `claude mcp add` (via `run_onchange_install-mcp.sh.tmpl`) or `claude plugin install` (downstream), Claude wrote user-scope state into a real `~/.claude/settings.json` — which `claude/.sync` then backed up to `.bak`, orphaning the freshly installed MCP/plugin entries and leaving `cc`/`ccp` pointing at nothing during the window.

## Change

- `chezmoi/.sync`: extend the prelink loop to include `settings.json`. Switch the source guard from `-d` to `-e` so the file source is handled alongside the existing dir sources. The no-clobber rule (`[[ -e $link || -L $link ]] && continue`) is unchanged — pre-existing real `settings.json` files stay untouched and `claude/.sync`'s backup pass remains the only path that touches them.
- `tests/chezmoi-wiring.bats`: update the two existing prelink tests (fresh-install + idempotence) to also assert the `settings.json` symlink, and add a third no-clobber test mirroring the existing one for real directories.

## Test plan

- [x] `bash -n chezmoi/.sync` — syntax clean
- [ ] `bats tests/chezmoi-wiring.bats` — fresh-install, idempotence, and the two no-clobber paths all green (cannot run in this env: bats not installed)
- [ ] On a fresh box: `dots sync`, then `ls -la ~/.claude/settings.json` resolves to `<dotfiles>/claude/settings.json` even before the `claude/.sync` pass runs

---
_Generated by [Claude Code](https://claude.ai/code/session_01GjowX2u6ybEvLiAtx22Z1s)_