### PR TITLE
feat(skills): add grok-codebase onboarding skill with adaptive quiz

### DIFF
--- a/skills/grok-codebase/GUIDE.md
+++ b/skills/grok-codebase/GUIDE.md
@@ -1,0 +1,187 @@
+# Grokking a codebase — Methodology guide
+
+Long-form human-readable companion to `SKILL.md`. Read this once, then let
+the skill drive on each new repo.
+
+## 1. Why four pillars, and why this order?
+
+The order — **Building Blocks → Entry Points → Infrastructure → Egress** — is
+a synthesis of three established methodologies:
+
+- **Spinellis, *Code Reading* (2003):** "Start with the system overview and
+  architecture. Examine entry points and main control flow. Focus on data
+  structures before algorithms." → Pillars 1 and 2.
+- **Brown's C4 model:** Context → Container → Component → Code (zoom in from
+  outside-in). Pillar 1 maps to Component, pillar 3 to Container, pillar 4
+  partly to Context.
+- **arc42 template:** §5 Building Block View, §6 Runtime View, §7 Deployment,
+  §8 Crosscutting Concepts. The four pillars cover §5, §6 (via the request
+  trace in Phase 5), §7, and a cross-cut of §8.
+
+**Why Egress is its own pillar** (vs. folding it into Building Blocks): most
+production incidents originate at egress — a third-party API rate-limit, a
+DB write under load, a webhook that silently drops. Senior engineers onboard
+by mapping the outbound surface first because that's the attack surface for
+change. Treating egress as first-class forces the seam discovery that makes
+the system testable later.
+
+## 2. Pillar 1 — Building Blocks (deep dive)
+
+A "building block" is anything reusable: a module, a class, a domain type, a
+service. The question to answer is: **"If I had to explain this system on a
+whiteboard in 5 minutes, which boxes would I draw?"**
+
+For TS/JS:
+
+- Start at `package.json` `workspaces` (monorepo roots).
+- Then `exports` field (the official multi-entry standard) — this is the
+  *intended* building block set. If `exports` is missing, fall back to
+  `main` / `module` and the de facto top-level `index.ts`.
+- `tsconfig.json` `paths` / `baseUrl` show alias-based module boundaries
+  (e.g. `@/lib/*`).
+- Run code-review-graph's `list_communities_tool` — the Leiden-clustered
+  modules are the **de facto** building blocks (vs. the **intended** ones
+  from `exports`). When they diverge, that's a smell.
+- For each block: `get_symbols_overview` + `tilth_grok` on the 3 most
+  central symbols.
+
+For other stacks:
+
+- **Python:** `pyproject.toml` `[project]` + `__init__.py` packages.
+- **Go:** `go.mod` modules + `internal/`.
+- **Rust:** `Cargo.toml` `[workspace]` + `lib.rs` `pub mod`.
+- **Java:** `pom.xml` modules + package declarations.
+
+The artifact: a table with columns
+`Block | Path | Public API | Key types | God-nodes?`.
+
+## 3. Pillar 2 — Entry Points (deep dive)
+
+Every way control flow can begin. **If there's no entry point that leads to
+a piece of code, that code is dead.** This is also Feathers's "change point"
+if you're modifying behavior.
+
+Categories to enumerate:
+
+- **HTTP:** framework-specific. See `SKILL.md` Phase 2 for search patterns.
+- **CLI:** `bin` in `package.json`; `process.argv` consumers.
+- **Scheduled:** cron, BullMQ repeatable, Inngest scheduled functions.
+- **Event-driven:** Lambda handlers, Cloudflare Workers, message-queue
+  consumers, EventBridge rules, Kafka subscribers.
+- **Real-time:** WebSocket handlers, tRPC subscriptions, gRPC streaming.
+- **Library API** (if this is a library): every named export in the
+  `exports` field.
+
+For each entry, ask **"what's the SLA?"** and **"who calls this?"** (graph
+dependents). If you can't answer the SLA, that's a documentation gap worth
+flagging.
+
+## 4. Pillar 3 — Infrastructure (deep dive)
+
+Two questions: **"What does it take to run this locally?"** and **"What does
+it take to ship a change to production?"** If you can answer both in <2
+minutes after a grok, the grok was good.
+
+The arc42 §7 Deployment view and §8 Crosscutting Concepts both live here.
+Crosscutting specifically includes: logging, error handling, auth, i18n,
+feature flags, observability. Scan for these patterns explicitly — they tend
+to be implemented once and used everywhere, so missing them in the grok
+means surprises later.
+
+## 5. Pillar 4 — Egress (deep dive)
+
+The Feathers lens applies: **every egress is a seam.** List them in a table:
+
+| Egress | Caller | Mechanism (lib) | Seam (where to fake it) | Has characterization test? |
+|---|---|---|---|---|
+
+A codebase with many egresses and no seams is a refactoring liability —
+flag it.
+
+## 6. Stack-specific cheatsheets
+
+### TypeScript / JavaScript (primary)
+
+- **Manifests:** `package.json` (`main`, `module`, `exports`, `bin`,
+  `scripts`, `workspaces`, `engines`, `type: "module"`).
+- **TS config:** `tsconfig.json` `compilerOptions.paths`, `baseUrl`,
+  `module`, `moduleResolution`, `target`, `lib`. `tsconfig.base.json` in
+  monorepos.
+- **Frameworks** (use Context7 for version-specific docs):
+  - **Next.js:** `app/` (App Router) vs `pages/` (Pages Router);
+    `middleware.ts`; `route.ts` and route handlers; `layout.tsx`;
+    `loading.tsx`; `error.tsx`.
+  - **Express / Fastify / Koa:** `app.use`, `app.METHOD`, middleware chains.
+  - **NestJS:** `@Module`, `@Controller`, `@Injectable`, `@Get`/`@Post`;
+    lifecycle hooks.
+  - **Remix / React Router:** `loader`, `action`, `route` configs.
+  - **tRPC:** `router`, `procedure`, `input`, `mutation`/`query`.
+- **Build tools:** Vite, Webpack, Turbopack, esbuild, swc, tsc, Rollup,
+  Parcel.
+- **Test:** Vitest, Jest, Playwright, Cypress, Mocha, Tap.
+- **Common egress libs:** `axios`, `node-fetch`, `got`, `ky`,
+  `@prisma/client`, `drizzle-orm`, `bullmq`, `kafkajs`, `@aws-sdk/*`,
+  `stripe`, `@sendgrid/mail`, `@sentry/*`, `@clerk/*`.
+
+### Python
+
+- **Manifests:** `pyproject.toml`, `setup.py`, `requirements*.txt`,
+  `poetry.lock`, `uv.lock`.
+- **Entry points:** `[project.scripts]`, `__main__.py`, FastAPI `@app.get`,
+  Flask `@app.route`, Django `urls.py`, Celery tasks, Lambda `handler`.
+
+### Go
+
+- **Manifests:** `go.mod`, `go.sum`.
+- **Entry points:** `main.go` per `cmd/<name>/`, `net/http` `Handler`, gin
+  `r.GET`, echo `e.GET`, cobra commands.
+
+### Rust
+
+- **Manifests:** `Cargo.toml`, `Cargo.lock`.
+- **Entry points:** `main.rs` per binary, `lib.rs` `pub fn`, axum
+  `Router::route`, actix `web::resource`.
+
+### Java / Kotlin
+
+- **Manifests:** `pom.xml`, `build.gradle(.kts)`, `settings.gradle(.kts)`.
+- **Entry points:** Spring `@RestController` / `@RequestMapping`, Spring
+  Boot `@SpringBootApplication`, scheduled `@Scheduled`.
+
+## 7. How to drive the skill
+
+1. In Claude Code, open the repo root.
+2. Say one of: "grok this codebase", "onboard me to this repo", "help me
+   memorize this project", or use the slash form
+   `/grok-codebase [optional focus area]`.
+3. Confirm scope after Phase 0 reconnaissance.
+4. Let the skill work through pillars 1–4, posting findings after each.
+5. Confirm the Phase 5 trace target (which entry point to walk
+   end-to-end).
+6. Say "quiz me" to start Phase 6.
+7. Re-run weekly on the same repo — the skill reads prior artifacts first
+   and focuses on diffs via `detect_changes_tool` + `tilth_diff`.
+
+## 8. When NOT to use this skill
+
+- Single-file scripts or repos <500 LOC: just `Read` the files.
+- Repos with no language-server support (exotic languages): the graph and
+  Serena will be weak; lean harder on `tilth_read --section` and
+  `tilth_files`.
+- Generated code (e.g. an ORM client output dir): include it in the egress
+  pillar by reference but don't grok internals.
+
+## 9. Glossary
+
+- **Seam:** a place where you can alter behavior without editing in that
+  place (Feathers).
+- **Blast radius:** the transitive set of callers / dependents / tests
+  affected by a change.
+- **God-node:** a function / module with disproportionately many inbound or
+  outbound edges.
+- **Characterization test:** a test that captures *current* behavior, used
+  to refactor safely.
+- **Bloom level:** Remember → Understand → Apply → Analyze → Evaluate →
+  Create.
+- **Community (graph):** a cluster of strongly-connected nodes detected by
+  the Leiden algorithm. Often corresponds to a "real" module boundary.

