### PR TITLE
fix(sync): silent skip cascade — gh skill install + .env load

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ This is a personal dotfiles repository that configures a vim-centric, terminal-b
 
 ### Agent Skill Management (`gh skill install`)
 
-Harness-agnostic — installs into each agent listed in `SKILL_HARNESSES` (`.env`). Auto-runs as part of `dots sync` via chezmoi's `run_onchange_install-claude-skills.sh.tmpl`, which invokes `chezmoi/lib/install-external.sh` (skipped silently when `gh skill` is unavailable).
+Harness-agnostic — installs into each agent listed in `SKILL_HARNESSES` (`.env`). Auto-runs as part of `dots sync` via chezmoi's `run_onchange_install-claude-skills.sh.tmpl`, which invokes `chezmoi/lib/install-external.sh`. Requires `gh` (v2.90+ with `skill` subcommand) and `gh auth login` — `dots sync` exits 1 if either is missing.
 
 - `skill-sync` - Install external skills from `skills/_registry.yaml` into each configured harness (also fires during `dots sync` via chezmoi)
 - `skill-sync-dry` - Preview skill installs without making changes

--- a/bin/dots
+++ b/bin/dots
@@ -8,6 +8,19 @@ set -euo pipefail
 DOTFILES_DIR="${DOTFILES_DIR:-${HOME}/Dev/dotfiles}"
 DOTFILES_STATE_DIR="${DOTFILES_STATE_DIR:-${HOME}/.local/state/dotfiles}"
 
+# Load .env so downstream sync steps (chezmoi apply, install-external.sh,
+# etc.) get API keys regardless of how `dots` was invoked. zsh/core.zsh only
+# fires for interactive zsh — running `dots sync` from bash, a script, or a
+# non-interactive shell would otherwise leave CONTEXT7_API_KEY / TAVILY_API_KEY
+# unset and abort `chezmoi apply` at the copilot template, skipping every
+# template that sorts after it (including ~/.gitconfig).
+if [[ -f "$DOTFILES_DIR/.env" ]]; then
+    set -a
+    # shellcheck disable=SC1091
+    source "$DOTFILES_DIR/.env"
+    set +a
+fi
+
 # Colors
 GREEN='\033[0;32m'
 BLUE='\033[0;34m'

--- a/chezmoi/.chezmoiscripts/run_onchange_install-claude-skills.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/run_onchange_install-claude-skills.sh.tmpl
@@ -23,8 +23,18 @@ DOTFILES_ROOT="$SOURCE_DIR/.."
     "$DOTFILES_ROOT/skills" \
     "$HOME/.claude/skills"
 
-# Phase 2: external skills via `gh skill install` (best-effort, non-fatal).
-# Skip silently when gh or `gh skill` is unavailable.
-if command -v gh &>/dev/null && gh skill --help &>/dev/null; then
-    "$SOURCE_DIR/lib/install-external.sh" "$DOTFILES_ROOT/skills/_registry.yaml" || true
+# Phase 2: external skills via `gh skill install` — required, not best-effort.
+# Failure aborts the sync so silent partial-install regressions can't reoccur.
+if ! command -v gh &>/dev/null; then
+    echo "Error: gh CLI not found. Install with: brew install gh" >&2
+    exit 1
 fi
+if ! gh skill --help &>/dev/null; then
+    echo "Error: 'gh skill' subcommand unavailable. Upgrade gh to v2.90+." >&2
+    exit 1
+fi
+if ! gh auth status &>/dev/null; then
+    echo "Error: gh is not authenticated. Run: gh auth login" >&2
+    exit 1
+fi
+"$SOURCE_DIR/lib/install-external.sh" "$DOTFILES_ROOT/skills/_registry.yaml"

--- a/chezmoi/lib/install-external.sh
+++ b/chezmoi/lib/install-external.sh
@@ -181,8 +181,15 @@ if [[ -s "$FAIL_COUNTER" ]]; then
 fi
 
 if [[ "$fail_count" -gt 0 ]]; then
-    echo -e "${YELLOW}$fail_count install(s) failed — cache not updated. Re-run to retry.${NC}"
-elif ! $DRY_RUN; then
+    # Fail loud: propagate non-zero so the chezmoi run_onchange records the
+    # apply as failed and reruns next `dots sync` instead of marking success
+    # and skipping until the skills tree hash changes (the silent partial
+    # install regression mode).
+    echo -e "${RED}$fail_count install(s) failed — cache not updated. Re-run to retry.${NC}" >&2
+    exit 1
+fi
+
+if ! $DRY_RUN; then
     mkdir -p "$(dirname "$CACHE_FILE")"
     echo "$COMBINED_DIGEST" > "$CACHE_FILE"
 fi

