### PR TITLE
feat(dots): skip up-to-date packages on `dots up`

### DIFF
--- a/bin/dots
+++ b/bin/dots
@@ -308,9 +308,23 @@ case "${1:-status}" in
 
         echo
         echo -e "${BLUE}⬆️  Refreshing remote skills...${NC}"
-        if ! bash "$DOTFILES_DIR/chezmoi/lib/install-external.sh" \
-                "$DOTFILES_DIR/skills/_registry.yaml" --force; then
-            echo -e "${YELLOW}⚠️  Remote skills refresh failed (continuing)${NC}" >&2
+        # Short-circuit when gh confirms every installed skill is at latest.
+        # Avoids re-running gh skill install --force across N harnesses ×
+        # ~24 skills when nothing's moved upstream.
+        NEED_SKILL_REFRESH=true
+        if command -v gh &>/dev/null \
+                && gh skill --help &>/dev/null \
+                && gh auth status &>/dev/null; then
+            if gh skill update --all --dry-run 2>&1 | grep -q "All skills are up to date"; then
+                NEED_SKILL_REFRESH=false
+                echo "  All gh-managed skills up to date — skipping refresh"
+            fi
+        fi
+        if [[ "$NEED_SKILL_REFRESH" == "true" ]]; then
+            if ! bash "$DOTFILES_DIR/chezmoi/lib/install-external.sh" \
+                    "$DOTFILES_DIR/skills/_registry.yaml" --force; then
+                echo -e "${YELLOW}⚠️  Remote skills refresh failed (continuing)${NC}" >&2
+            fi
         fi
         ;;
     status|st)

--- a/packages/packages.yaml
+++ b/packages/packages.yaml
@@ -113,6 +113,7 @@ packages:
 
   # Cargo
   - cargo-llvm-cov: { source: cargo }
+  - cargo-update: { source: cargo }            # provides `cargo install-update` for idempotent `dots up`
   - tilth: { source: cargo, git: "https://github.com/paulnsorensen/tilth", branch: main }
   - hallouminate: { source: cargo, git: "https://github.com/paulnsorensen/hallouminate", branch: main }
   # Install from Git because the crates.io `rtk` collides with the desired package.

