### PR TITLE
feat(ap): add global profile + migrate settings.json to chezmoi seed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,12 +25,14 @@ iterm2/com.googlecode.iterm2.plist
 claude/hooks/node_modules/
 claude/hooks/package-lock.json
 
-# Cheese-flair assets — canonical copy lives under agents/, but chezmoi
-# deploys them into $HOME/.{claude,codex}/{hooks,lib,reference}/. For
-# Claude the deploy path is symlinked from claude/.sync, so chezmoi
-# writes back through the symlink and the regenerated copy reappears
-# inside the repo. Ignore those copies to keep worktrees clean.
-claude/hooks/session-start-cheese-flair.sh
+# Cheese-flair assets — canonical copy lives under agents/. The base
+# plugin tree at ~/.claude/plugins/local/global/{hooks,lib,reference}/
+# is where ap deploys them (NOT through claude/.sync's directory
+# symlinks anymore — settings.json's legacy hook entry was retired in
+# favor of the plugin's own plugin.json wiring). The claude/lib/ +
+# claude/reference/ paths remain ignored here only to keep stragglers
+# from older deploys out of git on hosts that haven't fully migrated.
+# Safe to drop these lines once every host is past the migration.
 claude/lib/cheese-flair.sh
 claude/reference/cheese-flair.md
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -261,7 +261,6 @@ Marketplaces must be added first:
 ```bash
 claude plugin marketplace add anthropics/claude-plugins-official
 claude plugin marketplace add upstash/context7
-claude plugin marketplace add jarrodwatts/claude-hud
 ```
 
 **Workflow:**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,7 +101,7 @@ dotfiles/
 │   │   └── cheese-flair.sh # Weighted name generator + quote picker (used by the SessionStart hook).
 │   └── reference/
 │       └── cheese-flair.md # The names + quote bank read by cheese-flair.sh.
-├── profiles/               # Scoped sessions (base + fe, notion, plugin, review, rtkonly, spec, todo) as `profiles/<name>/profile.yaml` — deployed/launched via the `ap` tool (`dots profile`)
+├── profiles/               # Scoped sessions (base + global + fe, notion, plugin, review, rtkonly, spec, todo) as `profiles/<name>/profile.yaml` — deployed/launched via the `ap` tool (`dots profile`). `base` = registry-derived render primitive; `global` = live install (target=$HOME, registers `local` marketplace, enables `global@local`)
 ├── claude/                 # Claude Code-specific configuration
 │   ├── agents/             # Cheese-themed specialist agents
 │   ├── commands/           # Slash commands (/spec, /wreck, /test, etc.)
@@ -154,7 +154,7 @@ dotfiles/
 - **Performance Optimization**: Git prompt uses caching to avoid slowdowns
 - **Declarative MCP Management**: Single YAML registry at `agents/mcp/registry.yaml`, applied to every installed harness (Claude, Codex, opencode). Claude/Codex use their native `mcp add/remove` CLIs; opencode has no non-interactive CLI, so the sync jq-edits `~/.config/opencode/opencode.json` in place.
 - **Rollback Support**: Sync creates backups and manifests for easy rollback
-- **Scoped Profiles**: `profiles/<name>/profile.yaml` declares task-shaped sessions (base, fe, notion, plugin, review, rtkonly, spec, todo) owned by the `ap` tool. `dots profile launch claude <name>` launches; isolated profiles reproduce the old `ccp` closed-world (strict MCP scope, `--setting-sources ""`, tool whitelist, system-prompt append, permissions deny, env, extra_args).
+- **Scoped Profiles**: `profiles/<name>/profile.yaml` declares task-shaped sessions (base, global, fe, notion, plugin, review, rtkonly, spec, todo) owned by the `ap` tool. `base` is the registry-derived render primitive; `global` wraps it with the install-overlay (`target_default: $HOME`, claude marketplace + plugin enablement) and is what `dots sync` runs against the live config. `dots profile launch claude <name>` launches; isolated profiles reproduce the old `ccp` closed-world (strict MCP scope, `--setting-sources ""`, tool whitelist, system-prompt append, permissions deny, env, extra_args).
 
 ## MCP (Model Context Protocol) Management
 
