### PR TITLE
chore(packages): add crush AI coding agent

### DIFF
--- a/packages/packages.yaml
+++ b/packages/packages.yaml
@@ -55,6 +55,7 @@ packages:
   - gettext
   - taf2/tap/mdvi
   - anomalyco/tap/opencode                    # open-source AI coding agent (fresher than homebrew-core)
+  - charmbracelet/tap/crush                   # Charm terminal AI coding agent (MCP via crush.json)
 
   # Rust build acceleration
   - sccache                                   # rustc wrapper for compile caching


### PR DESCRIPTION
Declare `charmbracelet/tap/crush` in `packages/packages.yaml` so the Charm terminal AI coding agent (`crush`) is reproducible via `dots sync`.

The binary is already installed locally (`v0.74.0`). The `ap`-harness wiring — a `CrushRenderer` + registry/`ALL_HARNESSES` entry so crush receives the MCP registry union — is scoped separately in #223 (crush is non-isolated, MCP-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)