--- a/packages/sync.sh
+++ b/packages/sync.sh
@@ -305,11 +305,26 @@ sync_npm() {
     # In upgrade mode, ask npm once which globals are outdated. Anything
     # not in this set is at latest and gets skipped — no more
     # reinstall-every-package every `dots up`. `npm outdated -g` exits
-    # non-zero when packages are outdated (deliberate, per docs), so we
-    # don't gate on its exit code.
+    # non-zero when packages are outdated (deliberate, per docs); the
+    # real failure mode we guard against is registry / network / auth
+    # errors, where stdout is empty or non-JSON. In that case we don't
+    # know what's outdated, so fall back to the old "upgrade everything
+    # already-installed" behavior rather than silently skipping every
+    # package as "(latest)".
     outdated=""
+    local outdated_unknown=false
     if [[ "${UPGRADE_MODE:-false}" == "true" ]]; then
-        outdated=$(npm outdated -g --json 2>/dev/null | jq -r 'keys[]?' 2>/dev/null || true)
+        local outdated_raw outdated_stderr
+        outdated_stderr=$(mktemp)
+        outdated_raw=$(npm outdated -g --json 2>"$outdated_stderr") || true
+        if echo "$outdated_raw" | jq -e 'type == "object"' &>/dev/null; then
+            outdated=$(echo "$outdated_raw" | jq -r 'keys[]?' 2>/dev/null || true)
+        else
+            outdated_unknown=true
+            log_warning "npm outdated -g failed; upgrading all installed globals instead"
+            [[ -s "$outdated_stderr" ]] && log_warning "  $(head -1 "$outdated_stderr")"
+        fi
+        rm -f "$outdated_stderr"
     fi
 
     while IFS=$'\t' read -r name pkg; do
@@ -322,7 +337,7 @@ sync_npm() {
                 echo "  + $name"
                 continue
             fi
-            if ! echo "$outdated" | grep -qx "$pkg"; then
+            if ! $outdated_unknown && ! echo "$outdated" | grep -qx "$pkg"; then
                 echo "  + $name (latest)"
                 continue
             fi

--- a/packages/sync.sh
+++ b/packages/sync.sh
@@ -205,31 +205,26 @@ sync_cargo() {
     fi
 
     log_info "Syncing cargo packages"
-    local installed upgrade
+    local installed
     installed=$(cargo install --list 2>/dev/null | grep -E '^\S' | cut -d' ' -f1 || true)
-    upgrade="${UPGRADE_MODE:-false}"
 
+    # Install pass — only touch packages that aren't installed yet. The
+    # upgrade pass below handles already-installed packages idempotently
+    # (via cargo-install-update) instead of force-reinstalling every time.
     while IFS=$'\t' read -r name git_url branch; do
         [[ -z "$name" ]] && continue
-        local already=false
-        echo "$installed" | grep -qx "$name" && already=true
-
-        if $already && [[ "$upgrade" != "true" ]]; then
+        if echo "$installed" | grep -qx "$name"; then
             echo "  + $name"
             continue
         fi
 
-        local action="Installing"
-        local install_args=()
-        if $already; then
-            action="Upgrading"
-            install_args+=(--force)
-        fi
         if [[ -n "$branch" && -z "$git_url" ]]; then
             log_error "Invalid cargo package config for $name: branch requires git_url"
             FAILED+=("$name")
             continue
         fi
+
+        local install_args=()
         [[ -n "$git_url" ]] && install_args+=(--git "$git_url")
         [[ -n "$branch" ]] && install_args+=(--branch "$branch")
         install_args+=("$name")
@@ -237,15 +232,28 @@ sync_cargo() {
         if [[ -n "$git_url" ]]; then
             local source_desc="$git_url"
             [[ -n "$branch" ]] && source_desc="$source_desc#$branch"
-            echo "  $action $name from $source_desc..."
+            echo "  Installing $name from $source_desc..."
         else
-            echo "  $action $name..."
+            echo "  Installing $name..."
         fi
         if ! cargo install "${install_args[@]}" </dev/null; then
             log_error "Failed to install $name"
             FAILED+=("$name")
         fi
     done <<< "$cargo_pkgs"
+
+    # Upgrade pass — cargo-install-update checks crates.io / git tip per
+    # package and skips anything already at latest. Avoids the previous
+    # force-reinstall-everything-every-time behavior of `dots up`.
+    if [[ "${UPGRADE_MODE:-false}" == "true" ]]; then
+        if command -v cargo-install-update &>/dev/null; then
+            log_info "Upgrading cargo packages (skipping up-to-date)..."
+            cargo install-update --all --git </dev/null || log_warning "cargo install-update failed"
+        else
+            log_warning "cargo-update not installed — skipping cargo upgrade pass"
+            log_warning "  Install with: cargo install cargo-update"
+        fi
+    fi
 
     log_success "Cargo sync complete"
 }
@@ -291,19 +299,33 @@ sync_npm() {
     fi
 
     log_info "Syncing npm packages"
-    local installed upgrade
+    local installed outdated
     installed=$(npm ls -g --json 2>/dev/null | jq -r '.dependencies // {} | keys[]' || true)
-    upgrade="${UPGRADE_MODE:-false}"
+
+    # In upgrade mode, ask npm once which globals are outdated. Anything
+    # not in this set is at latest and gets skipped — no more
+    # reinstall-every-package every `dots up`. `npm outdated -g` exits
+    # non-zero when packages are outdated (deliberate, per docs), so we
+    # don't gate on its exit code.
+    outdated=""
+    if [[ "${UPGRADE_MODE:-false}" == "true" ]]; then
+        outdated=$(npm outdated -g --json 2>/dev/null | jq -r 'keys[]?' 2>/dev/null || true)
+    fi
 
     while IFS=$'\t' read -r name pkg; do
         [[ -z "$name" ]] && continue
-        local already
-        already=false
+        local already=false
         echo "$installed" | grep -qx "$pkg" && already=true
 
-        if $already && [[ "$upgrade" != "true" ]]; then
-            echo "  + $name"
-            continue
+        if $already; then
+            if [[ "${UPGRADE_MODE:-false}" != "true" ]]; then
+                echo "  + $name"
+                continue
+            fi
+            if ! echo "$outdated" | grep -qx "$pkg"; then
+                echo "  + $name (latest)"
+                continue
+            fi
         fi
 
         local action="Installing"

--- a/tests/packages.bats
+++ b/tests/packages.bats
@@ -499,7 +499,11 @@ MOCKRUSTUP
     grep -q "brew upgrade" "$BREW_LOG"
 }
 
-@test "UPGRADE_MODE re-installs cargo packages with --force when already installed" {
+@test "UPGRADE_MODE runs cargo-install-update --all --git instead of per-package --force" {
+    # New idempotent contract (PR #197): the install pass only handles
+    # *missing* packages, and the upgrade pass delegates to
+    # cargo-install-update so already-current crates are skipped
+    # instead of force-reinstalled every `dots up`.
     write_test_yaml
     cat > "$MOCK_BIN/cargo" << 'MOCKCARGO'
 #!/bin/bash
@@ -516,10 +520,52 @@ exit 0
 MOCKCARGO
     chmod +x "$MOCK_BIN/cargo"
 
+    # Just needs to exist on PATH so `command -v cargo-install-update`
+    # succeeds in sync.sh; the actual `cargo install-update …` call
+    # dispatches through the cargo mock above (cargo subcommand
+    # resolution happens inside real cargo, not in the test shell).
+    cat > "$MOCK_BIN/cargo-install-update" << 'MOCKUPDATE'
+#!/bin/bash
+exit 0
+MOCKUPDATE
+    chmod +x "$MOCK_BIN/cargo-install-update"
+
     UPGRADE_MODE=true run bash "$SYNC_SCRIPT"
     assert_success
-    grep -q "cargo install --force cargo-llvm-cov" "$CARGO_LOG"
-    assert_output_contains "Upgrading cargo-llvm-cov"
+    # Install pass skips already-installed crate — no per-package
+    # `cargo install cargo-llvm-cov` call at all.
+    ! grep -q "cargo install cargo-llvm-cov" "$CARGO_LOG"
+    ! grep -q -- "--force" "$CARGO_LOG"
+    # Upgrade pass delegates to `cargo install-update --all --git`.
+    grep -q "cargo install-update --all --git" "$CARGO_LOG"
+    assert_output_contains "Upgrading cargo packages"
+}
+
+@test "UPGRADE_MODE warns when cargo-install-update is not installed" {
+    # Missing-binary fallback: dots up should keep going with a loud
+    # warning instead of silently noop-ing or crashing.
+    write_test_yaml
+    cat > "$MOCK_BIN/cargo" << 'MOCKCARGO'
+#!/bin/bash
+echo "cargo $*" >> "$CARGO_LOG"
+case "$1" in
+    install)
+        if [[ "$2" == "--list" ]]; then
+            echo "cargo-llvm-cov v0.1.0:"
+            echo "    cargo-llvm-cov"
+        fi
+        ;;
+esac
+exit 0
+MOCKCARGO
+    chmod +x "$MOCK_BIN/cargo"
+    # Deliberately do NOT install a cargo-install-update mock.
+
+    UPGRADE_MODE=true run bash "$SYNC_SCRIPT"
+    assert_success
+    assert_output_contains "cargo-update not installed"
+    # And the install pass still skips the already-installed crate.
+    ! grep -q "cargo install cargo-llvm-cov" "$CARGO_LOG"
 }
 
 @test "non-upgrade mode does NOT pass --force to cargo install" {


### PR DESCRIPTION
## Summary

`dots up` previously force-reinstalled every cargo and npm package on every invocation, and re-ran `gh skill install --force` across N harnesses × M skills even when nothing had moved upstream. Three idempotency wins, one per ecosystem.

### cargo

- Drop the per-package `cargo install --force` upgrade branch.
- Add an upgrade pass via `cargo install-update --all --git`, which queries crates.io / git tip per package and skips up-to-date.
- Add `cargo-update` to `packages.yaml` so the binary is present after the next `dots sync`. When missing, the pass logs and skips (graceful degradation).

### npm

- Query `npm outdated -g --json` once at the start of the upgrade pass.
- Use the result as a per-package allowlist. Packages not in the outdated set print `+ name (latest)` and skip the install call.

### gh skills

- In `dots up`, run `gh skill update --all --dry-run` before invoking `install-external.sh --force`.
- When gh confirms every installed skill is at latest, skip the refresh entirely.

### Untouched

Brew, uv, and gh-extension paths were already idempotent (`brew upgrade`, `uv tool upgrade --all`, `gh extension upgrade --all` each skip up-to-date by themselves).

## Test plan

- [ ] Fresh `dots sync` installs `cargo-update`.
- [ ] `dots up` after `dots up` (no upstream changes): cargo prints no install lines, npm shows `+ name (latest)` for each global, gh skills prints "All gh-managed skills up to date — skipping refresh".
- [ ] Pin an old version of a npm global (`npm install -g @openai/codex@0.132.0`), run `dots up`: see only that package reinstall.
- [ ] Without `cargo-update` installed (simulate by `cargo uninstall cargo-update`): `dots up` logs the missing-tool warning and continues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)