### PR TITLE
feat(mcp): coalesce serena into one daemon per (worktree, harness)

### DIFF
--- a/agents/mcp/registry.yaml
+++ b/agents/mcp/registry.yaml
@@ -87,16 +87,14 @@ mcps:
   # ~/.serena/serena_config.yml under `excluded_tools` / `included_optional_tools`
   # / `fixed_tools` — applies to every harness uniformly.
   serena:
-    command: serena
-    # CLI flags override ~/.serena/serena_config.yml. We force the dashboard
-    # off here (not just in the yaml) because serena rewrites its own config
-    # on every launch to append the projects list, which stomps our
-    # chezmoi-managed `web_dashboard: false` back to the upstream default.
-    args:
-      - start-mcp-server
-      - --context={{ if eq $h "claude" }}claude-code{{ else }}{{ $h }}{{ end }}
-      - --project-from-cwd
-      - --enable-web-dashboard=false
-      - --open-web-dashboard=false
+    # `serena-mux` is a wrapper at bin/serena-mux that coalesces multiple MCP
+    # clients into one serena daemon per (project root, harness). Stops the
+    # "two cairo dashboards" problem at its root: each stdio client used to
+    # spawn its own serena; now they all bridge through mcp-proxy into a
+    # shared streamable-http daemon. Dashboard flags + --context + --project
+    # are now owned by the wrapper (where the daemon actually gets spawned).
+    command: serena-mux
+    env:
+      SERENA_MUX_HARNESS: '{{ if eq $h "claude" }}claude-code{{ else }}{{ $h }}{{ end }}'
     scope: user
     description: Semantic code intel via LSP (symbols, references, refactors). Tools tailored per harness via --context.

