### PR TITLE
feat(linux): one-shot bootstrap + Linux dots sync fixes + Moshi hooks

### DIFF
--- a/.sync-with-rollback
+++ b/.sync-with-rollback
@@ -71,14 +71,15 @@ run_sync() {
     init_state
     parse_sync_args "$@"
 
-    # Bootstrap yq (needed by packages/sync.sh to parse YAML)
-    if [[ "$(uname)" == "Darwin" ]] && ! command -v yq &>/dev/null; then
-      log_info "Bootstrapping yq..."
-      brew install yq
-    fi
-
+    # yq is bootstrapped by packages/sync.sh itself (macOS: brew, Linux: binary
+    # download to ~/.local/bin), so no platform-specific bootstrap is needed here.
+    # Record a package-sync failure instead of aborting (set -e would otherwise
+    # stop here, leaving symlinks + chezmoi un-applied on a box with missing
+    # toolchains). The SYNC_FAILURES summary below reports it and exits non-zero.
     log_info "Syncing packages"
-    bash "$dir/packages/sync.sh"
+    if ! bash "$dir/packages/sync.sh"; then
+        SYNC_FAILURES+=("packages")
+    fi
 
     upgrade_uv_tools
 

--- a/bin/dots
+++ b/bin/dots
@@ -55,6 +55,7 @@ ${BLUE}Commands:${NC}
   ${GREEN}rollback${NC}        Show how to undo a sync (git revert + dots sync)
   ${GREEN}doctor${NC}          Run health checks and profile shell
   ${GREEN}profile${NC}         Manage harness-agnostic agent profiles (run 'dots profile help')
+  ${GREEN}bootstrap${NC}       One-shot Linux provision (brew + rustup + packages)
   ${GREEN}test${NC}            Run test suite
   ${GREEN}help${NC}            Show this help message
 
@@ -359,6 +360,11 @@ case "${1:-status}" in
     profile|p)
         shift
         "$DOTFILES_DIR/agent-profile/ap" "$@"
+        ;;
+    bootstrap|b)
+        echo -e "${BLUE}🧰 Bootstrapping this Linux box (brew + rustup + packages)...${NC}"
+        cd_dotfiles
+        bash "$DOTFILES_DIR/packages/bootstrap-linux.sh"
         ;;
     test|t)
         shift

--- a/chezmoi/dot_claude/create_settings.json
+++ b/chezmoi/dot_claude/create_settings.json
@@ -149,15 +149,6 @@
             "async": true
           }
         ]
