### PR TITLE
fix(mcp): force serena dashboard off via CLI flags

### DIFF
--- a/agents/mcp/registry.yaml
+++ b/agents/mcp/registry.yaml
@@ -92,9 +92,15 @@ mcps:
   # / `fixed_tools` — applies to every harness uniformly.
   serena:
     command: serena
+    # CLI flags override ~/.serena/serena_config.yml. We force the dashboard
+    # off here (not just in the yaml) because serena rewrites its own config
+    # on every launch to append the projects list, which stomps our
+    # chezmoi-managed `web_dashboard: false` back to the upstream default.
     args:
       - start-mcp-server
       - --context={{ if eq $h "claude" }}claude-code{{ else }}{{ $h }}{{ end }}
       - --project-from-cwd
+      - --enable-web-dashboard=false
+      - --open-web-dashboard=false
     scope: user
     description: Semantic code intel via LSP (symbols, references, refactors). Tools tailored per harness via --context.


### PR DESCRIPTION
## Summary

- Pass `--enable-web-dashboard=false` and `--open-web-dashboard=false` to every serena spawn so the browser dashboard stays off.
- CLI flags override `~/.serena/serena_config.yml`, which is the durable fix — see context below.

## Why the yaml-only fix wasn't enough

`chezmoi/dot_serena/modify_serena_config.yml` already sets `web_dashboard: false` / `web_dashboard_open_on_launch: false`. But serena **rewrites `~/.serena/serena_config.yml` on every launch** to append the active project to its `projects:` list. That rewrite emits the upstream defaults (`true`) and stomps the chezmoi-set values, so every session start re-pops a dashboard tab.

Observed locally: 7 serena dashboards listening on ports 24282–24288 across worktrees, including two for `cairo` (one persistent Conductor Claude + one transient auxiliary Conductor Claude that also inherited user-scope MCPs).

CLI flags are evaluated after the yaml load and are not subject to the rewrite, so they win every time.

## Test plan

- [x] `chezmoi execute-template` renders both flags for `HARNESS=claude`
- [ ] `mcp-sync` re-registers serena in Claude with new args
- [ ] Restart a Claude session in any worktree → no browser tab opens, no port 2428x listener appears
- [ ] Same for Codex (`--context=codex` path) — also no dashboard
- [ ] Existing `~/.serena/serena_config.yml` still has `web_dashboard: false` after the next serena launch (the rewrite no longer matters, but the chezmoi belt-and-suspenders still applies)

## Follow-up (separate PR)

Switch the registry to a per-cwd serena daemon (`serena-mux` wrapper) so multiple Claude/Codex sessions in the same worktree share one serena + one set of LSPs. Addresses the "two dashboards for cairo" root cause, not just the symptom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)