--- a/skills/grok-codebase/QUIZ.md
+++ b/skills/grok-codebase/QUIZ.md
@@ -1,0 +1,237 @@
+# Adaptive Socratic quiz — protocol and question banks
+
+Loaded by `SKILL.md` Phase 6. Contains the protocol, the confidence-update
+rules, and the question banks per pillar × Bloom level.
+
+## Protocol (read once at quiz start)
+
+1. **State.** Maintain `confidence[pillar] ∈ {weak, mid, strong}` for each
+   of the four pillars. Initialize all to `mid`. Also maintain
+   `bloom[pillar] ∈ {remember, understand, apply, analyze, evaluate, create}`.
+   Initialize all to `understand`.
+2. **Turn loop.** Pick the pillar with the lowest confidence (ties broken
+   by ordering 1→2→3→4). Pull one question from the bank for that pillar
+   at the current `bloom` level. Ask it. Wait for the answer.
+3. **Confidence update** (apply in order, take first match):
+   - **Wrong / "I don't know"** → `confidence -= 2` (clamp to `weak`).
+     Re-teach by calling the relevant MCP tool (typically `tilth_grok` or
+     `query_graph_tool`), then ask a `remember`-level question next turn.
+   - **Hedging language detected** (regex:
+     `\b(I think|maybe|probably|kind of|sort of|I'm not sure|I guess|might be|possibly)\b`)
+     → `confidence -= 1`.
+   - **Partial recall** (concept right, specifics wrong / missing) → no
+     change.
+   - **Specific, file:line-grounded, named answer** → `confidence += 1` and
+     `bloom += 1`.
+   - **Three consecutive strong answers in a pillar** → mark pillar
+     **locked**, skip it in future turns.
+4. **Escalation ladder** (when an answer is weak or hedged, the next
+   question for that pillar should go one rung deeper):
+   1. **Clarify** — "When you said X, did you mean … or …?"
+   2. **Why-exists** — "Why does <component> exist? What problem does it
+      solve?"
+   3. **What-breaks** — "If you delete <symbol>, what tests fail? What
+      features break?"
+   4. **Trace** — "Walk me from <entry-point> to <DB-write>, naming every
+      file."
+   5. **Counterfactual** — "How would this system look if <constraint> were
+      different?"
+5. **Ease-off ladder** (when answers are strong, skip ahead to
+   Evaluate/Create):
+   - **Evaluate** — "What's the riskiest single change you could make
+     here?"
+   - **Create** — "Where would you add a new <X> (payment provider /
+     auth method / route)? What files would you touch?"
+6. **End conditions:** all four pillars `locked`, OR user says
+   "stop" / "enough" / "done", OR ~30 minutes elapsed (suggest a break).
+   On end, `Write` `.cheese/grok/<repo>/quiz-results.md` — strong areas,
+   weak areas, suggested next-session focus.
+
+## Question banks
+
+Each pillar has a bank of question stems organized by Bloom level. Substitute
+`<placeholders>` with concrete findings from the grok artifacts (read
+`.cheese/grok/<repo>/` first). Always prefer questions that reference
+specific names / paths the user actually saw during the grok — generic
+questions feel like a trivia quiz and don't lock the codebase in.
+
+### Pillar 1 — Building Blocks
+
+**Remember**
+
+- Name the top-level packages / workspaces in this repo.
+- What's the entry file for `<workspace-name>`?
+- List three core domain types.
+
+**Understand**
+
+- In your own words, what does `<package-name>` do?
+- Why is `<type>` defined as `<class | interface | type alias>` vs. the
+  other options?
+- What's the relationship between `<TypeA>` and `<TypeB>`?
+
+**Apply**
+
+- If you needed to add a new field to `<core-type>`, which files would you
+  touch?
+- Where would a new `<domain-concept>` live in this codebase?
+
+**Analyze**
+
+- Which module has the most inbound dependencies, and why? Is that
+  healthy?
+- The graph shows `<module-A>` and `<module-B>` in the same community —
+  what's their shared concern?
+- Identify a god-node. What's its blast radius?
+
+**Evaluate**
+
+- If you had to split this monorepo into two repos, where would you draw
+  the line?
+- Which abstraction here is over-engineered? Which is under-engineered?
+
+**Create**
+
+- Sketch a new module boundary that would reduce the blast radius of
+  `<god-node>`.
+
+### Pillar 2 — Entry Points
+
+**Remember**
+
+- How many HTTP routes does this app expose? Name three.
+- What does `npm run dev` actually do?
+- Is there a CLI binary? What does it do?
+
+**Understand**
+
+- Why are there separate `app/` and `pages/` directories? (Next.js) or
+- What's the difference between a `@Controller` and a `@Service` here?
+  (NestJS) or
+- What does the `middleware.ts` at the root do, and when does it run?
+
+**Apply**
+
+- Add a new GET `/health` endpoint. Which file and which pattern do you
+  copy?
+- The user reports `/api/users` is slow. Where do you put your first
+  `console.time`?
+
+**Analyze**
+
+- Trace one request from URL to response, naming every file:line.
+- Which entry point has the largest downstream blast radius? What does
+  that mean for risk?
+
+**Evaluate**
+
+- Are there entry points that look reachable but are actually dead (no
+  callers, no docs, no tests)?
+- Which entry point is missing input validation? How can you tell?
+
+**Create**
+
+- Design a new WebSocket endpoint for `<feature>`. What changes in
+  routing, in services, in tests?
+
+### Pillar 3 — Infrastructure
+
+**Remember**
+
+- Node version? Package manager? Build tool?
+- Where are tests configured?
+- What CI provider runs on push?
+
+**Understand**
+
+- Why does the build use `<tsc | swc | esbuild>`? What trade-off does
+  that reflect?
+- What does the Dockerfile's multi-stage build accomplish?
+
+**Apply**
+
+- Add a new env var `FEATURE_X_ENABLED`. Where do you declare it? Where
+  do you read it? Where do you validate it?
+- A new contributor can't run tests locally. What three things do you
+  ask them to check?
+
+**Analyze**
+
+- Which dependency is the biggest risk if it had a critical CVE
+  tomorrow, and why?
+- The CI takes 12 minutes. Looking at the workflow, where's the
+  bottleneck?
+
+**Evaluate**
+
+- Is the config validation strategy sound? (zod schema at boot?
+  scattered `process.env.X`? what happens on missing vars?)
+- Is there a circular dependency between build steps?
+
+**Create**
+
+- Add a `staging` deployment target. Which files change?
+
+### Pillar 4 — Egress
+
+**Remember**
+
+- List every third-party SDK in `dependencies`.
+- Which database client is used, and where is the connection string read
+  from?
+- Name three outbound HTTP calls.
+
+**Understand**
+
+- Why is `<egress-call>` retried with `<backoff-strategy>`? What failure
+  mode is that defending against?
+- The Stripe (or analogous) client is instantiated where? Singleton,
+  per-request, or DI?
+
+**Apply**
+
+- Add a new outbound webhook to `<service>`. Where does it go? How do
+  you sign it?
+- The DB write in `<file>` needs to become idempotent. How do you change
+  it?
+
+**Analyze**
+
+- For each egress, identify the seam: where would a test substitute a
+  fake?
+- Which egress is most likely to cause a production incident, and why?
+- Are any egresses on the synchronous request path that should be on a
+  queue?
+
+**Evaluate**
+
+- Audit: do all DB writes happen inside transactions? Where are the
+  exceptions?
+- Audit: which egress lacks a circuit breaker or timeout?
+
+**Create**
+
+- Replace `<provider-A>` with `<provider-B>` (e.g., Stripe → Adyen).
+  List every file you'd touch and every seam you'd use.
+
+## Sample turn (illustrative)
+
+> **Claude:** Pillar 2 — Entry Points. (Bloom: understand.) **Q:** Why are
+> there separate `app/` and `pages/` directories here?
+>
+> **User:** I think it's because they're migrating to the App Router but
+> haven't moved everything yet. Maybe.
+>
+> **Claude:** Detected hedging ("I think", "maybe"). Confidence: `mid` →
+> `weak` for Pillar 2. Re-teaching:
+> [calls `mcp__tilth__tilth_grok(target="app/layout.tsx")` and
+> `mcp__tilth__tilth_grok(target="pages/_app.tsx")`, shows excerpts].
+> Now: **Q (clarify rung):** looking at `app/(marketing)/page.tsx` and
+> `pages/checkout.tsx` — which features are still in `pages/`, and what's
+> blocking their migration?
+
+## Reset / partial-replay
+
+If the user wants to re-quiz only on a weak pillar later, run the skill with
+the focus flag (`/grok-codebase egress`) — the skill reads prior artifacts,
+skips phases 1–3, and jumps straight to the quiz for that pillar.