-      },
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash \"$HOME/.claude/hooks/session-start-cheese-flair.sh\"",
-            "timeout": 5
-          }
-        ]
       }
     ],
     "Stop": [

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -82,6 +82,17 @@
     "defaultMode": "auto"
   },
   "hooks": {
+    "PermissionRequest": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if command -v moshi-hook >/dev/null 2>&1; then moshi-hook claude-hook; fi",
+            "timeout": 300
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash",
@@ -135,6 +146,15 @@
         "hooks": [
           {
             "type": "command",
+            "command": "if command -v moshi-hook >/dev/null 2>&1; then moshi-hook claude-hook; fi",
+            "async": true
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
             "command": "bash \"$HOME/.claude/hooks/session-start-cheese-flair.sh\"",
             "timeout": 5
           }
@@ -148,6 +168,26 @@
             "type": "command",
             "command": "if [ -n \"$TMUX\" ]; then tmux set-option -q @jmux-attention 1; fi",
             "timeout": 5
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if command -v moshi-hook >/dev/null 2>&1; then moshi-hook claude-hook; fi",
+            "async": true
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if command -v moshi-hook >/dev/null 2>&1; then moshi-hook claude-hook; fi",
+            "async": true
           }
         ]
       }

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -1,8 +1,7 @@
 {
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
-    "ENABLE_TOOL_SEARCH": "true",
-    "SSL_CERT_FILE": "/etc/ssl/cert.pem"
+    "ENABLE_TOOL_SEARCH": "true"
   },
   "permissions": {
     "allow": [

--- a/packages/bootstrap-linux.sh
+++ b/packages/bootstrap-linux.sh
@@ -1,0 +1,173 @@
+#!/bin/bash
+############################
+# packages/bootstrap-linux.sh
+# One-shot Linux provisioner: brings a fresh box up to parity with the
+# packages.yaml registry, preferring Homebrew over apt.
+#
+# Flow:
+#   1. bootstrap_brew    — Homebrew (the one sudo step; print-and-pause)
+#   2. bootstrap_rustup  — Rust toolchain via rustup.rs (no sudo)
+#   3. install_brew_packages — taps + brew formulae derived from packages.yaml
+#   4. hand off to packages/sync.sh (SKIP_APT) for cargo/npm/uv/gh, which
+#      already work identically on Linux once the toolchains exist.
+#
+# Steady-state `dots sync` is unchanged (still apt on Linux). This is a
+# deliberate one-shot — run it once on a new machine via `dots bootstrap`.
+############################
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "${BASH_SOURCE%/*}" && pwd)"
+PACKAGES_FILE="${PACKAGES_FILE:-$SCRIPT_DIR/packages.yaml}"
+
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+FAILED=()
+
+log_info()    { echo -e "${BLUE}[bootstrap]${NC} $1"; }
+log_success() { echo -e "${GREEN}[bootstrap]${NC} $1"; }
+log_warning() { echo -e "${YELLOW}[bootstrap]${NC} $1" >&2; }
+log_error()   { echo -e "${RED}[bootstrap]${NC} $1" >&2; }
+
+LINUXBREW_BIN="/home/linuxbrew/.linuxbrew/bin/brew"
+
+########## Registry queries (brew names — distinct from sync.sh's apt names)
+
+# Brew formulae for Linux: bare scalars (default source brew) + maps that are
+# brew-sourced, non-dev, and not mac-only. Uses .key (the brew formula name).
+get_bootstrap_brew_pkgs() {
+    yq -r '.packages[] | select(kind == "scalar")' "$PACKAGES_FILE" 2>/dev/null
+    yq -r '.packages[] | select(kind == "map") | to_entries[0] | select((.value.source // "brew") == "brew" and (.value.dev // false) == false and (.value.platform // "") != "mac") | .key' "$PACKAGES_FILE" 2>/dev/null
+}
+
+# Homebrew taps (source: tap). Harmless to tap all on Linux even when a tap
+# only provides mac-only formulae (e.g. koekeishiya/formulae → skhd).
+get_bootstrap_taps() {
+    yq -r '.packages[] | select(kind == "map") | to_entries[0] | select(.value.source == "tap") | .key' "$PACKAGES_FILE" 2>/dev/null
+}
+
+########## Bootstrap steps
+
+# Homebrew. The installer needs sudo (creates /home/linuxbrew), which this
+# process can't assume — so print the command and pause for the user to run it
+# in a shell with sudo, then continue once brew is on PATH.
+bootstrap_brew() {
+    if command -v brew &>/dev/null; then
+        log_info "Homebrew already installed"
+        return 0
+    fi
+    if [[ -x "$LINUXBREW_BIN" ]]; then
+        eval "$("$LINUXBREW_BIN" shellenv)"
+        log_info "Homebrew found at $LINUXBREW_BIN"
+        return 0
+    fi
+
+    log_warning "Homebrew is not installed. Its installer needs sudo (creates /home/linuxbrew)."
+    echo
+    echo "  Run this in a shell with sudo access:" >&2
+    echo >&2
+    # shellcheck disable=SC2016  # literal command for the user to run — must not expand
+    echo '    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"' >&2
+    echo >&2
+
+    if [[ ! -t 0 ]]; then
+        log_error "No TTY to pause on. Install Homebrew with the command above, then re-run 'dots bootstrap'."
+        return 1
+    fi
+    read -r -p "Press Enter once Homebrew is installed (or Ctrl-C to abort)... " _
+
+    if [[ -x "$LINUXBREW_BIN" ]]; then
+        eval "$("$LINUXBREW_BIN" shellenv)"
+    fi
+    if ! command -v brew &>/dev/null; then
+        log_error "brew still not on PATH — aborting."
+        return 1
+    fi
+    log_success "Homebrew ready"
+}
+
+# Rust toolchain via rustup (no sudo; installs to ~/.rustup + ~/.cargo).
+bootstrap_rustup() {
+    if command -v cargo &>/dev/null; then
+        log_info "Rust toolchain already present"
+        return 0
+    fi
+    log_info "Installing Rust toolchain via rustup (no sudo)..."
+    if ! curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y; then
+        log_error "rustup install failed"
+        return 1
+    fi
+    # shellcheck disable=SC1091
+    [[ -f "$HOME/.cargo/env" ]] && source "$HOME/.cargo/env"
+    if ! command -v cargo &>/dev/null; then
+        log_error "cargo still not found after rustup"
+        return 1
+    fi
+    log_success "Rust toolchain ready"
+}
+
+install_brew_packages() {
+    local taps formulae
+    taps="$(get_bootstrap_taps)"
+    formulae="$(get_bootstrap_brew_pkgs)"
+
+    if [[ -n "$taps" ]]; then
+        log_info "Tapping Homebrew taps..."
+        while IFS= read -r tap; do
+            [[ -z "$tap" ]] && continue
+            brew tap "$tap" </dev/null || FAILED+=("tap:$tap")
+        done <<< "$taps"
+    fi
+
+    if [[ -n "$formulae" ]]; then
+        log_info "Installing brew formulae (already-installed are skipped)..."
+        # One invocation: brew installs what it can and skips satisfied formulae.
+        # shellcheck disable=SC2086  # intentional word-splitting of the list
+        brew install $formulae </dev/null || log_warning "one or more brew formulae failed (see above)"
+    fi
+}
+
+########## Main
+
+main() {
+    if [[ "$(uname)" != "Linux" ]]; then
+        log_error "bootstrap-linux.sh is Linux-only (use 'dots sync' on macOS)."
+        return 1
+    fi
+    if ! command -v yq &>/dev/null; then
+        log_error "yq is required. Run 'dots sync' once (it bootstraps yq), then 'dots bootstrap'."
+        return 1
+    fi
+    # Defend against a macOS SSL_CERT_FILE leaking into the env (e.g. from
+    # Claude's settings.json), which makes every curl below fail with
+    # "error setting certificate file". Only override a path that doesn't exist.
+    if [[ -n "${SSL_CERT_FILE:-}" && ! -f "${SSL_CERT_FILE}" && -f /etc/ssl/certs/ca-certificates.crt ]]; then
+        log_warning "SSL_CERT_FILE points at a missing file ($SSL_CERT_FILE); using the Linux bundle."
+        export SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+    fi
+
+    bootstrap_brew  || return 1
+    bootstrap_rustup || return 1
+    install_brew_packages
+
+    # Hand cargo/npm/uv/gh to the existing sync (works on Linux); SKIP_APT
+    # silences its apt report since brew already covers those tools.
+    log_info "Handing off to packages/sync.sh for cargo/npm/uv/gh..."
+    SKIP_APT=true FORCE_PACKAGES=true bash "$SCRIPT_DIR/sync.sh" || FAILED+=("sync.sh")
+
+    if ((${#FAILED[@]})); then
+        echo
+        log_error "bootstrap finished with failures: ${FAILED[*]}"
+        return 1
+    fi
+    log_success "Bootstrap complete — restart your shell (zrl) to pick up brew on PATH."
+}
+
+# Only run when executed directly, so tests can source the functions.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/packages/bootstrap-linux.sh
+++ b/packages/bootstrap-linux.sh
@@ -38,10 +38,13 @@ LINUXBREW_BIN="/home/linuxbrew/.linuxbrew/bin/brew"
 ########## Registry queries (brew names — distinct from sync.sh's apt names)
 
 # Brew formulae for Linux: bare scalars (default source brew) + maps that are
-# brew-sourced, non-dev, and not mac-only. Uses .key (the brew formula name).
+# brew-sourced, non-dev, not mac-only, and NOT carrying an apt_install command
+# (those entries opt out of brew on Linux — e.g. tailscale, which uses its own
+# apt source so the install goes through systemd. See packages.yaml).
+# Uses .key (the brew formula name).
 get_bootstrap_brew_pkgs() {
     yq -r '.packages[] | select(kind == "scalar")' "$PACKAGES_FILE" 2>/dev/null
-    yq -r '.packages[] | select(kind == "map") | to_entries[0] | select((.value.source // "brew") == "brew" and (.value.dev // false) == false and (.value.platform // "") != "mac") | .key' "$PACKAGES_FILE" 2>/dev/null
+    yq -r '.packages[] | select(kind == "map") | to_entries[0] | select((.value.source // "brew") == "brew" and (.value.dev // false) == false and (.value.platform // "") != "mac" and (.value.apt_install // null) == null) | .key' "$PACKAGES_FILE" 2>/dev/null
 }
 
 # Homebrew taps (source: tap). Harmless to tap all on Linux even when a tap
@@ -126,8 +129,14 @@ install_brew_packages() {
     if [[ -n "$formulae" ]]; then
         log_info "Installing brew formulae (already-installed are skipped)..."
         # One invocation: brew installs what it can and skips satisfied formulae.
+        # Record the failure so the bootstrap exits non-zero and the final
+        # summary lists it — silently logging a warning let "Bootstrap complete"
+        # print after formulae had failed.
         # shellcheck disable=SC2086  # intentional word-splitting of the list
-        brew install $formulae </dev/null || log_warning "one or more brew formulae failed (see above)"
+        if ! brew install $formulae </dev/null; then
+            log_error "one or more brew formulae failed (see above)"
+            FAILED+=("brew-install")
+        fi
     fi
 }
 
@@ -138,10 +147,12 @@ main() {
         log_error "bootstrap-linux.sh is Linux-only (use 'dots sync' on macOS)."
         return 1
     fi
-    if ! command -v yq &>/dev/null; then
-        log_error "yq is required. Run 'dots sync' once (it bootstraps yq), then 'dots bootstrap'."
-        return 1
-    fi
+    # Bootstrap yq up front — bootstrap-linux is the fresh-box entry point and
+    # the registry queries below all need yq. Shared with packages/sync.sh's
+    # bootstrap_yq via lib-bootstrap-yq.sh so both paths agree on behaviour.
+    # shellcheck disable=SC1091
+    source "$SCRIPT_DIR/lib-bootstrap-yq.sh"
+    PLATFORM=Linux bootstrap_yq || return 1
     # Defend against a macOS SSL_CERT_FILE leaking into the env (e.g. from
     # Claude's settings.json), which makes every curl below fail with
     # "error setting certificate file". Only override a path that doesn't exist.

--- a/packages/lib-bootstrap-yq.sh
+++ b/packages/lib-bootstrap-yq.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# packages/lib-bootstrap-yq.sh
+# Shared yq bootstrapper: ensure yq (mikefarah v4) is on PATH before any
+# yq-driven registry parsing. Sourced by both packages/sync.sh (steady-state
+# sync) and packages/bootstrap-linux.sh (fresh-box one-shot), so both paths
+# can run from a machine where yq isn't yet installed.
+#
+# macOS: brew install yq.
+# Linux: download the static binary to $YQ_INSTALL_DIR (default ~/.local/bin)
+#        — no sudo (yq is a snap on apt, which we can't assume is available
+#        non-interactively).
+#
+# Callers must provide log_info / log_warning. PLATFORM (Darwin|Linux) is
+# read from the parent env; if unset, falls back to `uname`.
+
+bootstrap_yq() {
+    command -v yq &>/dev/null && return 0
+
+    local platform="${PLATFORM:-$(uname)}"
+
+    if [[ "$platform" == "Darwin" ]]; then
+        if command -v brew &>/dev/null; then
+            log_info "Bootstrapping yq..."
+            brew install yq
+        else
+            log_warning "yq not found and brew not available"
+            return 1
+        fi
+    elif [[ "$platform" == "Linux" ]]; then
+        local arch yq_arch dest
+        arch="$(uname -m)"
+        case "$arch" in
+            x86_64) yq_arch="amd64" ;;
+            aarch64|arm64) yq_arch="arm64" ;;
+            *) log_warning "yq not found and no prebuilt binary for arch $arch"; return 1 ;;
+        esac
+        dest="${YQ_INSTALL_DIR:-$HOME/.local/bin}"
+        log_info "Bootstrapping yq (downloading yq_linux_${yq_arch})..."
+        mkdir -p "$dest"
+        if curl -fsSL -o "$dest/yq" "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_${yq_arch}"; then
+            chmod +x "$dest/yq"
+            export PATH="$dest:$PATH"
+        else
+            log_warning "Failed to download yq"
+            return 1
+        fi
+    fi
+}

--- a/packages/sync.sh
+++ b/packages/sync.sh
@@ -192,11 +192,16 @@ sync_cargo() {
                 FAILED+=("rustup-bootstrap")
                 return 0
             fi
-            # Brew-installed rustup keeps cargo proxies in opt/rustup/bin
-            local rustup_bin
-            rustup_bin="$(brew --prefix rustup 2>/dev/null)/bin"
-            if [[ -d "$rustup_bin" ]]; then
-                export PATH="$rustup_bin:$PATH"
+            # Brew-installed rustup (macOS) keeps cargo proxies under its prefix;
+            # rustup.rs (Linux) puts them in ~/.cargo/bin via ~/.cargo/env.
+            # Guard the brew lookup: calling brew when it's absent returns 127,
+            # which under `set -e` would abort the whole sync.
+            local rustup_prefix=""
+            if command -v brew &>/dev/null; then
+                rustup_prefix="$(brew --prefix rustup 2>/dev/null || true)"
+            fi
+            if [[ -n "$rustup_prefix" && -d "$rustup_prefix/bin" ]]; then
+                export PATH="$rustup_prefix/bin:$PATH"
             elif [[ -f "$HOME/.cargo/env" ]]; then
                 # shellcheck disable=SC1091
                 source "$HOME/.cargo/env"
@@ -464,6 +469,10 @@ apt_check_pkg() {
 }
 
 sync_apt() {
+    # The Linux bootstrap (packages/bootstrap-linux.sh) installs these via brew,
+    # then re-invokes this script for cargo/npm/uv/gh — SKIP_APT silences the
+    # otherwise-misleading apt "missing" report in that flow.
+    [[ "${SKIP_APT:-false}" == "true" ]] && return 0
     command -v apt-get &>/dev/null || return 0
 
     log_info "Checking apt packages"
@@ -490,17 +499,47 @@ sync_apt() {
     fi
 }
 
+########## Bootstrap
+
+# Ensure yq (mikefarah v4) is on PATH before any registry parsing.
+# macOS: brew. Linux: download the static binary to ~/.local/bin (no sudo;
+# yq is a snap on apt, which we can't assume is available non-interactively).
+bootstrap_yq() {
+    command -v yq &>/dev/null && return 0
+
+    if [[ "$PLATFORM" == "Darwin" ]]; then
+        if command -v brew &>/dev/null; then
+            log_info "Bootstrapping yq..."
+            brew install yq
+        else
+            log_warning "yq not found and brew not available"
+            return 1
+        fi
+    elif [[ "$PLATFORM" == "Linux" ]]; then
+        local arch yq_arch dest
+        arch="$(uname -m)"
+        case "$arch" in
+            x86_64) yq_arch="amd64" ;;
+            aarch64|arm64) yq_arch="arm64" ;;
+            *) log_warning "yq not found and no prebuilt binary for arch $arch"; return 1 ;;
+        esac
+        dest="${YQ_INSTALL_DIR:-$HOME/.local/bin}"
+        log_info "Bootstrapping yq (downloading yq_linux_${yq_arch})..."
+        mkdir -p "$dest"
+        if curl -fsSL -o "$dest/yq" "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_${yq_arch}"; then
+            chmod +x "$dest/yq"
+            export PATH="$dest:$PATH"
+        else
+            log_warning "Failed to download yq"
+            return 1
+        fi
+    fi
+}
+
 ########## Main
 
-# Bootstrap yq if needed (macOS only)
-if [[ "$PLATFORM" == "Darwin" ]] && ! command -v yq &>/dev/null; then
-    if command -v brew &>/dev/null; then
-        log_info "Bootstrapping yq..."
-        brew install yq
-    else
-        log_warning "yq not found and brew not available"
-        exit 1
-    fi
+if ! bootstrap_yq; then
+    exit 1
 fi
 
 if [[ "$PLATFORM" == "Darwin" ]]; then

--- a/packages/sync.sh
+++ b/packages/sync.sh
@@ -501,40 +501,10 @@ sync_apt() {
 
 ########## Bootstrap
 
-# Ensure yq (mikefarah v4) is on PATH before any registry parsing.
-# macOS: brew. Linux: download the static binary to ~/.local/bin (no sudo;
-# yq is a snap on apt, which we can't assume is available non-interactively).
-bootstrap_yq() {
-    command -v yq &>/dev/null && return 0
-
-    if [[ "$PLATFORM" == "Darwin" ]]; then
-        if command -v brew &>/dev/null; then
-            log_info "Bootstrapping yq..."
-            brew install yq
-        else
-            log_warning "yq not found and brew not available"
-            return 1
-        fi
-    elif [[ "$PLATFORM" == "Linux" ]]; then
-        local arch yq_arch dest
-        arch="$(uname -m)"
-        case "$arch" in
-            x86_64) yq_arch="amd64" ;;
-            aarch64|arm64) yq_arch="arm64" ;;
-            *) log_warning "yq not found and no prebuilt binary for arch $arch"; return 1 ;;
-        esac
-        dest="${YQ_INSTALL_DIR:-$HOME/.local/bin}"
-        log_info "Bootstrapping yq (downloading yq_linux_${yq_arch})..."
-        mkdir -p "$dest"
-        if curl -fsSL -o "$dest/yq" "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_${yq_arch}"; then
-            chmod +x "$dest/yq"
-            export PATH="$dest:$PATH"
-        else
-            log_warning "Failed to download yq"
-            return 1
-        fi
-    fi
-}
+# bootstrap_yq lives in packages/lib-bootstrap-yq.sh so packages/bootstrap-linux.sh
+# can reuse the same logic on a fresh Linux box (where yq is not yet installed).
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib-bootstrap-yq.sh"
 
 ########## Main
 

