### PR TITLE
feat(mcp): add hallouminate markdown wiki MCP

### DIFF
--- a/agents/mcp/registry.yaml
+++ b/agents/mcp/registry.yaml
@@ -40,6 +40,12 @@ mcps:
     description: AST-aware code search/read/edit (Tree-sitter); backs cheez-* skills when cheese-flow is unavailable
     gate_unless: CHEESE_FLOW
 
+  hallouminate:
+    command: hallouminate
+    args: ["serve"]
+    scope: user
+    description: Per-repo markdown wiki — semantic search (LanceDB + fastembed) and add/read/delete_markdown for LLM-authored notes
+
   context7:
     command: npx
     args: ["-y", "@upstash/context7-mcp"]

--- a/packages/packages.yaml
+++ b/packages/packages.yaml
@@ -61,6 +61,9 @@ packages:
   - sccache                                   # rustc wrapper for compile caching
   - cargo-nextest                             # faster, parallel test runner
 
+  # Rust build deps (transitive native toolchain requirements)
+  - protobuf                                  # protoc — required by lance-encoding build script (hallouminate)
+
   # macOS-only
   - mas: { platform: mac }                    # Mac App Store CLI
   - trash: { platform: mac }                  # Move to Trash (safer rm)
@@ -111,6 +114,7 @@ packages:
   # Cargo
   - cargo-llvm-cov: { source: cargo }
   - tilth: { source: cargo, git: "https://github.com/paulnsorensen/tilth", branch: main }
+  - hallouminate: { source: cargo, git: "https://github.com/paulnsorensen/hallouminate", branch: main }
   # Install from Git because the crates.io `rtk` collides with the desired package.
   # If an unrelated `rtk` is already present from `cargo install rtk`, remove it first
   # so `dots sync` does not incorrectly treat the Git-sourced package as already satisfied.


### PR DESCRIPTION
## Summary
- Registers `hallouminate` as a user-scoped MCP across all harnesses for semantic search over a per-repo markdown corpus (LanceDB + fastembed, plus `add_markdown` / `read_markdown` / `delete_markdown` for LLM-authored notes).
- Installs the binary from `paulnsorensen/hallouminate` via cargo and adds `protobuf` to brew packages so `protoc` is available for the `lance-encoding` build script.

## Test plan
- [ ] `dots sync` on a clean machine installs `protobuf` + builds `hallouminate` from Git
- [ ] `mcp-sync` registers `hallouminate` in Claude, Codex, and opencode
- [ ] `mcp__hallouminate__list_corpora` responds in a fresh session