### PR TITLE
feat(mcp): coalesce serena into one daemon per (worktree, harness)

### DIFF
--- a/agents/mcp/registry.yaml
+++ b/agents/mcp/registry.yaml
@@ -91,16 +91,14 @@ mcps:
   # ~/.serena/serena_config.yml under `excluded_tools` / `included_optional_tools`
   # / `fixed_tools` — applies to every harness uniformly.
   serena:
-    command: serena
-    # CLI flags override ~/.serena/serena_config.yml. We force the dashboard
-    # off here (not just in the yaml) because serena rewrites its own config
-    # on every launch to append the projects list, which stomps our
-    # chezmoi-managed `web_dashboard: false` back to the upstream default.
-    args:
-      - start-mcp-server
-      - --context={{ if eq $h "claude" }}claude-code{{ else }}{{ $h }}{{ end }}
-      - --project-from-cwd
-      - --enable-web-dashboard=false
-      - --open-web-dashboard=false
+    # `serena-mux` is a wrapper at bin/serena-mux that coalesces multiple MCP
+    # clients into one serena daemon per (project root, harness). Stops the
+    # "two cairo dashboards" problem at its root: each stdio client used to
+    # spawn its own serena; now they all bridge through mcp-proxy into a
+    # shared streamable-http daemon. Dashboard flags + --context + --project
+    # are now owned by the wrapper (where the daemon actually gets spawned).
+    command: serena-mux
+    env:
+      SERENA_MUX_HARNESS: "{{ if eq $h "claude" }}claude-code{{ else }}{{ $h }}{{ end }}"
     scope: user
     description: Semantic code intel via LSP (symbols, references, refactors). Tools tailored per harness via --context.

--- a/bin/serena-mux
+++ b/bin/serena-mux
@@ -48,11 +48,7 @@ harness="${SERENA_MUX_HARNESS:-claude-code}"
 # Resolve project root the same way serena's --project-from-cwd would, so
 # that a wrapper invocation from any subdir of the worktree reuses the
 # same daemon.
-if root=$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null); then
-    :
-else
-    root="$PWD"
-fi
+root=$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null || echo "$PWD")
 
 # slug = first 12 chars of sha256("$root|$harness"). Different harnesses
 # need different daemons because serena's --context= controls which tools
@@ -78,7 +74,7 @@ logfile="$state/log"
 spawn_lock="$state/spawn.lock"
 
 trace() {
-    [ -n "${SERENA_MUX_DEBUG:-}" ] && printf '[serena-mux] %s\n' "$*" >&2 || true
+    [[ -n ${SERENA_MUX_DEBUG:-} ]] && printf '[serena-mux] %s\n' "$*" >&2 || true
 }
 
 trace "root=$root harness=$harness slug=$slug"
@@ -86,9 +82,9 @@ trace "root=$root harness=$harness slug=$slug"
 # --- Reap dead daemon ----------------------------------------------------
 
 daemon_alive=0
-if [ -f "$pidfile" ]; then
-    pid=$(cat "$pidfile" 2>/dev/null || true)
-    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+if [[ -f $pidfile ]]; then
+    pid=$(<"$pidfile")
+    if [[ -n $pid ]] && kill -0 "$pid" 2>/dev/null; then
         daemon_alive=1
         trace "existing daemon alive at pid=$pid"
     else
