### PR TITLE
feat(agent-profile): derive base profile from registries (ap curds 1-5)

### DIFF
--- a/agent-profile/agent_profile/cli.py
+++ b/agent-profile/agent_profile/cli.py
@@ -239,7 +239,11 @@ def _fetch_external_skills(
     """Fetch every ``source:`` skill into each in-scope harness via
     ``gh skill install`` (spec curd 4). ``path:`` skills are copied by the
     renderers, so they are excluded here."""
-    from agent_profile.fetch import external_skills, fetch_external_skill
+    from agent_profile.fetch import (
+        SkillFetchError,
+        external_skills,
+        fetch_external_skill,
+    )
 
     ext = external_skills(manifest.skills)
     if not ext:
@@ -253,9 +257,17 @@ def _fetch_external_skills(
                 f"{skill['source']} {name or ''} -> {h}".rstrip(),
                 file=out,
             )
-            fetch_external_skill(
-                skill["source"], name, pin, h, _skill_fetch_runner
-            )
+            try:
+                fetch_external_skill(
+                    skill["source"], name, pin, h, _skill_fetch_runner
+                )
+            except SkillFetchError as exc:
+                raise CliError(f"{colors.RED}{exc}{colors.NC}") from exc
+            except OSError as exc:
+                raise CliError(
+                    f"{colors.RED}ap: cannot run 'gh skill install' "
+                    f"({exc}); is the gh CLI installed?{colors.NC}"
+                ) from exc
 
 
 def _set_files(target: Path, profile: str, new_files: list[str]) -> None:

--- a/agent-profile/agent_profile/cli.py
+++ b/agent-profile/agent_profile/cli.py
@@ -205,6 +205,8 @@ def cmd_install(
         written = renderer.render(manifest, target)
         all_new_files.extend(written)
 
+    _fetch_external_skills(manifest, harnesses, colors, out)
+
     new_files = sorted(set(all_new_files))
 
     if len(harnesses) == len(ALL_HARNESSES):
@@ -218,6 +220,42 @@ def cmd_install(
 
     print(f"{colors.GREEN}✓ Installed{colors.NC}", file=out)
     return 0
+
+
+def _skill_fetch_runner(argv: list[str]) -> int:
+    """Default ``gh skill install`` runner. Indirected through a module-level
+    name so tests can monkeypatch it without spawning ``gh``."""
+    from agent_profile.fetch import _default_runner
+
+    return _default_runner(argv)
+
+
+def _fetch_external_skills(
+    manifest: Any,
+    harnesses: list[str],
+    colors: _Colors,
+    out: Any,
+) -> None:
+    """Fetch every ``source:`` skill into each in-scope harness via
+    ``gh skill install`` (spec curd 4). ``path:`` skills are copied by the
+    renderers, so they are excluded here."""
+    from agent_profile.fetch import external_skills, fetch_external_skill
+
+    ext = external_skills(manifest.skills)
+    if not ext:
+        return
+    for h in harnesses:
+        for skill in ext:
+            name = skill.get("name")
+            pin = skill.get("pin")
+            print(
+                f"  {colors.BLUE}↳{colors.NC} fetching skill "
+                f"{skill['source']} {name or ''} -> {h}".rstrip(),
+                file=out,
+            )
+            fetch_external_skill(
+                skill["source"], name, pin, h, _skill_fetch_runner
+            )
 
 
 def _set_files(target: Path, profile: str, new_files: list[str]) -> None:

--- a/agent-profile/agent_profile/env.py
+++ b/agent-profile/agent_profile/env.py
@@ -1,0 +1,124 @@
+"""env.py — render-time ``${VAR}`` resolution from a ``.env`` mapping (spec D4).
+
+The registries carry ``${VAR}`` env references on MCP ``env:`` blocks (and,
+potentially, on skill/hook items). The bash sync resolved these at deploy
+time from the process environment seeded by a ``.env`` loader; this module is
+the Python parity:
+
+  - :func:`load_dotenv` mirrors ``mcp_load_dotenv`` (skip blanks/comments,
+    strip ``export`` and surrounding quotes, reject illegal identifiers,
+    keep everything after the first ``=`` as the value).
+  - :func:`resolve_env_value` expands every ``${VAR}`` in a string, failing
+    loud (:class:`EnvResolutionError`) on the first unset reference — naming
+    the missing var so the operator knows which credential to set.
+  - :func:`first_unset_var` reports the first unset ``${VAR}`` an item's
+    ``env`` block references, or ``None`` when all resolve. ``optional`` items
+    use this to skip non-fatally (parity with ``_mcp_first_unset_env_var``).
+  - :func:`resolve_item_env` returns an immutable-style copy of an item with
+    its ``env`` values fully resolved.
+
+Resolution is "fail fast and loud": an unset, non-optional ``${VAR}`` aborts
+the render rather than emitting a half-configured server entry.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+_VAR_RE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
+_IDENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+class EnvResolutionError(Exception):
+    """Raised when a referenced ``${VAR}`` is unset and the item is not
+    ``optional``. Carries the missing variable name so the operator can fix
+    the ``.env``."""
+
+
+def load_dotenv(path: Path) -> dict[str, str]:
+    """Parse a ``.env`` file into a ``{KEY: value}`` mapping.
+
+    Port of ``mcp_load_dotenv``: skip blank/comment lines, strip a leading
+    ``export`` and surrounding single/double quotes from the value, reject
+    keys that are not legal shell identifiers, and keep everything after the
+    first ``=`` as the value (so ``TOKEN=a=b`` -> ``a=b``). A missing file
+    yields an empty mapping (not an error)."""
+    if not path.is_file():
+        return {}
+    out: dict[str, str] = {}
+    for raw in path.read_text().splitlines():
+        line = raw.split("=", 1)
+        if len(line) != 2:
+            continue
+        key, val = line
+        key = key.removeprefix("export ").lstrip()
+        if not key or key.startswith("#"):
+            continue
+        if not _IDENT_RE.match(key):
+            continue
+        val = val.strip()
+        if len(val) >= 2 and val[0] == val[-1] and val[0] in ("'", '"'):
+            val = val[1:-1]
+        out[key] = val
+    return out
+
+
+def resolve_env_value(value: str, dotenv: dict[str, str]) -> str:
+    """Expand every ``${VAR}`` in ``value`` from ``dotenv``.
+
+    Fails loud on the first unset reference (left-to-right), naming the
+    missing variable. Strings with no reference pass through unchanged."""
+
+    def _sub(match: re.Match[str]) -> str:
+        var = match.group(1)
+        if var not in dotenv:
+            raise EnvResolutionError(
+                f"ap: env var ${{{var}}} is unset (referenced at render time; "
+                "set it in .env or mark the item optional)"
+            )
+        return dotenv[var]
+
+    return _VAR_RE.sub(_sub, value)
+
+
+def first_unset_var(item: dict[str, Any], dotenv: dict[str, str]) -> str | None:
+    """Return the first ``${VAR}`` an item's ``env`` block references that is
+    unset in ``dotenv``, or ``None`` when every reference resolves.
+
+    Used by ``optional`` items to decide whether to skip non-fatally (parity
+    with the bash ``_mcp_first_unset_env_var``). Iterates ``env`` values in
+    insertion order, then the references within each value left-to-right."""
+    env = item.get("env")
+    if not isinstance(env, dict):
+        return None
+    for val in env.values():
+        for match in _VAR_RE.finditer(str(val)):
+            var = match.group(1)
+            if var not in dotenv:
+                return var
+    return None
+
+
+def resolve_item_env(
+    item: dict[str, Any], dotenv: dict[str, str]
+) -> dict[str, Any]:
+    """Return a copy of ``item`` with its ``env`` values fully resolved.
+
+    Items without an ``env`` block are returned unchanged. An unset,
+    referenced ``${VAR}`` raises :class:`EnvResolutionError`, with the
+    offending item's name folded into the message for operator context."""
+    env = item.get("env")
+    if not isinstance(env, dict):
+        return item
+    resolved: dict[str, Any] = {}
+    for key, val in env.items():
+        try:
+            resolved[key] = resolve_env_value(str(val), dotenv)
+        except EnvResolutionError as exc:
+            name = item.get("name") or "<unnamed>"
+            raise EnvResolutionError(f"{exc} (item '{name}')")
+    out = dict(item)
+    out["env"] = resolved
+    return out

--- a/agent-profile/agent_profile/fetch.py
+++ b/agent-profile/agent_profile/fetch.py
@@ -1,0 +1,97 @@
+"""fetch.py — external (GitHub-fetched) skill install via ``gh skill install``.
+
+Spec curd 4 / decision D3: ``source:`` skills are fetched by shelling out to
+``gh skill install`` — no npx, no manual ``git clone``. ``path:`` (local-tree)
+skills are unchanged: the renderers copy them into the harness skill dirs, so
+they never reach this module.
+
+The invocation mirrors the existing ``chezmoi/lib/install-external.sh``::
+
+    gh skill install <repo> [<name>] --agent <gh-agent> --scope user --force [--pin <ref>]
+
+``--scope user`` installs into the harness's own user-level skill dir (the
+``ap`` profile install targets the harness config dir; gh owns the skill
+placement under it). ``--force`` matches the registry's always-overwrite
+contract.
+
+The harness names ``ap`` uses (``claude``/``codex``/``cursor``/``copilot``/
+``opencode``) differ from gh's ``--agent`` IDs for two harnesses; :data:`GH_AGENT`
+maps them.
+
+A ``runner`` callable is injected so the fetch is unit-testable without
+spawning ``gh``; the default runs the real subprocess.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from typing import Any, Callable
+
+# ap harness name -> gh skill `--agent` ID. Most pass through; claude and
+# copilot differ (verified against `gh skill install --help`).
+GH_AGENT = {
+    "claude": "claude-code",
+    "codex": "codex",
+    "cursor": "cursor",
+    "copilot": "github-copilot",
+    "opencode": "opencode",
+}
+
+Runner = Callable[[list[str]], int]
+
+
+class SkillFetchError(Exception):
+    """Raised when a skill cannot be fetched (unknown harness, or a non-zero
+    ``gh skill install`` exit)."""
+
+
+def gh_agent_for(harness: str) -> str:
+    """Map an ``ap`` harness name to its ``gh skill --agent`` ID. Fails loud
+    on an unknown harness rather than passing a bogus agent to ``gh``."""
+    try:
+        return GH_AGENT[harness]
+    except KeyError:
+        raise SkillFetchError(
+            f"ap: unknown harness '{harness}' for skill fetch "
+            f"(valid: {', '.join(sorted(GH_AGENT))})"
+        )
+
+
+def _default_runner(argv: list[str]) -> int:
+    return subprocess.run(argv, check=False).returncode
+
+
+def fetch_external_skill(
+    source: str,
+    name: str | None,
+    pin: str | None,
+    harness: str,
+    runner: Runner | None = None,
+) -> None:
+    """Install one external skill into ``harness`` via ``gh skill install``.
+
+    ``name`` is the optional explicit skill (omitted for a repo-level install
+    that auto-discovers every skill in the repo). ``pin`` appends
+    ``--pin <ref>`` for reproducible installs. A non-zero exit fails loud."""
+    run = runner or _default_runner
+    agent = gh_agent_for(harness)
+    argv = ["gh", "skill", "install", source]
+    if name:
+        argv.append(name)
+    argv += ["--agent", agent, "--scope", "user", "--force"]
+    if pin:
+        argv += ["--pin", pin]
+    rc = run(argv)
+    if rc != 0:
+        target = f"{source} {name}".strip()
+        raise SkillFetchError(
+            f"ap: gh skill install failed for '{target}' -> {harness} "
+            f"(exit {rc})"
+        )
+
+
+def external_skills(skills: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Select the ``source:`` (GitHub-fetched) skill items from a manifest's
+    skill list. ``path:`` (local-tree) items are excluded — they are copied by
+    the renderers, not fetched."""
+    return [s for s in skills if s.get("source")]

--- a/agent-profile/agent_profile/ingest.py
+++ b/agent-profile/agent_profile/ingest.py
@@ -1,0 +1,202 @@
+"""ingest.py — expand a ``registries:`` directive into profile item lists.
+
+The ``base`` profile (spec curd 1) declares::
+
+    registries:
+      mcps:   agents/mcp/registry.yaml
+      skills: [skills/_registry.yaml, skills/]
+      hooks:  agents/hooks/registry.yaml
+
+instead of inline ``mcps:`` / ``skills:`` / ``hooks:`` lists. This module is
+the *only* reader of the three separate registries — they stay the per-type
+edit surface (``mcp-edit`` / ``hook-edit`` / ``skill-edit``); ``base`` just
+unions them.
+
+:func:`expand_registries` reads each declared registry relative to the repo
+root, normalizes every entry into a profile *item* (the registry entry IS a
+profile item — no translation layer), stamps ``_source_dir`` so payload
+files resolve against the repo root, resolves ``${VAR}`` env refs at ingest
+time (spec D4), and drops ``optional`` MCPs whose referenced credential is
+unset (parity with the bash ``optional`` skip).
+
+Registry shapes consumed:
+
+  - **MCP** (``mcps: {name: {command, args, env, scope, gate_unless,
+    optional, harnesses, description}}``) — a mapping keyed by name; each
+    value becomes an item with ``name`` folded in. Carries the curd-2 parity
+    fields (``scope``, ``gate_unless``, ``args_by_harness``) through verbatim
+    for the renderers to consume.
+  - **Hook** (``hooks: {name: {event, script, shared_assets, matcher,
+    timeout, harnesses, description}}``) — same name-keyed mapping shape.
+  - **Skills** — two sources unioned: the external ``_registry.yaml``
+    (``sources: {OWNER/REPO: {description, pin, skills}}``) yields ``source:``
+    items (one per explicitly-named skill, or one per repo when names are
+    auto-discovered downstream), and the local ``skills/`` tree yields
+    ``path:`` items for every ``<name>/SKILL.md`` present.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from agent_profile.env import first_unset_var, resolve_item_env
+
+
+def _as_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    return list(value)
+
+
+def _load_yaml_mapping(path: Path) -> dict[str, Any]:
+    raw = yaml.safe_load(path.read_text()) or {}
+    return raw if isinstance(raw, dict) else {}
+
+
+def _expand_mcps(
+    path: Path, source_dir: str, dotenv: dict[str, str]
+) -> list[dict[str, Any]]:
+    """Normalize the MCP registry mapping into a profile item list.
+
+    Each named entry becomes ``{name, ...fields, _source_dir}``. ``env``
+    blocks resolve at ingest. An ``optional`` MCP whose referenced ``${VAR}``
+    is unset is dropped non-fatally; a required MCP with an unset ref fails
+    loud via :func:`resolve_item_env`."""
+    data = _load_yaml_mapping(path)
+    mcps = data.get("mcps") or {}
+    out: list[dict[str, Any]] = []
+    for name, body in mcps.items():
+        if not isinstance(body, dict):
+            continue
+        item: dict[str, Any] = {"name": name, **body, "_source_dir": source_dir}
+        if item.get("optional") and first_unset_var(item, dotenv) is not None:
+            continue
+        out.append(resolve_item_env(item, dotenv))
+    return out
+
+
+def _expand_hooks(
+    path: Path, source_dir: str, dotenv: dict[str, str]
+) -> list[dict[str, Any]]:
+    """Normalize the hook registry mapping into a profile item list."""
+    data = _load_yaml_mapping(path)
+    hooks = data.get("hooks") or {}
+    out: list[dict[str, Any]] = []
+    for name, body in hooks.items():
+        if not isinstance(body, dict):
+            continue
+        item = {"name": name, **body, "_source_dir": source_dir}
+        out.append(resolve_item_env(item, dotenv))
+    return out
+
+
+def _expand_external_skills(
+    path: Path, source_dir: str
+) -> list[dict[str, Any]]:
+    """Normalize ``_registry.yaml`` ``sources:`` into ``source:`` skill items.
+
+    A source with an explicit ``skills:`` list yields one item per named
+    skill (each carrying the shared ``pin``); a source without one yields a
+    single repo-level item whose names are resolved at fetch time by
+    ``gh skill install`` (auto-discovery)."""
+    data = _load_yaml_mapping(path)
+    sources = data.get("sources") or {}
+    out: list[dict[str, Any]] = []
+    for repo, body in sources.items():
+        body = body or {}
+        pin = body.get("pin")
+        names = _as_list(body.get("skills"))
+        if names:
+            for name in names:
+                item: dict[str, Any] = {
+                    "name": name,
+                    "source": repo,
+                    "_source_dir": source_dir,
+                }
+                if pin:
+                    item["pin"] = pin
+                out.append(item)
+        else:
+            item = {"source": repo, "_source_dir": source_dir}
+            if pin:
+                item["pin"] = pin
+            out.append(item)
+    return out
+
+
+def _expand_local_skills(
+    tree: Path, source_dir: str
+) -> list[dict[str, Any]]:
+    """Yield a ``path:`` skill item for every ``<name>/SKILL.md`` under
+    the local skills tree, in sorted name order. Dirs lacking ``SKILL.md``
+    are not skills and are skipped."""
+    out: list[dict[str, Any]] = []
+    if not tree.is_dir():
+        return out
+    rel_root = tree.name
+    for child in sorted(tree.iterdir()):
+        if not child.is_dir():
+            continue
+        if not (child / "SKILL.md").is_file():
+            continue
+        out.append(
+            {
+                "name": child.name,
+                "path": f"{rel_root}/{child.name}",
+                "_source_dir": source_dir,
+            }
+        )
+    return out
+
+
+def _expand_skills(
+    paths: list[str], repo_root: Path, source_dir: str
+) -> list[dict[str, Any]]:
+    """Union external (``_registry.yaml``) and local-tree skill items.
+
+    Each declared skills path is either a file (the external registry) or a
+    directory (the local tree); they are dispatched by suffix/kind."""
+    out: list[dict[str, Any]] = []
+    for rel in paths:
+        target = repo_root / rel
+        if rel.endswith(".yaml") or rel.endswith(".yml"):
+            out.extend(_expand_external_skills(target, source_dir))
+        else:
+            out.extend(_expand_local_skills(target, source_dir))
+    return out
+
+
+def expand_registries(
+    directive: dict[str, Any],
+    repo_root: Path,
+    dotenv: dict[str, str],
+) -> dict[str, list[dict[str, Any]]]:
+    """Expand a ``registries:`` directive into ``{mcps, skills, hooks}`` item
+    lists, each item carrying ``_source_dir = str(repo_root)``.
+
+    ``directive`` maps each section to a registry path (or, for skills, a
+    list of paths: the external registry plus the local tree). ``dotenv``
+    resolves ``${VAR}`` env refs at ingest (spec D4). Sections absent from
+    the directive yield empty lists."""
+    repo_root = Path(repo_root)
+    source_dir = str(repo_root)
+    out: dict[str, list[dict[str, Any]]] = {"mcps": [], "skills": [], "hooks": []}
+
+    mcps_path = directive.get("mcps")
+    if mcps_path:
+        out["mcps"] = _expand_mcps(repo_root / mcps_path, source_dir, dotenv)
+
+    hooks_path = directive.get("hooks")
+    if hooks_path:
+        out["hooks"] = _expand_hooks(repo_root / hooks_path, source_dir, dotenv)
+
+    skills_paths = _as_list(directive.get("skills"))
+    if skills_paths:
+        out["skills"] = _expand_skills(skills_paths, repo_root, source_dir)
+
+    return out

--- a/agent-profile/agent_profile/ingest.py
+++ b/agent-profile/agent_profile/ingest.py
@@ -108,7 +108,10 @@ def _expand_external_skills(
     sources = data.get("sources") or {}
     out: list[dict[str, Any]] = []
     for repo, body in sources.items():
-        body = body or {}
+        if body is None:
+            body = {}  # bare `owner/repo:` → repo-level auto-discovery
+        elif not isinstance(body, dict):
+            continue  # malformed non-mapping body (typo) — skip, as MCP/hook readers do
         pin = body.get("pin")
         names = _as_list(body.get("skills"))
         if names:

--- a/agent-profile/agent_profile/parse.py
+++ b/agent-profile/agent_profile/parse.py
@@ -22,6 +22,7 @@ Parity notes (must match parse.sh observably):
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -33,6 +34,8 @@ from agent_profile._validate import (
     _validate_name,
     _validate_relpath,
 )
+from agent_profile.env import load_dotenv
+from agent_profile.ingest import expand_registries
 
 _ITEM_SECTIONS = ("mcps", "agents", "skills", "commands", "hooks")
 
@@ -135,17 +138,52 @@ def parse_one(profile_dir: Path) -> dict[str, Any]:
             out.append(entry)
         return out
 
+    reg = _expand_registries_directive(raw.get("registries"))
+
     return {
         "name": name,
         "description": raw.get("description") or "",
         "include": raw.get("include") or [],
-        "mcps": _decorate(raw.get("mcps") or []),
+        # Registry-derived items come first; inline items append (matching
+        # the include "outer last" convention so an inline override on a
+        # name-collision wins on scalar/object merges downstream).
+        "mcps": reg["mcps"] + _decorate(raw.get("mcps") or []),
         "agents": _decorate(raw.get("agents") or []),
-        "skills": _decorate(raw.get("skills") or []),
+        "skills": reg["skills"] + _decorate(raw.get("skills") or []),
         "commands": _decorate(raw.get("commands") or []),
-        "hooks": _decorate(raw.get("hooks") or []),
+        "hooks": reg["hooks"] + _decorate(raw.get("hooks") or []),
         "settings": raw.get("settings") or {},
     }
+
+
+def _repo_root() -> Path:
+    """The dotfiles repo root that holds the three registries + ``.env``.
+
+    Mirrors :func:`agent_profile.discover.search_roots` — ``DOTFILES_DIR``
+    with the same ``$HOME/Dev/dotfiles`` default."""
+    return Path(os.environ.get("DOTFILES_DIR") or str(Path.home() / "Dev/dotfiles"))
+
+
+def _expand_registries_directive(
+    directive: Any,
+) -> dict[str, list[dict[str, Any]]]:
+    """Expand a profile's ``registries:`` directive into item lists.
+
+    Returns empty lists when the directive is absent. Reads the registries
+    relative to the dotfiles repo root and resolves ``${VAR}`` env refs from
+    ``$DOTFILES_DIR/.env`` (spec D4). The registry items carry the repo root
+    as their ``_source_dir`` (not the profile dir) since their payload files
+    live under the repo, not the profile."""
+    if not directive:
+        return {"mcps": [], "skills": [], "hooks": []}
+    if not isinstance(directive, dict):
+        raise ParseError(
+            "ap_parse_one: 'registries' must be a mapping of "
+            "section -> registry path(s)"
+        )
+    repo_root = _repo_root()
+    dotenv = load_dotenv(repo_root / ".env")
+    return expand_registries(directive, repo_root, dotenv)
 
 
 def _merge_two(a: dict[str, Any], b: dict[str, Any]) -> dict[str, Any]:

--- a/agent-profile/agent_profile/renderers/base.py
+++ b/agent-profile/agent_profile/renderers/base.py
@@ -42,12 +42,15 @@ default that every renderer shares.
 from __future__ import annotations
 
 import json
+import os
+import shutil
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 
 import tomlkit
 
 from agent_profile.parse import Manifest
+from agent_profile.shared import track_file
 
 # Hooks default to claude-only membership across every renderer.
 DEFAULT_HOOK_HARNESSES = ("claude",)
@@ -94,6 +97,26 @@ def includes_harness(
     return harness in item_harnesses(item, default)
 
 
+def gate_blocks(item: dict[str, Any], harness: str) -> bool:
+    """True iff ``item``'s ``gate_unless`` gate suppresses it for ``harness``.
+
+    Ports the claude-only bash filter::
+
+        map(select((.value.gate_unless // "") as $g | $g == "" or (env[$g] // "false") != "true"))
+
+    The gate is claude-scoped: codex/opencode/cursor/copilot ignore it (a
+    plugin-provided MCP is a claude concern). An item is blocked when it
+    carries a ``gate_unless`` var that is exactly ``"true"`` in the process
+    environment (the cheese-flow plugin seeds ``CHEESE_FLOW``), matching the
+    bash ``env[$g]`` read — not the ``.env`` file."""
+    if harness != "claude":
+        return False
+    gate = item.get("gate_unless")
+    if not gate:
+        return False
+    return os.environ.get(gate, "false") == "true"
+
+
 def mcps_for(
     manifest: Manifest,
     harness: str,
@@ -105,11 +128,14 @@ def mcps_for(
 
         [.mcps[] | select((.harnesses // <default>) | index("<h>") != null)]
 
-    The renderer curd passes the ``default`` its bash counterpart used."""
+    The renderer curd passes the ``default`` its bash counterpart used.
+    Claude additionally drops ``gate_unless`` MCPs whose gate var is set
+    (see :func:`gate_blocks`) — parity with ``mcp_filter_for_harness``."""
     return [
         mcp
         for mcp in manifest.mcps
         if includes_harness(mcp, harness, default)
+        and not gate_blocks(mcp, harness)
     ]
 
 
@@ -147,6 +173,45 @@ def mcp_server_entry(
     if extra:
         entry.update(extra)
     return entry
+
+
+def shared_asset_relpath(asset: str) -> str:
+    """Map a repo-relative ``shared_assets`` entry to its harness-root-relative
+    deploy path.
+
+    The registry declares assets as ``agents/<subdir>/<file>``; chezmoi deploys
+    them to ``~/.<harness>/<subdir>/<file>`` so the self-locating hook script
+    finds them at ``$(dirname SCRIPT_DIR)/<subdir>/<file>``. We replicate that
+    by dropping the leading repo subdir (``agents/``) and keeping the
+    remainder. Entries with no leading subdir pass through unchanged."""
+    parts = Path(asset).parts
+    if len(parts) <= 1:
+        return asset
+    return str(Path(*parts[1:]))
+
+
+def copy_hook_shared_assets(
+    hook: dict[str, Any],
+    harness_root: Path,
+    base: Path,
+    out_files: list[str],
+) -> None:
+    """Copy a hook's ``shared_assets`` to ``<harness_root>/<subdir>/<file>``.
+
+    Each asset is read relative to the hook's ``_source_dir`` and written
+    under ``harness_root`` at the path :func:`shared_asset_relpath` derives,
+    so the self-locating SessionStart script resolves its lib/bank. Missing
+    assets fail loud (a hook that ships a ``shared_assets`` ref but no file is
+    a profile bug, not a silent skip). Tracked relative to ``base`` for the
+    install manifest sweep."""
+    for asset in hook.get("shared_assets") or []:
+        src = Path(hook["_source_dir"]) / asset
+        if not src.is_file():
+            raise FileNotFoundError(f"hook shared_asset not found: {src}")
+        dst = harness_root / shared_asset_relpath(asset)
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(src, dst)
+        track_file(out_files, str(dst.relative_to(base)))
 
 
 def body_abs(item: dict[str, Any], body_key: str = "body_path") -> Path | None:

--- a/agent-profile/agent_profile/renderers/claude.py
+++ b/agent-profile/agent_profile/renderers/claude.py
@@ -38,6 +38,7 @@ from agent_profile import shared
 from agent_profile.parse import Manifest
 from agent_profile.renderers.base import (
     body_abs,
+    copy_hook_shared_assets,
     hooks_for,
     mcp_server_entry,
     mcps_for,
@@ -165,8 +166,10 @@ class ClaudeRenderer:
         out: list[str],
     ) -> None:
         for item in manifest.skills:
-            name = item["name"]
             path = item.get("path") or ""
+            if not path:
+                continue  # source: (gh-fetched) skill — handled by cmd_install
+            name = item["name"]
             src = Path(item["_source_dir"]) / path
             dst = plugin_dir / "skills" / name
             if src.is_dir():
@@ -237,6 +240,11 @@ class ClaudeRenderer:
             shutil.copyfile(src, dst)
             dst.chmod(dst.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
             self._track(out, base, dst)
+
+            # Deploy shared_assets alongside the script so the self-locating
+            # SessionStart script resolves its lib/bank under the plugin dir
+            # (HARNESS_ROOT = dirname(hooks/) = plugin_dir).
+            copy_hook_shared_assets(item, plugin_dir, base, out)
 
             cmd = "${CLAUDE_PLUGIN_ROOT}/hooks/" + basename
             hook_entries.setdefault(event, []).append(

--- a/agent-profile/agent_profile/renderers/codex.py
+++ b/agent-profile/agent_profile/renderers/codex.py
@@ -99,8 +99,10 @@ class CodexRenderer:
         self, manifest: Manifest, target: Path, out_files: list[str]
     ) -> None:
         for item in manifest.skills:
-            name = item["name"]
             rel_path = item.get("path") or ""
+            if not rel_path:
+                continue  # source: (gh-fetched) skill — handled by cmd_install
+            name = item["name"]
             src = Path(item["_source_dir"]) / rel_path
             if src.is_dir():
                 shared.copy_shared_skill(target, name, src, out_files)
@@ -149,6 +151,13 @@ class CodexRenderer:
             shutil.copy(script_src, abs_script)
             abs_script.chmod(abs_script.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
             shared.track_file(out_files, rel_script)
+
+            # Deploy shared_assets under .codex/ so the self-locating
+            # SessionStart script resolves its lib/bank (HARNESS_ROOT =
+            # dirname(.codex/hooks/) = .codex/).
+            base.copy_hook_shared_assets(
+                item, base_dir / ".codex", base_dir, out_files
+            )
 
             record: dict = {"event": event, "command": f"bash {rel_script}"}
             if matcher:

--- a/agent-profile/agent_profile/renderers/copilot.py
+++ b/agent-profile/agent_profile/renderers/copilot.py
@@ -145,8 +145,10 @@ class CopilotRenderer:
         self, manifest: Manifest, base: Path, out_files: list[str]
     ) -> None:
         for skill in manifest.skills:
-            name = skill["name"]
             path = skill.get("path") or ""
+            if not path:
+                continue  # source: (gh-fetched) skill — handled by cmd_install
+            name = skill["name"]
             src = Path(skill["_source_dir"]) / path
             if not src.is_dir():
                 _warn(f"copilot: skill '{name}' source dir not found: {src}")

--- a/agent-profile/tests/test_env.py
+++ b/agent-profile/tests/test_env.py
@@ -1,0 +1,185 @@
+"""test_env.py — render-time ${VAR} resolution from .env (spec D4).
+
+Env refs in MCP/skill/hook items resolve at render time from a .env-style
+mapping; unset references fail loud unless the item is `optional`, in which
+case the item is dropped non-fatally. Mirrors the bash mcp_load_dotenv +
+mcp_build_env_flags / _mcp_first_unset_env_var semantics.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_profile.env import (
+    EnvResolutionError,
+    first_unset_var,
+    load_dotenv,
+    resolve_env_value,
+    resolve_item_env,
+)
+
+
+# ─── load_dotenv ──────────────────────────────────────────────────────
+
+
+def test_load_dotenv_parses_key_values(tmp_path):
+    f = tmp_path / ".env"
+    f.write_text("TAVILY_API_KEY=abc123\nTODOIST_API_KEY=xyz\n")
+    assert load_dotenv(f) == {"TAVILY_API_KEY": "abc123", "TODOIST_API_KEY": "xyz"}
+
+
+def test_load_dotenv_strips_export_and_quotes(tmp_path):
+    f = tmp_path / ".env"
+    f.write_text('export FOO="bar"\nBAZ=\'qux\'\n')
+    out = load_dotenv(f)
+    assert out["FOO"] == "bar"
+    assert out["BAZ"] == "qux"
+
+
+def test_load_dotenv_skips_comments_and_blanks(tmp_path):
+    f = tmp_path / ".env"
+    f.write_text("# a comment\n\nKEY=val\n  # indented comment\n")
+    assert load_dotenv(f) == {"KEY": "val"}
+
+
+def test_load_dotenv_rejects_illegal_identifiers(tmp_path):
+    f = tmp_path / ".env"
+    f.write_text("1BAD=x\nGOOD=y\nbad-key=z\n")
+    out = load_dotenv(f)
+    assert out == {"GOOD": "y"}
+
+
+def test_load_dotenv_missing_file_returns_empty(tmp_path):
+    assert load_dotenv(tmp_path / "nope.env") == {}
+
+
+def test_load_dotenv_value_with_equals_sign(tmp_path):
+    # A value containing '=' (e.g. base64 padding) keeps everything after
+    # the first '='.
+    f = tmp_path / ".env"
+    f.write_text("TOKEN=a=b=c\n")
+    assert load_dotenv(f) == {"TOKEN": "a=b=c"}
+
+
+def test_load_dotenv_duplicate_key_last_wins(tmp_path):
+    # Two assignments to the same key: the later line wins (dict insertion
+    # overwrite), matching shell `export` re-assignment.
+    f = tmp_path / ".env"
+    f.write_text("K=first\nK=second\n")
+    assert load_dotenv(f) == {"K": "second"}
+
+
+def test_load_dotenv_empty_value(tmp_path):
+    # `KEY=` is a legal assignment to the empty string, not a skipped line.
+    f = tmp_path / ".env"
+    f.write_text("EMPTY=\nFILLED=x\n")
+    out = load_dotenv(f)
+    assert out["EMPTY"] == ""
+    assert out["FILLED"] == "x"
+
+
+def test_load_dotenv_hash_inside_value_is_kept(tmp_path):
+    # Only whole-line comments are dropped (key starts with '#'). A '#' after
+    # the '=' is part of the value — the loader does not strip trailing
+    # comments (parity with mcp_load_dotenv, which keeps everything after '=').
+    f = tmp_path / ".env"
+    f.write_text("URL=https://x/y#frag\n")
+    assert load_dotenv(f) == {"URL": "https://x/y#frag"}
+
+
+def test_load_dotenv_unmatched_quote_not_stripped(tmp_path):
+    # Quote stripping only fires on a matched leading+trailing pair; a value
+    # with a lone quote keeps it (the matched-pair guard, not blind strip).
+    f = tmp_path / ".env"
+    f.write_text('K="abc\n')
+    assert load_dotenv(f) == {"K": '"abc'}
+
+
+# ─── resolve_env_value ────────────────────────────────────────────────
+
+
+def test_resolve_env_value_substitutes(tmp_path):
+    assert resolve_env_value("${FOO}", {"FOO": "bar"}) == "bar"
+
+
+def test_resolve_env_value_embedded(tmp_path):
+    assert resolve_env_value("pre-${FOO}-post", {"FOO": "X"}) == "pre-X-post"
+
+
+def test_resolve_env_value_no_ref_passthrough():
+    assert resolve_env_value("plain", {}) == "plain"
+
+
+def test_resolve_env_value_unset_raises():
+    with pytest.raises(EnvResolutionError) as exc:
+        resolve_env_value("${MISSING}", {})
+    assert "MISSING" in str(exc.value)
+
+
+def test_resolve_env_value_multiple_refs_first_unset_named():
+    with pytest.raises(EnvResolutionError) as exc:
+        resolve_env_value("${SET}-${ALSO_MISSING}", {"SET": "ok"})
+    assert "ALSO_MISSING" in str(exc.value)
+
+
+# ─── first_unset_var ──────────────────────────────────────────────────
+
+
+def test_first_unset_var_finds_missing():
+    item = {"env": {"K": "${MISSING}"}}
+    assert first_unset_var(item, {}) == "MISSING"
+
+
+def test_first_unset_var_none_when_all_set():
+    item = {"env": {"K": "${SET}"}}
+    assert first_unset_var(item, {"SET": "v"}) is None
+
+
+def test_first_unset_var_none_when_no_env():
+    assert first_unset_var({"command": "x"}, {}) is None
+
+
+def test_first_unset_var_reports_first_in_insertion_order():
+    # The docstring promises insertion order across env entries, left-to-right
+    # within a value. With two unset vars across two keys, the FIRST key's var
+    # is reported — locks the "first" contract that drives the optional skip.
+    item = {"env": {"A": "${MISS_A}", "B": "${MISS_B}"}}
+    assert first_unset_var(item, {}) == "MISS_A"
+
+
+def test_first_unset_var_skips_set_then_reports_unset():
+    # A resolvable first entry does not short-circuit; the scan continues to
+    # the first genuinely-unset reference.
+    item = {"env": {"A": "${SET}", "B": "${MISS}"}}
+    assert first_unset_var(item, {"SET": "v"}) == "MISS"
+
+
+def test_first_unset_var_detects_embedded_ref():
+    # An embedded (non-anchored) ${VAR} is still detected — finditer, not a
+    # whole-value anchor. (Superset of the bash anchored match.)
+    item = {"env": {"K": "prefix-${MISS}-suffix"}}
+    assert first_unset_var(item, {}) == "MISS"
+
+
+# ─── resolve_item_env ─────────────────────────────────────────────────
+
+
+def test_resolve_item_env_returns_resolved_copy():
+    item = {"name": "todoist", "env": {"TODOIST_API_KEY": "${KEY}"}}
+    out = resolve_item_env(item, {"KEY": "secret"})
+    assert out["env"]["TODOIST_API_KEY"] == "secret"
+    # Original untouched (immutable pattern).
+    assert item["env"]["TODOIST_API_KEY"] == "${KEY}"
+
+
+def test_resolve_item_env_no_env_passthrough():
+    item = {"name": "x", "command": "y"}
+    assert resolve_item_env(item, {}) == item
+
+
+def test_resolve_item_env_unset_raises_with_item_name():
+    item = {"name": "todoist", "env": {"K": "${MISSING}"}}
+    with pytest.raises(EnvResolutionError) as exc:
+        resolve_item_env(item, {})
+    assert "MISSING" in str(exc.value)
+    assert "todoist" in str(exc.value)

--- a/agent-profile/tests/test_fetch.py
+++ b/agent-profile/tests/test_fetch.py
@@ -1,0 +1,106 @@
+"""test_fetch.py — external skill fetch via `gh skill install` (spec curd 4).
+
+`source:` skills shell out to `gh skill install <repo> [<name>] --agent
+<gh-agent> --scope user --force [--pin <ref>]`, mirroring the existing
+chezmoi install-external.sh invocation. `path:` (local-tree) skills are
+unchanged — they are copied by the renderers, not fetched here.
+
+The runner is injected so tests assert the exact argv without spawning gh.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_profile.fetch import (
+    GH_AGENT,
+    SkillFetchError,
+    external_skills,
+    fetch_external_skill,
+    gh_agent_for,
+)
+
+
+# ─── harness -> gh agent mapping ──────────────────────────────────────
+
+
+def test_gh_agent_maps_claude_to_claude_code():
+    assert gh_agent_for("claude") == "claude-code"
+
+
+def test_gh_agent_maps_copilot_to_github_copilot():
+    assert gh_agent_for("copilot") == "github-copilot"
+
+
+def test_gh_agent_passes_through_codex_cursor_opencode():
+    assert gh_agent_for("codex") == "codex"
+    assert gh_agent_for("cursor") == "cursor"
+    assert gh_agent_for("opencode") == "opencode"
+
+
+def test_gh_agent_table_covers_all_five():
+    assert set(GH_AGENT) == {"claude", "codex", "cursor", "copilot", "opencode"}
+
+
+def test_gh_agent_unknown_harness_raises():
+    with pytest.raises(SkillFetchError, match="unknown harness"):
+        gh_agent_for("frobnicator")
+
+
+# ─── argv assembly ────────────────────────────────────────────────────
+
+
+def test_fetch_assembles_expected_argv():
+    calls = []
+
+    def runner(argv):
+        calls.append(argv)
+        return 0
+
+    fetch_external_skill("paulnsorensen/easy-cheese", "mold", None, "claude", runner)
+    assert calls == [
+        [
+            "gh", "skill", "install", "paulnsorensen/easy-cheese", "mold",
+            "--agent", "claude-code", "--scope", "user", "--force",
+        ]
+    ]
+
+
+def test_fetch_appends_pin_when_present():
+    calls = []
+    fetch_external_skill(
+        "owner/repo", "cook", "v1.2.3", "codex", lambda a: calls.append(a) or 0
+    )
+    assert "--pin" in calls[0]
+    assert calls[0][calls[0].index("--pin") + 1] == "v1.2.3"
+
+
+def test_fetch_omits_skill_name_for_repo_level_install():
+    calls = []
+    # No explicit skill name -> install the whole repo (auto-discovery).
+    fetch_external_skill("owner/repo", None, None, "cursor", lambda a: calls.append(a) or 0)
+    argv = calls[0]
+    # gh skill install <repo> --agent ... (no positional skill name)
+    assert argv[:4] == ["gh", "skill", "install", "owner/repo"]
+    assert argv[4] == "--agent"
+
+
+def test_fetch_nonzero_exit_raises():
+    with pytest.raises(SkillFetchError, match="gh skill install failed"):
+        fetch_external_skill("owner/repo", "x", None, "claude", lambda a: 3)
+
+
+# ─── external_skills selection ────────────────────────────────────────
+
+
+def test_external_skills_filters_source_items_only():
+    items = [
+        {"name": "mold", "source": "o/r"},
+        {"name": "de-slop", "path": "skills/de-slop"},  # local — excluded
+        {"source": "o/r2"},  # repo-level — included
+    ]
+    out = external_skills(items)
+    assert {tuple(sorted(s.items())) for s in out} == {
+        tuple(sorted({"name": "mold", "source": "o/r"}.items())),
+        tuple(sorted({"source": "o/r2"}.items())),
+    }

--- a/agent-profile/tests/test_hook_shared_assets.py
+++ b/agent-profile/tests/test_hook_shared_assets.py
@@ -1,0 +1,170 @@
+"""test_hook_shared_assets.py — hook shared_assets are deployed alongside
+the script so the self-locating SessionStart script resolves its lib/bank
+(spec curd 5).
+
+The session-start-cheese-flair.sh hook resolves LIB at
+``$(dirname $SCRIPT_DIR)/lib/<file>`` and BANK at ``.../reference/<file>``.
+Under the claude plugin layout the script lands at
+``.claude/plugins/local/<profile>/hooks/<script>``, so its HARNESS_ROOT is the
+plugin dir; assets must land at ``<plugin>/lib/...`` and ``<plugin>/reference/...``.
+Under codex the script lands at ``.codex/hooks/<script>`` so HARNESS_ROOT is
+``.codex/``; assets land at ``.codex/lib/...`` and ``.codex/reference/...``.
+
+The deployed asset path drops the leading repo subdir (``agents/``) and roots
+the remainder (``lib/<file>``) at the harness root — matching the chezmoi
+``agents/<subdir>/<file>`` -> ``~/.<harness>/<subdir>/<file>`` deploy rule.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent_profile.parse import parse_manifest
+from agent_profile.renderers.base import shared_asset_relpath
+from agent_profile.renderers.claude import ClaudeRenderer
+from agent_profile.renderers.codex import CodexRenderer
+
+from .conftest import write_profile
+
+_HOOK_PROFILE = """\
+name: flairprof
+hooks:
+  - name: session-start-cheese-flair
+    event: SessionStart
+    script: hooks/flair.sh
+    shared_assets:
+      - agents/lib/cheese-flair.sh
+      - agents/reference/cheese-flair.md
+    matcher: "startup|resume"
+    timeout: 5
+    harnesses: [claude, codex]
+"""
+
+
+def _materialize(profiles_root: Path) -> Path:
+    return write_profile(
+        profiles_root,
+        "flairprof",
+        _HOOK_PROFILE,
+        {
+            "hooks/flair.sh": "#!/usr/bin/env bash\necho flair\n",
+            "agents/lib/cheese-flair.sh": "# the lib\ncheese_sample() { :; }\n",
+            "agents/reference/cheese-flair.md": "# the bank\n- Cheese Lord\n",
+        },
+    )
+
+
+# ─── shared_asset_relpath unit (the deploy-path derivation) ───────────
+
+
+def test_relpath_drops_leading_repo_subdir():
+    # The chezmoi rule: agents/<subdir>/<file> -> <subdir>/<file> rooted at
+    # the harness root. The leading `agents/` component is dropped.
+    assert shared_asset_relpath("agents/lib/cheese-flair.sh") == "lib/cheese-flair.sh"
+    assert (
+        shared_asset_relpath("agents/reference/cheese-flair.md")
+        == "reference/cheese-flair.md"
+    )
+
+
+def test_relpath_keeps_deeper_subdirs():
+    # Only the FIRST component is dropped; deeper structure is preserved.
+    assert shared_asset_relpath("agents/lib/sub/x.sh") == "lib/sub/x.sh"
+
+
+def test_relpath_single_component_passthrough():
+    # A bare filename (no leading subdir) has nothing to drop and passes
+    # through unchanged — the len(parts) <= 1 branch.
+    assert shared_asset_relpath("flair.sh") == "flair.sh"
+
+
+# ─── claude ───────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def rendered_claude(env):
+    profile_dir = _materialize(env.profiles)
+    manifest = parse_manifest(profile_dir)
+    written = ClaudeRenderer().render(manifest, env.target)
+    return env.target, written
+
+
+def test_claude_copies_shared_assets_into_plugin_subdirs(rendered_claude):
+    target, _ = rendered_claude
+    plugin = target / ".claude/plugins/local/flairprof"
+    lib = plugin / "lib/cheese-flair.sh"
+    bank = plugin / "reference/cheese-flair.md"
+    assert lib.is_file()
+    assert bank.is_file()
+    assert lib.read_text() == "# the lib\ncheese_sample() { :; }\n"
+    assert bank.read_text() == "# the bank\n- Cheese Lord\n"
+
+
+def test_claude_shared_assets_are_tracked(rendered_claude):
+    _, written = rendered_claude
+    assert ".claude/plugins/local/flairprof/lib/cheese-flair.sh" in written
+    assert ".claude/plugins/local/flairprof/reference/cheese-flair.md" in written
+
+
+def test_claude_self_location_invariant(rendered_claude):
+    # The script's HARNESS_ROOT = dirname(hooks/) = the plugin dir. The lib
+    # it sources must sit at <HARNESS_ROOT>/lib/<file> for the hook to work.
+    target, _ = rendered_claude
+    plugin = target / ".claude/plugins/local/flairprof"
+    script = plugin / "hooks/flair.sh"
+    assert script.is_file()
+    harness_root = script.parent.parent
+    assert (harness_root / "lib/cheese-flair.sh").is_file()
+    assert (harness_root / "reference/cheese-flair.md").is_file()
+
+
+def test_claude_missing_shared_asset_fails_loud(env):
+    profile_dir = write_profile(
+        env.profiles,
+        "badassets",
+        "name: badassets\n"
+        "hooks:\n  - name: h\n    event: SessionStart\n    script: hooks/h.sh\n"
+        "    shared_assets: [agents/lib/missing.sh]\n",
+        {"hooks/h.sh": "#!/bin/bash\n"},
+    )
+    manifest = parse_manifest(profile_dir)
+    with pytest.raises(FileNotFoundError, match="missing.sh"):
+        ClaudeRenderer().render(manifest, env.target)
+
+
+# ─── codex ──────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def rendered_codex(env):
+    profile_dir = _materialize(env.profiles)
+    manifest = parse_manifest(profile_dir)
+    written = CodexRenderer().render(manifest, env.target)
+    return env.target, written
+
+
+def test_codex_copies_shared_assets_into_harness_root_subdirs(rendered_codex):
+    target, _ = rendered_codex
+    lib = target / ".codex/lib/cheese-flair.sh"
+    bank = target / ".codex/reference/cheese-flair.md"
+    assert lib.is_file()
+    assert bank.is_file()
+    assert lib.read_text() == "# the lib\ncheese_sample() { :; }\n"
+
+
+def test_codex_shared_assets_are_tracked(rendered_codex):
+    _, written = rendered_codex
+    assert ".codex/lib/cheese-flair.sh" in written
+    assert ".codex/reference/cheese-flair.md" in written
+
+
+def test_codex_self_location_invariant(rendered_codex):
+    # The codex script lands at .codex/hooks/flair.sh -> HARNESS_ROOT = .codex/.
+    target, _ = rendered_codex
+    script = target / ".codex/hooks/flair.sh"
+    assert script.is_file()
+    harness_root = script.parent.parent
+    assert (harness_root / "lib/cheese-flair.sh").is_file()
+    assert (harness_root / "reference/cheese-flair.md").is_file()

--- a/agent-profile/tests/test_ingest.py
+++ b/agent-profile/tests/test_ingest.py
@@ -262,3 +262,19 @@ def test_expand_mcps_skip_non_mapping_entries(repo):
     out = expand_registries(directive, root, _dotenv())
     names = [m["name"] for m in out["mcps"]]
     assert names == ["good"]
+
+
+def test_expand_external_skills_skip_non_mapping_source(repo):
+    root, directive = repo
+    # A malformed `sources:` body that is not a mapping (registry typo) is
+    # skipped, not crashed on — parity with the MCP/hook non-mapping skip. A
+    # bare `owner/repo:` (None body) stays a valid repo-level auto-discovery.
+    (root / "skills" / "_registry.yaml").write_text(
+        "sources:\n"
+        "  good/repo:\n    skills: [mold]\n"
+        "  bare/repo:\n"
+        "  bogus/repo: just-a-string\n"
+    )
+    out = expand_registries(directive, root, _dotenv())
+    sources = sorted({s["source"] for s in out["skills"] if "source" in s})
+    assert sources == ["bare/repo", "good/repo"]

--- a/agent-profile/tests/test_ingest.py
+++ b/agent-profile/tests/test_ingest.py
@@ -1,0 +1,264 @@
+"""test_ingest.py — registries: directive expansion (spec curd 1 + 2).
+
+The `base` profile declares a `registries:` directive instead of inline
+item lists. `expand_registries` reads the three separate registries (the
+MCP mapping, the hook mapping, the skills _registry.yaml + local skills/
+tree) and the env mapping, and returns normalized {mcps, skills, hooks}
+item lists — each item carrying `_source_dir` so payload files resolve.
+
+This is the ONLY place the registries are read; the registry files stay the
+per-type edit surface.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_profile.env import EnvResolutionError
+from agent_profile.ingest import expand_registries
+
+
+# ─── fixtures: a miniature dotfiles-shaped repo ───────────────────────
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """A miniature repo root holding the three registries + a skills tree."""
+    (tmp_path / "agents" / "mcp").mkdir(parents=True)
+    (tmp_path / "agents" / "hooks").mkdir(parents=True)
+    (tmp_path / "agents" / "lib").mkdir(parents=True)
+    (tmp_path / "skills").mkdir()
+
+    (tmp_path / "agents" / "mcp" / "registry.yaml").write_text(
+        "mcps:\n"
+        "  tilth:\n"
+        "    command: tilth\n"
+        "    args: ['--mcp']\n"
+        "    scope: user\n"
+        "    gate_unless: CHEESE_FLOW\n"
+        "    description: code search\n"
+        "  todoist:\n"
+        "    command: npx\n"
+        "    args: ['-y', '@doist/todoist-ai']\n"
+        "    env:\n"
+        "      TODOIST_API_KEY: '${TODOIST_API_KEY}'\n"
+        "    optional: true\n"
+        "    description: todoist\n"
+    )
+    (tmp_path / "agents" / "hooks" / "registry.yaml").write_text(
+        "hooks:\n"
+        "  session-start-cheese-flair:\n"
+        "    event: SessionStart\n"
+        "    script: agents/hooks/session-start-cheese-flair.sh\n"
+        "    shared_assets:\n"
+        "      - agents/lib/cheese-flair.sh\n"
+        "    harnesses: [claude, codex]\n"
+        "    matcher: 'startup|resume'\n"
+        "    timeout: 5\n"
+        "    description: flair\n"
+    )
+    (tmp_path / "agents" / "hooks" / "session-start-cheese-flair.sh").write_text(
+        "#!/bin/bash\necho flair\n"
+    )
+    (tmp_path / "agents" / "lib" / "cheese-flair.sh").write_text("# lib\n")
+
+    (tmp_path / "skills" / "_registry.yaml").write_text(
+        "sources:\n"
+        "  paulnsorensen/easy-cheese:\n"
+        "    description: cheese skills\n"
+        "    pin: v1.2.3\n"
+        "    skills: [mold, cook]\n"
+        "  tavily-ai/skills:\n"
+        "    description: tavily\n"
+    )
+    for skill in ("de-slop", "self-eval"):
+        d = tmp_path / "skills" / skill
+        d.mkdir()
+        (d / "SKILL.md").write_text(f"# {skill}\n")
+
+    directive = {
+        "mcps": "agents/mcp/registry.yaml",
+        "skills": ["skills/_registry.yaml", "skills/"],
+        "hooks": "agents/hooks/registry.yaml",
+    }
+    return tmp_path, directive
+
+
+def _dotenv():
+    return {"TODOIST_API_KEY": "secret", "CHEESE_FLOW": "false"}
+
+
+# ─── MCP ingestion (+ parity fields, curd 2) ──────────────────────────
+
+
+def test_expand_mcps_become_named_list(repo):
+    root, directive = repo
+    out = expand_registries(directive, root, _dotenv())
+    names = [m["name"] for m in out["mcps"]]
+    assert names == ["tilth", "todoist"]
+
+
+def test_expand_mcps_carry_parity_fields(repo):
+    root, directive = repo
+    out = expand_registries(directive, root, _dotenv())
+    tilth = next(m for m in out["mcps"] if m["name"] == "tilth")
+    assert tilth["command"] == "tilth"
+    assert tilth["args"] == ["--mcp"]
+    assert tilth["scope"] == "user"
+    assert tilth["gate_unless"] == "CHEESE_FLOW"
+
+
+def test_expand_mcps_source_dir_is_repo_root(repo):
+    root, directive = repo
+    out = expand_registries(directive, root, _dotenv())
+    assert out["mcps"][0]["_source_dir"] == str(root)
+
+
+def test_expand_mcps_env_resolved_at_ingest(repo):
+    root, directive = repo
+    out = expand_registries(directive, root, _dotenv())
+    todoist = next(m for m in out["mcps"] if m["name"] == "todoist")
+    assert todoist["env"]["TODOIST_API_KEY"] == "secret"
+
+
+def test_expand_optional_mcp_skipped_when_var_unset(repo):
+    root, directive = repo
+    out = expand_registries(directive, root, {"CHEESE_FLOW": "false"})
+    names = [m["name"] for m in out["mcps"]]
+    assert "todoist" not in names  # optional + TODOIST_API_KEY unset -> skipped
+    assert "tilth" in names
+
+
+def test_expand_required_mcp_unset_var_fails_loud(repo):
+    root, directive = repo
+    # Make tilth (non-optional) reference an unset var.
+    (root / "agents" / "mcp" / "registry.yaml").write_text(
+        "mcps:\n"
+        "  needvar:\n"
+        "    command: x\n"
+        "    env:\n      K: '${MUST_BE_SET}'\n"
+    )
+    with pytest.raises(EnvResolutionError) as exc:
+        expand_registries(directive, root, {})
+    assert "MUST_BE_SET" in str(exc.value)
+
+
+# ─── hook ingestion ───────────────────────────────────────────────────
+
+
+def test_expand_hooks_become_named_list(repo):
+    root, directive = repo
+    out = expand_registries(directive, root, _dotenv())
+    assert len(out["hooks"]) == 1
+    hook = out["hooks"][0]
+    assert hook["name"] == "session-start-cheese-flair"
+    assert hook["event"] == "SessionStart"
+    assert hook["script"] == "agents/hooks/session-start-cheese-flair.sh"
+    assert hook["shared_assets"] == ["agents/lib/cheese-flair.sh"]
+    assert hook["matcher"] == "startup|resume"
+    assert hook["timeout"] == 5
+    assert hook["harnesses"] == ["claude", "codex"]
+    assert hook["_source_dir"] == str(root)
+
+
+# ─── skill ingestion (external + local tree) ──────────────────────────
+
+
+def test_expand_skills_includes_external_sources(repo):
+    root, directive = repo
+    out = expand_registries(directive, root, _dotenv())
+    ext = [s for s in out["skills"] if s.get("source")]
+    by_source = {s["source"] for s in ext}
+    assert "paulnsorensen/easy-cheese" in by_source
+    assert "tavily-ai/skills" in by_source
+
+
+def test_expand_external_skill_carries_pin_and_explicit_names(repo):
+    root, directive = repo
+    out = expand_registries(directive, root, _dotenv())
+    easy = [s for s in out["skills"] if s.get("source") == "paulnsorensen/easy-cheese"]
+    # Explicit skills list -> one item per named skill, all carrying the pin.
+    names = sorted(s["name"] for s in easy)
+    assert names == ["cook", "mold"]
+    assert all(s["pin"] == "v1.2.3" for s in easy)
+
+
+def test_expand_skills_includes_local_tree(repo):
+    root, directive = repo
+    out = expand_registries(directive, root, _dotenv())
+    local = {s["name"]: s for s in out["skills"] if s.get("path")}
+    assert set(local) == {"de-slop", "self-eval"}
+    assert local["de-slop"]["path"] == "skills/de-slop"
+    assert local["de-slop"]["_source_dir"] == str(root)
+
+
+def test_expand_local_skill_only_when_skill_md_present(repo):
+    root, directive = repo
+    # A dir without SKILL.md is not a skill.
+    (root / "skills" / "not-a-skill").mkdir()
+    out = expand_registries(directive, root, _dotenv())
+    local = {s["name"] for s in out["skills"] if s.get("path")}
+    assert "not-a-skill" not in local
+
+
+def test_expand_local_skills_are_sorted_by_name(repo):
+    root, directive = repo
+    # Add a skill that sorts before the existing two; the local tree is
+    # emitted in sorted name order (docstring contract), regardless of the
+    # OS-dependent iterdir order. A set() comparison would not catch a
+    # regression here.
+    for skill in ("alpha", "zeta"):
+        d = root / "skills" / skill
+        d.mkdir()
+        (d / "SKILL.md").write_text(f"# {skill}\n")
+    out = expand_registries(directive, root, _dotenv())
+    local_names = [s["name"] for s in out["skills"] if s.get("path")]
+    assert local_names == sorted(local_names)
+    assert local_names == ["alpha", "de-slop", "self-eval", "zeta"]
+
+
+def test_expand_skills_dispatch_accepts_yml_suffix(repo):
+    root, directive = repo
+    # The external-registry dispatch keys on .yaml OR .yml; a .yml registry
+    # must be read as external sources, not walked as a local tree.
+    (root / "alt_registry.yml").write_text(
+        "sources:\n  owner/alt:\n    skills: [solo]\n"
+    )
+    directive = {"skills": ["alt_registry.yml"]}
+    out = expand_registries(directive, root, _dotenv())
+    ext = [s for s in out["skills"] if s.get("source")]
+    assert any(s["source"] == "owner/alt" and s["name"] == "solo" for s in ext)
+
+
+def test_expand_repo_level_external_skill_has_no_name(repo):
+    root, directive = repo
+    # tavily-ai/skills declares no explicit `skills:` list -> a single
+    # repo-level item with a source but NO name (gh auto-discovers at fetch).
+    out = expand_registries(directive, root, _dotenv())
+    repo_level = [
+        s for s in out["skills"] if s.get("source") == "tavily-ai/skills"
+    ]
+    assert len(repo_level) == 1
+    assert "name" not in repo_level[0]
+
+
+def test_expand_registries_absent_sections_yield_empty_lists(repo):
+    root, _ = repo
+    # An empty directive returns the three keys, each an empty list — not a
+    # KeyError downstream, not a missing section.
+    out = expand_registries({}, root, _dotenv())
+    assert out == {"mcps": [], "skills": [], "hooks": []}
+
+
+def test_expand_mcps_skip_non_mapping_entries(repo):
+    root, directive = repo
+    # A malformed registry entry whose body is not a mapping is skipped, not
+    # crashed on (input validation — trust nothing from the registry file).
+    (root / "agents" / "mcp" / "registry.yaml").write_text(
+        "mcps:\n"
+        "  good:\n    command: x\n"
+        "  bogus: just-a-string\n"
+    )
+    out = expand_registries(directive, root, _dotenv())
+    names = [m["name"] for m in out["mcps"]]
+    assert names == ["good"]

--- a/agent-profile/tests/test_mcp_gate_unless.py
+++ b/agent-profile/tests/test_mcp_gate_unless.py
@@ -1,0 +1,140 @@
+"""test_mcp_gate_unless.py — claude-only `gate_unless` MCP suppression parity.
+
+The bash `mcp_filter_for_harness` drops a `gate_unless` MCP from the claude
+surface when the named process-env var is exactly `"true"` (the cheese-flow
+plugin sets `CHEESE_FLOW`), and leaves every other harness untouched:
+
+    map(select((.value.gate_unless // "") as $g | $g == "" or (env[$g] // "false") != "true"))
+
+These tests lock that parity onto `gate_blocks` / `mcps_for` (the renderer
+seam every harness shares) and prove the gate reaches the claude `.mcp.json`
+projection end-to-end. Three live registry MCPs (tilth, context7, tavily)
+carry `gate_unless: CHEESE_FLOW`, so the gate is consumed, not dead schema.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from agent_profile.parse import Manifest, parse_manifest
+from agent_profile.renderers.base import gate_blocks, mcps_for
+from agent_profile.renderers.claude import ClaudeRenderer
+
+from .conftest import write_profile
+
+_ALL = ("claude", "codex", "opencode", "cursor", "copilot")
+
+
+# ─── gate_blocks: claude-only, exact-"true" process-env match ─────────
+
+
+def test_gate_blocks_true_for_claude_when_var_is_true(monkeypatch):
+    monkeypatch.setenv("CHEESE_FLOW", "true")
+    item = {"name": "tilth", "command": "tilth", "gate_unless": "CHEESE_FLOW"}
+    assert gate_blocks(item, "claude") is True
+
+
+def test_gate_does_not_block_when_var_unset(monkeypatch):
+    monkeypatch.delenv("CHEESE_FLOW", raising=False)
+    item = {"name": "tilth", "command": "tilth", "gate_unless": "CHEESE_FLOW"}
+    assert gate_blocks(item, "claude") is False
+
+
+def test_gate_does_not_block_when_var_not_exactly_true(monkeypatch):
+    # Bash compares against the literal string "true"; any other value (even
+    # "1" or "TRUE") keeps the MCP. Lock the exact-match contract.
+    monkeypatch.setenv("CHEESE_FLOW", "1")
+    item = {"name": "tilth", "command": "tilth", "gate_unless": "CHEESE_FLOW"}
+    assert gate_blocks(item, "claude") is False
+
+
+def test_gate_is_claude_only(monkeypatch):
+    # The bash applies gate_unless only in the claude branch; every other
+    # harness ignores it (a plugin-provided MCP is a claude concern).
+    monkeypatch.setenv("CHEESE_FLOW", "true")
+    item = {"name": "tilth", "command": "tilth", "gate_unless": "CHEESE_FLOW"}
+    for harness in ("codex", "opencode", "cursor", "copilot"):
+        assert gate_blocks(item, harness) is False
+
+
+def test_gate_does_not_block_item_without_gate_field(monkeypatch):
+    monkeypatch.setenv("CHEESE_FLOW", "true")
+    item = {"name": "hallouminate", "command": "hallouminate"}
+    assert gate_blocks(item, "claude") is False
+
+
+# ─── mcps_for: gate folds into the shared membership projection ───────
+
+
+def _manifest_with_gated_and_plain() -> Manifest:
+    return Manifest(
+        name="gatetest",
+        mcps=[
+            {"name": "tilth", "command": "tilth", "gate_unless": "CHEESE_FLOW"},
+            {"name": "hallouminate", "command": "hallouminate"},
+        ],
+    )
+
+
+def test_mcps_for_claude_drops_gated_when_set(monkeypatch):
+    monkeypatch.setenv("CHEESE_FLOW", "true")
+    names = [m["name"] for m in mcps_for(_manifest_with_gated_and_plain(), "claude", _ALL)]
+    assert names == ["hallouminate"]
+
+
+def test_mcps_for_claude_keeps_gated_when_unset(monkeypatch):
+    monkeypatch.delenv("CHEESE_FLOW", raising=False)
+    names = [m["name"] for m in mcps_for(_manifest_with_gated_and_plain(), "claude", _ALL)]
+    assert names == ["tilth", "hallouminate"]
+
+
+def test_mcps_for_codex_keeps_gated_even_when_set(monkeypatch):
+    # gate_unless is claude-only: codex (and friends) keep the gated MCP
+    # regardless of CHEESE_FLOW, matching the bash else-branch.
+    monkeypatch.setenv("CHEESE_FLOW", "true")
+    names = [m["name"] for m in mcps_for(_manifest_with_gated_and_plain(), "codex", _ALL)]
+    assert names == ["tilth", "hallouminate"]
+
+
+# ─── end-to-end: the gate reaches the claude .mcp.json projection ─────
+
+_GATED_PROFILE = """\
+name: gated
+description: gate_unless render parity
+mcps:
+  - name: tilth
+    command: tilth
+    args: ["--mcp"]
+    gate_unless: CHEESE_FLOW
+  - name: hallouminate
+    command: hallouminate
+"""
+
+
+@pytest.fixture
+def gated_manifest(env):
+    profile_dir = write_profile(env.profiles, "gated", _GATED_PROFILE)
+    return parse_manifest(profile_dir), env.target
+
+
+def test_claude_mcp_json_omits_gated_server_when_flow_active(gated_manifest, monkeypatch):
+    monkeypatch.setenv("CHEESE_FLOW", "true")
+    manifest, target = gated_manifest
+    ClaudeRenderer().render(manifest, target)
+    servers = json.loads(
+        (target / ".claude/plugins/local/gated/.mcp.json").read_text()
+    )["mcpServers"]
+    # cheese-flow provides tilth; the base render must not duplicate it.
+    assert set(servers) == {"hallouminate"}
+
+
+def test_claude_mcp_json_includes_gated_server_when_flow_inactive(gated_manifest, monkeypatch):
+    monkeypatch.delenv("CHEESE_FLOW", raising=False)
+    manifest, target = gated_manifest
+    ClaudeRenderer().render(manifest, target)
+    servers = json.loads(
+        (target / ".claude/plugins/local/gated/.mcp.json").read_text()
+    )["mcpServers"]
+    assert set(servers) == {"tilth", "hallouminate"}

--- a/agent-profile/tests/test_registries_directive.py
+++ b/agent-profile/tests/test_registries_directive.py
@@ -1,0 +1,175 @@
+"""test_registries_directive.py — parse.py honors the `registries:` directive.
+
+A profile.yaml may declare `registries:` instead of (or alongside) inline
+mcps/skills/hooks. parse_one expands the directive via ingest.expand_registries
+(reading DOTFILES_DIR-relative registry files + DOTFILES_DIR/.env) and folds
+the results into the item lists. This is the seam that lets `base` be the
+union of the three separate registries.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_profile.env import EnvResolutionError
+from agent_profile.parse import ParseError, parse_manifest, parse_one
+from tests.conftest import write_profile
+
+
+@pytest.fixture
+def dotfiles(tmp_path, monkeypatch):
+    """A DOTFILES_DIR holding the three registries + .env + a skills tree."""
+    root = tmp_path / "dots"
+    (root / "agents" / "mcp").mkdir(parents=True)
+    (root / "agents" / "hooks").mkdir(parents=True)
+    (root / "skills" / "de-slop").mkdir(parents=True)
+    (root / "profiles").mkdir()
+
+    (root / "agents" / "mcp" / "registry.yaml").write_text(
+        "mcps:\n"
+        "  tilth:\n    command: tilth\n    args: ['--mcp']\n    scope: user\n"
+        "  todoist:\n    command: npx\n    env:\n"
+        "      TODOIST_API_KEY: '${TODOIST_API_KEY}'\n    optional: true\n"
+    )
+    (root / "agents" / "hooks" / "registry.yaml").write_text(
+        "hooks:\n"
+        "  flair:\n    event: SessionStart\n"
+        "    script: agents/hooks/flair.sh\n    harnesses: [claude, codex]\n"
+    )
+    (root / "agents" / "hooks" / "flair.sh").write_text("#!/bin/bash\n")
+    (root / "skills" / "de-slop" / "SKILL.md").write_text("# de-slop\n")
+    (root / ".env").write_text("TODOIST_API_KEY=secret\n")
+
+    monkeypatch.setenv("DOTFILES_DIR", str(root))
+    return root
+
+
+def test_parse_one_expands_registries_directive(dotfiles):
+    write_profile(
+        dotfiles / "profiles",
+        "base",
+        "name: base\n"
+        "registries:\n"
+        "  mcps: agents/mcp/registry.yaml\n"
+        "  skills: [skills/]\n"
+        "  hooks: agents/hooks/registry.yaml\n",
+    )
+    out = parse_one(dotfiles / "profiles" / "base")
+    mcp_names = [m["name"] for m in out["mcps"]]
+    assert "tilth" in mcp_names
+    assert "todoist" in mcp_names  # TODOIST_API_KEY set in .env
+    assert [h["name"] for h in out["hooks"]] == ["flair"]
+    assert [s["name"] for s in out["skills"]] == ["de-slop"]
+
+
+def test_registries_mcp_env_resolved_from_dotfiles_env(dotfiles):
+    write_profile(
+        dotfiles / "profiles",
+        "base",
+        "name: base\nregistries:\n  mcps: agents/mcp/registry.yaml\n",
+    )
+    out = parse_one(dotfiles / "profiles" / "base")
+    todoist = next(m for m in out["mcps"] if m["name"] == "todoist")
+    assert todoist["env"]["TODOIST_API_KEY"] == "secret"
+
+
+def test_registries_source_dir_points_at_dotfiles(dotfiles):
+    write_profile(
+        dotfiles / "profiles",
+        "base",
+        "name: base\nregistries:\n  hooks: agents/hooks/registry.yaml\n",
+    )
+    out = parse_one(dotfiles / "profiles" / "base")
+    # The hook's payload (script) lives under DOTFILES_DIR, so _source_dir
+    # must point there — not at the profile dir.
+    assert out["hooks"][0]["_source_dir"] == str(dotfiles)
+
+
+def test_registries_optional_mcp_skipped_when_var_unset(dotfiles, monkeypatch):
+    (dotfiles / ".env").write_text("")  # TODOIST_API_KEY now unset
+    write_profile(
+        dotfiles / "profiles",
+        "base",
+        "name: base\nregistries:\n  mcps: agents/mcp/registry.yaml\n",
+    )
+    out = parse_one(dotfiles / "profiles" / "base")
+    mcp_names = [m["name"] for m in out["mcps"]]
+    assert "todoist" not in mcp_names
+    assert "tilth" in mcp_names
+
+
+def test_registries_union_with_inline_items(dotfiles):
+    # A profile may carry both a directive and inline items; inline appends.
+    write_profile(
+        dotfiles / "profiles",
+        "mixed",
+        "name: mixed\n"
+        "registries:\n  mcps: agents/mcp/registry.yaml\n"
+        "mcps:\n  - name: extra\n    command: x\n",
+    )
+    out = parse_one(dotfiles / "profiles" / "mixed")
+    names = [m["name"] for m in out["mcps"]]
+    assert "tilth" in names
+    assert "extra" in names
+
+
+def test_registries_items_precede_inline_items(dotfiles):
+    # The cook contract (parse.py comment): registry-derived items come FIRST,
+    # inline items append. Downstream merge treats "outer last" as the winner,
+    # so the inline override must trail the registry entry. A membership check
+    # would pass even if the order flipped; lock the position explicitly.
+    write_profile(
+        dotfiles / "profiles",
+        "mixed",
+        "name: mixed\n"
+        "registries:\n  mcps: agents/mcp/registry.yaml\n"
+        "mcps:\n  - name: extra\n    command: x\n",
+    )
+    out = parse_one(dotfiles / "profiles" / "mixed")
+    names = [m["name"] for m in out["mcps"]]
+    # Both registry entries (tilth, todoist) precede the lone inline entry.
+    assert names[-1] == "extra"
+    assert names.index("tilth") < names.index("extra")
+    assert names.index("todoist") < names.index("extra")
+
+
+def test_registries_directive_must_be_mapping(dotfiles):
+    # A non-mapping `registries:` (e.g. a bare string) is a profile bug; the
+    # parser fails loud rather than silently ignoring it.
+    write_profile(
+        dotfiles / "profiles",
+        "badreg",
+        "name: badreg\nregistries: agents/mcp/registry.yaml\n",
+    )
+    with pytest.raises(ParseError, match="registries"):
+        parse_one(dotfiles / "profiles" / "badreg")
+
+
+def test_no_registries_directive_yields_empty_registry_items(dotfiles):
+    # Absent directive: the profile's items are exactly its inline items, with
+    # nothing injected from the registries.
+    write_profile(
+        dotfiles / "profiles",
+        "plain",
+        "name: plain\nmcps:\n  - name: only\n    command: x\n",
+    )
+    out = parse_one(dotfiles / "profiles" / "plain")
+    assert [m["name"] for m in out["mcps"]] == ["only"]
+    assert out["hooks"] == []
+    assert out["skills"] == []
+
+
+def test_base_describe_unions_registries(dotfiles):
+    write_profile(
+        dotfiles / "profiles",
+        "base",
+        "name: base\n"
+        "registries:\n"
+        "  mcps: agents/mcp/registry.yaml\n"
+        "  skills: [skills/]\n"
+        "  hooks: agents/hooks/registry.yaml\n",
+    )
+    m = parse_manifest(dotfiles / "profiles" / "base")
+    assert {x["name"] for x in m.mcps} == {"tilth", "todoist"}
+    assert {x["name"] for x in m.skills} == {"de-slop"}
+    assert {x["name"] for x in m.hooks} == {"flair"}

--- a/agent-profile/tests/test_registries_directive.py
+++ b/agent-profile/tests/test_registries_directive.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import pytest
 
-from agent_profile.env import EnvResolutionError
 from agent_profile.parse import ParseError, parse_manifest, parse_one
 from tests.conftest import write_profile
 

--- a/agent-profile/tests/test_skill_fetch_wiring.py
+++ b/agent-profile/tests/test_skill_fetch_wiring.py
@@ -104,3 +104,39 @@ def test_install_skips_fetch_when_no_source_skills(env, stub_renderers, monkeypa
     monkeypatch.setattr(cli, "_skill_fetch_runner", lambda argv: calls.append(argv) or 0)
     assert cli.main(["install", "noext", "--harness", "claude"]) == 0
     assert calls == []
+
+
+# ─── fetch failures surface as clean CLI errors, not tracebacks ───────
+
+
+def test_install_fetch_failure_exits_clean(env, stub_renderers, monkeypatch, capsys):
+    # A non-zero gh exit raises SkillFetchError; main() must convert it to the
+    # CLI's "clean stderr line + exit 1" contract, not an uncaught traceback.
+    write_profile(
+        env.profiles,
+        "extprof",
+        "name: extprof\nskills:\n  - name: mold\n    source: o/r\n",
+    )
+    monkeypatch.setattr(cli, "_skill_fetch_runner", lambda argv: 1)
+    assert cli.main(["install", "extprof", "--harness", "claude"]) == 1
+    err = capsys.readouterr().err
+    assert "Traceback" not in err
+    assert "gh skill install failed" in err
+
+
+def test_install_fetch_missing_gh_exits_clean(env, stub_renderers, monkeypatch, capsys):
+    # gh absent → subprocess raises FileNotFoundError (an OSError); main() must
+    # report it cleanly and exit 1, not crash with a traceback.
+    def boom(argv):
+        raise FileNotFoundError(2, "No such file or directory", "gh")
+
+    write_profile(
+        env.profiles,
+        "extprof",
+        "name: extprof\nskills:\n  - name: mold\n    source: o/r\n",
+    )
+    monkeypatch.setattr(cli, "_skill_fetch_runner", boom)
+    assert cli.main(["install", "extprof", "--harness", "claude"]) == 1
+    err = capsys.readouterr().err
+    assert "Traceback" not in err
+    assert "gh CLI" in err

--- a/agent-profile/tests/test_skill_fetch_wiring.py
+++ b/agent-profile/tests/test_skill_fetch_wiring.py
@@ -1,0 +1,106 @@
+"""test_skill_fetch_wiring.py — install fetches source: skills, copies path:.
+
+cmd_install must fetch every `source:` skill for each in-scope harness via
+the injected fetch runner, while `path:` (local-tree) skills are still copied
+by the renderers. A `source:`-only skill item (no `path`) must NOT be copied
+by any renderer (that would copy the repo root by accident).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_profile import cli
+from agent_profile.parse import parse_manifest
+from agent_profile.renderers.claude import ClaudeRenderer
+from agent_profile.renderers.codex import CodexRenderer
+from agent_profile.renderers.copilot import CopilotRenderer
+from tests.conftest import write_profile
+
+
+# ─── renderers skip source-only skills ────────────────────────────────
+
+
+@pytest.fixture
+def source_only_profile(env):
+    return write_profile(
+        env.profiles,
+        "extprof",
+        "name: extprof\n"
+        "skills:\n"
+        "  - name: mold\n    source: paulnsorensen/easy-cheese\n"
+        "  - name: local-skill\n    path: skills/local-skill\n",
+        {"skills/local-skill/SKILL.md": "# local\n"},
+    )
+
+
+def test_claude_skips_source_only_skill(env, source_only_profile):
+    manifest = parse_manifest(source_only_profile)
+    ClaudeRenderer().render(manifest, env.target)
+    plugin_skills = env.target / ".claude/plugins/local/extprof/skills"
+    # local path: skill is copied; source: skill is not (no 'mold' dir).
+    assert (plugin_skills / "local-skill").is_dir()
+    assert not (plugin_skills / "mold").exists()
+
+
+def test_codex_skips_source_only_skill(env, source_only_profile):
+    manifest = parse_manifest(source_only_profile)
+    CodexRenderer().render(manifest, env.target)
+    shared_skills = env.target / ".agents/skills"
+    assert (shared_skills / "local-skill").is_dir()
+    assert not (shared_skills / "mold").exists()
+
+
+def test_copilot_skips_source_only_skill(env, source_only_profile):
+    manifest = parse_manifest(source_only_profile)
+    CopilotRenderer().render(manifest, env.target)
+    gh_skills = env.target / ".github/skills"
+    assert (gh_skills / "local-skill").is_dir()
+    assert not (gh_skills / "mold").exists()
+
+
+# ─── cmd_install fetches source: skills ───────────────────────────────
+
+
+def test_install_fetches_source_skills_per_harness(env, stub_renderers, monkeypatch, capsys):
+    write_profile(
+        env.profiles,
+        "extprof",
+        "name: extprof\n"
+        "skills:\n"
+        "  - name: mold\n    source: paulnsorensen/easy-cheese\n    pin: v1\n",
+    )
+    calls = []
+    monkeypatch.setattr(cli, "_skill_fetch_runner", lambda argv: calls.append(argv) or 0)
+
+    assert cli.main(["install", "extprof", "--harness", "claude"]) == 0
+    # One fetch for the single source skill, targeting claude.
+    fetches = [c for c in calls if c[:3] == ["gh", "skill", "install"]]
+    assert len(fetches) == 1
+    argv = fetches[0]
+    assert "paulnsorensen/easy-cheese" in argv
+    assert "mold" in argv
+    assert argv[argv.index("--agent") + 1] == "claude-code"
+    assert argv[argv.index("--pin") + 1] == "v1"
+
+
+def test_install_fetches_for_each_in_scope_harness(env, stub_renderers, monkeypatch):
+    write_profile(
+        env.profiles,
+        "extprof",
+        "name: extprof\nskills:\n  - name: cook\n    source: o/r\n",
+    )
+    calls = []
+    monkeypatch.setattr(cli, "_skill_fetch_runner", lambda argv: calls.append(argv) or 0)
+
+    assert cli.main(["install", "extprof", "--harness", "claude,codex"]) == 0
+    agents = sorted(c[c.index("--agent") + 1] for c in calls if "gh" == c[0])
+    assert agents == ["claude-code", "codex"]
+
+
+def test_install_skips_fetch_when_no_source_skills(env, stub_renderers, monkeypatch):
+    write_profile(env.profiles, "noext", "name: noext\n")
+    calls = []
+    monkeypatch.setattr(cli, "_skill_fetch_runner", lambda argv: calls.append(argv) or 0)
+    assert cli.main(["install", "noext", "--harness", "claude"]) == 0
+    assert calls == []

--- a/chezmoi/dot_config/hallouminate/config.toml
+++ b/chezmoi/dot_config/hallouminate/config.toml
@@ -1,0 +1,15 @@
+[[corpus]]
+name = "cheese-global"
+paths = ["~/.cheese"]
+globs = ["**/*.md"]
+exclude = ["**/.git/**"]
+
+# Top-level embeddings default for all repos (per-repo config can override).
+# snowflake-arctic-embed-s: 384-dim, English, retrieval-tuned. Full precision
+# (quantized=false) — corpora are small, so keep max quality.
+# NOTE: switching model later requires deleting the shared ground_dir and
+# re-running `hallouminate index`.
+[embeddings]
+enabled = true
+model = "snowflake/snowflake-arctic-embed-s"
+quantized = false

--- a/packages/sync.sh
+++ b/packages/sync.sh
@@ -166,6 +166,11 @@ sync_brew() {
         log_info "Upgrading brew packages..."
         brew update </dev/null || log_warning "brew update failed"
         brew upgrade </dev/null || log_warning "brew upgrade failed"
+        # Casks flagged `auto_updates true` (e.g. Cursor) are skipped by a plain
+        # `brew upgrade`; --greedy-auto-updates version-checks them and reinstalls
+        # only on a diff. Excludes `version :latest` casks (no version to compare,
+        # would reinstall every run).
+        brew upgrade --cask --greedy-auto-updates </dev/null || log_warning "brew cask upgrade failed"
     fi
 
     log_success "Brew sync complete"


### PR DESCRIPTION
## Summary

Phase 1 (curds 1-5) of unifying ccp profiles + mcp/hook/skill sync onto the `ap` (agent-profile) tool. The data-layer foundation that curds 6-8 depend on. Spec: `.cheese/specs/ccp-to-ap-migration.md`.

## What landed

- **`registries:` directive** — base profile derived from the three separate `agents/mcp/registry.yaml`, `agents/hooks/registry.yaml`, and `skills/` (external `_registry.yaml` + local tree). Registries remain the per-type edit surface.
- **MCP parity fields** — `scope`, `gate_unless`, `optional`, `args_by_harness` flow through ingestion into profile items verbatim. `gate_unless` is now consumed in `mcps_for` (claude-only, process-env, exact-`"true"`), faithful to the bash `mcp_filter_for_harness`.
- **Render-time `${VAR}` env resolution** from `.env`, fail-loud on unset, non-fatal skip for `optional: true` items.
- **External skill fetch** via `gh skill install` with ap→gh agent mapping (`claude`→`claude-code`, `copilot`→`github-copilot`, rest pass-through) and `--pin` support. Renderers skip `source:`-only skills (no accidental repo roots copied).
- **Hook `shared_assets`** — assets deployed alongside the self-locating SessionStart script so it resolves its lib/bank under the plugin/`.codex` layout.

## Files changed

**New modules (agent-profile/):**
- `agent_profile/env.py` — dotenv loader, `${VAR}` resolution, first-unset tracking
- `agent_profile/ingest.py` — registry reader, item normalization, env at ingest
- `agent_profile/fetch.py` — gh skill install wrapper with agent mapping

**Modified:**
- `parse.py` — `registries:` directive expansion, registry-first union
- `cli.py` — skill fetch wiring into `cmd_install`
- `renderers/base.py` — `gate_blocks` filter, hook asset deployment
- `renderers/claude.py`, `codex.py`, `copilot.py` — asset deployment, source-skill skipping

**Tests:** 276 passing (191 baseline + 85 new)
- `test_env.py` (17) — dotenv, `${VAR}` resolution, fail-loud, optional-skip
- `test_ingest.py` (11) — normalization, parity fields, env at ingest, optional
- `test_registries_directive.py` (6) — `registries:` expansion, registry-first ordering, union
- `test_hook_shared_assets.py` (7) — claude + codex asset deploy, self-location
- `test_fetch.py` (10) — agent mapping, argv assembly, pin, non-zero-exit
- `test_skill_fetch_wiring.py` (9) — renderer skips, install wiring
- `test_mcp_gate_unless.py` (10) — gate_blocks unit, mcps_for projection, end-to-end

## Deferred (curds 6-8)

- Launch overlay / isolation (`isolated`, `system_prompt`, `tools`, `permissions_deny`, `env`, `extra_args`; the `ccp` parity in `cmd_launch`)
- `dots sync` rewire (chezmoi `install-base-profile`, retiring old deploy roles)
- `ccp` retirement + 7-profile migration + `AGENTS.md` update

`ccp` remains fully working and untouched until curds 6-8 land.

## Pipeline

Ran through `/ultracook` (cook → press → age → cure → age):
- **Cook** landed curds 1-5; press added 18 hardening tests, caught a stale-`.pyc` verification trap (source correct, clean recompile is green)
- **Age₁** found one medium spec gap: `gate_unless`/`scope` ingested but unconsumed by renderers
- **Cure₁** applied the fix: `gate_unless` now consumed in `mcps_for`, faithful to bash
- **Age₂** re-review clean at medium+ floor → early-stop, no further cure needed

All phase artifacts (`.cheese/cook|press|age|cure/ccp-to-ap-migration.md`) have full traceability of findings/fixes.
