### PR TITLE
feat(remote): Tailscale + mosh + tmux remote-access stack

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -454,6 +454,26 @@ Hotkey daemon for macOS, installed from the `koekeishiya/formulae` brew tap and 
 - **First-time setup**: grant Accessibility to `skhd` in System Settings → Privacy & Security after `dots sync`.
 - **Syntax reference**: <https://github.com/koekeishiya/skhd>. Hotkeys can run any shell command via `$SHELL -c`, support modal/chord modes, application-specific bindings, and key synthesis (`-k`).
 
+### Remote Access (Tailscale + mosh + tmux)
+
+The resilient remote-shell stack: **Tailscale** (private mesh transport) → SSH bootstrap → **mosh** (UDP shell that survives roaming/sleep) → **tmux** (session persistence across disconnects). Canonical invocation, wrapped by the `mtmux` shell function (`zsh/aliases.zsh`):
+
+```bash
+mtmux <host> [session]   # = mosh <host> -- tmux new -A -s <session>
+```
+
+**What the repo wires automatically (`dots sync`):**
+
+- `mosh` (both platforms) and `tailscale` (linux only) in `packages/packages.yaml`. Tailscale isn't in the default apt repos, so the entry carries an `apt_install` command and `packages/sync.sh` surfaces Tailscale's official installer (`curl … | sh`, which adds their apt repo) instead of a misleading `apt-get install tailscale`.
+- `~/.zshenv` (root `zshenv` file) sets a UTF-8 `LANG` default — mosh refuses to start without a UTF-8 locale — and prepends `/opt/homebrew/bin` so a non-interactive inbound SSH/mosh session finds `mosh-server` on Apple Silicon (it isn't on macOS `path_helper`'s default PATH).
+- `tmux.conf` already supports `tmux new -A -s` (attach-or-create); no tmux change is needed.
+
+**Manual, one-time steps (cannot be dotfiles):**
+
+- **macOS, to mosh *into* this Mac**: enable OpenSSH — System Settings → General → Sharing → **Remote Login** (or `sudo systemsetup -setremotelogin on`). mosh bootstraps over OpenSSH, so this is required even though Tailscale is the transport; the website-installed GUI Tailscale stays as-is (never run two macOS variants side by side). Tailscale's *own* SSH server is a separate feature only the open-source CLI variant can run — not needed for the mosh path.
+- **Linux host**: `curl -fsSL https://tailscale.com/install.sh | sh`, then `sudo systemctl enable --now ssh` and `locale-gen en_US.UTF-8` (mosh's UTF-8 requirement on the server side).
+- **Both**: `tailscale up` (add `--ssh` only if you want Tailscale's built-in SSH). Connect by MagicDNS name (`mtmux <machine>`); the default ACL already permits your own devices.
+
 ## Pre-Commit Hooks (prek)
 
 Pre-commit hooks are managed by [prek](https://prek.j178.dev/) via `prek.toml`. Hooks run automatically on commit and include: trailing whitespace, secret detection, shellcheck, large file checks, and a claude config sync check. Run `prek install` after cloning to set up hooks.

--- a/packages/packages.yaml
+++ b/packages/packages.yaml
@@ -3,12 +3,16 @@
 # Bare string = brew (mac) / apt (linux)
 # Key-value = override defaults
 #
-#   source:   brew (default) | cask | tap | cargo | npm | uv | gh-extension
-#   dev:      only when DOTFILES_DEV=true
-#   apt:      override name for linux
-#   platform: mac | linux (default: both)
-#   flags:    extra args spliced into the installer (uv source only;
-#             e.g. ["--python", "3.13", "--prerelease=allow"])
+#   source:      brew (default) | cask | tap | cargo | npm | uv | gh-extension
+#   dev:         only when DOTFILES_DEV=true
+#   apt:         override name for linux
+#   apt_install: custom install command surfaced on linux when the package is
+#                missing (for packages not in the default apt repos, e.g.
+#                Tailscale's own apt source). sync_apt prints this verbatim
+#                instead of the plain `sudo apt-get install` batch line.
+#   platform:    mac | linux (default: both)
+#   flags:       extra args spliced into the installer (uv source only;
+#                e.g. ["--python", "3.13", "--prerelease=allow"])
 
 packages:
   - tinted-theming/tinted: { source: tap }
@@ -55,6 +59,13 @@ packages:
   - vhs
   - gettext
   - taf2/tap/mdvi
+
+  # Remote access (Tailscale mesh VPN → SSH bootstrap → mosh → tmux)
+  - mosh                                        # resilient mobile shell (UDP 60000-61000); survives roaming/sleep
+  # Tailscale: macOS uses the website/App Store install (a single GUI variant —
+  # never run two variants side by side). Linux isn't in the default apt repos,
+  # so apt_install surfaces Tailscale's official installer (adds their apt repo).
+  - tailscale: { platform: linux, apt_install: "curl -fsSL https://tailscale.com/install.sh | sh" }
   - anomalyco/tap/opencode                    # open-source AI coding agent (fresher than homebrew-core)
 
   # Rust build acceleration

--- a/packages/sync.sh
+++ b/packages/sync.sh
@@ -438,10 +438,19 @@ sync_gh_extensions() {
 
 ########## APT
 
+# Custom apt_install command for a linux package name (apt override or entry
+# key). Empty when the package has no apt_install field. Plain yq lookup —
+# avoids bash-4 associative arrays so the apt path runs under bash 3.2 too.
+apt_custom_cmd() {
+    local pkg="$1"
+    yq -r ".packages[] | select(kind == \"map\") | to_entries[0] | select((.value.apt // .key) == \"$pkg\" and .value.apt_install != null) | .value.apt_install" "$PACKAGES_FILE" 2>/dev/null | head -1
+}
+
+# Classifies one package into the right global bucket. Uses plain global
+# arrays (APT_MISSING / APT_CUSTOM_MISSING) rather than namerefs so it works
+# on bash 3.2 (macOS) as well as the bash 4.3+ on real apt hosts.
 apt_check_pkg() {
     local pkg="$1"
-    # shellcheck disable=SC2178  # nameref to caller's array
-    local -n _missing="$2"
     if [[ "$pkg" == "yq" ]]; then
         if command -v yq &>/dev/null; then
             echo "  + $pkg"
@@ -452,9 +461,14 @@ apt_check_pkg() {
     fi
     if dpkg -s "$pkg" &>/dev/null; then
         echo "  + $pkg"
+        return
+    fi
+    if printf '%s\n' "$APT_CUSTOM_NAMES" | grep -qx "$pkg"; then
+        echo "  - $pkg (missing — needs custom apt source)"
+        APT_CUSTOM_MISSING+=("$pkg")
     else
         echo "  - $pkg (missing)"
-        _missing+=("$pkg")
+        APT_MISSING+=("$pkg")
     fi
 }
 
@@ -462,26 +476,40 @@ sync_apt() {
     command -v apt-get &>/dev/null || return 0
 
     log_info "Checking apt packages"
-    local missing=()
+    APT_MISSING=()
+    APT_CUSTOM_MISSING=()
+    # Newline-separated linux package names that carry a custom apt_install
+    # command (outside the default apt repos, e.g. Tailscale's own source).
+    APT_CUSTOM_NAMES="$(yq -r '.packages[] | select(kind == "map") | to_entries[0] | select(.value.apt_install != null) | (.value.apt // .key)' "$PACKAGES_FILE" 2>/dev/null)"
 
     echo -e "\n${GREEN}Packages:${NC}"
     while IFS= read -r pkg; do
         [[ -z "$pkg" ]] && continue
-        apt_check_pkg "$pkg" missing
+        apt_check_pkg "$pkg"
     done <<< "$(get_platform_pkgs)"
 
     if [[ "${DOTFILES_DEV:-false}" == "true" ]]; then
         echo -e "\n${GREEN}Dev packages:${NC}"
         while IFS= read -r pkg; do
             [[ -z "$pkg" ]] && continue
-            apt_check_pkg "$pkg" missing
+            apt_check_pkg "$pkg"
         done <<< "$(get_platform_pkgs "--dev")"
     fi
 
-    if ((${#missing[@]})); then
+    if ((${#APT_MISSING[@]})); then
         echo ""
-        log_warning "Missing packages: ${missing[*]}"
-        echo "  sudo apt-get install -y ${missing[*]}"
+        log_warning "Missing packages: ${APT_MISSING[*]}"
+        echo "  sudo apt-get install -y ${APT_MISSING[*]}"
+    fi
+
+    if ((${#APT_CUSTOM_MISSING[@]})); then
+        echo ""
+        log_warning "Packages needing a custom apt source (run the listed command):"
+        local p
+        for p in "${APT_CUSTOM_MISSING[@]}"; do
+            echo "  $p:"
+            echo "    $(apt_custom_cmd "$p")"
+        done
     fi
 }
 

--- a/packages/sync.sh
+++ b/packages/sync.sh
@@ -439,11 +439,13 @@ sync_gh_extensions() {
 ########## APT
 
 # Custom apt_install command for a linux package name (apt override or entry
-# key). Empty when the package has no apt_install field. Plain yq lookup —
-# avoids bash-4 associative arrays so the apt path runs under bash 3.2 too.
+# key). Reads from the APT_CUSTOM_CMDS map (newline-separated "name<TAB>cmd"
+# pairs) populated once at the top of sync_apt — avoids re-shelling yq per
+# package, and avoids bash-4 associative arrays so the apt path runs under
+# bash 3.2 too. Empty when the package has no apt_install field.
 apt_custom_cmd() {
     local pkg="$1"
-    yq -r ".packages[] | select(kind == \"map\") | to_entries[0] | select((.value.apt // .key) == \"$pkg\" and .value.apt_install != null) | .value.apt_install" "$PACKAGES_FILE" 2>/dev/null | head -1
+    printf '%s\n' "$APT_CUSTOM_CMDS" | awk -F'\t' -v p="$pkg" '$1 == p { print $2; exit }'
 }
 
 # Classifies one package into the right global bucket. Uses plain global
@@ -478,9 +480,12 @@ sync_apt() {
     log_info "Checking apt packages"
     APT_MISSING=()
     APT_CUSTOM_MISSING=()
-    # Newline-separated linux package names that carry a custom apt_install
-    # command (outside the default apt repos, e.g. Tailscale's own source).
-    APT_CUSTOM_NAMES="$(yq -r '.packages[] | select(kind == "map") | to_entries[0] | select(.value.apt_install != null) | (.value.apt // .key)' "$PACKAGES_FILE" 2>/dev/null)"
+    # One yq pass: emit "name<TAB>command" for every entry that carries a
+    # custom apt_install. APT_CUSTOM_NAMES = names only (for the membership
+    # check in apt_check_pkg); APT_CUSTOM_CMDS = the full map (for the
+    # printout). Both are populated once here, not per package.
+    APT_CUSTOM_CMDS="$(yq -r '.packages[] | select(kind == "map") | to_entries[0] | select(.value.apt_install != null) | ((.value.apt // .key) + "\t" + .value.apt_install)' "$PACKAGES_FILE" 2>/dev/null)"
+    APT_CUSTOM_NAMES="$(printf '%s\n' "$APT_CUSTOM_CMDS" | awk -F'\t' 'NF { print $1 }')"
 
     echo -e "\n${GREEN}Packages:${NC}"
     while IFS= read -r pkg; do

--- a/tests/packages.bats
+++ b/tests/packages.bats
@@ -396,7 +396,10 @@ YAML
     assert_success
 
     assert_output_contains "+ tailscale"
-    ! grep -q "needs a custom apt source" <<< "$output"
+    # Match a stable fragment shared by both real strings — the per-package
+    # "needs custom apt source" line and the "needing a custom apt source"
+    # warning header (neither contains the literal "needs a custom apt source").
+    ! grep -q "custom apt source" <<< "$output"
     ! grep -q "install.sh" <<< "$output"
 }
 

--- a/tests/packages.bats
+++ b/tests/packages.bats
@@ -335,6 +335,71 @@ run_sync() {
     ! grep -q "gh extension upgrade" "$GH_LOG"
 }
 
+# --- Integration: apt custom-source (apt_install) ---
+
+# Force the Linux apt path on any host by mocking uname + apt tooling.
+# dpkg -s exits non-zero (nothing installed) so every package reads as missing.
+mock_linux_apt() {
+    cat > "$MOCK_BIN/uname" << 'EOF'
+#!/bin/bash
+echo "Linux"
+EOF
+    cat > "$MOCK_BIN/apt-get" << 'EOF'
+#!/bin/bash
+exit 0
+EOF
+    cat > "$MOCK_BIN/dpkg" << 'EOF'
+#!/bin/bash
+exit 1
+EOF
+    chmod +x "$MOCK_BIN/uname" "$MOCK_BIN/apt-get" "$MOCK_BIN/dpkg"
+}
+
+@test "apt routes apt_install packages to the custom-source section" {
+    mock_linux_apt
+    cat > "$PACKAGES_FILE" << 'YAML'
+packages:
+  - curl
+  - tailscale: { platform: linux, apt_install: "curl -fsSL https://tailscale.com/install.sh | sh" }
+YAML
+
+    run_sync
+    assert_success
+
+    # Custom installer surfaced verbatim, under the custom-source warning.
+    assert_output_contains "needing a custom apt source"
+    assert_output_contains "https://tailscale.com/install.sh"
+    # Ordinary missing packages still go through the plain apt-get batch line…
+    assert_output_contains "sudo apt-get install -y"
+    # …but tailscale must NOT be lumped into that batch line.
+    local batch
+    batch=$(grep -E 'sudo apt-get install -y' <<< "$output")
+    ! grep -q "tailscale" <<< "$batch"
+}
+
+@test "apt skips an installed apt_install package (no custom command shown)" {
+    mock_linux_apt
+    # dpkg reports tailscale present; everything else missing.
+    cat > "$MOCK_BIN/dpkg" << 'EOF'
+#!/bin/bash
+[[ "$2" == "tailscale" ]] && exit 0
+exit 1
+EOF
+    chmod +x "$MOCK_BIN/dpkg"
+
+    cat > "$PACKAGES_FILE" << 'YAML'
+packages:
+  - tailscale: { platform: linux, apt_install: "curl -fsSL https://tailscale.com/install.sh | sh" }
+YAML
+
+    run_sync
+    assert_success
+
+    assert_output_contains "+ tailscale"
+    ! grep -q "needs a custom apt source" <<< "$output"
+    ! grep -q "install.sh" <<< "$output"
+}
+
 # --- Integration: cache behavior ---
 
 @test "sync saves cache on success" {

--- a/zsh/aliases.zsh
+++ b/zsh/aliases.zsh
@@ -67,6 +67,25 @@ alias zrl="source ~/.zshrc"
 alias trl='tmux source-file ~/.tmux.conf && echo "tmux config reloaded"'
 
 # =============================================================================
+# Remote access (Tailscale + mosh + tmux)
+# =============================================================================
+# Canonical resilient remote shell: mosh keeps the connection alive across
+# network changes / sleep; tmux keeps the session alive across disconnects.
+# Usage: mtmux <host> [session]   (host = MagicDNS name or Tailscale IP)
+mtmux() {
+    local host="$1" session="${2:-main}"
+    if [[ -z "$host" ]]; then
+        echo "usage: mtmux <host> [session]" >&2
+        return 2
+    fi
+    mosh "$host" -- tmux new -A -s "$session"
+}
+
+# Tailscale shortcuts
+alias tss='tailscale status'
+alias tsip='tailscale ip -4'
+
+# =============================================================================
 # Search and Find (using ripgrep)
 # =============================================================================
 # Basic ripgrep shortcuts

--- a/zshenv
+++ b/zshenv
@@ -10,7 +10,8 @@ export LANG="${LANG:-en_US.UTF-8}"
 # Homebrew bin on PATH for non-interactive SSH/mosh sessions. On Apple Silicon
 # /opt/homebrew/bin is NOT in macOS path_helper's default PATH, so an inbound
 # `mosh thismac` can't find mosh-server without this. Interactive shells get it
-# via zsh/core.zsh; this covers the non-interactive bootstrap.
-if [[ "$OSTYPE" == darwin* && -d /opt/homebrew/bin ]]; then
+# via zsh/core.zsh; this covers the non-interactive bootstrap. Idempotent
+# guard so nested zsh invocations (or .zshrc re-prepending) don't grow PATH.
+if [[ "$OSTYPE" == darwin* && -d /opt/homebrew/bin && ":$PATH:" != *":/opt/homebrew/bin:"* ]]; then
   export PATH="/opt/homebrew/bin:$PATH"
 fi

--- a/zshenv
+++ b/zshenv
@@ -1,0 +1,16 @@
+# .zshenv — sourced for EVERY zsh invocation, including non-interactive ones
+# (`ssh host <cmd>` and mosh's `mosh-server` bootstrap). Keep this minimal:
+# interactive setup lives in .zshrc → zsh/*.zsh. Only what the non-interactive
+# remote path needs belongs here.
+
+# UTF-8 locale — mosh refuses to start without a UTF-8 native locale, and it
+# forwards LANG/LC_* to mosh-server over SSH. Respect an already-set locale.
+export LANG="${LANG:-en_US.UTF-8}"
+
+# Homebrew bin on PATH for non-interactive SSH/mosh sessions. On Apple Silicon
+# /opt/homebrew/bin is NOT in macOS path_helper's default PATH, so an inbound
+# `mosh thismac` can't find mosh-server without this. Interactive shells get it
+# via zsh/core.zsh; this covers the non-interactive bootstrap.
+if [[ "$OSTYPE" == darwin* && -d /opt/homebrew/bin ]]; then
+  export PATH="/opt/homebrew/bin:$PATH"
+fi


### PR DESCRIPTION
## What

Wires the resilient remote-shell stack for both macOS and Linux:

**Tailscale** (private mesh transport) → **OpenSSH** bootstrap → **mosh** (UDP shell that survives roaming/sleep) → **tmux** (session persistence across disconnects).

Canonical usage, via a new `mtmux` helper:

```bash
mtmux <host> [session]   # = mosh <host> -- tmux new -A -s <session>
```

## Wired automatically (`dots sync`)

- **`packages/packages.yaml`** — `mosh` (both platforms) and `tailscale` (linux-only). Tailscale isn't in the default apt repos, so a new **`apt_install`** field carries its official installer.
- **`packages/sync.sh`** — the apt path now routes `apt_install` packages to a "needs a custom apt source" section (prints Tailscale's `curl … | sh` installer instead of a misleading `apt-get install tailscale`). Refactored off bash-4 namerefs / associative arrays to plain global arrays + grep membership, so the apt path also runs under macOS bash 3.2.
- **`zshenv`** (new → `~/.zshenv`) — sets a UTF-8 `LANG` default (mosh hard-requires a UTF-8 locale) and prepends `/opt/homebrew/bin` so a non-interactive inbound SSH/mosh session finds `mosh-server` on Apple Silicon (it isn't on macOS `path_helper`'s default PATH).
- **`zsh/aliases.zsh`** — `mtmux` helper + `tss` / `tsip` Tailscale shortcuts.
- **`AGENTS.md`** — new "Remote Access" subsection.

`tmux.conf` needed **no change** — it already supports `tmux new -A -s` (attach-or-create).

## Tests

`tests/packages.bats` — two new cases covering `apt_install` routing (missing → custom-source section; installed → skipped), mocking `uname`/`apt-get`/`dpkg` so they run on any host. Full `packages.bats` green except one pre-existing, host-dependent failure (`cargo-install-update` test, unrelated to this change).

## Manual one-time steps (cannot be dotfiles)

- **macOS, to mosh *into* this Mac**: enable Remote Login (System Settings → General → Sharing, or `sudo systemsetup -setremotelogin on`). mosh bootstraps over OpenSSH; the website-installed GUI Tailscale stays as-is.
- **Linux host**: `curl -fsSL https://tailscale.com/install.sh | sh`, `sudo systemctl enable --now ssh`, `locale-gen en_US.UTF-8`.
- **Both**: `tailscale up`, then connect by MagicDNS name (`mtmux <machine>`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