--- a/tests/chezmoi-wiring.bats
+++ b/tests/chezmoi-wiring.bats
@@ -16,6 +16,44 @@ teardown() { teardown_test_env; }
 
 # ── chezmoi/.sync wiring ────────────────────────────────────────────────
 
+# Helper: drop a fake `gh` binary on PATH that satisfies the PR #196 Phase 2
+# preflight checks (`gh skill --help`, `gh auth status`) so `chezmoi apply`
+# doesn't abort in CI runners where gh exists but isn't authenticated.
+# Also no-ops `gh skill install` and `gh api .../contents/skills` so any
+# downstream install loop completes without network access.
+make_fake_gh() {
+    local fake_bin="${1:-$TEST_HOME/fake-bin}"
+    mkdir -p "$fake_bin"
+    cat > "$fake_bin/gh" <<'SH'
+#!/usr/bin/env bash
+case "${1:-}" in
+    skill)
+        # gh skill --help / gh skill install ... — both succeed, no-op.
+        exit 0
+        ;;
+    auth)
+        # gh auth status — succeed.
+        exit 0
+        ;;
+    api)
+        # gh api repos/<owner>/<repo>/contents/skills — return empty so
+        # install-external.sh's resolve_skills yields no candidates.
+        echo "[]"
+        exit 0
+        ;;
+    *)
+        # Fail loud on unexpected subcommands so a future code path that
+        # adds a new `gh <foo>` call surfaces a fixture gap instead of
+        # silently fake-succeeding.
+        echo "fake gh: unexpected invocation: gh $*" >&2
+        exit 99
+        ;;
+esac
+SH
+    chmod +x "$fake_bin/gh"
+    echo "$fake_bin"
+}
+
 # Helper: drop a fake chezmoi binary on PATH that records its args and
 # (optionally) writes a config file when invoked as `chezmoi init`. Returns
 # the bin-dir path so callers can extend PATH themselves.
@@ -449,16 +487,22 @@ EOF
     fi
 }
 
-@test "chezmoi/run_onchange template guards Phase 2 behind 'gh skill --help'" {
-    # Spec invariant (PR #2 §3): the external installer must skip silently
-    # when gh is missing or `gh skill` is unavailable. Without this guard, a
-    # machine without gh would fail chezmoi apply on every run.
+@test "chezmoi/run_onchange template fails loud when gh / gh skill / gh auth missing" {
+    # Spec invariant (PR #196): the external installer must FAIL LOUD when
+    # gh, the `gh skill` subcommand, or gh auth is missing — not skip
+    # silently, and not swallow per-invocation failure with `|| true`.
+    # Silent skip + `|| true` masked silent partial installs (the bug PR
+    # #196 fixes); guarding against regression of either swallow path is
+    # the whole point of this assertion.
     grep -qF 'command -v gh' "$INSTALLER_TMPL"
     grep -qF 'gh skill --help' "$INSTALLER_TMPL"
-    # Phase 2 must also tolerate per-invocation failure so a flaky network
-    # doesn't break chezmoi apply.
+    grep -qF 'gh auth status' "$INSTALLER_TMPL"
     grep -qF 'install-external.sh' "$INSTALLER_TMPL"
-    grep -qE 'install-external\.sh.*\|\| *true' "$INSTALLER_TMPL"
+    # Must NOT tolerate per-invocation failure; the `|| true` swallow is gone.
+    if grep -qE 'install-external\.sh.*\|\| *true' "$INSTALLER_TMPL"; then
+        echo "install-external.sh invocation still has '|| true' — silent partial install regression risk" >&2
+        return 1
+    fi
 }
 
 @test "chezmoi/.chezmoiignore excludes lib/ so helpers aren't applied to \$HOME" {
@@ -477,6 +521,57 @@ EOF
 
 @test "chezmoi/lib/install-external.sh exists and is executable" {
     [[ -x "$REAL_DOTFILES_DIR/chezmoi/lib/install-external.sh" ]]
+}
+
+@test "install-external.sh exits non-zero when a gh skill install fails (PR #196 regression)" {
+    # Spec invariant (PR #196 finding 3): install-external.sh MUST propagate
+    # failure so the chezmoi run_onchange records the apply as failed and
+    # reruns next `dots sync`, rather than marking success and skipping
+    # until the skills-tree hash changes. Without this exit-1, silent
+    # partial installs persist — the exact bug PR #196 was filed to fix.
+    local fake_bin="$TEST_HOME/fake-bin-failing-install"
+    mkdir -p "$fake_bin"
+    cat > "$fake_bin/gh" <<'SH'
+#!/usr/bin/env bash
+case "${1:-}" in
+    skill)
+        # `gh skill --help` succeeds; `gh skill install ...` fails.
+        if [[ "${2:-}" == "install" ]]; then
+            echo "fake: simulated install failure" >&2
+            exit 1
+        fi
+        exit 0
+        ;;
+    *)
+        echo "fake gh: unexpected invocation: gh $*" >&2
+        exit 99
+        ;;
+esac
+SH
+    chmod +x "$fake_bin/gh"
+    PATH="$fake_bin:$PATH"
+
+    # Minimal registry with explicit `skills:` to avoid the `gh api` discovery
+    # path (we only need install_skill to fire).
+    local registry="$TEST_HOME/test-registry.yaml"
+    cat > "$registry" <<YAML
+sources:
+  fake/repo:
+    description: regression fixture for PR #196 finding 3
+    skills:
+      - fake-skill
+YAML
+
+    # Force a non-empty harness list so the script doesn't early-exit at the
+    # SKILL_HARNESSES-empty branch. On dev machines the script will then
+    # re-source the real .env's SKILL_HARNESSES on top of this value — that's
+    # harmless here because every fake install fails regardless of which
+    # harnesses are in the loop.
+    export SKILL_HARNESSES="test-harness"
+
+    run "$REAL_DOTFILES_DIR/chezmoi/lib/install-external.sh" "$registry"
+    assert_failure
+    assert_output_contains "install(s) failed"
 }
 
 # ── end-to-end: chezmoi apply runs the installer ───────────────────────
