### PR TITLE
feat(ghostty): enable ssh-terminfo/ssh-env shell integration

### DIFF
--- a/ghostty/config
+++ b/ghostty/config
@@ -63,3 +63,7 @@ scrollback-limit = 10000
 
 # Clipboard (macOS)
 copy-on-select = clipboard
+
+# SSH integration: auto-install xterm-ghostty terminfo on remote hosts
+# and forward TERM/COLORTERM so ncurses apps render correctly over SSH
+shell-integration-features = ssh-terminfo,ssh-env

--- a/theme/generate.sh
+++ b/theme/generate.sh
@@ -591,6 +591,10 @@ scrollback-limit = 10000
 
 # Clipboard (macOS)
 copy-on-select = clipboard
+
+# SSH integration: auto-install xterm-ghostty terminfo on remote hosts
+# and forward TERM/COLORTERM so ncurses apps render correctly over SSH
+shell-integration-features = ssh-terminfo,ssh-env
 GHOSTTY
 
   log_ok "Generated ghostty/config"


### PR DESCRIPTION
## Summary
- Add `shell-integration-features = ssh-terminfo,ssh-env` to the Ghostty config so the wrapper auto-installs the `xterm-ghostty` terminfo on remote hosts (via `tic`) and forwards `TERM`/`COLORTERM` over SSH.
- Update both the in-repo `ghostty/config` and the generator (`theme/generate.sh`) so the setting survives the next `dots sync`.

## Why
Without this, SSH-ing into a remote host with `TERM=xterm-ghostty` produces broken ncurses rendering because the remote `terminfo` database has no `xterm-ghostty` entry. The alternative — `infocmp -x xterm-ghostty | ssh <host> -- tic -x -` — has to be re-run per host. The Ghostty SSH integration auto-bootstraps every remote.

## Test plan
- [x] `bash theme/generate.sh` regenerates `ghostty/config` with the new line
- [x] `bash ghostty/.sync` installs the config to `~/.config/ghostty/config`
- [ ] Reload Ghostty (`cmd+shift+,`) and SSH into a remote host; verify `infocmp xterm-ghostty` resolves on the remote and ncurses apps (e.g. `htop`, `tmux`) render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)