### PR TITLE
chore: remove employer-specific git machinery before going public

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,7 +113,7 @@ dotfiles/
 ├── cursor/                 # Cursor-specific configuration
 │   └── plugins/local/      # In-repo Cursor plugins (cheese-grok) deployed by chezmoi to ~/.cursor/{skills,rules,commands,hooks}/ plus hooks.json/modes.json merges.
 ├── skills/                 # Single source of truth for skills — flat tree of skill dirs plus `_registry.yaml` for external (`npx skills add`) sources. Unioned into the `base` profile and rendered into every harness by `ap`.
-├── chezmoi/                # chezmoi source dir. Wires `~/.config/chezmoi/chezmoi.toml` (via `.chezmoi.toml.tmpl`, prompts for email + work on first run), renders templated dotfiles (`private_dot_gitconfig.tmpl`, `private_dot_copilot/mcp-config.json.tmpl`), and runs run_onchange scripts: install-base-profile (renders the registry-derived `base` profile — MCPs + skills + hooks — into every harness via `ap`; supersedes the retired install-mcp/install-hooks/install-claude-skills deploy scripts), install-agents-doc (agents/AGENTS.md → both harnesses, agents/RTK.md → Claude), install-codex (codex/config.toml → ~/.codex/ first-time only), install-agent-profile (warms the `ap` uv env).
+├── chezmoi/                # chezmoi source dir. Wires `~/.config/chezmoi/chezmoi.toml` (via `.chezmoi.toml.tmpl`, prompts for email on first run), renders templated dotfiles (`private_dot_gitconfig.tmpl`, `private_dot_copilot/mcp-config.json.tmpl`), and runs run_onchange scripts: install-base-profile (renders the registry-derived `base` profile — MCPs + skills + hooks — into every harness via `ap`; supersedes the retired install-mcp/install-hooks/install-claude-skills deploy scripts), install-agents-doc (agents/AGENTS.md → both harnesses, agents/RTK.md → Claude), install-codex (codex/config.toml → ~/.codex/ first-time only), install-agent-profile (warms the `ap` uv env).
 ├── packages/
 │   ├── packages.yaml       # Flat package registry (brew, cargo, apt)
 │   └── sync.sh             # Package sync with hash cache