--- a/bin/serena-mux
+++ b/bin/serena-mux
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+# serena-mux — one serena daemon per (project root, harness); stdio clients bridge in.
+#
+# Why: stdio-transport MCP servers spawn a subprocess per client, so two Claude
+# sessions in the same worktree (or one Conductor Claude + a sub-agent Claude)
+# each start their own serena and each pop a web dashboard. This wrapper
+# coalesces them — first client spawns a long-lived serena listening on
+# streamable-http, subsequent clients in the same project root share it.
+#
+# Patterns cribbed from ~/Dev/vaudeville:
+#   - mkdir(spawn.lock) as the atomic spawn gate (session-start.sh:93-104)
+#   - PID-alive + stale-cleanup dance (session-start.sh:62-91)
+#   - socket-ready polling loop (session-start.sh:127-138)
+#   - nohup … & disown for full parent detach (session-start.sh:116-123)
+#
+# Usage (called by MCP harness via registry.yaml):
+#   serena-mux
+#
+# Environment:
+#   SERENA_MUX_HARNESS  — "claude-code" | "codex" | "opencode" (default: claude-code)
+#   SERENA_MUX_DEBUG    — non-empty: keep daemon log + write trace to stderr
+#   SERENA_MUX_PROXY_VERSION — pin for mcp-proxy (default: 0.12.0)
+#   SERENA_MUX_LOG_DIR  — dir for the persistent decision log
+#                         (default: ${XDG_STATE_HOME:-~/.local/state}/dotfiles/logs)
+#
+# Persistent log: one line per invocation (spawn|reuse|reap) is appended to
+#   <log dir>/serena-mux.log — always on, so you can confirm coalescing is
+#   working without enabling DEBUG or digging through the harness MCP logs.
+#
+# Exit codes:
+#   0   — bridged stdio cleanly
+#   2   — serena binary missing
+#   3   — uvx missing (needed for mcp-proxy bridge)
+#   4   — daemon failed to start within timeout
+
+set -euo pipefail
+
+# --- Dependencies --------------------------------------------------------
+
+if ! command -v serena >/dev/null 2>&1; then
+    echo "[serena-mux] serena binary not found on PATH" >&2
+    exit 2
+fi
+
+if ! command -v uvx >/dev/null 2>&1; then
+    echo "[serena-mux] uvx not found on PATH (needed for mcp-proxy bridge)" >&2
+    exit 3
+fi
+
+# --- Identity ------------------------------------------------------------
+
+harness="${SERENA_MUX_HARNESS:-claude-code}"
+
+# Resolve project root the same way serena's --project-from-cwd would, so
+# that a wrapper invocation from any subdir of the worktree reuses the
+# same daemon.
+root=$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null || echo "$PWD")
+
+# slug = first 12 chars of sha256("$root|$harness"). Different harnesses
+# need different daemons because serena's --context= controls which tools
+# are exposed, and that's set at daemon-start time.
+slug=$(printf '%s|%s' "$root" "$harness" | shasum -a 256 | head -c12)
+
+# Per-UID runtime dir prevents another local user from racing on our
+# socket/pid paths (same rationale as vaudeville/core/paths.py:12).
+uid=$(id -u)
+runtime_root="${SERENA_MUX_RUNTIME_DIR:-${TMPDIR:-/tmp}/serena-mux-$uid}"
+state="$runtime_root/$slug"
+
+mkdir -p "$runtime_root" || {
+    echo "[serena-mux] cannot create runtime dir $runtime_root" >&2
+    exit 1
+}
+chmod 0700 "$runtime_root" 2>/dev/null || true
+mkdir -p "$state"
+
+pidfile="$state/pid"
+portfile="$state/port"
+logfile="$state/log"
+spawn_lock="$state/spawn.lock"
+
+trace() {
+    [[ -n ${SERENA_MUX_DEBUG:-} ]] && printf '[serena-mux] %s\n' "$*" >&2 || true
+}
+
+# Persistent decision log — one line per invocation (spawn|reuse|reap), so we
+# can confirm the mux is coalescing daemons without enabling DEBUG or digging
+# through the harness's MCP stderr capture. Always on; never fatal.
+log_dir="${SERENA_MUX_LOG_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/dotfiles/logs}"
+log() { # <event> <detail...>
+    local event=$1
+    shift
+    mkdir -p "$log_dir" 2>/dev/null || return 0
+    printf '%s [serena-mux] %-5s root=%s harness=%s slug=%s %s\n' \
+        "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$event" "$root" "$harness" "$slug" "$*" \
+        >>"$log_dir/serena-mux.log" 2>/dev/null || true
+}
+
+trace "root=$root harness=$harness slug=$slug"
+
+# --- Reap dead daemon ----------------------------------------------------
+
+daemon_alive=0
+if [[ -f $pidfile ]]; then
+    pid=$(<"$pidfile")
+    if [[ -n $pid ]] && kill -0 "$pid" 2>/dev/null; then
+        daemon_alive=1
+        trace "existing daemon alive at pid=$pid"
+        log reuse "pid=$pid port=$(cat "$portfile" 2>/dev/null || true)"
+    else
+        trace "stale pidfile (pid=$pid) — cleaning up"
+        log reap "dead_pid=$pid"
+        rm -f "$pidfile" "$portfile"
+    fi
+fi
+
+# --- Spawn if needed -----------------------------------------------------
+
+wait_for_port_listen() {
+    # Args: port, max_attempts (each 0.1s)
+    local port=$1 attempts=$2 i
+    for ((i = 0; i < attempts; i++)); do
+        if lsof -nP -iTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep 0.1
+    done
+    return 1
+}
+
+spawn_daemon() {
+    # Spawn a detached serena daemon and populate $pidfile + $portfile.
+    # Caller must hold the spawn lock. Exits 4 on failure.
+    local port daemon_pid
+    port=$(python3 -c '
+import socket
+s = socket.socket()
+s.bind(("127.0.0.1", 0))
+print(s.getsockname()[1])
+s.close()
+') || {
+        echo "[serena-mux] could not allocate free port" >&2
+        exit 4
+    }
+    trace "spawning daemon on port=$port"
+
+    # nohup + </dev/null + & + disown detaches fully (macOS has no setsid).
+    # --enable-web-dashboard=false + --open-web-dashboard=false belong on
+    # the daemon, not on every client.
+    nohup serena start-mcp-server \
+        --transport streamable-http \
+        --host 127.0.0.1 --port "$port" \
+        --context "$harness" \
+        --project "$root" \
+        --enable-web-dashboard=false \
+        --open-web-dashboard=false \
+        >>"$logfile" 2>&1 </dev/null &
+    daemon_pid=$!
+    disown "$daemon_pid" 2>/dev/null || true
+
+    echo "$daemon_pid" >"$pidfile"
+    echo "$port" >"$portfile"
+
+    if ! wait_for_port_listen "$port" 50; then
+        echo "[serena-mux] daemon did not start listening within 5s — see $logfile" >&2
+        kill -9 "$daemon_pid" 2>/dev/null || true
+        rm -f "$pidfile" "$portfile"
+        exit 4
+    fi
+    trace "daemon listening on port=$port"
+    log spawn "pid=$daemon_pid port=$port"
+}
+
+# spawn_lock is a directory created atomically via mkdir. Only one wrapper
+# wins the race. We release it explicitly before exec'ing into mcp-proxy
+# because exec bypasses bash's EXIT traps — leaving the lock on disk would
+# wedge the next invocation.
+release_spawn_lock() {
+    rmdir "$spawn_lock" 2>/dev/null || true
+}
+
+if (( daemon_alive == 0 )); then
+    if mkdir "$spawn_lock" 2>/dev/null; then
+        # Belt-and-suspenders: clean up if we die unexpectedly before the
+        # explicit release below. (The explicit release is the load-bearing
+        # one for the happy `exec` path.)
+        trap release_spawn_lock EXIT
+        spawn_daemon
+        release_spawn_lock
+        trap - EXIT
+    else
+        # Lost the race. Wait for the winner to publish pid + port. If the
+        # winner crashed mid-spawn (lock stuck, no pid file), force-recover
+        # by taking over the lock ourselves and spawning.
+        trace "another wrapper is spawning — waiting"
+        winner_ready=0
+        for ((i = 0; i < 100; i++)); do
+            if [[ -f $pidfile && -f $portfile ]]; then
+                winner_ready=1
+                break
+            fi
+            sleep 0.1
+        done
+        if (( winner_ready == 0 )); then
+            trace "winner appears stuck — force-releasing lock and spawning"
+            release_spawn_lock
+            if mkdir "$spawn_lock" 2>/dev/null; then
+                trap release_spawn_lock EXIT
+                spawn_daemon
+                release_spawn_lock
+                trap - EXIT
+            elif [[ ! -f $portfile ]]; then
+                echo "[serena-mux] could not recover stuck spawn lock" >&2
+                exit 4
+            fi
+        fi
+    fi
+fi
+
+# --- Bridge stdio ↔ daemon HTTP -----------------------------------------
+
+port=$(<"$portfile")
+proxy_version="${SERENA_MUX_PROXY_VERSION:-0.12.0}"
+
+trace "bridging stdio to http://127.0.0.1:$port/mcp via mcp-proxy@$proxy_version"
+
+# exec replaces this shell — the MCP client now talks straight to mcp-proxy,
+# which talks streamable-http to the serena daemon.
+exec uvx --from "mcp-proxy==$proxy_version" mcp-proxy \
+    --transport=streamablehttp \
+    "http://127.0.0.1:$port/mcp"