--- a/tests/bootstrap-linux.bats
+++ b/tests/bootstrap-linux.bats
@@ -65,6 +65,23 @@ YAML
     assert_output_not_contains "pyenv"            # dev-gated
 }
 
+@test "get_bootstrap_brew_pkgs excludes entries with apt_install (opt-out marker)" {
+    # Entries carrying apt_install opt out of the brew bootstrap on Linux —
+    # they install via their own apt source (e.g. tailscale uses Tailscale's
+    # installer for systemd integration). Reconciles with PR 206's tailscale
+    # entry; without this filter, dots bootstrap would brew-install AND
+    # sync_apt would surface the custom-source installer for the same package.
+    cat > "$PACKAGES_FILE" << 'YAML'
+packages:
+  - jq
+  - tailscale: { platform: linux, apt_install: "curl -fsSL https://tailscale.com/install.sh | sh" }
+YAML
+    run get_bootstrap_brew_pkgs
+    assert_success
+    assert_output_contains "jq"
+    assert_output_not_contains "tailscale"
+}
+
 @test "get_bootstrap_taps returns only tap sources" {
     write_test_yaml
     run get_bootstrap_taps

--- a/tests/bootstrap-linux.bats
+++ b/tests/bootstrap-linux.bats
@@ -1,0 +1,103 @@
+#!/usr/bin/env bats
+# Unit tests for packages/bootstrap-linux.sh
+#
+# Sources the script (main is guarded behind BASH_SOURCE==$0) and exercises the
+# registry-derivation + toolchain-detection functions directly. Network/sudo
+# paths (the actual brew/rustup installs) are not exercised here.
+
+load test_helper
+
+BOOTSTRAP="$REAL_DOTFILES_DIR/packages/bootstrap-linux.sh"
+
+setup() {
+    setup_test_env
+    export PACKAGES_FILE="$TEST_HOME/packages.yaml"
+    export MOCK_BIN="$TEST_HOME/bin"
+    mkdir -p "$MOCK_BIN"
+    # shellcheck disable=SC1090
+    source "$BOOTSTRAP"
+}
+
+teardown() {
+    teardown_test_env
+}
+
+write_test_yaml() {
+    cat > "$PACKAGES_FILE" << 'YAML'
+packages:
+  - some/tap-repo: { source: tap }
+  - jq
+  - taf2/tap/mdvi
+  - fd: { apt: fd-find }
+  - xclip: { platform: linux }
+  - mas: { platform: mac }
+  - docker: { source: cask, platform: mac }
+  - cargo-llvm-cov: { source: cargo }
+  - markdownlint-cli2: { source: npm }
+  - ralphify: { source: uv }
+  - gh-stack: { source: gh-extension, pkg: github/gh-stack }
+  - pyenv: { dev: true }
+YAML
+}
+
+@test "get_bootstrap_brew_pkgs returns brew formulae by their key" {
+    write_test_yaml
+    run get_bootstrap_brew_pkgs
+    assert_success
+    assert_output_contains "jq"
+    assert_output_contains "fd"            # uses .key, NOT the apt 'fd-find' name
+    assert_output_contains "taf2/tap/mdvi" # bare scalar with a tap-qualified name
+    assert_output_contains "xclip"         # linux-only brew formula is included
+}
+
+@test "get_bootstrap_brew_pkgs excludes cask/tap/cargo/npm/uv/gh-extension/dev/mac" {
+    write_test_yaml
+    run get_bootstrap_brew_pkgs
+    assert_success
+    assert_output_not_contains "fd-find"          # apt name must not leak
+    assert_output_not_contains "mas"              # mac-only
+    assert_output_not_contains "docker"           # cask + mac-only
+    assert_output_not_contains "some/tap-repo"    # tap
+    assert_output_not_contains "cargo-llvm-cov"   # cargo
+    assert_output_not_contains "markdownlint-cli2" # npm
+    assert_output_not_contains "ralphify"         # uv
+    assert_output_not_contains "gh-stack"         # gh-extension
+    assert_output_not_contains "pyenv"            # dev-gated
+}
+
+@test "get_bootstrap_taps returns only tap sources" {
+    write_test_yaml
+    run get_bootstrap_taps
+    assert_success
+    assert_output_contains "some/tap-repo"
+    assert_output_not_contains "jq"
+    assert_output_not_contains "docker"
+}
+
+@test "bootstrap_brew is a no-op when brew is already on PATH" {
+    printf '#!/bin/bash\nexit 0\n' > "$MOCK_BIN/brew"
+    chmod +x "$MOCK_BIN/brew"
+    PATH="$MOCK_BIN:$PATH" run bootstrap_brew
+    assert_success
+    assert_output_contains "already installed"
+}
+
+@test "bootstrap_rustup is a no-op when cargo is already on PATH" {
+    printf '#!/bin/bash\nexit 0\n' > "$MOCK_BIN/cargo"
+    chmod +x "$MOCK_BIN/cargo"
+    PATH="$MOCK_BIN:$PATH" run bootstrap_rustup
+    assert_success
+    assert_output_contains "already present"
+}
+
+@test "real packages.yaml: bootstrap brew list excludes mac-only and non-brew sources" {
+    export PACKAGES_FILE="$REAL_DOTFILES_DIR/packages/packages.yaml"
+    run get_bootstrap_brew_pkgs
+    assert_success
+    # Spot-check a few known entries from the real registry.
+    assert_output_contains "ripgrep"
+    assert_output_contains "node"
+    assert_output_not_contains "skhd"        # mac-only (koekeishiya tap)
+    assert_output_not_contains "claude-code" # cask, mac-only
+    assert_output_not_contains "rtk"         # cargo (git-sourced)
+}

--- a/tests/chezmoi-wiring.bats
+++ b/tests/chezmoi-wiring.bats
@@ -1029,16 +1029,19 @@ SH
     jq -e 'type == "object"' "$REAL_DOTFILES_DIR/chezmoi/dot_claude/create_settings.json" >/dev/null
 }
 
