### PR TITLE
fix(ccw): route worktree launch through cc so the preamble is injected

### DIFF
--- a/cursor/plugins/local/cheese-grok/skills/design-doc/templates/00X-template.md
+++ b/cursor/plugins/local/cheese-grok/skills/design-doc/templates/00X-template.md
@@ -51,7 +51,9 @@ without changing the rationale, you have not written real
 alternatives — go again.
 
 ### Alternative A
+
 ### Alternative B
+
 ### Alternative C — Do nothing
 
 ## Risks & Mitigations (your words; specific, not generic)

--- a/cursor/plugins/local/cheese-grok/skills/read-mode-probe/SKILL.md
+++ b/cursor/plugins/local/cheese-grok/skills/read-mode-probe/SKILL.md
@@ -24,6 +24,7 @@ they're enforced. Catalog what would happen if each invariant were
 violated (silent corruption? hard panic? rejected request?).
 
 Tool order:
+
 1. `mcp__serena__find_symbol` for the central type/function.
 2. `mcp__tilth__tilth_grok` to pull its callers + tests in one shot.
 3. `mcp__serena__find_referencing_symbols` to find every check site.
@@ -35,6 +36,7 @@ from its entry point to its persistence or external use. Name every
 file:line where the value is read, transformed, or written.
 
 Tool order:
+
 1. `mcp__tilth__tilth_search` (kind=content) for the literal name.
 2. `mcp__serena__find_referencing_symbols` on each definition site.
 3. `mcp__code-review-graph__get_affected_flows_tool` for the
@@ -48,6 +50,7 @@ triggered, who catches it (if anyone), and whether it's recoverable
 or terminal.
 
 Tool order:
+
 1. `mcp__tilth__tilth_grok(target=<function>)` for body + callers.
 2. `mcp__tilth__tilth_search(query="catch,try,Result,Err,panic,throw,reject")`
    to find the surrounding error machinery.
@@ -59,6 +62,7 @@ allocations. Sort findings by likely impact — flag the worst offender
 first.
 
 Tool order:
+
 1. `mcp__code-review-graph__get_hub_nodes_tool` for high-fan-in
    functions.
 2. `mcp__code-review-graph__find_large_functions_tool` for >150-LOC
@@ -72,6 +76,7 @@ Audit input validation, authz checks, secret handling, deserialization
 sinks, SQL/shell injection vectors, SSRF, prototype pollution.
 
 Tool order:
+
 1. `mcp__tilth__tilth_search(query="JSON.parse,eval,exec,Function,vm,child_process,spawn")`
    for deserialization + exec sinks.
 2. `mcp__tilth__tilth_search(query="req.body,req.params,req.query,process.argv")`

--- a/zsh/claude.zsh
+++ b/zsh/claude.zsh
@@ -215,7 +215,7 @@ ccw() {
     wt_path="$(echo "$result" | jq -er '.path')" || { echo "ccw: failed to parse worktree path" >&2; return 1; }
     [[ -d "$wt_path" ]] || { echo "ccw: worktree path not found: $wt_path" >&2; return 1; }
 
-    cd "${wt_path}" && claude "$@"
+    cd "${wt_path}" && cc "$@"
 }
 
 # Clean worktrees — single-repo (current dir) or full sweep (~/Dev)


### PR DESCRIPTION
## Summary

- `ccw <slug>` was calling bare `claude`, so worktree sessions ran with Anthropic's default system prompt instead of `agents/preamble.md`.
- The rest of the `cc` family (`cc` / `ccc` / `ccr` / `ccfresh` / `dotsclaude`) already routed through `--system-prompt-file agents/preamble.md`. This patches the one outlier.
- One-line change in `zsh/claude.zsh`: `claude "$@"` → `cc "$@"` at the end of the `ccw` function.

## Test plan

- [ ] `zrl` after merge, then `ccw test-preamble` and confirm Serena / code-review-graph / tilth routing tables are present in the system prompt (e.g. by asking the model to recite the routing self-check).
- [ ] `ccw <slug> --resume` still resumes correctly.
- [ ] `ccw-init` / `ccw-clean` / `ccw-sweep` / `ccw-ls` / `ccw-check` unaffected (none of them invoke claude).

🤖 Generated with [Claude Code](https://claude.com/claude-code)