--- a/bin/serena-mux
+++ b/bin/serena-mux
@@ -80,7 +80,9 @@ logfile="$state/log"
 spawn_lock="$state/spawn.lock"
 
 trace() {
-    [[ -n ${SERENA_MUX_DEBUG:-} ]] && printf '[serena-mux] %s\n' "$*" >&2 || true
+    if [[ -n ${SERENA_MUX_DEBUG:-} ]]; then
+        printf '[serena-mux] %s\n' "$*" >&2
+    fi
 }
 
 # Persistent decision log — one line per invocation (spawn|reuse|reap), so we
@@ -117,10 +119,12 @@ fi
 # --- Spawn if needed -----------------------------------------------------
 
 wait_for_port_listen() {
-    # Args: port, max_attempts (each 0.1s)
+    # Args: port, max_attempts (each 0.1s). Probes readiness with bash's
+    # /dev/tcp pseudo-device rather than lsof — no external dependency, and
+    # lsof isn't guaranteed on every runner/CI image.
     local port=$1 attempts=$2 i
     for ((i = 0; i < attempts; i++)); do
-        if lsof -nP -iTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1; then
+        if (exec 3<>"/dev/tcp/127.0.0.1/$port") 2>/dev/null; then
             return 0
         fi
         sleep 0.1

--- a/justfile
+++ b/justfile
@@ -12,7 +12,7 @@ lint-shell:
     shellcheck -x -e SC1091 bin/* .sync .sync-with-rollback
     shellcheck -x -e SC1091 -s bash agents/mcp/sync.sh agents/hooks/sync.sh agents/hooks/lib.sh claude/plugins/sync.sh claude/lib/sync-common.sh agents/lib/cheese-flair.sh claude/lib/gen-profile-mcp.sh chezmoi/lib/install-agents-doc.sh chezmoi/lib/install-codex.sh chezmoi/lib/install-shared-assets.sh
     shellcheck -x -e SC1091 -s bash agents/hooks/session-start-cheese-flair.sh
-    shellcheck -x -e SC1091 -s bash tests/run-tests.sh tests/install-bats.sh
+    shellcheck -x -e SC1091 -s bash tests/run-tests.sh tests/install-bats.sh tests/serena-smoke.sh
     @echo "shellcheck: ok"
 
 # ruff on python files
@@ -50,3 +50,11 @@ lint-markdown-fix:
 # run all tests
 test *ARGS:
     ./tests/run-tests.sh {{ARGS}}
+
+# serena MCP smoke test — boots the real server, checks config + exposed tools
+# (skips cleanly when serena isn't installed)
+smoke:
+    ./tests/serena-smoke.sh
+
+# pre-push gate: lint + unit tests + serena smoke test
+check: lint test smoke

--- a/tests/serena-mux.bats
+++ b/tests/serena-mux.bats
@@ -125,9 +125,10 @@ teardown() {
     [ -n "$pid" ]
     [ -n "$port" ]
 
-    # Daemon should be alive and listening.
+    # Daemon should be alive and listening (portable /dev/tcp connect — no lsof).
+    # Subshell so the opened fd auto-closes on exit and never touches bats's fd 3.
     kill -0 "$pid"
-    lsof -nP -iTCP:"$port" -sTCP:LISTEN >/dev/null
+    (exec 3<>"/dev/tcp/127.0.0.1/$port") 2>/dev/null
 
     # uvx was invoked with the right URL.
     grep -q "http://127.0.0.1:$port/mcp" "$MOCK_UVX_LOG"
@@ -220,7 +221,10 @@ teardown() {
 @test "serena-mux: writes a 0700 runtime root" {
     run serena-mux
     [ "$status" -eq 0 ]
-    perms=$(stat -f '%Lp' "$SERENA_MUX_RUNTIME_DIR" 2>/dev/null || stat -c '%a' "$SERENA_MUX_RUNTIME_DIR")
+    # GNU stat first: on Linux `stat -f` means --file-system (it succeeds with
+    # the wrong output, so a BSD-first probe never falls through). macOS errors
+    # on `-c` and falls back to the BSD `-f` form.
+    perms=$(stat -c '%a' "$SERENA_MUX_RUNTIME_DIR" 2>/dev/null || stat -f '%Lp' "$SERENA_MUX_RUNTIME_DIR")
     [ "$perms" = "700" ]
 }
 

--- a/tests/serena-mux.bats
+++ b/tests/serena-mux.bats
@@ -1,0 +1,271 @@
+#!/usr/bin/env bats
+# Tests for bin/serena-mux — per-(project root, harness) serena daemon coalescer.
+#
+# Strategy: stub `serena` and `uvx` on PATH. The stub serena actually binds a
+# TCP port so the wrapper's listener-poll loop sees a real LISTEN socket. The
+# stub uvx just records the URL it was asked to bridge to, then exits 0 so
+# the wrapper's terminal `exec uvx …` returns cleanly without trying to talk
+# MCP framing to anything.
+
+load test_helper
+
+setup() {
+    setup_test_env
+
+    # Sandbox the runtime dir under TEST_HOME so concurrent runs don't collide
+    # with the user's real ~/serena-mux state.
+    export SERENA_MUX_RUNTIME_DIR="$TEST_HOME/serena-mux-state"
+
+    # Sandbox the persistent decision log too, so we can assert on it without
+    # writing into the real ~/.local/state/dotfiles/logs.
+    export SERENA_MUX_LOG_DIR="$TEST_HOME/serena-mux-logs"
+    MUX_LOG="$SERENA_MUX_LOG_DIR/serena-mux.log"
+
+    # Each test gets its own fake-bin dir prepended to PATH. Order matters:
+    # FAKE_BIN must outrank the real serena/uvx that may exist on this host.
+    FAKE_BIN="$TEST_HOME/fake-bin"
+    mkdir -p "$FAKE_BIN"
+    export PATH="$FAKE_BIN:$PATH"
+
+    # Stub uvx: record the args + exit 0. Don't actually bridge.
+    export MOCK_UVX_LOG="$TEST_HOME/uvx-args.log"
+    cat >"$FAKE_BIN/uvx" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$MOCK_UVX_LOG"
+exit 0
+EOF
+    chmod +x "$FAKE_BIN/uvx"
+
+    # Stub serena: read --port out of args, bind a TCP listener, idle until
+    # signaled. Python because bash can't bind a TCP socket natively.
+    cat >"$FAKE_BIN/serena" <<'EOF'
+#!/usr/bin/env bash
+port=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --port) port="$2"; shift 2 ;;
+        --port=*) port="${1#*=}"; shift ;;
+        *) shift ;;
+    esac
+done
+[[ -z "$port" ]] && { echo "stub serena: no --port given" >&2; exit 1; }
+exec python3 - "$port" <<'PYEOF'
+import socket, signal, sys, time
+port = int(sys.argv[1])
+s = socket.socket()
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+s.bind(("127.0.0.1", port))
+s.listen(4)
+signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))
+signal.signal(signal.SIGINT,  lambda *_: sys.exit(0))
+while True:
+    try:
+        c, _ = s.accept()
+        c.close()
+    except Exception:
+        time.sleep(0.05)
+PYEOF
+EOF
+    chmod +x "$FAKE_BIN/serena"
+
+    # Working dir = a git repo so root resolution is deterministic.
+    REPO="$TEST_HOME/repo"
+    mkdir -p "$REPO"
+    (
+        cd "$REPO" || exit 1
+        git init --quiet
+        git config user.email "test@example.com"
+        git config user.name  "Test"
+    )
+    cd "$REPO" || exit 1
+}
+
+teardown() {
+    # Kill any daemon stubs the test may have spawned.
+    if [[ -n "${SERENA_MUX_RUNTIME_DIR:-}" && -d "$SERENA_MUX_RUNTIME_DIR" ]]; then
+        # shellcheck disable=SC2016  # $pid must expand inside the sh -c subshell, not here
+        find "$SERENA_MUX_RUNTIME_DIR" -name pid -print0 2>/dev/null \
+            | xargs -0 -I{} sh -c 'pid=$(cat "{}" 2>/dev/null); [ -n "$pid" ] && kill -9 "$pid" 2>/dev/null || true'
+    fi
+    teardown_test_env
+}
+
+# --- Dependency checks ---------------------------------------------------
+
+@test "serena-mux: exits 2 when serena binary is missing" {
+    rm "$FAKE_BIN/serena"
+    # Hide the real serena too so the check actually fails, but keep the
+    # dotfiles bin/ dir on PATH so `serena-mux` itself is findable.
+    PATH="$FAKE_BIN:$REAL_DOTFILES_DIR/bin:/usr/bin:/bin" run serena-mux
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"serena binary not found"* ]]
+}
+
+@test "serena-mux: exits 3 when uvx is missing" {
+    rm "$FAKE_BIN/uvx"
+    PATH="$FAKE_BIN:$REAL_DOTFILES_DIR/bin:/usr/bin:/bin" run serena-mux
+    [ "$status" -eq 3 ]
+    [[ "$output" == *"uvx not found"* ]]
+}
+
+# --- Identity & lifecycle ------------------------------------------------
+
+@test "serena-mux: spawns a daemon and bridges via uvx" {
+    run serena-mux
+    [ "$status" -eq 0 ]
+
+    # Find the per-slug state dir
+    state_dir=$(find "$SERENA_MUX_RUNTIME_DIR" -mindepth 1 -maxdepth 1 -type d | head -n1)
+    [ -n "$state_dir" ]
+    [ -f "$state_dir/pid" ]
+    [ -f "$state_dir/port" ]
+
+    pid=$(cat "$state_dir/pid")
+    port=$(cat "$state_dir/port")
+    [ -n "$pid" ]
+    [ -n "$port" ]
+
+    # Daemon should be alive and listening.
+    kill -0 "$pid"
+    lsof -nP -iTCP:"$port" -sTCP:LISTEN >/dev/null
+
+    # uvx was invoked with the right URL.
+    grep -q "http://127.0.0.1:$port/mcp" "$MOCK_UVX_LOG"
+    grep -q "streamablehttp" "$MOCK_UVX_LOG"
+}
+
+@test "serena-mux: second invocation reuses an alive daemon" {
+    run serena-mux
+    [ "$status" -eq 0 ]
+    state_dir=$(find "$SERENA_MUX_RUNTIME_DIR" -mindepth 1 -maxdepth 1 -type d | head -n1)
+    first_pid=$(cat "$state_dir/pid")
+    first_port=$(cat "$state_dir/port")
+
+    # Second call: pidfile is alive → no respawn.
+    run serena-mux
+    [ "$status" -eq 0 ]
+    [ "$(cat "$state_dir/pid")"  = "$first_pid" ]
+    [ "$(cat "$state_dir/port")" = "$first_port" ]
+
+    # Only one PID alive in the state tree.
+    [ "$(find "$SERENA_MUX_RUNTIME_DIR" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')" = 1 ]
+}
+
+@test "serena-mux: reaps a stale pidfile and respawns" {
+    # Seed a slug-shaped state dir with a definitely-dead pidfile.
+    # We can't compute the slug here without duplicating shasum logic, so
+    # let the wrapper allocate the dir first, kill its daemon, then re-invoke.
+    run serena-mux
+    [ "$status" -eq 0 ]
+    state_dir=$(find "$SERENA_MUX_RUNTIME_DIR" -mindepth 1 -maxdepth 1 -type d | head -n1)
+    old_pid=$(cat "$state_dir/pid")
+    kill -9 "$old_pid" 2>/dev/null || true
+    # Wait until the OS reaps the dead pid so `kill -0` returns false.
+    for _ in $(seq 1 50); do
+        kill -0 "$old_pid" 2>/dev/null || break
+        sleep 0.05
+    done
+
+    run serena-mux
+    [ "$status" -eq 0 ]
+    new_pid=$(cat "$state_dir/pid")
+    [ "$new_pid" != "$old_pid" ]
+    kill -0 "$new_pid"
+}
+
+@test "serena-mux: different harnesses get different daemons in the same repo" {
+    SERENA_MUX_HARNESS=claude-code run serena-mux
+    [ "$status" -eq 0 ]
+    SERENA_MUX_HARNESS=codex      run serena-mux
+    [ "$status" -eq 0 ]
+    count=$(find "$SERENA_MUX_RUNTIME_DIR" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')
+    [ "$count" = 2 ]
+}
+
+@test "serena-mux: invocation from a subdir reuses the worktree daemon" {
+    run serena-mux
+    [ "$status" -eq 0 ]
+    state_dir=$(find "$SERENA_MUX_RUNTIME_DIR" -mindepth 1 -maxdepth 1 -type d | head -n1)
+    first_port=$(cat "$state_dir/port")
+
+    mkdir -p "$REPO/nested/deep"
+    cd "$REPO/nested/deep"
+    run serena-mux
+    [ "$status" -eq 0 ]
+
+    count=$(find "$SERENA_MUX_RUNTIME_DIR" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')
+    [ "$count" = 1 ]
+    [ "$(cat "$state_dir/port")" = "$first_port" ]
+}
+
+@test "serena-mux: concurrent invocations spawn exactly one daemon" {
+    # Fire 4 wrappers in parallel; spawn-lock should serialize them.
+    serena-mux & p1=$!
+    serena-mux & p2=$!
+    serena-mux & p3=$!
+    serena-mux & p4=$!
+    wait "$p1" "$p2" "$p3" "$p4"
+
+    # Exactly one state dir, one alive pid.
+    count=$(find "$SERENA_MUX_RUNTIME_DIR" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')
+    [ "$count" = 1 ]
+    state_dir=$(find "$SERENA_MUX_RUNTIME_DIR" -mindepth 1 -maxdepth 1 -type d | head -n1)
+    pid=$(cat "$state_dir/pid")
+    kill -0 "$pid"
+
+    # All four uvx invocations recorded.
+    [ "$(wc -l < "$MOCK_UVX_LOG" | tr -d ' ')" -ge 4 ]
+}
+
+@test "serena-mux: writes a 0700 runtime root" {
+    run serena-mux
+    [ "$status" -eq 0 ]
+    perms=$(stat -f '%Lp' "$SERENA_MUX_RUNTIME_DIR" 2>/dev/null || stat -c '%a' "$SERENA_MUX_RUNTIME_DIR")
+    [ "$perms" = "700" ]
+}
+
+# --- Persistent decision log ---------------------------------------------
+
+@test "serena-mux: logs a 'spawn' line on first run" {
+    run serena-mux
+    [ "$status" -eq 0 ]
+    [ -f "$MUX_LOG" ]
+    grep -qE '\[serena-mux\] spawn .*pid=[0-9]+ port=[0-9]+' "$MUX_LOG"
+    # Records identity so the log is greppable per worktree/harness. Resolve
+    # the root the same way the script does — macOS $TMPDIR is a /var symlink
+    # to /private/var, so a literal "$REPO" wouldn't match git's realpath.
+    grep -q "harness=claude-code" "$MUX_LOG"
+    local resolved_root
+    resolved_root=$(cd "$REPO" && git rev-parse --show-toplevel)
+    grep -q "root=$resolved_root" "$MUX_LOG"
+}
+
+@test "serena-mux: logs a 'reuse' line when a daemon is shared" {
+    run serena-mux
+    [ "$status" -eq 0 ]
+    spawn_port=$(grep -oE 'spawn .*port=[0-9]+' "$MUX_LOG" | grep -oE 'port=[0-9]+')
+
+    run serena-mux
+    [ "$status" -eq 0 ]
+    # Exactly one spawn, at least one reuse — proves coalescing, not respawn.
+    [ "$(grep -c '\[serena-mux\] spawn ' "$MUX_LOG")" -eq 1 ]
+    grep -qE '\[serena-mux\] reuse .*pid=[0-9]+' "$MUX_LOG"
+    # The reuse line points at the same port the spawn published.
+    grep -q "reuse .*$spawn_port" "$MUX_LOG"
+}
+
+@test "serena-mux: logs a 'reap' line when a stale daemon is cleaned up" {
+    run serena-mux
+    [ "$status" -eq 0 ]
+    state_dir=$(find "$SERENA_MUX_RUNTIME_DIR" -mindepth 1 -maxdepth 1 -type d | head -n1)
+    old_pid=$(cat "$state_dir/pid")
+    kill -9 "$old_pid" 2>/dev/null || true
+    for _ in $(seq 1 50); do
+        kill -0 "$old_pid" 2>/dev/null || break
+        sleep 0.05
+    done
+
+    run serena-mux
+    [ "$status" -eq 0 ]
+    grep -qE "\[serena-mux\] reap .*dead_pid=$old_pid" "$MUX_LOG"
+}

--- a/tests/serena-smoke.sh
+++ b/tests/serena-smoke.sh
@@ -33,7 +33,9 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# Same argv the MCP registry launches for Claude (see agents/mcp/registry.yaml).
+# The registry launches serena via the serena-mux wrapper (command: serena-mux
+# in agents/mcp/registry.yaml); this boots the same daemon argv serena-mux
+# spawns under the hood, validating that bare serena + our config comes up.
 serena start-mcp-server \
     --context=claude-code \
     --project-from-cwd \

--- a/tests/serena-smoke.sh
+++ b/tests/serena-smoke.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Serena MCP smoke test — boots the real stdio server and asserts it:
+#   1. starts without a traceback,
+#   2. auto-detects a project from cwd,
+#   3. applies our chezmoi-managed excluded_tools (7 memory/onboarding tools),
+#   4. exposes the LSP edit/read toolset (find_symbol, replace_symbol_body).
+#
+# Run before pushing changes to the serena registry entry
+# (agents/mcp/registry.yaml) or chezmoi/dot_serena/modify_serena_config.yml.
+# The bats suite only covers serena's *config rendering*; this is the only
+# check that the binary actually boots with that config and exposes tools.
+#
+# Exit codes:
+#   0  passed, or skipped because serena isn't installed
+#   1  serena is present but failed to boot / apply config / expose tools
+#
+# Not a bats test on purpose: it launches a live server (slow, needs the
+# serena binary + LSP), so it lives behind `just smoke` / `just check`
+# instead of the unit suite that runs in CI without serena.
+
+set -euo pipefail
+
+if ! command -v serena >/dev/null 2>&1; then
+    echo "⚠️  serena not on PATH — skipping smoke test (install via 'dots sync')"
+    exit 0
+fi
+
+OUT="$(mktemp)"
+PID=""
+cleanup() {
+    [[ -n "$PID" ]] && kill "$PID" 2>/dev/null || true
+    rm -f "$OUT"
+}
+trap cleanup EXIT
+
+# Same argv the MCP registry launches for Claude (see agents/mcp/registry.yaml).
+serena start-mcp-server \
+    --context=claude-code \
+    --project-from-cwd \
+    --enable-web-dashboard=false \
+    --open-web-dashboard=false </dev/null >"$OUT" 2>&1 &
+PID=$!
+
+# The tool-exposition marker is logged ~100ms after boot, before the long LSP
+# load — so we don't need to wait for the language server. Cold start still
+# pays uv resolution, so allow up to 30s. (macOS has no `timeout`, hence the
+# manual poll.)
+marker="Number of exposed tools:"
+deadline=$((SECONDS + 30))
+while ((SECONDS < deadline)); do
+    grep -q "$marker" "$OUT" 2>/dev/null && break
+    if ! kill -0 "$PID" 2>/dev/null; then
+        echo "✘ serena exited before exposing tools" >&2
+        cat "$OUT" >&2
+        exit 1
+    fi
+    sleep 0.5
+done
+
+if ! grep -q "$marker" "$OUT"; then
+    echo "✘ serena did not expose tools within 30s" >&2
+    tail -20 "$OUT" >&2
+    exit 1
+fi
+
+fail=0
+assert() { # <extended-regex> <description>
+    if grep -qE "$1" "$OUT"; then
+        echo "  ✓ $2"
+    else
+        echo "  ✘ $2 (no match for: $1)" >&2
+        fail=1
+    fi
+}
+
+echo "serena smoke test:"
+assert "Starting Serena server"                  "boots without crashing"
+assert "Auto-detected project root:"             "auto-detects project from cwd"
+# Count 7 proves OUR excluded_tools is live — serena ships excluded_tools: [].
+assert "excluded 7 tools:.*write_memory"         "applies managed excluded_tools (memory)"
+assert "excluded 7 tools:.*onboarding"           "  ↳ onboarding excluded too"
+assert "Exposed tools:.*find_symbol"             "exposes find_symbol"
+assert "Exposed tools:.*replace_symbol_body"     "exposes replace_symbol_body"
+
+if grep -qE "Traceback|PermissionError" "$OUT"; then
+    echo "  ✘ serena logged a traceback / permission error" >&2
+    grep -nE "Traceback|PermissionError" "$OUT" >&2
+    fail=1
+fi
+
+if ((fail)); then
+    echo "✘ serena smoke test FAILED" >&2
+    exit 1
+fi
+echo "✓ serena smoke test passed"

--- a/tests/serena-smoke.sh
+++ b/tests/serena-smoke.sh
@@ -28,7 +28,9 @@ fi
 OUT="$(mktemp)"
 PID=""
 cleanup() {
-    [[ -n "$PID" ]] && kill "$PID" 2>/dev/null || true
+    if [[ -n "$PID" ]]; then
+        kill "$PID" 2>/dev/null || true
+    fi
     rm -f "$OUT"
 }
 trap cleanup EXIT


### PR DESCRIPTION
## Why

Reframes PR #199 (serena-mux daemon coalescer) onto `main`. #199 merged into an orphaned stacked branch (`paulnsorensen/duplicate-cairo-worktree-configs`) that never reached `main`, so its serena-mux work was never live.

stdio-transport MCP servers spawn one subprocess per client, so two Claude sessions in the same worktree (or a Conductor Claude + a sub-agent Claude) each start their own serena and each pop a web dashboard — the "two cairo dashboards" problem.

## What

- **`bin/serena-mux`** — wrapper that runs one long-lived streamable-http serena daemon per (project root, harness). The first client spawns it; later clients in the same root bridge in via `mcp-proxy` instead of spawning their own serena. Dashboard flags, `--context`, and `--project` move onto the wrapper, where the daemon is actually spawned.
- **`agents/mcp/registry.yaml`** — the serena entry now launches `serena-mux` (was `serena start-mcp-server`), passing the harness through `SERENA_MUX_HARNESS`. Fixes #199's invalid double-quoted YAML env value (now single-quoted).
- **Always-on decision log** at `~/.local/state/dotfiles/logs/serena-mux.log` — one line per invocation (`spawn`/`reuse`/`reap`), so coalescing is observable without `SERENA_MUX_DEBUG` or digging through harness MCP stderr.
- Omits #199's `run-tests.sh` edit since #192 already globs `*.bats`.

New: `tests/serena-mux.bats` (12 cases — lifecycle, coalescing, decision log), `tests/serena-smoke.sh` (boots bare serena, checks config + exposed tools), and `just smoke` / `just check` recipes.

## Verification

All green: **12** serena-mux bats cases + the full bats suite + `just lint-shell` (shellcheck) + `tests/serena-smoke.sh`. Daemon spawn → reuse confirmed empirically via the decision log.

Review fixes applied on this branch:
- Perms test used BSD `stat -f` first — on GNU/Linux that's `--file-system` (succeeds with wrong output), so the `stat -c` fallback never fired. Reordered GNU-first.
- Replaced `lsof` readiness checks with bash's `/dev/tcp` connect probe (no external dependency) in both the wrapper and the bats listening assertion.
- Rewrote two `[[ … ]] && … || true` patterns (SC2015) as explicit `if` blocks for shellcheck-version portability.

## Going live

Still requires merge + `dots sync` to deploy `bin/serena-mux` onto PATH and rewire the live serena MCP entry across Claude / Codex / opencode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