@@ -388,7 +388,7 @@ A subset of dotfiles is rendered by [chezmoi](https://chezmoi.io/) instead of sy
 - `~/.config/opencode/opencode.json` — `chezmoi/dot_config/opencode/create_opencode.json` (analogous: seed once, then `ap install base --target $HOME/.config/opencode --harness opencode` mutates the `mcp` block)
 - `~/.claude/skills/`, `~/.claude/CLAUDE.md`, `~/.codex/AGENTS.md`, `~/.codex/config.toml`, and MCP entries — handled by `run_onchange_*` scripts under `chezmoi/.chezmoiscripts/` that fork to helpers in `chezmoi/lib/`
 
-**First-init (interactive):** `dots sync` dispatches to `chezmoi/.sync`, which invokes `chezmoi init --source $DOTFILES/chezmoi` if `~/.config/chezmoi/chezmoi.toml` is missing. The `.chezmoi.toml.tmpl` prompts for: `email`, `work`. Answers persist to `~/.config/chezmoi/chezmoi.toml` (alongside the persisted `sourceDir`) and aren't re-prompted.
+**First-init (interactive):** `dots sync` dispatches to `chezmoi/.sync`, which invokes `chezmoi init --source $DOTFILES/chezmoi` if `~/.config/chezmoi/chezmoi.toml` is missing. The `.chezmoi.toml.tmpl` prompts for: `email`. The answer persists to `~/.config/chezmoi/chezmoi.toml` (alongside the persisted `sourceDir`) and isn't re-prompted.
 
 **Subsequent runs:** `dots sync` calls `chezmoi apply --force` via `chezmoi/.sync`. Non-interactive.
 
@@ -405,7 +405,7 @@ chezmoi doctor                                       # health check (also wired 
 
 **Re-prompt:** delete `~/.config/chezmoi/chezmoi.toml` and re-run `dots sync` (or `chezmoi init --source $DOTFILES/chezmoi` directly).
 
-**Adding a file:** drop a templated source under `chezmoi/` using the [chezmoi naming attributes](https://chezmoi.io/reference/source-state-attributes/) (`private_`, `dot_`, `executable_`, `encrypted_`, `.tmpl`). Reference data via `{{ .email }}`, `{{ .work }}`, etc. — see the existing templates for patterns. Add a corresponding test to `tests/chezmoi-wiring.bats`.
+**Adding a file:** drop a templated source under `chezmoi/` using the [chezmoi naming attributes](https://chezmoi.io/reference/source-state-attributes/) (`private_`, `dot_`, `executable_`, `encrypted_`, `.tmpl`). Reference data via `{{ .email }}`, etc. — see the existing templates for patterns. Add a corresponding test to `tests/chezmoi-wiring.bats`.
 
 **Secrets upgrade path:** `mcp-config.json.tmpl` uses `{{ env "..." }}` today. Swap to `{{ onepasswordRead "op://<vault>/<item>/credential" }}` once 1Password CLI is set up; remove the corresponding `.env` entries.
 
@@ -436,7 +436,7 @@ chezmoi doctor                                       # health check (also wired 
 
 ### Git Integration
 
-- Work email: <paul.sorensen@uber.com>
+- Default git email is templated via chezmoi (`{{ .email }}`); set a different address per repo with `git config user.email <addr>` (the `cpersonal` alias is a shortcut)
 - Aliases follow oh-my-zsh conventions for familiarity
 - Custom `grb` alias rebases from main (not master)
 - Kdiff3 configured as merge/diff tool
@@ -500,10 +500,9 @@ Pre-commit hooks are managed by [prek](https://prek.j178.dev/) via `prek.toml`. 
 ## Important Gotchas
 
 1. **Use `dots sync`**: Don't manually symlink - use the sync script for rollback support
-2. **Work-Specific Config**: Git configuration includes Uber-specific settings
-3. **macOS Specific**: Paths and some utilities assume macOS environment
-4. **Vi Mode**: Shell is in vi mode by default
-5. **MCP Scope**: Use `user` scope for dev tools, `project` for team-shared MCPs
-6. **Reference Folder**: Put reference docs in `reference/` (gitignored, not symlinked)
-7. **zsh Loading Order**: Files in `zsh/` are sourced in the order they appear in `zshrc`. If you add a new config file, edit `zshrc` to source it at the right point. For example, completions must load before `fzf.zsh` or keybindings might conflict.
-8. **Pre-Commit Hook Failures**: If prek blocks a commit (e.g., detected secrets), fix the issue before retrying. Only use `--no-verify` for temporary overrides. Check `prek.toml` to understand what's being checked.
+2. **macOS Specific**: Paths and some utilities assume macOS environment
+3. **Vi Mode**: Shell is in vi mode by default
+4. **MCP Scope**: Use `user` scope for dev tools, `project` for team-shared MCPs
+5. **Reference Folder**: Put reference docs in `reference/` (gitignored, not symlinked)
+6. **zsh Loading Order**: Files in `zsh/` are sourced in the order they appear in `zshrc`. If you add a new config file, edit `zshrc` to source it at the right point. For example, completions must load before `fzf.zsh` or keybindings might conflict.
+7. **Pre-Commit Hook Failures**: If prek blocks a commit (e.g., detected secrets), fix the issue before retrying. Only use `--no-verify` for temporary overrides. Check `prek.toml` to understand what's being checked.

--- a/chezmoi/.chezmoi.toml.tmpl
+++ b/chezmoi/.chezmoi.toml.tmpl
@@ -14,4 +14,3 @@ sourceDir = "{{ .chezmoi.sourceDir }}"
 
 [data]
 email = {{ promptStringOnce . "email" "Git email" "paulnsorensen@gmail.com" | quote }}
-work  = {{ promptBoolOnce   . "work"  "Is this a work machine?" false }}

--- a/chezmoi/private_dot_gitconfig.tmpl
+++ b/chezmoi/private_dot_gitconfig.tmpl
@@ -33,7 +33,6 @@
 	prompt = 103    # blue (#768da1)
 
 [alias]
-	cwork = !git config user.email paul.sorensen@uber.com
 	cpersonal = !git config user.email paulnsorensen@gmail.com
 
 [difftool "kdiff3"]
@@ -55,16 +54,8 @@
     name = mergiraf
     driver = mergiraf merge --git "%O" "%A" "%B" -s "%S" -x "%X" -y "%Y" -p "%P"
 
-{{- if .work }}
-[url "ssh://code.uber.internal/"]
-	insteadOf = https://code.uber.internal/
-[url "ssh://config.uber.internal/"]
-	insteadOf = https://config.uber.internal/
-[http "https://gopkg.uberinternal.com"]
-	followRedirects = true
 [http "https://gopkg.in"]
 	followRedirects = true
-{{- end }}
 [rerere]
 	enabled = true
 [include]

--- a/tests/chezmoi-wiring.bats
+++ b/tests/chezmoi-wiring.bats
@@ -624,18 +624,32 @@ YAML
     assert_file_exists "$REAL_DOTFILES_DIR/chezmoi/.gitattributes"
 }
 
-@test ".chezmoi.toml.tmpl prompts for email and work, and persists sourceDir" {
+@test ".chezmoi.toml.tmpl prompts for email and persists sourceDir" {
     local toml="$REAL_DOTFILES_DIR/chezmoi/.chezmoi.toml.tmpl"
     grep -q 'promptStringOnce . "email"' "$toml"
-    grep -q 'promptBoolOnce' "$toml"
     grep -q '\.chezmoi\.sourceDir' "$toml"
+    # The work-machine prompt was removed with the employer git machinery;
+    # per-repo email is native git (`git config user.email`).
+    if grep -q 'promptBoolOnce' "$toml"; then
+        echo ".chezmoi.toml.tmpl still has the removed work prompt" >&2
+        return 1
+    fi
 }
 
-@test "gitconfig template references .email and gates Uber URLs on .work" {
+@test "gitconfig template references .email and carries no employer machinery" {
     local tmpl="$REAL_DOTFILES_DIR/chezmoi/private_dot_gitconfig.tmpl"
     grep -q 'email = {{ .email }}' "$tmpl"
-    grep -q '{{- if .work }}' "$tmpl"
-    grep -q 'code.uber.internal' "$tmpl"
+    # Public-repo guard: the template must carry no work gate and no
+    # internal/employer hostname or address. Per-repo email is native git
+    # (`git config user.email`), so no `.work`-gated block is needed.
+    if grep -q '\.work' "$tmpl"; then
+        echo "gitconfig template still references removed .work gate" >&2
+        return 1
+    fi
+    if grep -qi 'uber' "$tmpl"; then
+        echo "gitconfig template still references an employer hostname/address" >&2
+        return 1
+    fi
 }
 
 @test "copilot template warns on missing env vars and renders both keys" {
@@ -734,9 +748,9 @@ TOML
     # the bootstrapped email.
     assert_file_exists "$HOME/.gitconfig"
     grep -qF "email = test@example.com" "$HOME/.gitconfig"
-    # work=false → Uber [url] redirects must NOT appear.
-    if grep -qF 'code.uber.internal' "$HOME/.gitconfig"; then
-        echo "Uber [url] redirects rendered even though work=false" >&2
+    # Public-repo guard: no employer hostname/address in the rendered config.
+    if grep -qi 'uber' "$HOME/.gitconfig"; then
+        echo "employer hostname/address rendered into .gitconfig" >&2
         return 1
     fi
 
@@ -778,35 +792,6 @@ TOML
     assert_file_exists "$HOME/.copilot/mcp-config.json"
     grep -qF '"mcpServers": {}' "$HOME/.copilot/mcp-config.json"
     grep -qF 'Stub written by chezmoi' "$HOME/.copilot/mcp-config.json"
-}
-
-@test "gitconfig template renders Uber URL redirects when work=true" {
-    command -v chezmoi >/dev/null 2>&1 || skip "chezmoi not installed"
-
-    # Stub fake npx so the run_onchange installer's `command -v npx` preflight
-    # doesn't abort chezmoi apply before the gitconfig template runs.
-    local fake_npx_bin
-    fake_npx_bin=$(make_fake_npx)
-    PATH="$fake_npx_bin:$PATH"
-
-    mkdir -p "$HOME/.config/chezmoi"
-    cat > "$HOME/.config/chezmoi/chezmoi.toml" <<TOML
-sourceDir = "$REAL_DOTFILES_DIR/chezmoi"
-
-[data]
-email = "paul.sorensen@uber.com"
-work = true
-TOML
-    export CONTEXT7_API_KEY="test-context7-key"
-    export TAVILY_API_KEY="test-tavily-key"
-
-    run chezmoi apply --force
-    assert_success
-
-    assert_file_exists "$HOME/.gitconfig"
-    grep -qF "email = paul.sorensen@uber.com" "$HOME/.gitconfig"
-    grep -qF 'ssh://code.uber.internal/' "$HOME/.gitconfig"
-    grep -qF 'gopkg.uberinternal.com' "$HOME/.gitconfig"
 }
 
 # ── serena config (modify_ pattern) ────────────────────────────────────────


### PR DESCRIPTION
Scrubs all Uber references and the `.work`-gate machinery from tracked files so the repo is safe to make public. Verified there is **nothing in git history** to scrub — `.env` and `.codex/config.toml` were never committed; this is purely tracked-file content.

## Changes
- **`private_dot_gitconfig.tmpl`** — drop the `cwork` alias (hardcoded work email) and the `{{ if .work }}` block of internal hostnames (`code`/`config.uber.internal`, `gopkg.uberinternal.com`). The generic `gopkg.in` redirect is kept, now ungated.
- **`.chezmoi.toml.tmpl`** — remove the now-unused `work` machine prompt.
- **`AGENTS.md`** — drop the work-email line + "Uber-specific" gotcha (renumbered), fix the chezmoi-prompt docs and the `{{ .work }}` template-data example.
- **`chezmoi-wiring.bats`** — rewrite the gitconfig/toml tests as public-repo **regression guards** (assert no `.work`, no employer hostname, no work prompt) and delete the `work=true` Uber-render test.

## Per-repo email still works
Native git: `git config user.email <addr>` in any repo. The `cpersonal` alias remains as a shortcut. No `.work` machinery needed.

## Tests
`bats tests/chezmoi-wiring.bats` → 52/52. Templates render clean (no employer strings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)