--- a/skills/grok-codebase/SKILL.md
+++ b/skills/grok-codebase/SKILL.md
@@ -214,6 +214,7 @@ exercise tests all four pillars at once and is the strongest grok artifact.
 gloss per hop.
 
 Then `Write` `.cheese/grok/<repo>/summary.md` containing:
+
 1. One-paragraph elevator pitch of the codebase.
 2. The four-pillar table.
 3. The end-to-end trace.

--- a/skills/grok-codebase/SKILL.md
+++ b/skills/grok-codebase/SKILL.md
@@ -1,0 +1,268 @@
+---
+name: grok-codebase
+description: >
+  ALWAYS use this skill when the user wants to deeply understand, memorize, or
+  onboard onto an unfamiliar codebase. Loads a repo into long-term understanding
+  using a four-pillar model — Building Blocks, Entry Points, Infrastructure,
+  Egress — then runs an adaptive Socratic quiz that probes weak spots and eases
+  off strong areas. Orchestrates code-review-graph (Tree-sitter graph + blast
+  radius), Serena (LSP symbols), tilth (token-efficient reads + structural
+  diff), and Context7 (framework docs). Trigger on any of: "help me understand
+  this codebase", "grok this repo", "onboard me", "learn this project",
+  "memorize this codebase", "load this repo into memory", "study this code",
+  "explain this project to me", "walk me through this code", "quiz me on this
+  repo", or whenever the user opens an unfamiliar TypeScript, JavaScript,
+  Python, Go, Rust, or Java project and asks for orientation. Especially tuned
+  for TS/JS monorepos and Next.js / Express / NestJS / Fastify apps; methodology
+  is stack-agnostic. Do NOT use for single-file scripts, repos under 500 LOC,
+  or editing tasks — this skill is for understanding only.
+argument-hint: <optional focus area, e.g. "auth flow" or "payments">
+allowed-tools: Read, Write, TodoWrite, Skill, Bash(git:*), Bash(ls:*), Bash(cat:*), Bash(jq:*), Bash(yq:*), Bash(tokei:*), Bash(code-review-graph:*), mcp__serena__find_symbol, mcp__serena__find_referencing_symbols, mcp__serena__find_implementations, mcp__serena__find_declaration, mcp__serena__get_symbols_overview, mcp__serena__search_for_pattern, mcp__tilth__*, mcp__code-review-graph__*, mcp__context7__*
+metadata:
+  version: 1.0.0
+  author: paulnsorensen
+  last-updated: 2026-05-21
+---
+
+# /grok-codebase — Lock a repo into long-term understanding
+
+You are about to help the user **grok** this codebase: not just read it, but
+internalize it well enough to explain it on a whiteboard in five minutes and
+answer "what breaks if I change X" without re-checking. You will work the
+**four-pillar model** in order, persist artifacts under `.cheese/grok/<repo>/`,
+and finish with an adaptive Socratic quiz.
+
+**Focus area** (optional): $ARGUMENTS
+
+## Hard rules (read first, no skipping)
+
+1. **Structural tools before raw reads.** Call
+   `mcp__code-review-graph__get_minimal_context_tool` FIRST on any new repo
+   (~100 tokens). Then prefer `mcp__serena__get_symbols_overview`,
+   `mcp__tilth__tilth_read` (outline mode), and `mcp__tilth__tilth_grok` over
+   reading whole files. Whole-file `Read` is a last resort for non-code files
+   (README, manifests, CI YAML, env templates) — the user's CLAUDE.md
+   explicitly routes code search through tilth.
+2. **One pillar at a time.** Don't skip ahead. Complete pillar 1 before
+   starting pillar 2 — out-of-order grokking produces shallow understanding
+   that fails on the quiz.
+3. **Persist findings to disk, not memory.** This setup excludes serena's
+   memory tools. Instead, after each pillar `Write` an artifact to
+   `.cheese/grok/<repo-name>/<pillar-slug>.md`. Pillar slugs:
+   `01-building-blocks`, `02-entry-points`, `03-infrastructure`, `04-egress`,
+   `05-trace.md`, `summary.md`, `quiz-results.md`. The user can review
+   artifacts later and re-runs read them first.
+4. **Stack-agnostic, TS/JS-leaning examples.** Look up language-specific
+   conventions in `GUIDE.md §6` (Stack-specific cheatsheets) when you hit a
+   stack you don't recognize.
+5. **Token budget.** Aim for ≤30k tokens of tool output across phases 0–5
+   combined. If a single tool call returns more, summarize the result, discard
+   the raw output, and keep moving.
+6. **Adaptive quiz comes last.** Only start Phase 6 after all four pillars are
+   mapped AND the user confirms "yes, quiz me" (or equivalent). Drive it from
+   `QUIZ.md` — don't improvise the question selection.
+7. **Track progress.** Use `TodoWrite` to maintain a checklist of the seven
+   phases so the user can see where you are.
+
+## Phase 0 — Reconnaissance (≤5 tool calls, ≤2 minutes)
+
+Goal: enough context to confirm scope with the user.
+
+Run in parallel where possible:
+
+1. `git log --oneline -10 && git status` — recent activity, branch state.
+2. `mcp__code-review-graph__get_minimal_context_tool(task="initial onboarding")`
+   if the graph exists. If not, ask the user to run `code-review-graph build`
+   then re-invoke. Don't proceed without the graph for repos >500 files —
+   you'll burn tokens.
+3. `Read` of `README.md`, the primary manifest (`package.json` /
+   `pyproject.toml` / `go.mod` / `Cargo.toml` / `pom.xml`), and any
+   `CLAUDE.md` / `AGENTS.md` at the repo root.
+4. `tokei` for a rough LOC-per-language breakdown.
+
+Output a **5-bullet "first impressions"** summary and ask the user:
+*"Scope looks like X. Proceed with full four-pillar grok, or focus on
+<area>?"* Wait for confirmation. If they already passed a focus area in
+`$ARGUMENTS`, confirm that area covers it.
+
+## Phase 1 — BUILDING BLOCKS
+
+**Question to answer:** "If I had to draw this system on a whiteboard in
+5 minutes, which boxes would I draw?"
+
+Workflow:
+
+1. `mcp__code-review-graph__get_architecture_overview_tool` and
+   `mcp__code-review-graph__list_communities_tool` — Leiden-clustered modules
+   are the closest thing to an automated C4 Component diagram.
+2. For each top-level source directory:
+   `mcp__serena__get_symbols_overview(relative_path=<dir>)`.
+3. **TS/JS specifically:** read `package.json` `workspaces`, `exports`, and
+   `tsconfig.json` `paths`/`baseUrl`. These define the *intended* module
+   boundaries — compare them against the graph's *de facto* communities. When
+   they diverge, that's a smell worth surfacing.
+4. Identify 5–10 core domain symbols (`User`, `Order`, `Tenant`, …) and call
+   `mcp__tilth__tilth_grok(target=<symbol>)` on each — that returns
+   def + body + sig + callees + callers + siblings + tests in one shot.
+5. Spot god-nodes: `mcp__code-review-graph__find_large_functions_tool` and
+   `mcp__code-review-graph__get_hub_nodes_tool`. Flag any function >150 LOC
+   or any module with >25 inbound edges.
+
+`Write` `.cheese/grok/<repo>/01-building-blocks.md` with a table:
+`Block | Path | Public API | Key types | God-nodes?`. See `GUIDE.md §2` for
+the full pillar-1 checklist if you get stuck.
+
+## Phase 2 — ENTRY POINTS
+
+**Question to answer:** "Every way control flow can begin." If no entry point
+leads to a piece of code, that code is dead.
+
+Workflow (TS/JS-first; other stacks in `GUIDE.md §6`):
+
+1. `package.json` → `main`, `module`, `bin`, `scripts.start`, `scripts.dev`.
+   Each is an entry point.
+2. HTTP routes — match the framework, then probe:
+   - **Next.js:** `mcp__tilth__tilth_files(patterns=["**/app/**/route.ts", "**/app/**/page.tsx", "**/pages/api/**"])`.
+   - **Express:** `mcp__tilth__tilth_search(query="app.get,app.post,router.get,router.post", kind="content")`.
+   - **NestJS:** `mcp__tilth__tilth_search(query="@Controller,@Get,@Post,@Put,@Delete,@Patch", kind="content")`.
+   - **Fastify:** `mcp__tilth__tilth_search(query="fastify.get,fastify.post,fastify.register", kind="content")`.
+3. **CLI:** `process.argv` usages, `commander` / `yargs` / `oclif`
+   registrations.
+4. **Workers / cron:** `node-cron`, BullMQ `Worker`, AWS Lambda handlers
+   (`exports.handler`), Inngest functions, Cloudflare Workers
+   `addEventListener('fetch'`.
+5. **Real-time:** `socket.io`, tRPC routers, gRPC services.
+6. For the top 3 entry points by importance, call
+   `mcp__code-review-graph__get_affected_flows_tool(target=<entry>)` to trace
+   the downstream flow.
+
+`Write` `.cheese/grok/<repo>/02-entry-points.md` with one line per entry
+point: `<method> <path> → <handler file:line>`. For each, also note **SLA?**
+and **who calls this?** — if either can't be answered, that's a doc gap.
+
+## Phase 3 — INFRASTRUCTURE
+
+**Questions to answer:** "What does it take to run this locally?" and "What
+does it take to ship a change to production?" If you can answer both in
+<2 minutes after the grok, the grok was good.
+
+Workflow:
+
+1. **Runtime:** `engines.node`, `.nvmrc`, `Dockerfile` `FROM`.
+2. **Build:** search for `tsc`, `swc`, `esbuild`, `vite`, `webpack`,
+   `turbopack`, `rollup`, `nx`, `turbo`. `package.json scripts.build` is the
+   source of truth.
+3. **Test:** `vitest.config.*`, `jest.config.*`, `playwright.config.*`,
+   `.spec.ts` / `.test.ts` count.
+4. **Lint / format:** `.eslintrc*`, `eslint.config.*`, `biome.json`,
+   `.prettierrc*`.
+5. **CI:** `Read` `.github/workflows/*.yml`, `.gitlab-ci.yml`,
+   `.circleci/config.yml`.
+6. **Deploy:** `Dockerfile`, `docker-compose.yml`, `k8s/`, `helm/`,
+   `terraform/`, `vercel.json`, `netlify.toml`, `serverless.yml`,
+   `sst.config.*`.
+7. **Config & env:** `mcp__tilth__tilth_files(patterns=["**/.env*"])` and
+   `mcp__tilth__tilth_search(query="process.env", kind="content")`. List
+   every env var referenced — missing-on-boot validation is a common bug.
+8. **Dependency hygiene:** top 10 dependencies by inbound import count via
+   `mcp__code-review-graph__query_graph_tool(action="importers_of",
+   target=<pkg>)`. For the top 3, use `mcp__context7__query-docs` for
+   current docs (don't trust your training data for framework specifics).
+
+`Write` `.cheese/grok/<repo>/03-infrastructure.md`. Also explicitly scan for
+arc42 §8 crosscutting concerns: logging, error handling, auth, i18n, feature
+flags, observability. Missing these in the grok = surprised later.
+
+## Phase 4 — EGRESS
+
+**Question to answer:** "Where does this system reach out or mutate the
+world?" Egress is the Feathers seam surface — and most production incidents
+originate here.
+
+Workflow:
+
+1. **Outbound HTTP:** `mcp__tilth__tilth_search(query="fetch,axios,got,ky,node-fetch", kind="content")`.
+2. **DB writes:** Prisma `.create/.update/.delete/.upsert`, Drizzle
+   `db.insert/update/delete`, TypeORM `repository.save/remove`, Knex
+   `.insert/.update/.del`, raw `INSERT/UPDATE/DELETE`.
+3. **Queues & pub/sub:** `bullmq`, `kafkajs`, `amqplib`,
+   `@aws-sdk/client-sqs`, `nats`.
+4. **File I/O:** `fs.writeFile`, `fs.appendFile`, `@aws-sdk/client-s3`
+   `PutObject`, `@google-cloud/storage`.
+5. **Third-party SDKs:** scan `package.json dependencies` for `stripe`,
+   `@sendgrid/mail`, `resend`, `@sentry/*`, `posthog-js`, `mixpanel`,
+   `twilio`, `auth0`, `@clerk/*`.
+6. **Outbound webhooks:** search `webhook` / `signature` patterns.
+7. **For each egress, name the seam** (à la Feathers): "where could a test
+   substitute a fake?" — usually the import statement or a DI registration.
+
+`Write` `.cheese/grok/<repo>/04-egress.md` as a table:
+`Egress | Caller | Mechanism (lib) | Seam (where to fake) | Has characterization test?`.
+Many egresses + no seams = refactoring liability; flag it.
+
+## Phase 5 — Trace one full request
+
+Pick the entry point with the largest `get_affected_flows_tool` output (or
+whatever the user's focus area points at). Walk it end-to-end:
+
+**entry → middleware → handler → service → repository → DB → response**
+
+Name every file:line. Use `mcp__tilth__tilth_grok` per hop. This single
+exercise tests all four pillars at once and is the strongest grok artifact.
+
+`Write` `.cheese/grok/<repo>/05-trace.md` with the path and a one-line
+gloss per hop.
+
+Then `Write` `.cheese/grok/<repo>/summary.md` containing:
+1. One-paragraph elevator pitch of the codebase.
+2. The four-pillar table.
+3. The end-to-end trace.
+4. Top 3 risks / god-nodes.
+5. Suggested first PR for a new contributor.
+
+## Phase 6 — Adaptive Socratic quiz
+
+**Only start if the user confirms.** Ask: *"Pillars mapped. Want me to quiz
+you to lock it in?"*
+
+If yes, load `QUIZ.md` and follow its protocol. Maintain an internal
+`confidence[pillar]` map and update it after every answer per the rules in
+`QUIZ.md §Confidence rules`. Escalate Bloom level on strength, descend on
+hedging or partial recall. Mark a pillar "locked" after three consecutive
+strong answers. End when all four pillars are locked OR the user says "stop"
+OR ~30 minutes have elapsed (then suggest a break).
+
+On end, `Write` `.cheese/grok/<repo>/quiz-results.md` — strong areas, weak
+areas, suggested next-session focus.
+
+## Output format per pillar
+
+After each pillar phase, post a Markdown section in chat with:
+
+- 🔍 **What I found** — 3–7 bullets, named, file:line where possible.
+- ⚠️ **Risks / unknowns** — anything that surprised you, anything missing.
+- 📌 **Artifact written**: `.cheese/grok/<repo>/<file>.md`
+
+For the quiz, post each question as a numbered prompt; on each answer, post
+the detected confidence change and the next question — don't hide the
+adaptive state from the user.
+
+## Re-running on the same repo
+
+The skill is designed to re-run weekly. On re-invocation:
+
+1. Check for existing `.cheese/grok/<repo>/` artifacts; read them first.
+2. Use `mcp__code-review-graph__detect_changes_tool` and
+   `mcp__tilth__tilth_diff` to find what's changed since the last grok.
+3. Focus the new run on diffs and partial-replay the quiz for any pillar
+   that changed materially.
+
+If the user passed a focus area in `$ARGUMENTS` (e.g.
+`/grok-codebase egress`), skip pillars 1–3, read their prior summaries, and
+jump straight to that pillar + its quiz section.
+
+---
+
+For methodology depth (why four pillars, why this order, stack-specific
+cheatsheets, glossary), see `GUIDE.md`. For the question banks and adaptive
+protocol, see `QUIZ.md`.


### PR DESCRIPTION
## Summary

Adds `skills/grok-codebase/` — a four-pillar codebase-onboarding skill (Building Blocks → Entry Points → Infrastructure → Egress) that orchestrates code-review-graph, Serena, tilth, and Context7 to map a repo, then runs a Bloom-laddered adaptive Socratic quiz to lock the understanding in.

- `SKILL.md` (268 lines) drives Phases 0–6 and persists artifacts under `.cheese/grok/<repo>/` (instead of serena memory, which is excluded in this setup).
- `GUIDE.md` (187 lines) is the methodology deep-dive: why these four pillars in this order, plus per-stack cheatsheets (TS/JS, Python, Go, Rust, Java).
- `QUIZ.md` (237 lines) is the adaptive protocol: confidence rules, escalation/ease-off ladders, and question banks per pillar × Bloom level.

All `code-review-graph` references use the actual `…_tool`-suffixed names, and the skill routes code reads through tilth per the project's MCP routing rules. Install via `dots sync`; invoke with `/grok-codebase [optional focus area]`.