@@ -101,8 +97,8 @@ fi
 
 wait_for_port_listen() {
     # Args: port, max_attempts (each 0.1s)
-    local port=$1 attempts=$2
-    for _ in $(seq 1 "$attempts"); do
+    local port=$1 attempts=$2 i
+    for ((i = 0; i < attempts; i++)); do
         if lsof -nP -iTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1; then
             return 0
         fi
@@ -161,7 +157,7 @@ release_spawn_lock() {
     rmdir "$spawn_lock" 2>/dev/null || true
 }
 
-if [ "$daemon_alive" -eq 0 ]; then
+if (( daemon_alive == 0 )); then
     if mkdir "$spawn_lock" 2>/dev/null; then
         # Belt-and-suspenders: clean up if we die unexpectedly before the
         # explicit release below. (The explicit release is the load-bearing
@@ -176,14 +172,14 @@ if [ "$daemon_alive" -eq 0 ]; then
         # by taking over the lock ourselves and spawning.
         trace "another wrapper is spawning — waiting"
         winner_ready=0
-        for _ in $(seq 1 100); do
-            if [ -f "$pidfile" ] && [ -f "$portfile" ]; then
+        for ((i = 0; i < 100; i++)); do
+            if [[ -f $pidfile && -f $portfile ]]; then
                 winner_ready=1
                 break
             fi
             sleep 0.1
         done
-        if [ "$winner_ready" -eq 0 ]; then
+        if (( winner_ready == 0 )); then
             trace "winner appears stuck — force-releasing lock and spawning"
             release_spawn_lock
             if mkdir "$spawn_lock" 2>/dev/null; then
@@ -191,7 +187,7 @@ if [ "$daemon_alive" -eq 0 ]; then
                 spawn_daemon
                 release_spawn_lock
                 trap - EXIT
-            elif [ ! -f "$portfile" ]; then
+            elif [[ ! -f $portfile ]]; then
                 echo "[serena-mux] could not recover stuck spawn lock" >&2
                 exit 4
             fi
@@ -201,7 +197,7 @@ fi
 
 # --- Bridge stdio ↔ daemon HTTP -----------------------------------------
 
-port=$(cat "$portfile")
+port=$(<"$portfile")
 proxy_version="${SERENA_MUX_PROXY_VERSION:-0.12.0}"
 
 trace "bridging stdio to http://127.0.0.1:$port/mcp via mcp-proxy@$proxy_version"

--- a/bin/serena-mux
+++ b/bin/serena-mux
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# serena-mux — one serena daemon per (project root, harness); stdio clients bridge in.
+#
+# Why: stdio-transport MCP servers spawn a subprocess per client, so two Claude
+# sessions in the same worktree (or one Conductor Claude + a sub-agent Claude)
+# each start their own serena and each pop a web dashboard. This wrapper
+# coalesces them — first client spawns a long-lived serena listening on
+# streamable-http, subsequent clients in the same project root share it.
+#
+# Patterns cribbed from ~/Dev/vaudeville:
+#   - mkdir(spawn.lock) as the atomic spawn gate (session-start.sh:93-104)
+#   - PID-alive + stale-cleanup dance (session-start.sh:62-91)
+#   - socket-ready polling loop (session-start.sh:127-138)
+#   - nohup … & disown for full parent detach (session-start.sh:116-123)
+#
+# Usage (called by MCP harness via registry.yaml):
+#   serena-mux
+#
+# Environment:
+#   SERENA_MUX_HARNESS  — "claude-code" | "codex" | "opencode" (default: claude-code)
+#   SERENA_MUX_DEBUG    — non-empty: keep daemon log + write trace to stderr
+#   SERENA_MUX_PROXY_VERSION — pin for mcp-proxy (default: 0.12.0)
+#
+# Exit codes:
+#   0   — bridged stdio cleanly
+#   2   — serena binary missing
+#   3   — uvx missing (needed for mcp-proxy bridge)
+#   4   — daemon failed to start within timeout
+
+set -euo pipefail
+
+# --- Dependencies --------------------------------------------------------
+
+if ! command -v serena >/dev/null 2>&1; then
+    echo "[serena-mux] serena binary not found on PATH" >&2
+    exit 2
+fi
+
+if ! command -v uvx >/dev/null 2>&1; then
+    echo "[serena-mux] uvx not found on PATH (needed for mcp-proxy bridge)" >&2
+    exit 3
+fi
+
+# --- Identity ------------------------------------------------------------
+
+harness="${SERENA_MUX_HARNESS:-claude-code}"
+
+# Resolve project root the same way serena's --project-from-cwd would, so
+# that a wrapper invocation from any subdir of the worktree reuses the
+# same daemon.
+if root=$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null); then
+    :
+else
+    root="$PWD"
+fi
+
+# slug = first 12 chars of sha256("$root|$harness"). Different harnesses
+# need different daemons because serena's --context= controls which tools
+# are exposed, and that's set at daemon-start time.
+slug=$(printf '%s|%s' "$root" "$harness" | shasum -a 256 | head -c12)
+
+# Per-UID runtime dir prevents another local user from racing on our
+# socket/pid paths (same rationale as vaudeville/core/paths.py:12).
+uid=$(id -u)
+runtime_root="${SERENA_MUX_RUNTIME_DIR:-${TMPDIR:-/tmp}/serena-mux-$uid}"
+state="$runtime_root/$slug"
+
+mkdir -p "$runtime_root" || {
+    echo "[serena-mux] cannot create runtime dir $runtime_root" >&2
+    exit 1
+}
+chmod 0700 "$runtime_root" 2>/dev/null || true
+mkdir -p "$state"
+
+pidfile="$state/pid"
+portfile="$state/port"
+logfile="$state/log"
+spawn_lock="$state/spawn.lock"
+
+trace() {
+    [ -n "${SERENA_MUX_DEBUG:-}" ] && printf '[serena-mux] %s\n' "$*" >&2 || true
+}
+
+trace "root=$root harness=$harness slug=$slug"
+
+# --- Reap dead daemon ----------------------------------------------------
+
+daemon_alive=0
+if [ -f "$pidfile" ]; then
+    pid=$(cat "$pidfile" 2>/dev/null || true)
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+        daemon_alive=1
+        trace "existing daemon alive at pid=$pid"
+    else
+        trace "stale pidfile (pid=$pid) — cleaning up"
+        rm -f "$pidfile" "$portfile"
+    fi
+fi
+
+# --- Spawn if needed -----------------------------------------------------
+
+wait_for_port_listen() {
+    # Args: port, max_attempts (each 0.1s)
+    local port=$1 attempts=$2
+    for _ in $(seq 1 "$attempts"); do
+        if lsof -nP -iTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep 0.1
+    done
+    return 1
+}
+
+spawn_daemon() {
+    # Spawn a detached serena daemon and populate $pidfile + $portfile.
+    # Caller must hold the spawn lock. Exits 4 on failure.
+    local port daemon_pid
+    port=$(python3 -c '
+import socket
+s = socket.socket()
+s.bind(("127.0.0.1", 0))
+print(s.getsockname()[1])
+s.close()
+') || {
+        echo "[serena-mux] could not allocate free port" >&2
+        exit 4
+    }
+    trace "spawning daemon on port=$port"
+
+    # nohup + </dev/null + & + disown detaches fully (macOS has no setsid).
+    # --enable-web-dashboard=false + --open-web-dashboard=false belong on
+    # the daemon, not on every client.
+    nohup serena start-mcp-server \
+        --transport streamable-http \
+        --host 127.0.0.1 --port "$port" \
+        --context "$harness" \
+        --project "$root" \
+        --enable-web-dashboard=false \
+        --open-web-dashboard=false \
+        >>"$logfile" 2>&1 </dev/null &
+    daemon_pid=$!
+    disown "$daemon_pid" 2>/dev/null || true
+
+    echo "$daemon_pid" >"$pidfile"
+    echo "$port" >"$portfile"
+
+    if ! wait_for_port_listen "$port" 50; then
+        echo "[serena-mux] daemon did not start listening within 5s — see $logfile" >&2
+        kill -9 "$daemon_pid" 2>/dev/null || true
+        rm -f "$pidfile" "$portfile"
+        exit 4
+    fi
+    trace "daemon listening on port=$port"
+}
+
+# spawn_lock is a directory created atomically via mkdir. Only one wrapper
+# wins the race. We release it explicitly before exec'ing into mcp-proxy
+# because exec bypasses bash's EXIT traps — leaving the lock on disk would
+# wedge the next invocation.
+release_spawn_lock() {
+    rmdir "$spawn_lock" 2>/dev/null || true
+}
+
+if [ "$daemon_alive" -eq 0 ]; then
+    if mkdir "$spawn_lock" 2>/dev/null; then
+        # Belt-and-suspenders: clean up if we die unexpectedly before the
+        # explicit release below. (The explicit release is the load-bearing
+        # one for the happy `exec` path.)
+        trap release_spawn_lock EXIT
+        spawn_daemon
+        release_spawn_lock
+        trap - EXIT
+    else
+        # Lost the race. Wait for the winner to publish pid + port. If the
+        # winner crashed mid-spawn (lock stuck, no pid file), force-recover
+        # by taking over the lock ourselves and spawning.
+        trace "another wrapper is spawning — waiting"
+        winner_ready=0
+        for _ in $(seq 1 100); do
+            if [ -f "$pidfile" ] && [ -f "$portfile" ]; then
+                winner_ready=1
+                break
+            fi
+            sleep 0.1
+        done
+        if [ "$winner_ready" -eq 0 ]; then
+            trace "winner appears stuck — force-releasing lock and spawning"
+            release_spawn_lock
+            if mkdir "$spawn_lock" 2>/dev/null; then
+                trap release_spawn_lock EXIT
+                spawn_daemon
+                release_spawn_lock
+                trap - EXIT
+            elif [ ! -f "$portfile" ]; then
+                echo "[serena-mux] could not recover stuck spawn lock" >&2
+                exit 4
+            fi
+        fi
+    fi
+fi
+
+# --- Bridge stdio ↔ daemon HTTP -----------------------------------------
+
+port=$(cat "$portfile")
+proxy_version="${SERENA_MUX_PROXY_VERSION:-0.12.0}"
+
+trace "bridging stdio to http://127.0.0.1:$port/mcp via mcp-proxy@$proxy_version"
+
+# exec replaces this shell — the MCP client now talks straight to mcp-proxy,
+# which talks streamable-http to the serena daemon.
+exec uvx --from "mcp-proxy==$proxy_version" mcp-proxy \
+    --transport=streamablehttp \
+    "http://127.0.0.1:$port/mcp"

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -75,7 +75,7 @@ run_tests() {
     if (( ${#SPECIFIC_TESTS[@]} > 0 )); then
         test_files="${SPECIFIC_TESTS[*]}"
     else
-        test_files="dots-simple.bats dots.bats git-hooks.bats sync.bats config-validation.bats prompt.bats sync-claude.bats sync-rollback.bats hooks-blockers.bats hooks-session.bats iterm2-fonts.bats worktree-settings.bats skills-external.bats skills-local.bats chezmoi-wiring.bats install-codex.bats install-agents-doc.bats install-prompts.bats packages.bats cheese-flair.bats mcp-lib.bats mcp-opencode.bats agents-hooks-sync.bats"
+        test_files="dots-simple.bats dots.bats git-hooks.bats sync.bats config-validation.bats prompt.bats sync-claude.bats sync-rollback.bats hooks-blockers.bats hooks-session.bats iterm2-fonts.bats worktree-settings.bats skills-external.bats skills-local.bats chezmoi-wiring.bats install-codex.bats install-agents-doc.bats install-prompts.bats packages.bats cheese-flair.bats mcp-lib.bats mcp-opencode.bats agents-hooks-sync.bats serena-mux.bats"
     fi
 
     # Count total tests

--- a/tests/serena-mux.bats
+++ b/tests/serena-mux.bats
@@ -1,0 +1,219 @@
+#!/usr/bin/env bats
+# Tests for bin/serena-mux — per-(project root, harness) serena daemon coalescer.
+#
+# Strategy: stub `serena` and `uvx` on PATH. The stub serena actually binds a
+# TCP port so the wrapper's listener-poll loop sees a real LISTEN socket. The
+# stub uvx just records the URL it was asked to bridge to, then exits 0 so
+# the wrapper's terminal `exec uvx …` returns cleanly without trying to talk
+# MCP framing to anything.
+
+load test_helper
+
+setup() {
+    setup_test_env
+
+    # Sandbox the runtime dir under TEST_HOME so concurrent runs don't collide
+    # with the user's real ~/serena-mux state.
+    export SERENA_MUX_RUNTIME_DIR="$TEST_HOME/serena-mux-state"
+
+    # Each test gets its own fake-bin dir prepended to PATH. Order matters:
+    # FAKE_BIN must outrank the real serena/uvx that may exist on this host.
+    FAKE_BIN="$TEST_HOME/fake-bin"
+    mkdir -p "$FAKE_BIN"
+    export PATH="$FAKE_BIN:$PATH"
+
+    # Stub uvx: record the args + exit 0. Don't actually bridge.
+    export MOCK_UVX_LOG="$TEST_HOME/uvx-args.log"
+    cat >"$FAKE_BIN/uvx" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$MOCK_UVX_LOG"
+exit 0
+EOF
+    chmod +x "$FAKE_BIN/uvx"
+
+    # Stub serena: read --port out of args, bind a TCP listener, idle until
+    # signaled. Python because bash can't bind a TCP socket natively.
+    cat >"$FAKE_BIN/serena" <<'EOF'
+#!/usr/bin/env bash
+port=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --port) port="$2"; shift 2 ;;
+        --port=*) port="${1#*=}"; shift ;;
+        *) shift ;;
+    esac
+done
+[[ -z "$port" ]] && { echo "stub serena: no --port given" >&2; exit 1; }
+exec python3 - "$port" <<'PYEOF'
+import socket, signal, sys, time
+port = int(sys.argv[1])
+s = socket.socket()
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+s.bind(("127.0.0.1", port))
+s.listen(4)
+signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))
+signal.signal(signal.SIGINT,  lambda *_: sys.exit(0))
+while True:
+    try:
+        c, _ = s.accept()
+        c.close()
+    except Exception:
+        time.sleep(0.05)
+PYEOF
+EOF
+    chmod +x "$FAKE_BIN/serena"
+
+    # Working dir = a git repo so root resolution is deterministic.
+    REPO="$TEST_HOME/repo"
+    mkdir -p "$REPO"
+    (
+        cd "$REPO" || exit 1
+        git init --quiet
+        git config user.email "test@example.com"
+        git config user.name  "Test"
+    )
+    cd "$REPO" || exit 1
+}
+
+teardown() {
+    # Kill any daemon stubs the test may have spawned.
+    if [[ -n "${SERENA_MUX_RUNTIME_DIR:-}" && -d "$SERENA_MUX_RUNTIME_DIR" ]]; then
+        find "$SERENA_MUX_RUNTIME_DIR" -name pid -print0 2>/dev/null \
+            | xargs -0 -I{} sh -c 'pid=$(cat "{}" 2>/dev/null); [ -n "$pid" ] && kill -9 "$pid" 2>/dev/null || true'
+    fi
+    teardown_test_env
+}
+
+# --- Dependency checks ---------------------------------------------------
+
+@test "serena-mux: exits 2 when serena binary is missing" {
+    rm "$FAKE_BIN/serena"
+    # Hide the real serena too so the check actually fails, but keep the
+    # dotfiles bin/ dir on PATH so `serena-mux` itself is findable.
+    PATH="$FAKE_BIN:$REAL_DOTFILES_DIR/bin:/usr/bin:/bin" run serena-mux
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"serena binary not found"* ]]
+}
+
+@test "serena-mux: exits 3 when uvx is missing" {
+    rm "$FAKE_BIN/uvx"
+    PATH="$FAKE_BIN:$REAL_DOTFILES_DIR/bin:/usr/bin:/bin" run serena-mux
+    [ "$status" -eq 3 ]
+    [[ "$output" == *"uvx not found"* ]]
+}
+
+# --- Identity & lifecycle ------------------------------------------------
+
+@test "serena-mux: spawns a daemon and bridges via uvx" {
+    run serena-mux
+    [ "$status" -eq 0 ]
+
+    # Find the per-slug state dir
+    state_dir=$(find "$SERENA_MUX_RUNTIME_DIR" -mindepth 1 -maxdepth 1 -type d | head -n1)
+    [ -n "$state_dir" ]
+    [ -f "$state_dir/pid" ]
+    [ -f "$state_dir/port" ]
+
+    pid=$(cat "$state_dir/pid")
+    port=$(cat "$state_dir/port")
+    [ -n "$pid" ]
+    [ -n "$port" ]
+
+    # Daemon should be alive and listening.
+    kill -0 "$pid"
+    lsof -nP -iTCP:"$port" -sTCP:LISTEN >/dev/null
+
+    # uvx was invoked with the right URL.
+    grep -q "http://127.0.0.1:$port/mcp" "$MOCK_UVX_LOG"
+    grep -q "streamablehttp" "$MOCK_UVX_LOG"
+}
+
+@test "serena-mux: second invocation reuses an alive daemon" {
+    run serena-mux
+    [ "$status" -eq 0 ]
+    state_dir=$(find "$SERENA_MUX_RUNTIME_DIR" -mindepth 1 -maxdepth 1 -type d | head -n1)
+    first_pid=$(cat "$state_dir/pid")
+    first_port=$(cat "$state_dir/port")
+
+    # Second call: pidfile is alive → no respawn.
+    run serena-mux
+    [ "$status" -eq 0 ]
+    [ "$(cat "$state_dir/pid")"  = "$first_pid" ]
+    [ "$(cat "$state_dir/port")" = "$first_port" ]
+
+    # Only one PID alive in the state tree.
+    [ "$(find "$SERENA_MUX_RUNTIME_DIR" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')" = 1 ]
+}
+
+@test "serena-mux: reaps a stale pidfile and respawns" {
+    # Seed a slug-shaped state dir with a definitely-dead pidfile.
+    # We can't compute the slug here without duplicating shasum logic, so
+    # let the wrapper allocate the dir first, kill its daemon, then re-invoke.
+    run serena-mux
+    [ "$status" -eq 0 ]
+    state_dir=$(find "$SERENA_MUX_RUNTIME_DIR" -mindepth 1 -maxdepth 1 -type d | head -n1)
+    old_pid=$(cat "$state_dir/pid")
+    kill -9 "$old_pid" 2>/dev/null || true
+    # Wait until the OS reaps the dead pid so `kill -0` returns false.
+    for _ in $(seq 1 50); do
+        kill -0 "$old_pid" 2>/dev/null || break
+        sleep 0.05
+    done
+
+    run serena-mux
+    [ "$status" -eq 0 ]
+    new_pid=$(cat "$state_dir/pid")
+    [ "$new_pid" != "$old_pid" ]
+    kill -0 "$new_pid"
+}
+
+@test "serena-mux: different harnesses get different daemons in the same repo" {
+    SERENA_MUX_HARNESS=claude-code run serena-mux
+    [ "$status" -eq 0 ]
+    SERENA_MUX_HARNESS=codex      run serena-mux
+    [ "$status" -eq 0 ]
+    count=$(find "$SERENA_MUX_RUNTIME_DIR" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')
+    [ "$count" = 2 ]
+}
+
+@test "serena-mux: invocation from a subdir reuses the worktree daemon" {
+    run serena-mux
+    [ "$status" -eq 0 ]
+    state_dir=$(find "$SERENA_MUX_RUNTIME_DIR" -mindepth 1 -maxdepth 1 -type d | head -n1)
+    first_port=$(cat "$state_dir/port")
+
+    mkdir -p "$REPO/nested/deep"
+    cd "$REPO/nested/deep"
+    run serena-mux
+    [ "$status" -eq 0 ]
+
+    count=$(find "$SERENA_MUX_RUNTIME_DIR" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')
+    [ "$count" = 1 ]
+    [ "$(cat "$state_dir/port")" = "$first_port" ]
+}
+
+@test "serena-mux: concurrent invocations spawn exactly one daemon" {
+    # Fire 4 wrappers in parallel; spawn-lock should serialize them.
+    serena-mux & p1=$!
+    serena-mux & p2=$!
+    serena-mux & p3=$!
+    serena-mux & p4=$!
+    wait "$p1" "$p2" "$p3" "$p4"
+
+    # Exactly one state dir, one alive pid.
+    count=$(find "$SERENA_MUX_RUNTIME_DIR" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')
+    [ "$count" = 1 ]
+    state_dir=$(find "$SERENA_MUX_RUNTIME_DIR" -mindepth 1 -maxdepth 1 -type d | head -n1)
+    pid=$(cat "$state_dir/pid")
+    kill -0 "$pid"
+
+    # All four uvx invocations recorded.
+    [ "$(wc -l < "$MOCK_UVX_LOG" | tr -d ' ')" -ge 4 ]
+}
+
+@test "serena-mux: writes a 0700 runtime root" {
+    run serena-mux
+    [ "$status" -eq 0 ]
+    perms=$(stat -f '%Lp' "$SERENA_MUX_RUNTIME_DIR" 2>/dev/null || stat -c '%a' "$SERENA_MUX_RUNTIME_DIR")
+    [ "$perms" = "700" ]
+}


### PR DESCRIPTION
**Stacked on #198.** Base branch is `paulnsorensen/duplicate-cairo-worktree-configs`; merge that first or rebase this onto main after.

## Summary

- New `bin/serena-mux` — wrapper that ensures one long-lived serena per `(project_root, harness)`. MCP clients bridge stdio into it via `uvx mcp-proxy`.
- `agents/mcp/registry.yaml` switches `command: serena` → `command: serena-mux`. Dashboard flags + `--context` + `--project` are now owned by the daemon, not the client.
- `tests/serena-mux.bats` — 9 cases covering spawn, reuse, stale-reap, race, harness isolation, subdir resolution.

## Why

Stdio MCP transport spawns one subprocess per client. Two Claude sessions in the same worktree (e.g. one Conductor Claude + one cmux Claude, or a Conductor parent + a sub-agent) = two serenas = two browser dashboards = two sets of LSP child processes. Observed locally: 7 serenas across one machine (3× `~/Dev/dotfiles`, 2× `cairo`, 1× `tilth`, 1× `puebla`).

With this wrapper, all clients in the same worktree share one serena + one set of LSPs. Different harnesses still get different daemons (so `--context=claude-code` vs `--context=codex` tool filtering still works correctly).

## Design ref

Lifecycle patterns cribbed from `~/Dev/vaudeville`:

| Vaudeville | serena-mux equivalent |
|---|---|
| `hooks/session-start.sh:93-104` mkdir spawn.lock | Same — atomic on macOS/Linux |
| `hooks/session-start.sh:62-91` stale-PID cleanup | Same shape (`kill -0` alive check + unlink) |
| `hooks/session-start.sh:116-123` nohup + disown | Same; dropped `setsid` (not on macOS) |
| `hooks/session-start.sh:127-138` socket-ready poll | Same, against TCP listener via `lsof` |
| `core/paths.py:12` per-UID `/tmp` dir | Same, `0700` perms |

Vaudeville is a global singleton (one SLM in memory). serena-mux is per-(root, harness) — slug = `sha256(root|harness)[:12]`. Recovery for stuck spawn locks: loser thread takes over if winner never publishes a port file.

## Test plan

- [x] `bats tests/serena-mux.bats` — 9 green locally (dependency exits, single spawn, alive-reuse, stale-reap, harness isolation, subdir resolution, concurrent serialization, 0700 runtime dir, listener-ready)
- [ ] After merge: `mcp-sync` to re-register, restart Conductor + cmux Claude in cairo, verify exactly one serena process + one daemon log under `/tmp/serena-mux-<uid>/<slug>/`
- [ ] Codex session in same worktree → second daemon (different slug — expected)
- [ ] Kill the daemon manually; next MCP call respawns it

## Follow-up

If we ever want cross-worktree LSP sharing (one bash-lsp for everything), that's a serena/solidlsp change, not something this wrapper can do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)