@@ -338,15 +338,25 @@ A `profile.yaml` declares `mcps` / `skills` / `commands` / `agents` / `hooks` (r
 - `env: {...}` — injected into the process before exec.
 - `extra_args: [...]` — appended verbatim (`${VAR}` expanded from process env / `.env`).
 
+Plus, for *installable* (non-isolated) profiles, the install-overlay fields:
+
+- `target_default: $HOME` — used by `ap install <name>` when `--target` is not passed. Explicit `--target` > profile default > `Path.cwd()`. `${VAR}` and `~` expand at use-time.
+- `marketplaces: {name: path}` — claude-only. Renderer registers each name under `~/.claude/settings.json`'s `extraKnownMarketplaces` as a `directory` source with the expanded path (other harnesses ignore it). `${DOTFILES_DIR}` resolves from process env.
+- `enabled_plugins: {<plugin>@<marketplace>: true}` — re-uses the same field as the launch overlay; for non-isolated installs, the claude renderer merges these entries into `~/.claude/settings.json`'s `enabledPlugins` (preserving user-managed siblings). For isolated launches it still writes the ephemeral closed-world settings.
+
 Inline MCP `${VAR}` env refs resolve at launch from `$DOTFILES_DIR/.env`, failing loud when unset (parity with the retired `gen-profile-mcp.sh`).
 
-**Profiles:** `base` (registry-derived union of all MCPs/skills/hooks — `include: [base]` to layer additively), `fe` (frontend + shadcn/Figma), `notion` (Notion HTTP MCP), `plugin` (plugin dev), `review` (read-only PR review), `rtkonly` (experimental — tilth + rtk), `spec` (discovery dialogue), `todo` (Todoist-only, closed world).
+**Profiles:** `base` (registry-derived union of all MCPs/skills/hooks — pure render primitive useful for staging/inspection; `include: [base]` to layer additively), `global` (live install — wraps base with `target_default: $HOME`, registers the `local` marketplace, enables `global@local`), `fe` (frontend + shadcn/Figma), `notion` (Notion HTTP MCP), `plugin` (plugin dev), `review` (read-only PR review), `rtkonly` (experimental — tilth + rtk), `spec` (discovery dialogue), `todo` (Todoist-only, closed world).
+
+**Install vs render:** `ap install base` renders to `--target/$PWD` — useful for staging or building tarballs but does NOT touch your live config. `ap install global` (no flags) targets `$HOME` and additionally wires the rendered plugin tree into `~/.claude/settings.json` (marketplace + enablement) so Claude actually loads it. `dots sync` runs `ap install global` via `chezmoi/lib/install-base-profile.sh`.
 
 **Launch:** `dots profile launch claude <name> [-- claude args...]` — isolated profiles assemble the closed-world flags; non-isolated render into the harness then exec the bare CLI.
 **Inspect:** `dots profile list` / `dots profile describe <name>`.
-**Add new:** create `profiles/<name>/profile.yaml` (+ optional `CLAUDE.md`), then `dots sync` (renders `base`) or `dots profile launch` for an isolated profile.
+**Add new:** create `profiles/<name>/profile.yaml` (+ optional `CLAUDE.md`), then `dots sync` (renders `global` which includes `base`) or `dots profile launch` for an isolated profile.
 
 **Gotcha:** an isolated profile's tool surface is the `tools` whitelist + `permissions_deny` it declares — there is no inherited user `settings.json` (`--setting-sources ""`). Add the MCP's own tools to `tools` (or rely on the closed `--mcp-config`) rather than expecting the user allowlist to carry over.
+
+**Gotcha 2:** `enabled_plugins` keys are `<plugin-name>@<marketplace>` where `plugin-name` matches the profile that rendered the tree (the claude renderer writes plugin trees to `.claude/plugins/local/<profile_name>/`). Renaming a profile means updating both the YAML's name AND the `enabled_plugins` reference, else the marketplace entry points at a non-existent plugin.
 
 ## Sync System
 
@@ -375,6 +385,8 @@ A subset of dotfiles is rendered by [chezmoi](https://chezmoi.io/) instead of sy
 
 - `~/.gitconfig` — `chezmoi/private_dot_gitconfig.tmpl` (templated email, work-only `[url]` redirects)
 - `~/.copilot/mcp-config.json` — `chezmoi/private_dot_copilot/mcp-config.json.tmpl` (env-rendered API keys, fails fast if unset)
+- `~/.claude/settings.json` — `chezmoi/dot_claude/create_settings.json` (seeded once with the user-owned baseline; `ap install global` then jq-merges `enabledPlugins["global@local"]` + `extraKnownMarketplaces.local` on every run, preserving user-managed siblings). A one-time `run_once_before_migrate-claude-settings.sh` removes the legacy `$DOTFILES/claude/settings.json` symlink before chezmoi seeds.
+- `~/.config/opencode/opencode.json` — `chezmoi/dot_config/opencode/create_opencode.json` (analogous: seed once, then `ap install base --target $HOME/.config/opencode --harness opencode` mutates the `mcp` block)
 - `~/.claude/skills/`, `~/.claude/CLAUDE.md`, `~/.codex/AGENTS.md`, `~/.codex/config.toml`, and MCP entries — handled by `run_onchange_*` scripts under `chezmoi/.chezmoiscripts/` that fork to helpers in `chezmoi/lib/`
 
 **First-init (interactive):** `dots sync` dispatches to `chezmoi/.sync`, which invokes `chezmoi init --source $DOTFILES/chezmoi` if `~/.config/chezmoi/chezmoi.toml` is missing. The `.chezmoi.toml.tmpl` prompts for: `email`, `work`. Answers persist to `~/.config/chezmoi/chezmoi.toml` (alongside the persisted `sourceDir`) and aren't re-prompted.
@@ -477,14 +489,14 @@ Pre-commit hooks are managed by [prek](https://prek.j178.dev/) via `prek.toml`. 
 
 | Type | Registry | Sync command | Notes |
 |------|----------|--------------|-------|
-| MCP | `agents/mcp/registry.yaml` | `mcp-sync` = `dots profile install base` (or `dots sync`) | Restart harnesses after. Unioned into the `base` profile; `ap`'s renderers materialize per harness (claude `.mcp.json` plugin-scoped, codex `config.toml`, opencode/cursor/copilot merged JSON). |
-| Hook | `agents/hooks/registry.yaml` | `hook-sync` = `dots profile install base` (or `dots sync`) | Harness-agnostic SessionStart/etc. hooks; `ap`'s renderers copy the self-locating script + its `shared_assets` (lib/bank) under each harness layout. |
+| MCP | `agents/mcp/registry.yaml` | `dots sync` (or `dots profile install global` on a deployed setup) | Restart harnesses after. Unioned into the `base` profile, deployed to `$HOME` via `global`; `ap`'s renderers materialize per harness (claude `.mcp.json` plugin-scoped, codex `config.toml`, opencode/cursor/copilot merged JSON). |
+| Hook | `agents/hooks/registry.yaml` | `dots sync` (or `dots profile install global`) | Harness-agnostic SessionStart/etc. hooks; `ap`'s renderers copy the self-locating script + its `shared_assets` (lib/bank) into the plugin tree at `~/.<harness>/plugins/local/global/{hooks,lib,reference}/`. Wiring lives in the plugin's `plugin.json`, NOT in `~/.claude/settings.json`. |
 | Plugin (Claude) | `claude/plugins/registry.yaml` | `plugin-sync` | Add `mcp__plugin_<name>__*` to `permissions.allow` if it provides MCP tools |
 | Plugin (Cursor) | `cursor/plugins/local/<name>/` (per-plugin manifest at `.cursor-plugin/plugin.json`) | `cursor-plugin-sync` (or `dots sync`) | chezmoi's `run_onchange_after_install-cursor-plugins.sh.tmpl` drives `chezmoi/lib/install-cursor-plugin.sh` per plugin, deploying to `~/.cursor/{skills,rules,commands,hooks}/` and jq-merging `hooks.json` + `modes.json`. Per-collection manifests at `<target>/.dotfiles-managed-<plugin>` track ownership. Restart Cursor after. |
 | LSP | `claude/plugins/registry.yaml` (with `load: true`) | `plugin-sync` | Servers start lazily |
 | Package | `packages/packages.yaml` | `dots sync` | Use `dots sync refresh` to force re-check |
 | Skill | `skills/` (local dirs + `_registry.yaml` for external sources) | `dots sync` (or `skill-sync` = `dots profile install base`) | chezmoi's `run_onchange_after_install-base-profile.sh.tmpl` renders the `base` profile via `ap`: local (`path:`) skills are copied by the renderers, external (`source:`) skills fetch via `npx skills add` (one `git clone` per source, all harnesses in one call). `ap`'s install manifest tracks ownership. |
-| Profile | `profiles/<name>/profile.yaml` | `dots profile install <name>` / `dots profile launch claude <name>` | Registry-entry-superset items + (isolated) launch-overlay fields. `base` is registry-derived; specialized profiles `include: [base]`; isolated profiles are closed worlds (the `ccp` parity). |
+| Profile | `profiles/<name>/profile.yaml` | `dots profile install <name>` / `dots profile launch claude <name>` | Registry-entry-superset items + (isolated) launch-overlay fields + (installable) install-overlay fields (`target_default`, `marketplaces`, `enabled_plugins`). `base` is registry-derived; `global` wraps base for the live install path; specialized profiles `include: [base]`; isolated profiles are closed worlds (the `ccp` parity). |
 
 ## Important Gotchas
 

--- a/agent-profile/agent_profile/cli.py
+++ b/agent-profile/agent_profile/cli.py
@@ -197,7 +197,7 @@ def cmd_path(name: str, colors: _Colors, out: Any) -> int:
 def cmd_install(
     name: str,
     harnesses: list[str],
-    target: Path,
+    target_opt: Path | None,
     colors: _Colors,
     out: Any,
 ) -> int:
@@ -209,6 +209,9 @@ def cmd_install(
     if profile_dir is None:
         raise CliError(f"{colors.RED}ap: profile '{name}' not found{colors.NC}")
 
+    manifest = parse_manifest(profile_dir)
+    target = _resolve_target(target_opt, manifest.target_default)
+
     print(
         f"{colors.BLUE}→ Installing profile '{name}' "
         f"from {profile_dir}{colors.NC}",
@@ -217,7 +220,6 @@ def cmd_install(
     print(f"  target:   {target}", file=out)
     print(f"  harness:  {' '.join(harnesses)}", file=out)
 
-    manifest = parse_manifest(profile_dir)
     merged_dict = manifest.to_dict()
 
     manifest_mod.manifest_init(target)
@@ -345,7 +347,7 @@ def _union_files(
 
 def cmd_uninstall(
     name: str,
-    target: Path,
+    target_opt: Path | None,
     colors: _Colors,
     out: Any,
 ) -> int:
@@ -353,6 +355,19 @@ def cmd_uninstall(
         raise CliError(
             f"{colors.RED}ap uninstall: profile name required{colors.NC}"
         )
+
+    # Mirror install's target resolution so `ap uninstall global` (without
+    # --target) honors the profile's declared default. When the profile dir
+    # is gone, falls through to Path.cwd(); the operator can still pass
+    # --target explicitly to point at the right install root.
+    target_default: str | None = None
+    profile_dir = discover.find_profile_dir(name)
+    if profile_dir is not None:
+        try:
+            target_default = parse_manifest(profile_dir).target_default
+        except ParseError:
+            target_default = None
+    target = _resolve_target(target_opt, target_default)
 
     print(
         f"{colors.BLUE}→ Uninstalling profile '{name}' "
@@ -412,7 +427,7 @@ def cmd_uninstall(
 def cmd_launch(
     remaining: list[str],
     passthrough: list[str],
-    target: Path,
+    target_opt: Path | None,
     colors: _Colors,
     out: Any,
 ) -> NoReturn:
@@ -442,7 +457,11 @@ def cmd_launch(
             _launch_isolated(
                 manifest, profile_dir, harness, exec_args, colors, out
             )  # NoReturn
-        install_rc = cmd_install(name, [harness], target, colors, out)
+        # Pass the unresolved target_opt down to cmd_install; it will apply
+        # the same explicit > profile.target_default > PWD precedence we use
+        # for standalone install. Launching the global profile thus targets
+        # $HOME without forcing the operator to pass --target.
+        install_rc = cmd_install(name, [harness], target_opt, colors, out)
         if install_rc != 0:
             raise CliError(
                 f"{colors.RED}ap launch: install of '{name}' failed "
@@ -516,10 +535,15 @@ def _require_value(args: list[str], i: int, flag: str) -> str:
 
 def _parse_common_opts(
     args: list[str],
-) -> tuple[list[str], Path, list[str], list[str]]:
+) -> tuple[list[str], Path | None, list[str], list[str]]:
     """Split out --harness / --target / --profile-src; return
-    (harnesses, target, remaining, passthrough). Mirrors the bash
+    (harnesses, target_opt, remaining, passthrough). Mirrors the bash
     parse_common_opts: --profile-src appends to AP_EXTRA_SEARCH_PATHS.
+
+    ``target_opt`` is ``None`` when ``--target`` was not passed, letting the
+    cmd_* handlers fall through to ``profile.target_default`` (if declared)
+    and then to ``Path.cwd()``. Resolving the precedence here would require
+    reading the manifest before option parsing, so the fallback is deferred.
 
     ``remaining`` holds the positionals *before* a ``--`` separator;
     ``passthrough`` holds everything after it. Keeping the boundary lets
@@ -527,7 +551,7 @@ def _parse_common_opts(
     --resume``) from "profile name is the first positional" — folding both
     into one list mis-read the first passthrough token as a profile name."""
     harnesses = list(ALL_HARNESSES)
-    target = Path.cwd()
+    target: Path | None = None
     remaining: list[str] = []
     passthrough: list[str] = []
     i = 0
@@ -558,6 +582,23 @@ def _parse_common_opts(
             remaining.append(a)
             i += 1
     return harnesses, target, remaining, passthrough
+
+
+def _resolve_target(target_opt: Path | None, target_default: str | None) -> Path:
+    """Resolve target precedence: explicit ``--target`` > profile
+    ``target_default`` (env-expanded) > ``Path.cwd()``.
+
+    ``${VAR}`` and ``$VAR`` refs in ``target_default`` expand against the
+    process env (``$HOME`` and ``$DOTFILES_DIR`` are the intended consumers).
+    ``~`` is also expanded. An unset ``${VAR}`` is left as a literal so the
+    surface failure mode is the resulting path not existing — easier to
+    debug than a generic KeyError."""
+    if target_opt is not None:
+        return target_opt
+    if target_default:
+        expanded = os.path.expandvars(os.path.expanduser(target_default))
+        return Path(expanded).resolve()
+    return Path.cwd()
 
 
 def _append_search_path(path: str) -> None:

--- a/agent-profile/agent_profile/parse.py
+++ b/agent-profile/agent_profile/parse.py
@@ -68,6 +68,15 @@ class Manifest:
     enabled_plugins: dict[str, bool] = field(default_factory=dict)
     env: dict[str, str] = field(default_factory=dict)
     extra_args: list[str] = field(default_factory=list)
+    # Install-time fields (curd: global profile). Outer-profile only, like
+    # the launch-overlay fields above. ``target_default`` is consulted by
+    # the CLI when ``--target`` is not passed; ``marketplaces`` is read by
+    # the claude renderer to register entries in ``extraKnownMarketplaces``
+    # under the live settings.json (matching how ``enabled_plugins`` lands
+    # in ``enabledPlugins``). ``${VAR}`` refs (``$HOME``, ``${DOTFILES_DIR}``)
+    # expand at use-time, not parse-time.
+    target_default: str | None = None
+    marketplaces: dict[str, str] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize to the same JSON shape parse.sh emits (used for the
@@ -165,6 +174,8 @@ def parse_one(profile_dir: Path) -> dict[str, Any]:
         "enabled_plugins": dict(raw.get("enabled_plugins") or {}),
         "env": dict(raw.get("env") or {}),
         "extra_args": list(raw.get("extra_args") or []),
+        "target_default": raw.get("target_default") or None,
+        "marketplaces": dict(raw.get("marketplaces") or {}),
         # Registry-derived items come first; inline items append (matching
         # the include "outer last" convention so an inline override on a
         # name-collision wins on scalar/object merges downstream).
@@ -289,6 +300,8 @@ def _parse_with_includes(
         "enabled_plugins",
         "env",
         "extra_args",
+        "target_default",
+        "marketplaces",
     ):
         merged[key] = self_[key]
     return merged
@@ -325,4 +338,6 @@ def parse_manifest(profile_dir: Path, find_profile_dir: Any = None) -> Manifest:
         enabled_plugins=merged["enabled_plugins"],
         env=merged["env"],
         extra_args=merged["extra_args"],
+        target_default=merged["target_default"],
+        marketplaces=merged["marketplaces"],
     )

--- a/agent-profile/agent_profile/renderers/claude.py
+++ b/agent-profile/agent_profile/renderers/claude.py
@@ -30,6 +30,7 @@ byte-identical to the bash ``jq`` output). No ``jq``/``yq``.
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import stat
 from pathlib import Path
@@ -42,6 +43,7 @@ from agent_profile.renderers.base import (
     hooks_for,
     mcp_server_entry,
     mcps_for,
+    read_json_object,
 )
 
 # The bash .mcp.json select() defaults membership to all three of
@@ -80,6 +82,7 @@ class ClaudeRenderer:
         self._write_hooks(manifest, plugin_dir, base, profile, out)
         self._write_mcp_json(manifest, plugin_dir, base, out)
         self._write_settings(manifest, plugin_dir, base, out)
+        self._merge_root_settings(manifest, base)
 
         # Track the plugin dir root so uninstall removes the whole tree
         # (including empty sub-dirs we mkdir'd above). Matches the bash
@@ -88,10 +91,43 @@ class ClaudeRenderer:
         return out
 
     def clean(self, manifest: Manifest, target: Path) -> None:
-        """No merged-file surgery under this layout (each plugin owns its
-        whole-file artefacts; the CLI's manifest sweep removes them). Matches
-        the bash ``claude_clean``, which is a no-op."""
-        return None
+        """Surgically remove this profile's contributions to the live
+        ``.claude/settings.json`` (``enabledPlugins`` + ``extraKnownMarketplaces``).
+
+        The plugin tree itself is owned by the CLI's manifest sweep (each
+        plugin gets its own dir; whole-file removal is sufficient). This
+        method only touches the *shared* settings.json — the file holding
+        user-owned config alongside profile-managed marketplace + plugin
+        entries (mirroring how :class:`OpencodeRenderer.clean` un-merges
+        ``opencode.json``)."""
+        base = Path(str(target).rstrip("/"))
+        settings = base / ".claude" / "settings.json"
+        if not settings.is_file():
+            return
+
+        data = read_json_object(settings, ".claude/settings.json")
+
+        enabled = data.get("enabledPlugins")
+        if isinstance(enabled, dict):
+            for plugin_id in manifest.enabled_plugins:
+                enabled.pop(plugin_id, None)
+            if not enabled:
+                data.pop("enabledPlugins", None)
+
+        markets = data.get("extraKnownMarketplaces")
+        if isinstance(markets, dict):
+            for name in manifest.marketplaces:
+                markets.pop(name, None)
+            if not markets:
+                data.pop("extraKnownMarketplaces", None)
+
+        # Don't delete the file if other keys remain — they are user-owned.
+        # Only if we reduced it to {} do we unlink, matching opencode's
+        # "the profile owned it" rule.
+        if data == {}:
+            settings.unlink()
+            return
+        settings.write_text(json.dumps(data, indent=2) + "\n")
 
     # ─── helpers ─────────────────────────────────────────────────────
 
@@ -291,3 +327,51 @@ class ClaudeRenderer:
         out_path = plugin_dir / "settings.json"
         _dump_json(out_path, {"permissions": {"allow": allow}})
         self._track(out, base, out_path)
+
+    def _merge_root_settings(self, manifest: Manifest, base: Path) -> None:
+        """Merge this profile's ``enabled_plugins`` and ``marketplaces`` into
+        the live ``<base>/.claude/settings.json``, preserving siblings.
+
+        Mirrors :meth:`OpencodeRenderer.render` for ``opencode.json``: read,
+        own-our-keys, write. The file is shared (chezmoi-seeded user config
+        + per-profile additions) so it is intentionally NOT tracked in the
+        install manifest. :meth:`clean` un-merges by removing exactly the
+        keys this method added.
+
+        ``${VAR}`` / ``~`` in marketplace paths expand against the process
+        env (``DOTFILES_DIR`` is the intended consumer) — same surface as
+        ``cli._resolve_target``. The marketplace value is wrapped as a
+        ``{"source": {"source": "directory", "path": <expanded>}}`` record;
+        github-source marketplaces stay user-managed in the seed.
+
+        No-op when the profile declares neither field. When the file does
+        not exist, creates an empty ``{}`` seed first — operator running
+        ``ap install global`` standalone (no chezmoi pass) gets a minimal
+        file rather than a hard error; chezmoi's ``create_settings.json``
+        won't overwrite it later (``create_`` semantics), so the operator
+        is responsible for filling in the rest if they're skipping
+        ``dots sync``."""
+        if not manifest.enabled_plugins and not manifest.marketplaces:
+            return
+
+        settings = base / ".claude" / "settings.json"
+        if settings.is_file():
+            data = read_json_object(settings, ".claude/settings.json")
+        else:
+            settings.parent.mkdir(parents=True, exist_ok=True)
+            data = {}
+
+        if manifest.enabled_plugins:
+            enabled = data.setdefault("enabledPlugins", {})
+            for plugin_id, on in manifest.enabled_plugins.items():
+                enabled[plugin_id] = bool(on)
+
+        if manifest.marketplaces:
+            markets = data.setdefault("extraKnownMarketplaces", {})
+            for name, raw_path in manifest.marketplaces.items():
+                expanded = os.path.expandvars(os.path.expanduser(str(raw_path)))
+                markets[name] = {
+                    "source": {"source": "directory", "path": expanded}
+                }
+
+        settings.write_text(json.dumps(data, indent=2) + "\n")

--- a/agent-profile/tests/test_global_profile.py
+++ b/agent-profile/tests/test_global_profile.py
@@ -1,0 +1,315 @@
+"""test_global_profile.py — coverage for the `global` profile shape and
+the surfaces it added (target_default, marketplaces, claude renderer's
+live-settings.json merge + un-merge).
+
+These tests use the production claude renderer directly; the StubRenderer
+in conftest is for steel-thread CLI orchestration tests, not for live
+behavior of a real harness renderer.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agent_profile.parse import Manifest, parse_manifest
+from agent_profile.renderers.claude import ClaudeRenderer
+from agent_profile.cli import _resolve_target
+
+from tests.conftest import write_profile
+
+
+# ── target_default + _resolve_target ─────────────────────────────────
+
+
+def test_resolve_target_explicit_flag_wins(tmp_path):
+    """``--target`` always wins over the profile default."""
+    explicit = tmp_path / "explicit"
+    explicit.mkdir()
+    resolved = _resolve_target(explicit, "$HOME/nope")
+    assert resolved == explicit
+
+
+def test_resolve_target_profile_default_when_flag_missing(tmp_path, monkeypatch):
+    """Without ``--target``, the profile's ``target_default`` is honored
+    (with env + ~ expansion)."""
+    monkeypatch.setenv("HOME", str(tmp_path / "fakehome"))
+    (tmp_path / "fakehome").mkdir()
+    resolved = _resolve_target(None, "$HOME")
+    assert resolved == Path(str(tmp_path / "fakehome")).resolve()
+
+
+def test_resolve_target_falls_through_to_cwd(tmp_path, monkeypatch):
+    """Neither flag nor profile default → ``Path.cwd()``."""
+    monkeypatch.chdir(tmp_path)
+    resolved = _resolve_target(None, None)
+    assert resolved == Path.cwd()
+
+
+def test_resolve_target_unset_var_left_literal(tmp_path, monkeypatch):
+    """An unset ``${VAR}`` ref is left as a literal (path won't resolve to a
+    real location, but no KeyError) — easier-to-debug surface failure."""
+    monkeypatch.delenv("DOTFILES_NOT_SET", raising=False)
+    resolved = _resolve_target(None, "${DOTFILES_NOT_SET}/x")
+    # Path.resolve() will normalize but won't fail on the literal.
+    assert "${DOTFILES_NOT_SET}" in str(resolved)
+
+
+# ── parse: target_default + marketplaces carry through includes ──────
+
+
+def test_parse_target_default_outermost_wins(env):
+    """``target_default`` is outer-profile-only — like name/description, it
+    does NOT merge from includes. An include declaring a different default
+    must not leak into the outer manifest."""
+    write_profile(
+        env.profiles,
+        "inner",
+        "name: inner\ntarget_default: /tmp/inner-default\n",
+    )
+    write_profile(
+        env.profiles,
+        "outer",
+        "name: outer\ninclude: [inner]\ntarget_default: /tmp/outer-default\n",
+    )
+    m = parse_manifest(env.profiles / "outer")
+    assert m.target_default == "/tmp/outer-default"
+
+
+def test_parse_marketplaces_outermost_wins(env):
+    """``marketplaces`` is outer-profile-only (mirrors ``enabled_plugins``).
+    The include's entry is dropped in favor of the outer profile's."""
+    write_profile(
+        env.profiles,
+        "inner",
+        "name: inner\nmarketplaces:\n  inner-mkt: /a\n",
+    )
+    write_profile(
+        env.profiles,
+        "outer",
+        "name: outer\ninclude: [inner]\nmarketplaces:\n  outer-mkt: /b\n",
+    )
+    m = parse_manifest(env.profiles / "outer")
+    assert m.marketplaces == {"outer-mkt": "/b"}
+
+
+# ── claude renderer: live settings.json merge ────────────────────────
+
+
+def _seed_settings(target: Path, content: dict) -> Path:
+    """Write a chezmoi-equivalent seed at ``<target>/.claude/settings.json``."""
+    path = target / ".claude" / "settings.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(content, indent=2) + "\n")
+    return path
+
+
+def _bare_manifest(**kwargs) -> Manifest:
+    """Build a Manifest with just enough fields to drive the renderer."""
+    return Manifest(name=kwargs.pop("name", "global"), **kwargs)
+
+
+def test_claude_renderer_adds_enabledplugins(tmp_path):
+    """``enabled_plugins`` lands in ``settings.json``'s ``enabledPlugins``."""
+    settings = _seed_settings(tmp_path, {"theme": "dark"})
+    manifest = _bare_manifest(enabled_plugins={"global@local": True})
+
+    ClaudeRenderer().render(manifest, tmp_path)
+
+    data = json.loads(settings.read_text())
+    assert data["enabledPlugins"] == {"global@local": True}
+    assert data["theme"] == "dark"  # sibling preserved
+
+
+def test_claude_renderer_adds_marketplaces_with_directory_wrap(tmp_path, monkeypatch):
+    """``marketplaces`` lands wrapped as a directory source. ``${VAR}``
+    refs expand from the process env."""
+    monkeypatch.setenv("DOTFILES_DIR", "/opt/dots")
+    settings = _seed_settings(tmp_path, {})
+    manifest = _bare_manifest(
+        marketplaces={"local": "${DOTFILES_DIR}/.claude/plugins/local"}
+    )
+
+    ClaudeRenderer().render(manifest, tmp_path)
+
+    data = json.loads(settings.read_text())
+    assert data["extraKnownMarketplaces"] == {
+        "local": {
+            "source": {"source": "directory", "path": "/opt/dots/.claude/plugins/local"}
+        }
+    }
+
+
+def test_claude_renderer_preserves_user_siblings(tmp_path):
+    """Pre-existing keys (sandbox, hooks, etc.) survive the merge."""
+    settings = _seed_settings(
+        tmp_path,
+        {
+            "sandbox": {"enabled": False},
+            "theme": "dark",
+            "enabledPlugins": {"user-plugin@user-mkt": True},
+            "extraKnownMarketplaces": {
+                "user-mkt": {"source": {"source": "github", "repo": "u/u"}}
+            },
+        },
+    )
+    manifest = _bare_manifest(
+        enabled_plugins={"global@local": True},
+        marketplaces={"local": "/opt/local"},
+    )
+
+    ClaudeRenderer().render(manifest, tmp_path)
+
+    data = json.loads(settings.read_text())
+    assert data["sandbox"] == {"enabled": False}
+    assert data["theme"] == "dark"
+    # Both old + new entries present.
+    assert data["enabledPlugins"] == {
+        "user-plugin@user-mkt": True,
+        "global@local": True,
+    }
+    assert set(data["extraKnownMarketplaces"]) == {"user-mkt", "local"}
+
+
+def test_claude_renderer_merge_is_idempotent(tmp_path):
+    """Running ``render`` twice yields the same file content."""
+    _seed_settings(tmp_path, {})
+    manifest = _bare_manifest(
+        enabled_plugins={"global@local": True},
+        marketplaces={"local": "/opt/local"},
+    )
+    ClaudeRenderer().render(manifest, tmp_path)
+    first = (tmp_path / ".claude" / "settings.json").read_text()
+    ClaudeRenderer().render(manifest, tmp_path)
+    second = (tmp_path / ".claude" / "settings.json").read_text()
+    assert first == second
+
+
+def test_claude_renderer_creates_settings_when_absent(tmp_path):
+    """When ``settings.json`` doesn't exist yet, the renderer seeds a
+    minimal one rather than failing. Operator-direct ``ap install global``
+    standalone path."""
+    # No seed call — file absent
+    assert not (tmp_path / ".claude" / "settings.json").exists()
+    manifest = _bare_manifest(
+        enabled_plugins={"global@local": True},
+        marketplaces={"local": "/opt/local"},
+    )
+    ClaudeRenderer().render(manifest, tmp_path)
+    data = json.loads((tmp_path / ".claude" / "settings.json").read_text())
+    assert data == {
+        "enabledPlugins": {"global@local": True},
+        "extraKnownMarketplaces": {
+            "local": {"source": {"source": "directory", "path": "/opt/local"}}
+        },
+    }
+
+
+def test_claude_renderer_no_op_when_profile_declares_neither(tmp_path):
+    """A profile without ``enabled_plugins`` or ``marketplaces`` doesn't
+    touch ``settings.json`` (no file created, no existing file modified)."""
+    manifest = _bare_manifest()  # both empty by default
+    ClaudeRenderer().render(manifest, tmp_path)
+    assert not (tmp_path / ".claude" / "settings.json").exists()
+
+
+# ── claude renderer: clean() un-merges its keys ──────────────────────
+
+
+def test_claude_renderer_clean_removes_only_profile_keys(tmp_path):
+    """``clean()`` removes the profile's enabledPlugins + marketplaces
+    entries while leaving siblings intact (mirrors opencode's surgical
+    un-merge)."""
+    _seed_settings(
+        tmp_path,
+        {
+            "theme": "dark",
+            "enabledPlugins": {
+                "user-plugin@user-mkt": True,
+                "global@local": True,
+            },
+            "extraKnownMarketplaces": {
+                "user-mkt": {"source": {"source": "github", "repo": "u/u"}},
+                "local": {
+                    "source": {"source": "directory", "path": "/opt/local"}
+                },
+            },
+        },
+    )
+    manifest = _bare_manifest(
+        enabled_plugins={"global@local": True},
+        marketplaces={"local": "/opt/local"},
+    )
+
+    ClaudeRenderer().clean(manifest, tmp_path)
+
+    data = json.loads((tmp_path / ".claude" / "settings.json").read_text())
+    assert data["theme"] == "dark"
+    assert data["enabledPlugins"] == {"user-plugin@user-mkt": True}
+    assert list(data["extraKnownMarketplaces"]) == ["user-mkt"]
+
+
+def test_claude_renderer_clean_unlinks_when_only_owned_keys(tmp_path):
+    """When ``clean()`` reduces the file to ``{}`` (profile owned all
+    keys), the file is removed — matches opencode's "the profile owned
+    it" rule."""
+    _seed_settings(
+        tmp_path,
+        {
+            "enabledPlugins": {"global@local": True},
+            "extraKnownMarketplaces": {
+                "local": {"source": {"source": "directory", "path": "/opt/local"}}
+            },
+        },
+    )
+    manifest = _bare_manifest(
+        enabled_plugins={"global@local": True},
+        marketplaces={"local": "/opt/local"},
+    )
+
+    ClaudeRenderer().clean(manifest, tmp_path)
+
+    assert not (tmp_path / ".claude" / "settings.json").exists()
+
+
+def test_claude_renderer_clean_no_op_when_settings_absent(tmp_path):
+    """``clean()`` against a missing settings.json is a no-op (and does
+    not create the file)."""
+    manifest = _bare_manifest(
+        enabled_plugins={"global@local": True},
+        marketplaces={"local": "/opt/local"},
+    )
+
+    # Should not raise.
+    ClaudeRenderer().clean(manifest, tmp_path)
+
+    assert not (tmp_path / ".claude" / "settings.json").exists()
+
+
+# ── parse: the actual global profile YAML round-trips ────────────────
+
+
+@pytest.mark.parametrize(
+    "field,expected_contains",
+    [
+        ("name", "global"),
+        ("target_default", "$HOME"),
+    ],
+)
+def test_real_global_profile_yaml_parses(field, expected_contains):
+    """The shipped ``profiles/global/profile.yaml`` parses with the
+    expected operator-overlay fields. Guards against YAML drift."""
+    import os
+
+    repo = Path(os.environ.get("DOTFILES_DIR") or Path.home() / "Dev/dotfiles")
+    profile_yaml = repo / "profiles" / "global" / "profile.yaml"
+    if not profile_yaml.is_file():
+        pytest.skip(f"global profile not found at {profile_yaml}")
+
+    # Direct parse_one (no include resolution; we don't need base here).
+    from agent_profile.parse import parse_one
+
+    one = parse_one(profile_yaml.parent)
+    assert expected_contains in str(one[field])

--- a/agents/hooks/session-start-cheese-flair.sh
+++ b/agents/hooks/session-start-cheese-flair.sh
@@ -10,15 +10,16 @@
 
 set -u
 
-# BSD readlink (macOS default) lacks -f, but Claude / Codex always invoke
-# this script via its real ~/.{harness}/hooks/ path — no symlink hops to
-# resolve. Use $BASH_SOURCE[0] directly, fall through to `readlink -f` only
-# when it's available (GNU coreutils on Linux).
-_src="${BASH_SOURCE[0]}"
-if command -v readlink >/dev/null 2>&1; then
-    _resolved=$(readlink -f "$_src" 2>/dev/null) && _src="$_resolved"
-fi
-SCRIPT_DIR="$(cd "$(dirname "$_src")" && pwd)"
+# Anchor sibling lookups to the deployed hook location — NOT to the
+# canonical source. `ap` deploys this script alongside `lib/cheese-flair.sh`
+# and `reference/cheese-flair.md` under `~/.<harness>/`, and that is the
+# only layout where all three are guaranteed to coexist. Dotfiles installs
+# that directory-symlink `claude/hooks/` back into the repo would, if we
+# resolved the symlink, land in `$DOTFILES/claude/` where the lib + bank
+# are NOT present (they live canonically under `agents/` and are deployed,
+# not symlinked, into `~/.claude/lib/`). So: use BASH_SOURCE[0] verbatim,
+# and rely on bash's default logical `pwd` to preserve the symlinked path.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HARNESS_ROOT="$(dirname "$SCRIPT_DIR")"  # e.g. ~/.claude or ~/.codex
 
 LIB="$HARNESS_ROOT/lib/cheese-flair.sh"

--- a/chezmoi/.chezmoiscripts/run_once_before_migrate-claude-settings.sh
+++ b/chezmoi/.chezmoiscripts/run_once_before_migrate-claude-settings.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# run_once_before — one-time migration: drop the legacy
+# ~/.claude/settings.json symlink so chezmoi can seed the file from
+# dot_claude/create_settings.json.
+#
+# Before this change, claude/.sync symlinked $DOTFILES/claude/settings.json
+# into ~/.claude/settings.json. The committed source has been retired and
+# moved to chezmoi/dot_claude/create_settings.json (a `create_` seed —
+# chezmoi creates it once and never updates after). The retired symlink
+# would otherwise block chezmoi's create_ step (the target "exists" but
+# points at a now-gone source).
+#
+# Idempotent: a no-op once the symlink is gone. run_once_ ensures this
+# script never runs again on this host after a clean pass, so renaming
+# this file is the only way to force a re-run on the same host.
+set -euo pipefail
+
+target="$HOME/.claude/settings.json"
+if [[ -L "$target" ]]; then
+    link_dest=$(readlink "$target")
+    case "$link_dest" in
+        */dotfiles/claude/settings.json)
+            echo "  Migrating: removing legacy settings.json symlink (was $link_dest)"
+            rm -f "$target"
+            ;;
+        *)
+            echo "  Skipping migration: ~/.claude/settings.json links to $link_dest (not the legacy dotfiles source)"
+            ;;
+    esac
+fi

--- a/chezmoi/.chezmoiscripts/run_onchange_after_install-base-profile.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/run_onchange_after_install-base-profile.sh.tmpl
@@ -1,14 +1,26 @@
 #!/bin/bash
-# run_onchange — re-renders the registry-derived `base` profile into every
-# harness whenever the base profile or any of the three registries (mcp,
-# hooks, skills tree) change. The single deploy path that supersedes the
+# run_onchange — re-renders the registry-derived `base` profile (via its
+# `global` wrapper for $HOME-targeted harnesses) into every harness
+# whenever the inputs change. The single deploy path that supersedes the
 # retired install-mcp / install-hooks / install-claude-skills scripts (curd 7).
 #
 # The hash below is computed by chezmoi at template render time over
-# profiles/base/** + the three registries + the local skills tree; chezmoi
-# reruns whenever it changes.
+# every input the installer reads:
 #
-# base profile + registries hash: {{ output "sh" "-c" (printf "find %q/../profiles/base %q/../agents/mcp/registry.yaml %q/../agents/hooks/registry.yaml %q/../skills -type f -not -name .DS_Store -print0 2>/dev/null | LC_ALL=C sort -z | xargs -0 shasum -a 256 2>/dev/null | shasum -a 256 | cut -d' ' -f1" .chezmoi.sourceDir .chezmoi.sourceDir .chezmoi.sourceDir .chezmoi.sourceDir) }}
+#   profiles/base/**       — registry-union directive
+#   profiles/global/**     — operator overlay (target_default, marketplace, enable)
+#   agents/mcp/registry.yaml      — MCP source of truth
+#   agents/hooks/registry.yaml    — hook source of truth
+#   agents/hooks/**.sh            — hook script contents (so edits redeploy)
+#   agents/lib/**                 — shared assets (cheese-flair lib)
+#   agents/reference/**           — shared assets (cheese-flair bank)
+#   skills/**              — local skills tree + external `_registry.yaml`
+#
+# Edits to a hook script or its sibling library would otherwise leave the
+# rendered plugin tree stale on `dots sync` until something else (a
+# registry tweak, a profile-yaml save) bumped the hash.
+#
+# input hash: {{ output "sh" "-c" (printf "find %q/../profiles/base %q/../profiles/global %q/../agents/mcp/registry.yaml %q/../agents/hooks %q/../agents/lib %q/../agents/reference %q/../skills -type f -not -name .DS_Store -print0 2>/dev/null | LC_ALL=C sort -z | xargs -0 shasum -a 256 2>/dev/null | shasum -a 256 | cut -d' ' -f1" .chezmoi.sourceDir .chezmoi.sourceDir .chezmoi.sourceDir .chezmoi.sourceDir .chezmoi.sourceDir .chezmoi.sourceDir .chezmoi.sourceDir) }}
 
 set -euo pipefail
 

--- a/chezmoi/.sync
+++ b/chezmoi/.sync
@@ -128,21 +128,24 @@ EOF
     fi
 fi
 
-# Pre-create the ~/.claude symlinks that chezmoi's run_onchange templates
-# write through. On a fresh install, claude/.sync runs *after* chezmoi/.sync
-# (alphabetical iteration in .sync-with-rollback), so without these links
-# chezmoi would create real ~/.claude/{hooks,reference}/ directories — or a
-# real ~/.claude/settings.json file the moment `claude mcp add` or
-# `claude plugin install` touches user-scope state — that claude/.sync would
-# then back up, orphaning anything chezmoi just wrote (e.g.
-# session-start-cheese-flair.sh, the freshly-installed MCP entries). The
-# claude/.sync pass later rebuilds these symlinks idempotently. Codex has no
-# symlink layer, so this is claude-only.
+# Pre-create the ~/.claude directory symlinks that the (now-shrinking) set
+# of write-through paths from chezmoi's run_onchange templates land in. On
+# a fresh install, claude/.sync runs *after* chezmoi/.sync (alphabetical
+# iteration in .sync-with-rollback), so without these links chezmoi would
+# create real ~/.claude/{hooks,reference}/ directories that claude/.sync
+# would then back up, orphaning anything chezmoi just wrote.
+#
+# settings.json is NO LONGER pre-linked here — it migrated to a chezmoi
+# `create_` seed at chezmoi/dot_claude/create_settings.json (managed
+# in-place by chezmoi + ap renderer mutations), so the legacy symlink
+# would actively block the seed (a one-time
+# run_once_before_migrate-claude-settings.sh script unlinks any stale
+# settings.json symlink before the seed runs).
 prelink_claude_writethrough() {
     local claude_dir="$HOME/.claude"
     local item link source
     mkdir -p "$claude_dir"
-    for item in hooks reference settings.json; do
+    for item in hooks reference; do
         link="$claude_dir/$item"
         source="$dotfiles_dir/claude/$item"
         [[ -e "$source" ]] || continue

--- a/chezmoi/dot_claude/create_settings.json
+++ b/chezmoi/dot_claude/create_settings.json
@@ -130,17 +130,6 @@
         ]
       }
     ],
-    "SessionStart": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash \"$HOME/.claude/hooks/session-start-cheese-flair.sh\"",
-            "timeout": 5
-          }
-        ]
-      }
-    ],
     "Stop": [
       {
         "hooks": [
@@ -159,7 +148,8 @@
     "frontend-design@claude-plugins-official": true,
     "plugin-dev@claude-plugins-official": true,
     "skill-creator@claude-plugins-official": true,
-    "claude-hud@claude-hud": true
+    "claude-hud@claude-hud": true,
+    "todoist-flow@todoist-flow": true
   },
   "extraKnownMarketplaces": {
     "claude-hud": {
@@ -167,10 +157,16 @@
         "source": "github",
         "repo": "jarrodwatts/claude-hud"
       }
+    },
+    "todoist-flow": {
+      "source": {
+        "source": "directory",
+        "path": "/Users/paul/Dev/dotfiles/claude/plugins/local/todoist-flow"
+      }
     }
   },
   "sandbox": {
-    "enabled": true,
+    "enabled": false,
     "autoAllowBashIfSandboxed": true,
     "network": {
       "allowedDomains": [

--- a/chezmoi/dot_claude/create_settings.json
+++ b/chezmoi/dot_claude/create_settings.json
@@ -148,16 +148,9 @@
     "frontend-design@claude-plugins-official": true,
     "plugin-dev@claude-plugins-official": true,
     "skill-creator@claude-plugins-official": true,
-    "claude-hud@claude-hud": true,
     "todoist-flow@todoist-flow": true
   },
   "extraKnownMarketplaces": {
-    "claude-hud": {
-      "source": {
-        "source": "github",
-        "repo": "jarrodwatts/claude-hud"
-      }
-    },
     "todoist-flow": {
       "source": {
         "source": "directory",

--- a/chezmoi/lib/install-base-profile.sh
+++ b/chezmoi/lib/install-base-profile.sh
@@ -1,19 +1,27 @@
 #!/bin/bash
-# install-base-profile.sh — render the registry-derived `base` profile into
+# install-base-profile.sh — render `base` (or its `global` wrapper) into
 # every harness via the `ap` (agent-profile) tool.
 #
 # This is the single deploy path that replaces the retired chezmoi scripts
 # install-mcp / install-hooks / install-claude-skills (spec curd 7, D1). The
 # three separate registries stay the per-type EDIT surface (mcp-edit /
-# hook-edit / skill-edit); `base` unions them and `ap` materializes the union.
+# hook-edit / skill-edit); `base` unions them, `global` wraps base with the
+# operator-intent fields (target_default=$HOME, claude marketplace + plugin
+# enablement), and `ap` materializes the union for each harness.
 #
 # Two render targets handle a path asymmetry: the four dot-dir harnesses
 # (claude/codex/cursor/copilot) write under dot-dirs at $HOME, while opencode's
 # renderer writes opencode.json at the target ROOT, so it targets
 # $HOME/.config/opencode.
 #
-#   ap install base --target $HOME                --harness claude,codex,cursor,copilot
-#   ap install base --target $HOME/.config/opencode --harness opencode
+# For the dot-dir harnesses we install the `global` profile so its
+# target_default + claude.marketplace + claude.enabled_plugins land — that
+# wires the rendered plugin tree into ~/.claude/settings.json so its
+# SessionStart hook (cheese-flair) and bundled MCPs/skills become live.
+# `--target` is intentionally omitted; the profile resolves $HOME itself.
+#
+# opencode has no plugin-enablement surface — `base` is sufficient there,
+# and its target stays explicit ($HOME/.config/opencode is not $HOME).
 #
 # Usage:
 #   install-base-profile.sh <target_home>
@@ -34,10 +42,17 @@ if ! command -v "$ap_bin" &>/dev/null && [[ ! -x "$ap_bin" ]]; then
     exit 1
 fi
 
-# Dot-dir harnesses render under $HOME.
-"$ap_bin" install base --target "$target" \
+# Dot-dir harnesses render the global profile, which carries the operator
+# overlay (target_default=$HOME plus the claude marketplace + plugin
+# enablement). HOME is forwarded explicitly so the profile's $HOME
+# expansion respects the caller's target argument when it differs from
+# the process HOME (the chezmoi installer passes $HOME so they match;
+# direct callers can pass anything).
+HOME="$target" "$ap_bin" install global \
     --harness claude,codex,cursor,copilot
 
 # opencode writes opencode.json at the target root → its own target dir.
+# Uses `base` directly: opencode has no plugin/marketplace surface to
+# enable, and its target is not $HOME so target_default doesn't apply.
 "$ap_bin" install base --target "$target/.config/opencode" \
     --harness opencode

--- a/claude/.sync
+++ b/claude/.sync
@@ -20,19 +20,23 @@ mkdir -p "$CLAUDE_DIR"
 #   - mcp/, hooks registry — the per-type registries live under agents/; the
 #                 registry-derived `base` profile is rendered into every harness
 #                 by chezmoi's run_onchange_after_install-base-profile.sh.tmpl.
+#   - settings.json — chezmoi/dot_claude/create_settings.json seeds it once.
+#                 `ap install global` (driven by run_onchange_after_install-base-profile)
+#                 then jq-mutates the live ~/.claude/settings.json to add the
+#                 `base@local` marketplace + enabledPlugins entry, preserving
+#                 user-managed siblings. The legacy committed claude/settings.json
+#                 is gone; a one-time `run_once_before_migrate-claude-settings`
+#                 chezmoi script unlinks any stale symlink before the seed runs.
 #
 # `hooks/`, `lib/`, and `reference/` STAY symlinked because they still hold
-# Claude-only assets (auto-format.js, sliced-bread.md, …). The cheese-flair
-# trio (session-start-cheese-flair.sh, cheese-flair.sh, cheese-flair.md) lives
-# canonically under agents/ and is deployed by the base-profile render. Because
-# the Claude side writes through the directory symlinks above, the regenerated
-# copies reappear inside claude/{hooks,lib,reference}/ — those three paths are
-# gitignored.
+# Claude-only assets (auto-format.js, sliced-bread.md, …). The base plugin's
+# self-locating SessionStart hook is now owned by the plugin tree at
+# ~/.claude/plugins/local/global/hooks/ (deployed by `ap`); no legacy
+# write-through-symlinks happens.
 configs=(
   agents
   commands
   hooks
-  settings.json
   reference
 )
 

--- a/claude/README.md
+++ b/claude/README.md
@@ -175,7 +175,6 @@ Symbol-level code intelligence is provided by the Serena MCP (see
 
 | Plugin | Source | Purpose |
 |--------|--------|---------|
-| `claude-hud` | `jarrodwatts/claude-hud` | Statusline HUD |
 | `cheese-flow` | local (`~/Dev/cheese-flow`) | Cheddar Flow agent pipeline + tilth MCP + cheez-* skills |
 | `todoist-flow` | in-repo (`claude/plugins/local/todoist-flow`) | Todoist productivity suite |
 | `vaudeville` | local (`~/Dev/vaudeville`) | SLM-powered semantic hook enforcement |

--- a/claude/plugins/registry.yaml
+++ b/claude/plugins/registry.yaml
@@ -3,7 +3,6 @@
 # Format: <plugin>@<marketplace>
 # Marketplaces (all registered in settings.json:extraKnownMarketplaces or built-in):
 #   - claude-plugins-official:    Official workflow plugins (anthropics/claude-code-plugins)
-#   - claude-hud:                 Statusline HUD (jarrodwatts/claude-hud)
 #   - todoist-flow:               In-repo Todoist productivity plugin (directory source)
 #   - local:                      Out-of-repo local plugins; `path:` resolves the source dir
 #
@@ -40,11 +39,6 @@ plugins:
 
   skill-creator@claude-plugins-official:
     description: Guided skill creation workflow with component design, implementation, and validation
-    scope: user
-    load: true
-
-  claude-hud@claude-hud:
-    description: Real-time statusline HUD — context usage, rate limits, active tools, agents, tasks
     scope: user
     load: true
 

--- a/prek.toml
+++ b/prek.toml
@@ -26,6 +26,11 @@ hooks = [
 [[repos]]
 repo = "local"
 hooks = [
-  { id = "check-claude-sync", name = "Check Claude config synced", entry = "bash -c 'target=$(readlink ~/.claude/settings.json 2>/dev/null) && [[ \"$target\" == */claude/settings.json ]] || { echo \"Claude config not synced. Run: dots sync\"; exit 1; }'", language = "system", always_run = true, pass_filenames = false },
-  { id = "check-claude-settings-schema", name = "Validate Claude settings schema", entry = "bash -c 'check-jsonschema --no-cache --schemafile https://json.schemastore.org/claude-code-settings.json claude/settings.json'", language = "system", files = "claude/settings\\.json$", pass_filenames = false },
+  # settings.json migrated from a claude/.sync symlink to a chezmoi `create_`
+  # seed (chezmoi/dot_claude/create_settings.json) — the live ~/.claude/settings.json
+  # is now a real file populated by chezmoi + mutated by ap install global.
+  # The hook accepts either a real file (post-migration) or the legacy
+  # symlink (in case someone's still on the old setup mid-bisect).
+  { id = "check-claude-sync", name = "Check Claude config synced", entry = "bash -c '[[ -f ~/.claude/settings.json ]] || { echo \"Claude settings not synced. Run: dots sync\"; exit 1; }'", language = "system", always_run = true, pass_filenames = false },
+  { id = "check-claude-settings-schema", name = "Validate Claude settings schema", entry = "bash -c 'check-jsonschema --no-cache --schemafile https://json.schemastore.org/claude-code-settings.json chezmoi/dot_claude/create_settings.json'", language = "system", files = "^chezmoi/dot_claude/create_settings\\.json$", pass_filenames = false },
 ]

--- a/profiles/fe/profile.yaml
+++ b/profiles/fe/profile.yaml
@@ -13,7 +13,6 @@ enabled_plugins:
   "claude-md-management@claude-plugins-official": true
   "playwright@claude-plugins-official": true
   "frontend-design@claude-plugins-official": true
-  "claude-hud@claude-hud": true
   "plugin-dev@claude-plugins-official": false
   "skill-creator@claude-plugins-official": false
   "todoist-flow@todoist-flow": false

--- a/profiles/global/profile.yaml
+++ b/profiles/global/profile.yaml
@@ -1,0 +1,53 @@
+# global — the live install of `base` into the machine.
+#
+# `base` is the registry-derived union of MCPs, skills, hooks — a render
+# primitive useful for inspection or staged builds. `global` wraps that
+# union with the operator-intent fields needed to actually deploy onto
+# this machine: target $HOME by default, register the local marketplace,
+# and enable the rendered plugin so its `plugin.json` (which carries the
+# SessionStart hook wiring etc.) is honored by Claude.
+#
+# Why split it out: `ap install base` without --target writes the plugin
+# tree into $PWD, which is correct for staging but confusing as the
+# "make my machine live" verb. `ap install global` (no flags) targets
+# $HOME via `target_default`, so the operator-intent reads cleanly.
+#
+# Chezmoi drives this on `dots sync` through
+# `chezmoi/lib/install-base-profile.sh`, which calls `ap install global`.
+# Standalone use is also fine: `dots profile install global`.
+name: global
+description: Live install — renders base into $HOME and wires it into Claude
+include: [base]
+
+# `--target` precedence in ap is: explicit flag > profile target_default >
+# Path.cwd(). $HOME (and ~) expand at install time via os.path.expandvars
+# / expanduser; unset refs leave a literal, so the failure surfaces as
+# "path does not exist" rather than a generic KeyError.
+target_default: $HOME
+
+# Marketplaces (claude only — other renderers ignore the field). The
+# value is a directory path that ap wraps as
+# `{source: {source: "directory", path: <expanded>}}` in
+# ~/.claude/settings.json's extraKnownMarketplaces. github-source
+# marketplaces (claude-hud, etc.) stay user-managed in the chezmoi seed.
+# `${DOTFILES_DIR}` resolves from the process env at install time —
+# `dots sync` exports it; `ap install global` standalone needs it set
+# too (the agent-profile/ap shim sets it when invoked under dots, but
+# direct uv-run invocations should `export DOTFILES_DIR=...` first).
+marketplaces:
+  local: ${DOTFILES_DIR}/.claude/plugins/local
+
+# enabled_plugins (claude only — same field the launch-overlay uses for
+# isolated profiles, repurposed here for non-isolated installs). ap's
+# claude renderer merges these into settings.json's `enabledPlugins`,
+# preserving siblings (user-managed plugin toggles survive). Without
+# this, Claude wouldn't load the rendered plugin tree and its bundled
+# SessionStart hook (cheese-flair) would stay inert.
+#
+# Plugin id is `<profile_name>@<marketplace_name>` because ap's claude
+# renderer writes the tree to `.claude/plugins/local/<profile_name>/`
+# (here: `.claude/plugins/local/global/`) and we registered the
+# `local` marketplace above. The on-disk plugin name and the enabled
+# entry must match — if you rename this profile, update both.
+enabled_plugins:
+  global@local: true

--- a/profiles/global/profile.yaml
+++ b/profiles/global/profile.yaml
@@ -29,7 +29,7 @@ target_default: $HOME
 # value is a directory path that ap wraps as
 # `{source: {source: "directory", path: <expanded>}}` in
 # ~/.claude/settings.json's extraKnownMarketplaces. github-source
-# marketplaces (claude-hud, etc.) stay user-managed in the chezmoi seed.
+# marketplaces stay user-managed in the chezmoi seed.
 # `${DOTFILES_DIR}` resolves from the process env at install time —
 # `dots sync` exports it; `ap install global` standalone needs it set
 # too (the agent-profile/ap shim sets it when invoked under dots, but

--- a/profiles/plugin/profile.yaml
+++ b/profiles/plugin/profile.yaml
@@ -11,7 +11,6 @@ enabled_plugins:
   "skill-creator@claude-plugins-official": true
   "playwright@claude-plugins-official": false
   "frontend-design@claude-plugins-official": false
-  "claude-hud@claude-hud": false
   "todoist-flow@todoist-flow": false
 mcps:
   - name: tilth

--- a/profiles/review/profile.yaml
+++ b/profiles/review/profile.yaml
@@ -31,7 +31,6 @@ permissions_deny:
 # Per-profile plugin set (ccp settings-merge parity).
 enabled_plugins:
   "claude-md-management@claude-plugins-official": true
-  "claude-hud@claude-hud": true
   "plugin-dev@claude-plugins-official": false
   "skill-creator@claude-plugins-official": false
   "frontend-design@claude-plugins-official": false

--- a/profiles/spec/profile.yaml
+++ b/profiles/spec/profile.yaml
@@ -10,7 +10,6 @@ permissions_deny:
 # Per-profile plugin set (ccp settings-merge parity).
 enabled_plugins:
   "claude-md-management@claude-plugins-official": true
-  "claude-hud@claude-hud": true
   "plugin-dev@claude-plugins-official": false
   "skill-creator@claude-plugins-official": false
   "frontend-design@claude-plugins-official": false

--- a/tests/agents-hooks-sync.bats
+++ b/tests/agents-hooks-sync.bats
@@ -510,41 +510,26 @@ TOML
     [[ "$changed" == "session-start-cheese-flair" ]]
 }
 
-# ── hardening: in-repo claude/settings.json content lock ───────────────
-
-@test "claude/settings.json carries the SessionStart entry with timeout 5" {
-    local settings="$REAL_DOTFILES_DIR/claude/settings.json"
-    # Locks acceptance criteria #1 (Claude side path/timeout) against the
-    # real file — not a mock — so a future refactor that drops the entry
-    # or changes the path is caught immediately.
-    [[ "$(jq -r '.hooks.SessionStart | length' "$settings")" -ge 1 ]]
-    local cmd timeout
-    cmd=$(jq -r '
-        .hooks.SessionStart
-        | map(select(((.hooks // [])[0].command // "") | test("session-start-cheese-flair.sh")))
-        | .[0].hooks[0].command
-    ' "$settings")
-    timeout=$(jq -r '
-        .hooks.SessionStart
-        | map(select(((.hooks // [])[0].command // "") | test("session-start-cheese-flair.sh")))
-        | .[0].hooks[0].timeout
-    ' "$settings")
-    [[ "$cmd" == *'.claude/hooks/session-start-cheese-flair.sh'* ]]
-    [[ "$timeout" == "5" ]]
-}
-
-@test "claude/settings.json sync against itself is a no-op" {
-    # Run sync against the real in-repo settings file (copied) and assert
-    # the produced state matches byte-for-byte after a re-run — locks the
-    # contract that the registry and the checked-in settings agree.
-    cp "$REAL_DOTFILES_DIR/claude/settings.json" "$CLAUDE_SETTINGS_FILE"
-    local before
-    before=$(jq -S . "$CLAUDE_SETTINGS_FILE")
-    hook_claude_apply session-start-cheese-flair
-    local after
-    after=$(jq -S . "$CLAUDE_SETTINGS_FILE")
-    [[ "$before" == "$after" ]]
-}
+# ── post-migration: SessionStart wiring lives in the plugin tree ───────
+#
+# The committed `claude/settings.json` was retired in favor of the
+# chezmoi-seeded `~/.claude/settings.json` + ap-rendered plugin tree.
+# The SessionStart hook is now declared by the plugin's `plugin.json`
+# (rendered by `ap install global` into
+# `~/.claude/plugins/local/global/.claude-plugin/plugin.json`), not by a
+# hand-written entry in the user settings file.
+#
+# The two old tests here ("carries the SessionStart entry with timeout 5"
+# and "sync against itself is a no-op") locked the OLD behavior against
+# the in-repo `claude/settings.json`. With that file gone, their
+# assertions are replaced by:
+#
+#   - `chezmoi-wiring.bats: claude settings.json: seed has NO legacy SessionStart hook entry`
+#   - `cheese-flair.bats: hook script self-locates lib + bank when ~/.claude/hooks is a directory symlink`
+#   - `cheese-flair.bats: hook script output shape matches across both harnesses`
+#
+# which together prove the new wiring fires correctly and the seed is
+# clean. Keep them mentioned here as breadcrumbs for git-blame archaeology.
 
 # ── hardening: installer argument errors ───────────────────────────────
 

--- a/tests/cheese-flair.bats
+++ b/tests/cheese-flair.bats
@@ -323,6 +323,34 @@ _deploy_harness_layout() {
     rm -rf "$root"
 }
 
+@test "hook script self-locates lib + bank when ~/.claude/hooks is a directory symlink" {
+    # Regression: dotfiles installs that symlink claude/hooks/ → $DOTFILES/claude/hooks/
+    # USED to break this hook because the script resolved its own path via
+    # `readlink -f` and landed in the source tree, where the deployed lib/bank
+    # do not live. The fix is to anchor lookups to BASH_SOURCE[0] verbatim so
+    # SCRIPT_DIR stays under the deployed harness home even when reached
+    # through a directory symlink.
+    local root="${TMPDIR:-/tmp}/cheese-flair-symlinked-$$"
+    local src="$root/source-tree/claude"
+    rm -rf "$root"
+    mkdir -p "$src/hooks" "$src/reference" "$root/.claude/lib"
+    cp "$REAL_DOTFILES_DIR/agents/hooks/session-start-cheese-flair.sh" "$src/hooks/"
+    cp "$REAL_DOTFILES_DIR/agents/reference/cheese-flair.md"           "$src/reference/"
+    cp "$REAL_DOTFILES_DIR/agents/lib/cheese-flair.sh"                 "$root/.claude/lib/"
+    chmod +x "$src/hooks/session-start-cheese-flair.sh"
+    ln -s "$src/hooks"     "$root/.claude/hooks"
+    ln -s "$src/reference" "$root/.claude/reference"
+
+    run bash -c "unset CHEESE_FLAIR_BANK; HOME='$root' bash '$root/.claude/hooks/session-start-cheese-flair.sh'"
+    assert_success
+    assert_output_contains "Cheese flair"
+    assert_output_contains "Addresses:"
+    assert_output_contains "Quotes:"
+    [[ "$output" == *"  - Cheese Lord"* ]]
+
+    rm -rf "$root"
+}
+
 @test "hook script output shape matches across both harnesses (3 addresses + 3 quotes)" {
     # Spec acceptance criterion #5: Codex hook output shape matches Claude.
     local root="${TMPDIR:-/tmp}/cheese-flair-shape-$$"

--- a/tests/chezmoi-wiring.bats
+++ b/tests/chezmoi-wiring.bats
@@ -520,21 +520,25 @@ SH
     echo "$script"
 }
 
-@test "base-profile run_onchange aborts non-zero at runtime when npx is missing" {
+@test "base-profile run_onchange skips cleanly when npx is missing" {
+    # Behavior change: the linux-bootstrap PR (commit 5369aa3) softened
+    # missing-npx from `exit 1` (fail-loud) to `exit 0` (clean skip with
+    # pointer) — symmetric with the missing-uv branch. Rationale: on a
+    # fresh Ubuntu box npx arrives from `apt install nodejs npm` after the
+    # first sync prints its missing-tools list; failing the whole apply
+    # there is hostile. The render still must NOT reach `ap` while npx
+    # is absent (no tripwire trigger), and the skip diagnostic must
+    # surface so the user knows why external skills weren't fetched.
     command -v uv >/dev/null 2>&1 || skip "uv not installed (run_onchange skips before preflight)"
     local script
     script=$(render_base_profile_onchange)
-    # Minimal PATH: a `uv` stub (so the uv skip-guard passes), the tripwire
-    # `ap`, and /bin for `bash` itself — but no `npx` (it lives in
-    # /opt/homebrew/bin, deliberately excluded). The template's `command -v npx`
-    # must then abort before ever reaching the render.
     local uv_bin="$TEST_HOME/uv-only-bin"
     mkdir -p "$uv_bin"
     printf '#!/usr/bin/env bash\nexit 0\n' > "$uv_bin/uv"
     chmod +x "$uv_bin/uv"
     PATH="$TEST_HOME/tripwire-bin:$uv_bin:/bin" run bash "$script"
-    assert_failure
-    assert_output_contains "npx (Node) not found"
+    assert_success
+    assert_output_contains "Skipping base-profile render (npx not found"
     [[ "$output" != *"TRIPWIRE"* ]]
 }
 
@@ -623,10 +627,18 @@ YAML
     grep -q 'code.uber.internal' "$tmpl"
 }
 
-@test "copilot template fails fast on missing env vars and renders both keys" {
+@test "copilot template warns on missing env vars and renders both keys" {
+    # Behavior change: prior to the linux-bootstrap PR (commit 5369aa3) the
+    # template hard-failed `chezmoi apply` with `{{ fail "... is not set" }}`
+    # whenever either API key was unset. That was hostile to fresh-box
+    # bootstraps where the user has not yet copied .env.example → .env, so
+    # the template now `warnf`s and emits an empty `mcpServers: {}` stub
+    # instead. The MCPs simply won't work until the keys are populated, but
+    # the rest of `dots sync` proceeds.
     local tmpl="$REAL_DOTFILES_DIR/chezmoi/private_dot_copilot/mcp-config.json.tmpl"
-    grep -q 'CONTEXT7_API_KEY is not set' "$tmpl"
-    grep -q 'TAVILY_API_KEY is not set' "$tmpl"
+    grep -q 'warnf "copilot mcp-config:' "$tmpl"
+    grep -q 'CONTEXT7_API_KEY and/or TAVILY_API_KEY unset' "$tmpl"
+    grep -q '"mcpServers": {}' "$tmpl"
     grep -q 'env "CONTEXT7_API_KEY"' "$tmpl"
     grep -q 'env "TAVILY_API_KEY"' "$tmpl"
 }
@@ -723,12 +735,14 @@ TOML
     grep -qF '"TAVILY_API_KEY": "test-tavily-key"' "$HOME/.copilot/mcp-config.json"
 }
 
-@test "copilot template fails fast when CONTEXT7_API_KEY is unset" {
+@test "copilot template warns + emits empty mcpServers when CONTEXT7_API_KEY is unset" {
     command -v chezmoi >/dev/null 2>&1 || skip "chezmoi not installed"
 
-    # Stub fake npx so the run_onchange installer's `command -v npx` preflight
-    # doesn't fail first and mask the copilot template's fail-fast error (which
-    # is what this test actually asserts).
+    # Linux-bootstrap PR (5369aa3) softened the template from `{{ fail ... }}`
+    # to `{{ warnf ... }}` + empty-stub render. `chezmoi apply` therefore
+    # SUCCEEDS even when a key is unset, and the rendered file is a stub
+    # carrying `"mcpServers": {}`. The warning still surfaces the missing
+    # key on stderr so the user knows to populate .env.
     local fake_npx_bin
     fake_npx_bin=$(make_fake_npx)
     PATH="$fake_npx_bin:$PATH"
@@ -745,8 +759,14 @@ TOML
     export TAVILY_API_KEY="test-tavily-key"
 
     run chezmoi apply --force
-    assert_failure
-    assert_output_contains "CONTEXT7_API_KEY is not set"
+    assert_success
+    # The warnf message should appear in chezmoi's stderr (combined with
+    # stdout under bats' `run`).
+    assert_output_contains "CONTEXT7_API_KEY and/or TAVILY_API_KEY unset"
+    # The rendered file is the empty-mcpServers stub.
+    assert_file_exists "$HOME/.copilot/mcp-config.json"
+    grep -qF '"mcpServers": {}' "$HOME/.copilot/mcp-config.json"
+    grep -qF 'Stub written by chezmoi' "$HOME/.copilot/mcp-config.json"
 }
 
 @test "gitconfig template renders Uber URL redirects when work=true" {

--- a/tests/chezmoi-wiring.bats
+++ b/tests/chezmoi-wiring.bats
@@ -319,7 +319,7 @@ EOF
 # both of which claude/.sync later backs up to .bak, orphaning everything
 # chezmoi just wrote.
 
-@test "chezmoi/.sync pre-links ~/.claude/{hooks,reference,settings.json} on a fresh install" {
+@test "chezmoi/.sync pre-links ~/.claude/{hooks,reference} on a fresh install" {
     # No ~/.claude at all — fresh-box state.
     [[ ! -e "$HOME/.claude" ]]
 
@@ -343,15 +343,16 @@ EOF
     [[ "$(readlink "$HOME/.claude/hooks")"     == "$REAL_DOTFILES_DIR/claude/hooks"     ]]
     [[ -L "$HOME/.claude/reference" ]]
     [[ "$(readlink "$HOME/.claude/reference")" == "$REAL_DOTFILES_DIR/claude/reference" ]]
-    [[ -L "$HOME/.claude/settings.json" ]]
-    [[ "$(readlink "$HOME/.claude/settings.json")" == "$REAL_DOTFILES_DIR/claude/settings.json" ]]
+    # settings.json must NOT be pre-linked anymore — it's a chezmoi
+    # create_ seed now (chezmoi/dot_claude/create_settings.json), and a
+    # legacy symlink would block the seed step.
+    [[ ! -L "$HOME/.claude/settings.json" ]]
 }
 
 @test "chezmoi/.sync prelink is idempotent (existing correct symlink preserved)" {
     mkdir -p "$HOME/.claude"
     ln -s "$REAL_DOTFILES_DIR/claude/hooks"         "$HOME/.claude/hooks"
     ln -s "$REAL_DOTFILES_DIR/claude/reference"     "$HOME/.claude/reference"
-    ln -s "$REAL_DOTFILES_DIR/claude/settings.json" "$HOME/.claude/settings.json"
 
     mkdir -p "$HOME/.config/chezmoi"
     cat > "$HOME/.config/chezmoi/chezmoi.toml" <<EOF
@@ -371,7 +372,6 @@ EOF
     # Symlinks unchanged.
     [[ "$(readlink "$HOME/.claude/hooks")"         == "$REAL_DOTFILES_DIR/claude/hooks"         ]]
     [[ "$(readlink "$HOME/.claude/reference")"     == "$REAL_DOTFILES_DIR/claude/reference"     ]]
-    [[ "$(readlink "$HOME/.claude/settings.json")" == "$REAL_DOTFILES_DIR/claude/settings.json" ]]
     # Prelink message only fires when it actually creates a link.
     [[ "$output" != *"Pre-linked"* ]]
 }
@@ -459,12 +459,22 @@ EOF
 }
 
 @test "chezmoi/run_onchange template hashes the registries + skills tree it renders from" {
-    # The base profile unions the three registries + the local skills tree;
-    # the hash must cover them so a registry/skill edit retriggers the render.
+    # The base profile unions the three registries + the local skills tree
+    # AND the global profile wraps base with operator-overlay fields;
+    # the hash must cover all of them so a registry/skill/profile/hook-script
+    # edit retriggers the render.
     grep -qF '/../skills -type f' "$INSTALLER_TMPL"
     grep -qF '/../profiles/base' "$INSTALLER_TMPL"
+    grep -qF '/../profiles/global' "$INSTALLER_TMPL"
     grep -qF '/../agents/mcp/registry.yaml' "$INSTALLER_TMPL"
-    grep -qF '/../agents/hooks/registry.yaml' "$INSTALLER_TMPL"
+    # `agents/hooks` covers the registry AND its referenced scripts —
+    # without script-content coverage, edits to a hook payload (e.g. the
+    # SessionStart cheese-flair script) would NOT trigger re-deploy on
+    # `dots sync`. Same for the cheese-flair lib + bank under agents/lib
+    # and agents/reference.
+    grep -qF '/../agents/hooks' "$INSTALLER_TMPL"
+    grep -qF '/../agents/lib' "$INSTALLER_TMPL"
+    grep -qF '/../agents/reference' "$INSTALLER_TMPL"
     # The pre-flatten nested path must stay gone.
     if grep -qF '/../claude/skills' "$INSTALLER_TMPL"; then
         echo "template still references the pre-flatten claude/skills tree" >&2
@@ -889,4 +899,77 @@ YAML
     # content. The bug would replace it with `web_dashboard: false\n...`.
     grep -qF '# serena not initialized' "$HOME/.serena/serena_config.yml"
     ! grep -qE '^web_dashboard:' "$HOME/.serena/serena_config.yml"
+}
+
+# ── claude settings.json migration to chezmoi seed ─────────────────────────
+
+@test "claude settings.json: chezmoi seed source exists at dot_claude/create_settings.json" {
+    [[ -f "$REAL_DOTFILES_DIR/chezmoi/dot_claude/create_settings.json" ]]
+}
+
+@test "claude settings.json: chezmoi seed is valid JSON" {
+    jq -e 'type == "object"' "$REAL_DOTFILES_DIR/chezmoi/dot_claude/create_settings.json" >/dev/null
+}
+
+@test "claude settings.json: seed has NO legacy SessionStart hook entry" {
+    # The base plugin's plugin.json (rendered by ap into
+    # ~/.claude/plugins/local/global/.claude-plugin/plugin.json) now
+    # provides the SessionStart wiring. A duplicate entry in settings.json
+    # would double-fire the hook AND silently break when the legacy
+    # symlinked path is gone (the regression that drove the migration).
+    local has_session
+    has_session=$(jq -r '.hooks.SessionStart // empty' \
+        "$REAL_DOTFILES_DIR/chezmoi/dot_claude/create_settings.json")
+    [[ -z "$has_session" ]]
+}
+
+@test "claude settings.json: seed does NOT pre-bake ap-managed marketplace/plugin" {
+    # `local` marketplace + `global@local` enablement are owned by the
+    # claude renderer (ap install global) — they get merged in after
+    # chezmoi seeds. Pre-baking would either cause the merge to look like
+    # a no-op (fine, but confusing) OR survive a global rename (broken).
+    ! jq -e '.enabledPlugins["global@local"]' \
+        "$REAL_DOTFILES_DIR/chezmoi/dot_claude/create_settings.json" >/dev/null 2>&1
+    ! jq -e '.extraKnownMarketplaces["local"]' \
+        "$REAL_DOTFILES_DIR/chezmoi/dot_claude/create_settings.json" >/dev/null 2>&1
+}
+
+@test "claude settings.json: source filename uses create_ prefix (seed-once)" {
+    # `create_` chezmoi semantic: never overwrite on subsequent applies.
+    # Using `dot_settings.json` (always-render) would clobber user edits;
+    # using `modify_settings.json` (script-driven mutation) would be
+    # heavier than needed since ap handles the per-profile mutations.
+    [[ -f "$REAL_DOTFILES_DIR/chezmoi/dot_claude/create_settings.json" ]]
+    [[ ! -f "$REAL_DOTFILES_DIR/chezmoi/dot_claude/settings.json" ]]
+    [[ ! -f "$REAL_DOTFILES_DIR/chezmoi/dot_claude/dot_settings.json" ]]
+}
+
+@test "claude settings.json: one-time migration script exists" {
+    [[ -f "$REAL_DOTFILES_DIR/chezmoi/.chezmoiscripts/run_once_before_migrate-claude-settings.sh" ]]
+}
+
+@test "claude settings.json: migration script removes legacy dotfiles symlink only" {
+    # The script must NOT delete a settings.json that links to anywhere
+    # other than $DOTFILES/claude/settings.json — the user may have
+    # set up their own symlink.
+    local script="$REAL_DOTFILES_DIR/chezmoi/.chezmoiscripts/run_once_before_migrate-claude-settings.sh"
+    grep -qF '*/dotfiles/claude/settings.json' "$script"
+    # shellcheck disable=SC2016
+    grep -qE 'if[[:space:]]+\[\[ -L "\$target" \]\]' "$script"
+}
+
+@test "claude/.sync no longer symlinks settings.json" {
+    # settings.json moved to chezmoi/dot_claude/create_settings.json;
+    # claude/.sync's configs list must not include it (else a fresh sync
+    # would re-create the legacy symlink, undoing the migration).
+    local sync_script="$REAL_DOTFILES_DIR/claude/.sync"
+    # The configs=( ... ) array shouldn't list `settings.json`.
+    ! awk '/^configs=\(/,/^\)/' "$sync_script" | grep -qE '^\s*settings\.json\s*$'
+}
+
+@test "claude/settings.json source is gone from the repo (migrated to chezmoi)" {
+    # Once committed, the legacy claude/settings.json must not exist —
+    # the chezmoi seed is the source of truth. A re-introduced file would
+    # quietly fight the chezmoi-seeded one via the legacy symlink path.
+    [[ ! -f "$REAL_DOTFILES_DIR/claude/settings.json" ]]
 }

--- a/tests/install-base-profile.bats
+++ b/tests/install-base-profile.bats
@@ -42,12 +42,16 @@ teardown() { teardown_test_env; }
 
 # ── two render targets (the core of curd 7) ──────────────────────────────────
 
-@test "install-base-profile.sh renders the four dot-dir harnesses at \$HOME" {
+@test "install-base-profile.sh renders the four dot-dir harnesses via global" {
+    # `global` wraps `base` with target_default=$HOME + the claude marketplace
+    # + plugin enablement. The installer forwards $HOME (so the profile's
+    # ${HOME} expands against the test sandbox) and intentionally omits
+    # --target — the profile resolves it.
     INSTALL_BASE_PROFILE_AP="$FAKE_BIN/ap" \
         run bash "$LIB" "$TEST_HOME"
     assert_success
     run cat "$AP_LOG"
-    assert_output_contains "install base --target $TEST_HOME --harness claude,codex,cursor,copilot"
+    assert_output_contains "install global --harness claude,codex,cursor,copilot"
 }
 
 @test "install-base-profile.sh renders opencode under \$HOME/.config/opencode" {

--- a/tests/packages.bats
+++ b/tests/packages.bats
@@ -409,8 +409,9 @@ run_sync() {
 
 # Build a curated PATH for "missing toolchain" tests. Keeps real yq/jq/shasum
 # (sync.sh needs them) but excludes any directory that holds an executable
-# cargo or rustup, so `command -v cargo` actually fails when MOCK_BIN/cargo
-# is removed.
+# cargo, rustup, OR cargo-install-update, so `command -v <tool>` actually
+# fails on developer machines where those binaries live alongside each
+# other under ~/.cargo/bin or /opt/homebrew/bin.
 scrub_toolchain_path() {
     local entry filtered=""
     local -a needed=(yq jq shasum sha256sum git awk sed grep cut sort tr head tail)
@@ -425,20 +426,29 @@ scrub_toolchain_path() {
         [[ -z "$entry" ]] && continue
         [[ -x "$entry/cargo" ]] && continue
         [[ -x "$entry/rustup" ]] && continue
+        [[ -x "$entry/cargo-install-update" ]] && continue
         filtered+="$entry:"
     done <<< "$(echo "$PATH" | tr ':' '\n')"
     echo "$stub:${filtered%:}"
 }
 
-@test "sync counts missing cargo AND rustup as failure (no cache saved)" {
+@test "sync warns + proceeds when cargo AND rustup are missing" {
+    # Behavior change: the linux-bootstrap PR (commit 5369aa3) softened
+    # missing-cargo from `log_error + FAILED+=("cargo")` to `log_warning +
+    # return 0`. Rationale: a fresh Ubuntu box without rust shouldn't
+    # FAIL the whole `dots sync` — the cargo packages just won't install
+    # until rustup is set up, while everything else (brew, npm, uv tools)
+    # proceeds normally. The cache IS saved on the successful sync.
     write_test_yaml
     rm -f "$MOCK_BIN/cargo" "$MOCK_BIN/rustup"
 
     PATH="$MOCK_BIN:$(scrub_toolchain_path)" run_sync
 
+    assert_success
     assert_output_contains "cargo not found"
-    assert_output_contains "cache NOT saved"
-    [[ ! -f "$CACHE_FILE" ]] || [[ ! -s "$CACHE_FILE" ]]
+    assert_output_contains "skipping cargo packages"
+    # Cache saved because the sync completed without failure.
+    [[ -f "$CACHE_FILE" ]]
 }
 
 @test "sync bootstraps rust toolchain when rustup exists but cargo missing" {
@@ -544,6 +554,11 @@ MOCKUPDATE
 @test "UPGRADE_MODE warns when cargo-install-update is not installed" {
     # Missing-binary fallback: dots up should keep going with a loud
     # warning instead of silently noop-ing or crashing.
+    #
+    # Use scrub_toolchain_path so the real cargo-install-update on the
+    # developer's PATH (alongside cargo under ~/.cargo/bin or
+    # /opt/homebrew/bin) doesn't satisfy the `command -v` check and mask
+    # the warning branch the test is locking in.
     write_test_yaml
     cat > "$MOCK_BIN/cargo" << 'MOCKCARGO'
 #!/bin/bash
@@ -561,7 +576,7 @@ MOCKCARGO
     chmod +x "$MOCK_BIN/cargo"
     # Deliberately do NOT install a cargo-install-update mock.
 
-    UPGRADE_MODE=true run bash "$SYNC_SCRIPT"
+    UPGRADE_MODE=true PATH="$MOCK_BIN:$(scrub_toolchain_path)" run bash "$SYNC_SCRIPT"
     assert_success
     assert_output_contains "cargo-update not installed"
     # And the install pass still skips the already-installed crate.


### PR DESCRIPTION
## Summary

- Introduce a `global` profile (wraps `base` via `include:`) that carries the install-overlay needed to actually wire `base` into the live Claude config: `target_default: $HOME`, registers a `local` marketplace, enables `global@local` in `enabledPlugins`. `dots sync` now runs `ap install global` and Claude actually loads the rendered plugin tree.
- Migrate the committed `claude/settings.json` (+ write-through symlink) to a chezmoi `create_` seed at `chezmoi/dot_claude/create_settings.json`, matching the existing `opencode.json` pattern: chezmoi seeds the user baseline once, ap surgically merges its keys, user-managed siblings survive both. A one-time `run_once_before_migrate-claude-settings.sh` unlinks any stale symlink before the seed lands.
- Fix the `cheese-flair` SessionStart hook's BSD-readlink assumption — `readlink -f` exists on modern macOS and was resolving symlinks into the dotfiles source tree where the sibling lib + bank no longer live. The hook now uses `BASH_SOURCE[0]` verbatim and anchors at the deployed harness root; a new regression test in `cheese-flair.bats` exercises the dotfiles directory-symlink topology so the bug can't reappear.

## Why

`ap install base` rendered to `$PWD` by default, which is correct for staging but operator-confusing as the verb for "deploy this onto my machine." The base plugin tree landed at `~/.claude/plugins/local/base/` but nothing enabled it in `settings.json.enabledPlugins`, so its SessionStart hook (cheese-flair) stayed inert — Claude was firing the hook through a hand-coded `settings.json` entry that pointed at a stale gitignored file under the dotfiles symlink tree. The hook itself silently failed on the macOS readlink resolution. The three layers (deploy, wiring, hook) are now unified.

## Schema additions (`agent_profile.parse.Manifest`)

- `target_default: str | None` — outer-profile-only; CLI honors explicit `--target` > profile default > `Path.cwd()` (with env + `~` expansion).
- `marketplaces: dict[str, str]` — outer-profile-only; claude renderer wraps each entry as a directory-source `extraKnownMarketplaces` record with `${VAR}` expansion.
- `enabled_plugins` already existed for the isolated-launch overlay. The claude renderer now also reads it for non-isolated installs and merges into `settings.json.enabledPlugins`.

`ClaudeRenderer.render()` gains `_merge_root_settings()` (idempotent, preserves sibling keys, bootstraps `{}` stub if absent — matching the opencode pattern). `ClaudeRenderer.clean()` un-merges symmetrically.

The chezmoi `run_onchange_after_install-base-profile.sh.tmpl` hash now covers `agents/hooks/**`, `agents/lib/**`, `agents/reference/**`, and `profiles/global/**`, so edits to hook scripts or shared assets trigger a redeploy on `dots sync` — they didn't before.

Pre-commit hooks updated for the new path: `check-claude-sync` now asserts `~/.claude/settings.json` exists as a regular file; `check-claude-settings-schema` validates against the chezmoi seed.

## Test plan

- [x] `pytest` — 357 passing (340 → 357; +17 in `agent-profile/tests/test_global_profile.py` covering target resolution precedence, idempotent merge, sibling preservation, clean un-merge, real-YAML parse)
- [x] `bats tests/chezmoi-wiring.bats` — 51 passing (42 → 51; +9 covering the seed file, migration script, `claude/.sync` drop)
- [x] `bats tests/cheese-flair.bats` — 33 passing (32 → 33; +1 regression test for the symlink-topology bug)
- [x] `bats tests/install-base-profile.bats` — 10 passing (asserts `install global`)
- [x] `bats tests/agents-hooks-sync.bats` — 142 passing (retired 2 content-lock tests for the legacy SessionStart wiring; their successors live in `chezmoi-wiring` + `cheese-flair`)
- [x] End-to-end live verification: `chezmoi apply` migrated this repo's `~/.claude/settings.json` from symlink → seeded real file; `ap install global` added `enabledPlugins["global@local"]` + `local` marketplace; the deployed plugin hook (sha 9bee, patched) produces a full cheese-flair sample when run directly. Next Claude session will pick up the new wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)