### PR TITLE
fix(sandbox): allowlist uv/hallouminate/cheese writes and schema/HF hosts

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -193,14 +193,20 @@
         "static.crates.io",
         "api.githubcopilot.com",
         "api.tavily.com",
-        "mcp.tavily.com"
+        "mcp.tavily.com",
+        "json.schemastore.org",
+        "huggingface.co",
+        "cdn-lfs.huggingface.co"
       ],
       "allowLocalBinding": true
     },
     "filesystem": {
       "allowWrite": [
         "~/Dev/.prek",
-        "~/.cache"
+        "~/.cache",
+        "~/.local/share",
+        "~/.local/bin",
+        "~/.cheese"
       ]
     },
     "excludedCommands": [


### PR DESCRIPTION
## Why

While debugging a chain of \"the sandbox blocked it\" failures (gh, `git commit`, and the `code-review-graph` MCP), three distinct sandbox gaps surfaced — all in `claude/settings.json`'s Seatbelt config. The earlier `gh` fix (`3d011e8`, `excludedCommands: ["gh *"]`) handled gh's TLS/trustd block, but these are separate layers: a network-allowlist gap and a filesystem-write gap.

## What broke

| Symptom | Root cause |
|---|---|
| `code-review-graph` MCP `✗ Failed to connect` | It's the only **uvx**-based MCP. uvx materializes tool environments under `~/.local/share/uv`, which wasn't in `allowWrite`. (`~/.cache` covered uv's *cache* dir but not its *tools* dir.) Reproduced: sandbox-off works, sandbox-on → `Operation not permitted` writing `~/.local/share/uv/tools/`. |
| `git commit` touching `claude/settings.json` blocked | The `check-claude-settings-schema` prek hook fetches `json.schemastore.org` with `--no-cache`; that host wasn't in `allowedDomains`. |
| hallouminate / tilth writes | `~/.local/share/hallouminate` (LanceDB vector store) and `~/.cheese` (tilth data + `cheese-global` corpus per `~/.config/hallouminate/config.toml`) weren't writable; the embeddings model pulls from `huggingface.co` on a fresh machine. |

## Changes (`claude/settings.json`)

**`sandbox.filesystem.allowWrite`** — added:
- `~/.local/share` — covers uvx tool environments **and** hallouminate's `ground/` store
- `~/.local/bin` — uvx entry-point shims
- `~/.cheese` — tilth data + hallouminate `cheese-global` corpus

**`sandbox.network.allowedDomains`** — added:
- `json.schemastore.org` — the commit-hook schema fetch
- `huggingface.co`, `cdn-lfs.huggingface.co` — hallouminate embeddings model download

`api.github.com` was already present (no change). Repo-local `.hallouminate` / `.milknado` / `.cheese` live under the project root and are already writable — no global allowlist entry needed.

## Notes

- Chose the broad `~/.local/share` over `~/.local/share/{uv,hallouminate}` so future XDG-data tools inherit it — flag if you'd prefer least-privilege narrow entries.
- Validated: `jq` parse OK + `check-jsonschema` against the claude-code-settings schema returns `ok`. All prek hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)