@@ -547,6 +642,14 @@ EOF
 @test "chezmoi apply triggers the skill installer (real files in ~/.claude/skills)" {
     command -v chezmoi >/dev/null 2>&1 || skip "chezmoi not installed"
 
+    # PR #196: Phase 2 of the run_onchange installer now fails loud when
+    # `gh auth status` returns non-zero. CI runners have gh installed but
+    # unauthenticated, so stub a fake gh that satisfies all three preflight
+    # checks. Phase 1 (install-local.sh) is what this test actually asserts.
+    local fake_gh_bin
+    fake_gh_bin=$(make_fake_gh)
+    PATH="$fake_gh_bin:$PATH"
+
     # Templated dotfiles need [data] for .email and env vars for the
     # copilot template's fail-fast guard. Bootstrap both before .sync runs
     # so chezmoi apply renders cleanly.
@@ -601,6 +704,13 @@ TOML
 @test "copilot template fails fast when CONTEXT7_API_KEY is unset" {
     command -v chezmoi >/dev/null 2>&1 || skip "chezmoi not installed"
 
+    # PR #196: stub fake gh so the run_onchange installer's `gh auth status`
+    # check doesn't fail first and mask the copilot template's fail-fast
+    # error (which is what this test actually asserts).
+    local fake_gh_bin
+    fake_gh_bin=$(make_fake_gh)
+    PATH="$fake_gh_bin:$PATH"
+
     mkdir -p "$HOME/.config/chezmoi"
     cat > "$HOME/.config/chezmoi/chezmoi.toml" <<TOML
 sourceDir = "$REAL_DOTFILES_DIR/chezmoi"
@@ -619,6 +729,12 @@ TOML
 
 @test "gitconfig template renders Uber URL redirects when work=true" {
     command -v chezmoi >/dev/null 2>&1 || skip "chezmoi not installed"
+
+    # PR #196: stub fake gh so the run_onchange installer's `gh auth status`
+    # check doesn't abort chezmoi apply before the gitconfig template runs.
+    local fake_gh_bin
+    fake_gh_bin=$(make_fake_gh)
+    PATH="$fake_gh_bin:$PATH"
 
     mkdir -p "$HOME/.config/chezmoi"
     cat > "$HOME/.config/chezmoi/chezmoi.toml" <<TOML

--- a/tests/skills-external.bats
+++ b/tests/skills-external.bats
@@ -249,7 +249,13 @@ EOF
     assert_output_contains "gh skill install acme/widgets alpha --agent claude-code --scope user --force --pin v1.2.3"
 }
 
-@test "skill sync: failed install is reported but doesn't abort other installs" {
+@test "skill sync: every install in the batch is attempted, then script exits non-zero on per-skill failure" {
+    # PR #196 finding 3: the script must run every install in the batch
+    # (so partial failures don't mask each other) and THEN propagate
+    # non-zero so the chezmoi run_onchange records the apply as failed
+    # and reruns next sync. Pre-#196 this exited 0, which silently
+    # marked the chezmoi apply successful → no retry → partial installs
+    # persisted until the skills-tree hash changed.
     write_registry "acme/widgets" "    skills:
       - alpha
       - bravo"
@@ -257,8 +263,8 @@ EOF
     export GH_BEHAVIOR="fail-skill-install"
 
     run_sync
-    assert_success  # script itself doesn't bail on per-skill failure
-    # Both skills attempted, both shown as failed
+    assert_failure  # PR #196: per-skill failure now propagates exit 1
+    # Both skills attempted before exit — script does NOT bail on first failure
     local stripped
     stripped=$(strip_colors "$output")
     [[ "$stripped" == *"✗ alpha → claude-code"* ]]
@@ -476,7 +482,9 @@ MOCK
     fi
 }
 
-@test "skill sync: failed installs do not write the cache" {
+@test "skill sync: failed installs do not write the cache (and propagate exit 1)" {
+    # PR #196 finding 3: cache must stay un-written on any failure, AND
+    # the script must exit non-zero so the run_onchange retries.
     write_registry "acme/widgets" "    skills:
       - alpha
       - bravo"
@@ -484,7 +492,7 @@ MOCK
     export GH_BEHAVIOR="fail-skill-install"
 
     run_sync
-    assert_success  # script does not abort on per-skill failure
+    assert_failure  # PR #196: per-skill failure propagates exit 1
 
     if [[ -f "$HOME/.local/state/dotfiles/skill-external-hash" ]]; then
         echo "cache written despite failures" >&2


### PR DESCRIPTION
## Summary

Two related silent-skip bugs in `dots sync` that combine to leave fresh installs broken without anyone noticing:

1. **`gh skill install` swallowed all failures.** The chezmoi wrapper called `install-external.sh` with `|| true`, so a single failed install (or missing `gh`/`gh skill`/`gh auth login`) recorded a "successful" `run_onchange` and never retried — even though zero external skills got installed. Symptom: `~/.claude/skills/` only contains the dotfiles-local copies; easy-cheese / tavily / skillz-that-grillz absent entirely.

2. **`.env` only loaded by interactive zsh.** `zsh/core.zsh` is the only place `dotfiles/.env` gets sourced. Running `dots sync` from bash, a script, or a non-interactive shell leaves `CONTEXT7_API_KEY` / `TAVILY_API_KEY` unset → `chezmoi apply` aborts at `private_dot_copilot/mcp-config.json.tmpl` (which `fail`s loud on missing env vars) → every template that sorts after it silently skips, including `private_dot_gitconfig.tmpl`. The sync chain's `|| WARN` masks the abort.

## Changes

- `chezmoi/.chezmoiscripts/run_onchange_install-claude-skills.sh.tmpl`: drop `|| true`, gate phase 2 on hard preflight (`gh` present, `gh skill` available, `gh auth status` clean). Each failure exits 1 with an actionable message.
- `bin/dots`: load `.env` near the top so downstream sync steps (`chezmoi apply`, `install-external.sh`) get API keys regardless of invoking shell.
- `AGENTS.md`: reflect the new hard requirement on `gh auth login`.

Both changes attack the same anti-pattern (swallow-and-continue silent skip) at different layers.

## Test plan

- [ ] `bash -c '/path/to/bin/dots help'` — confirm `.env` keys are present (no zsh involved).
- [ ] `chezmoi --source $DOTFILES/chezmoi apply --dry-run` — clean exit with `.env` loaded.
- [ ] Move ~/.gitconfig aside, run `dots sync` from bash, confirm chezmoi re-renders it.
- [ ] Unauth `gh` (`gh auth logout`) and run `dots sync` — confirm exit 1 with `Run: gh auth login`.
- [ ] Re-auth and `dots sync` — confirm easy-cheese / tavily / skillz-that-grillz install into every harness in `SKILL_HARNESSES`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)