-@test "claude settings.json: seed has NO legacy SessionStart hook entry" {
+@test "claude settings.json: seed has NO legacy cheese-flair SessionStart hook entry" {
     # The base plugin's plugin.json (rendered by ap into
     # ~/.claude/plugins/local/global/.claude-plugin/plugin.json) now
-    # provides the SessionStart wiring. A duplicate entry in settings.json
-    # would double-fire the hook AND silently break when the legacy
-    # symlinked path is gone (the regression that drove the migration).
-    local has_session
-    has_session=$(jq -r '.hooks.SessionStart // empty' \
+    # provides the cheese-flair SessionStart wiring. A duplicate entry in
+    # settings.json would double-fire the hook AND silently break when the
+    # legacy symlinked path is gone (the regression that drove the
+    # migration). Other SessionStart hooks the plugin does NOT provide
+    # (e.g. the moshi-hook PATH command) may still live in the seed.
+    local has_cheese_flair
+    has_cheese_flair=$(jq -r \
+        '[.hooks.SessionStart[]?.hooks[]? | select(.command | test("session-start-cheese-flair"))] | length' \
         "$REAL_DOTFILES_DIR/chezmoi/dot_claude/create_settings.json")
-    [[ -z "$has_session" ]]
+    [[ "$has_cheese_flair" -eq 0 ]]
 }
 
 @test "claude settings.json: seed does NOT pre-bake ap-managed marketplace/plugin" {

--- a/tests/packages.bats
+++ b/tests/packages.bats
@@ -186,6 +186,12 @@ run_sync() {
     local real_yq; real_yq="$(command -v yq)"
     [[ -n "$real_yq" ]] || skip "no real yq to proxy"
 
+    # If the system yq lives under /usr/bin or /bin (e.g. CI runner with
+    # apt-installed yq), the restricted PATH below can't hide it and
+    # bootstrap_yq early-returns — making the assertions false-negative.
+    # Skip honestly rather than silently always-pass.
+    PATH="/usr/bin:/bin" command -v yq &>/dev/null && skip "yq is on /usr/bin or /bin — restricted PATH cannot exercise bootstrap"
+
     local curl_log="$TEST_HOME/curl.log"
     export YQ_INSTALL_DIR="$TEST_HOME/yqbin"
 

--- a/tests/packages.bats
+++ b/tests/packages.bats
@@ -176,6 +176,52 @@ run_sync() {
     fi
 }
 
+# --- yq bootstrap (Linux: download static binary, no sudo) ---
+
+@test "bootstrap_yq downloads the arch-matched binary when yq is absent (Linux)" {
+    [[ "$(uname)" == "Linux" ]] || skip "Linux-only yq download path"
+
+    # Resolve the real yq before we scrub it from PATH, so the curl mock can
+    # stand in a working binary at the download destination.
+    local real_yq; real_yq="$(command -v yq)"
+    [[ -n "$real_yq" ]] || skip "no real yq to proxy"
+
+    local curl_log="$TEST_HOME/curl.log"
+    export YQ_INSTALL_DIR="$TEST_HOME/yqbin"
+
+    cat > "$MOCK_BIN/curl" << CURLMOCK
+#!/bin/bash
+echo "curl \$*" >> "$curl_log"
+dest=""; url=""
+while [[ \$# -gt 0 ]]; do
+  case "\$1" in
+    -o) dest="\$2"; shift 2;;
+    -*) shift;;
+    *) url="\$1"; shift;;
+  esac
+done
+[[ "\$url" == *yq_linux* ]] || exit 1
+cp "$real_yq" "\$dest"
+CURLMOCK
+    chmod +x "$MOCK_BIN/curl"
+
+    # A registry with only apt packages so cargo/npm/uv/gh passes early-return
+    # and the script exits 0 once yq is bootstrapped.
+    cat > "$PACKAGES_FILE" << 'YAML'
+packages:
+  - jq
+  - fd: { apt: fd-find }
+YAML
+
+    # PATH without ~/.local/bin (where the real yq lives) → yq is "absent".
+    FORCE_PACKAGES=true PATH="$MOCK_BIN:/usr/bin:/bin" run bash "$SYNC_SCRIPT"
+    assert_success
+    assert_output_contains "Bootstrapping yq"
+    local want; case "$(uname -m)" in x86_64) want=amd64;; aarch64|arm64) want=arm64;; *) want="" ;; esac
+    [[ -n "$want" ]] && grep -q "yq_linux_$want" "$curl_log"
+    [[ -x "$YQ_INSTALL_DIR/yq" ]]
+}
+
 # --- Integration: sync installs the right packages ---
 
 @test "sync installs bare-string formulae via brew" {

--- a/tests/sync-rollback.bats
+++ b/tests/sync-rollback.bats
@@ -119,6 +119,23 @@ teardown() {
 }
 
 
+@test "package sync failure is non-fatal — symlinks still run, failure reported" {
+    # A failing package sync must NOT abort the whole run (set -e used to stop
+    # here, leaving symlinks + chezmoi un-applied). It should be recorded and
+    # reported, while the rest of the sync proceeds.
+    printf '#!/bin/bash\nexit 1\n' > "$FAKE_DOTFILES/packages/sync.sh"
+    echo "alias foo=bar" > "$FAKE_DOTFILES/myaliases"
+    cd "$FAKE_DOTFILES"
+    run bash "$SYNC_SCRIPT"
+    assert_failure
+    assert_output_contains "FAILURES in: packages"
+    assert_output_not_contains "Sync completed successfully"
+    # Proof the symlink step ran despite the package failure.
+    local resolved_home
+    resolved_home=$(cd "$TEST_HOME" && pwd -P)
+    [[ -L "$resolved_home/.myaliases" ]]
+}
+
 @test ".git directory is not symlinked" {
     cd "$FAKE_DOTFILES"
     mkdir -p "$FAKE_DOTFILES/.git"

--- a/zsh/core.zsh
+++ b/zsh/core.zsh
@@ -15,10 +15,15 @@ if [[ $OSTYPE == darwin* ]]; then
   [[ -d "${_brew_prefix}/opt/openssl/bin" ]] && export PATH="${_brew_prefix}/opt/openssl/bin:$PATH"
   [[ -d "${_brew_prefix}/opt/rustup/bin" ]] && export PATH="${_brew_prefix}/opt/rustup/bin:$PATH"
   unset _brew_prefix
+  # macOS cert bundle for gh / Go TLS inside the Claude Seatbelt sandbox.
+  # Was previously pinned in claude/settings.json's env block, but that broke
+  # Linux (that file doesn't exist there) — moved here so each platform branch
+  # exports the correct path and Claude subprocesses inherit it from the
+  # launching shell.
+  [[ -f /etc/ssl/cert.pem ]] && export SSL_CERT_FILE=/etc/ssl/cert.pem
 else
-  # claude/settings.json pins SSL_CERT_FILE to the macOS bundle (/etc/ssl/cert.pem)
-  # to fix gh/Go TLS inside the Seatbelt sandbox. That path doesn't exist on Linux,
-  # which breaks curl/Go TLS — point at the real Linux bundle instead.
+  # Linux cert bundle — Claude subprocesses inherit this from the launching
+  # shell (claude/settings.json no longer hard-codes the macOS path).
   [[ -f /etc/ssl/certs/ca-certificates.crt ]] && export SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
   # Homebrew on Linux (installed by `dots bootstrap`) lives under /home/linuxbrew.
   [[ -x /home/linuxbrew/.linuxbrew/bin/brew ]] && eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"

--- a/zsh/core.zsh
+++ b/zsh/core.zsh
@@ -15,6 +15,13 @@ if [[ $OSTYPE == darwin* ]]; then
   [[ -d "${_brew_prefix}/opt/openssl/bin" ]] && export PATH="${_brew_prefix}/opt/openssl/bin:$PATH"
   [[ -d "${_brew_prefix}/opt/rustup/bin" ]] && export PATH="${_brew_prefix}/opt/rustup/bin:$PATH"
   unset _brew_prefix
+else
+  # claude/settings.json pins SSL_CERT_FILE to the macOS bundle (/etc/ssl/cert.pem)
+  # to fix gh/Go TLS inside the Seatbelt sandbox. That path doesn't exist on Linux,
+  # which breaks curl/Go TLS — point at the real Linux bundle instead.
+  [[ -f /etc/ssl/certs/ca-certificates.crt ]] && export SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+  # Homebrew on Linux (installed by `dots bootstrap`) lives under /home/linuxbrew.
+  [[ -x /home/linuxbrew/.linuxbrew/bin/brew ]] && eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
 fi
 
 # Add dotfiles bin to PATH


### PR DESCRIPTION
## Summary

Makes this dotfiles repo work on Linux (it was macOS-only in several places) and wires up the Moshi notification hooks. Came out of bringing up a fresh Linux box where `dots sync` crashed immediately.

### New: `dots bootstrap` (one-shot Linux provisioner)
- `packages/bootstrap-linux.sh` — installs Homebrew (**print-and-pause** for the one sudo step) + rustup, installs brew taps/formulae **derived from `packages.yaml`** (no drift), then hands off to `packages/sync.sh` for cargo/npm/uv/gh (which already work on Linux). Steady-state `dots sync` is unchanged (still apt on Linux).

### Bug fixes (the macOS-isms that broke Linux)
- **yq bootstrap was macOS-only** → `dots sync` died with exit 127 before any package check. `bootstrap_yq()` now downloads the static binary on Linux (no sudo).
- **rust-bootstrap aborted under `set -e`** — `sync_cargo` called `brew --prefix rustup`; on a brew-less Linux box `brew` returns 127 and killed the whole sync. Now guarded; falls back to `~/.cargo/env` (the rustup.rs layout). *(This was the pre-existing red test in `packages.bats`.)*
- **`SSL_CERT_FILE` pinned to `/etc/ssl/cert.pem`** (macOS bundle, added for the Seatbelt gh/Go TLS fix) breaks curl/Go TLS on Linux. `zsh/core.zsh` now points it at `/etc/ssl/certs/ca-certificates.crt` on Linux (macOS untouched) and loads `brew shellenv`.
- **Package-sync failure aborted the whole run** before symlinks/chezmoi. `.sync-with-rollback` now records it in `SYNC_FAILURES` and reports at the end (its intended design).

### Moshi hooks (getmoshi.app)
- `claude/settings.json` tracks Moshi hooks on `PermissionRequest`/`SessionStart`/`Stop`/`UserPromptSubmit` with a guarded, exit-safe command (`if command -v moshi-hook …; then moshi-hook claude-hook; fi`) — portable to macOS and a safe no-op where moshi-hook is absent. Ordered so the hook-sync-managed cheese-flair `SessionStart` entry stays last (keeps the sync idempotent).

## Test plan
- [x] `bats tests/packages.bats` — incl. new yq-Linux-bootstrap test; rust-bootstrap test now green
- [x] `bats tests/bootstrap-linux.bats` — new: brew/tap list derivation + brew/rustup no-op detection
- [x] `bats tests/sync-rollback.bats` — new: package failure is non-fatal, symlinks still run
- [x] `bats tests/agents-hooks-sync.bats` — settings.json self-sync no-op (Moshi ordering)
- [x] Ran `dots bootstrap` end-to-end on a fresh Linux box: brew formulae, rustup, cargo crates (`rtk`/`tilth`/`hallouminate`), npm globals, gh-stack all installed
- Remaining full-suite reds are environmental on the bring-up box (missing `codex`, a stray untracked `gitconfig`, `cargo-install-update` now present, chezmoi `work=true` data), not introduced here

🤖 Generated with [Claude Code](https://claude.com/claude-code)