### PR TITLE
fix(ap): make global-profile MCPs + hooks actually load on a fresh box

### DIFF
--- a/agent-profile/agent_profile/renderers/claude.py
+++ b/agent-profile/agent_profile/renderers/claude.py
@@ -53,6 +53,13 @@ _MCP_DEFAULT = ("claude", "codex", "opencode")
 # `(.harnesses // ["claude"])`).
 _HOOK_DEFAULT = ("claude",)
 
+# Name of the directory marketplace that backs the rendered plugin tree.
+# Matches the hardcoded ``local`` path segment in ``plugin_dir`` below and
+# the marketplace key profiles register (``global@local``). A Claude
+# ``directory`` marketplace resolves plugins through a ``marketplace.json``
+# whose ``name`` equals the registered key, so the three must agree.
+_LOCAL_MARKETPLACE = "local"
+
 
 def _dump_json(path: Path, data: object) -> None:
     """Write ``data`` as 2-space-indented JSON + trailing newline (the exact
@@ -82,6 +89,7 @@ class ClaudeRenderer:
         self._write_hooks(manifest, plugin_dir, base, profile, out)
         self._write_mcp_json(manifest, plugin_dir, base, out)
         self._write_settings(manifest, plugin_dir, base, out)
+        self._write_local_marketplace(manifest, base, profile, desc)
         self._merge_root_settings(manifest, base)
 
         # Track the plugin dir root so uninstall removes the whole tree
@@ -101,6 +109,7 @@ class ClaudeRenderer:
         entries (mirroring how :class:`OpencodeRenderer.clean` un-merges
         ``opencode.json``)."""
         base = Path(str(target).rstrip("/"))
+        self._clean_local_marketplace(base, manifest.name)
         settings = base / ".claude" / "settings.json"
         if not settings.is_file():
             return
@@ -259,33 +268,55 @@ class ClaudeRenderer:
             event = item.get("event")
             matcher = item.get("matcher") or ""
             script = item.get("script") or ""
+            command = item.get("command") or ""
             source_dir = item["_source_dir"]
-            if not script:
+
+            if script and command:
                 raise ValueError(
-                    f"claude_render: hook event '{event}' is missing 'script' "
+                    f"claude_render: hook event '{event}' sets both 'script' "
+                    f"and 'command' — they are mutually exclusive "
                     f"(profile {source_dir})"
                 )
-            src = Path(source_dir) / script
-            if not src.is_file():
-                raise FileNotFoundError(
-                    f"claude_render: hook script not found: {src}"
+            if script:
+                src = Path(source_dir) / script
+                if not src.is_file():
+                    raise FileNotFoundError(
+                        f"claude_render: hook script not found: {src}"
+                    )
+                basename = Path(script).name
+                dst = plugin_dir / "hooks" / basename
+                shutil.copyfile(src, dst)
+                dst.chmod(
+                    dst.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+                )
+                self._track(out, base, dst)
+                # Deploy shared_assets alongside the script so the
+                # self-locating SessionStart script resolves its lib/bank
+                # under the plugin dir (HARNESS_ROOT = dirname(hooks/)).
+                copy_hook_shared_assets(item, plugin_dir, base, out)
+                cmd = "${CLAUDE_PLUGIN_ROOT}/hooks/" + basename
+            elif command:
+                # Literal command, used verbatim — no file deploy. For
+                # external bridges (e.g. moshi-hook) that aren't deployed
+                # scripts.
+                cmd = command
+            else:
+                raise ValueError(
+                    f"claude_render: hook event '{event}' has neither 'script' "
+                    f"nor 'command' (profile {source_dir})"
                 )
 
-            basename = Path(script).name
-            dst = plugin_dir / "hooks" / basename
-            shutil.copyfile(src, dst)
-            dst.chmod(dst.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
-            self._track(out, base, dst)
-
-            # Deploy shared_assets alongside the script so the self-locating
-            # SessionStart script resolves its lib/bank under the plugin dir
-            # (HARNESS_ROOT = dirname(hooks/) = plugin_dir).
-            copy_hook_shared_assets(item, plugin_dir, base, out)
-
-            cmd = "${CLAUDE_PLUGIN_ROOT}/hooks/" + basename
-            hook_entries.setdefault(event, []).append(
-                {"matcher": matcher, "hooks": [{"type": "command", "command": cmd}]}
+            inner = {"type": "command", "command": cmd}
+            if item.get("timeout") is not None:
+                inner["timeout"] = item["timeout"]
+            if item.get("async") is not None:
+                inner["async"] = item["async"]
+            entry = (
+                {"matcher": matcher, "hooks": [inner]}
+                if matcher
+                else {"hooks": [inner]}
             )
+            hook_entries.setdefault(event, []).append(entry)
             wrote_any = True
 
         if not wrote_any:
@@ -375,3 +406,70 @@ class ClaudeRenderer:
                 }
 
         settings.write_text(json.dumps(data, indent=2) + "\n")
+
+    def _write_local_marketplace(
+        self, manifest: Manifest, base: Path, profile: str, desc: str
+    ) -> None:
+        """Ensure the directory-marketplace manifest at
+        ``<base>/.claude/plugins/local/.claude-plugin/marketplace.json``
+        lists this profile as a plugin.
+
+        Without this manifest a Claude ``directory`` marketplace has no
+        ``plugins[]`` to resolve, so an ``enabledPlugins`` entry like
+        ``global@local`` is silently dropped and the plugin's bundled
+        ``.mcp.json`` never loads. The manifest is shared across every
+        profile rendered into the same local marketplace (like the live
+        ``settings.json``), so the entry is upserted by name and siblings
+        are preserved; :meth:`clean` removes exactly this profile's entry.
+
+        A profile advertises itself here only when it enables itself in the
+        local marketplace (``<profile>@local`` in ``enabled_plugins``) — a
+        bare plugin render that no one enables stays out of the manifest.
+        """
+        if not manifest.enabled_plugins.get(f"{profile}@{_LOCAL_MARKETPLACE}"):
+            return
+        manifest_path = (
+            base / ".claude" / "plugins" / "local" / ".claude-plugin"
+            / "marketplace.json"
+        )
+        if manifest_path.is_file():
+            data = read_json_object(manifest_path, "marketplace.json")
+        else:
+            manifest_path.parent.mkdir(parents=True, exist_ok=True)
+            data = {}
+
+        data["name"] = _LOCAL_MARKETPLACE
+        # Claude's marketplace schema requires a non-empty `owner` object.
+        data["owner"] = {"name": "agent-profile"}
+        entry = {"name": profile, "source": f"./{profile}"}
+        if desc:
+            entry["description"] = desc
+        siblings = [
+            p
+            for p in data.get("plugins", [])
+            if isinstance(p, dict) and p.get("name") != profile
+        ]
+        data["plugins"] = siblings + [entry]
+        _dump_json(manifest_path, data)
+
+    def _clean_local_marketplace(self, base: Path, profile: str) -> None:
+        """Remove ``profile``'s entry from the shared local marketplace
+        manifest; delete the manifest when no plugins remain. Mirrors the
+        ``settings.json`` un-merge in :meth:`clean`."""
+        manifest_path = (
+            base / ".claude" / "plugins" / "local" / ".claude-plugin"
+            / "marketplace.json"
+        )
+        if not manifest_path.is_file():
+            return
+        data = read_json_object(manifest_path, "marketplace.json")
+        remaining = [
+            p
+            for p in data.get("plugins", [])
+            if isinstance(p, dict) and p.get("name") != profile
+        ]
+        if not remaining:
+            manifest_path.unlink()
+            return
+        data["plugins"] = remaining
+        _dump_json(manifest_path, data)

--- a/agent-profile/agent_profile/renderers/claude.py
+++ b/agent-profile/agent_profile/renderers/claude.py
@@ -53,6 +53,13 @@ _MCP_DEFAULT = ("claude", "codex", "opencode")
 # `(.harnesses // ["claude"])`).
 _HOOK_DEFAULT = ("claude",)
 
+# Events for which Claude writes a `matcher` field into the outer hook block
+# (a tool-name regex). Mirrors `_hook_event_uses_matcher` for claude in
+# agents/hooks/lib.sh — keep the two in sync. For any other event (e.g. a
+# SessionStart entry carrying a codex-only source matcher) Claude ignores the
+# matcher, so it is dropped on write rather than emitted as a dead field.
+_CLAUDE_MATCHER_EVENTS = frozenset({"PreToolUse", "PostToolUse"})
+
 # Name of the directory marketplace that backs the rendered plugin tree.
 # Matches the hardcoded ``local`` path segment in ``plugin_dir`` below and
 # the marketplace key profiles register (``global@local``). A Claude
@@ -313,7 +320,7 @@ class ClaudeRenderer:
                 inner["async"] = item["async"]
             entry = (
                 {"matcher": matcher, "hooks": [inner]}
-                if matcher
+                if matcher and event in _CLAUDE_MATCHER_EVENTS
                 else {"hooks": [inner]}
             )
             hook_entries.setdefault(event, []).append(entry)

--- a/agent-profile/tests/test_global_profile.py
+++ b/agent-profile/tests/test_global_profile.py
@@ -142,6 +142,96 @@ def test_claude_renderer_adds_marketplaces_with_directory_wrap(tmp_path, monkeyp
     }
 
 
+# ── local directory-marketplace manifest (plugin resolution) ─────────
+
+
+def test_local_marketplace_manifest_is_written(tmp_path):
+    """render emits a directory ``marketplace.json`` listing the profile as
+    a plugin, so ``enabledPlugins: <profile>@local`` can resolve."""
+    _seed_settings(tmp_path, {})
+    ClaudeRenderer().render(
+        _bare_manifest(
+            name="global",
+            description="Live install",
+            enabled_plugins={"global@local": True},
+        ),
+        tmp_path,
+    )
+
+    mpath = tmp_path / ".claude/plugins/local/.claude-plugin/marketplace.json"
+    assert mpath.is_file()
+    data = json.loads(mpath.read_text())
+    assert data["name"] == "local"
+    assert data["plugins"] == [
+        {"name": "global", "source": "./global", "description": "Live install"}
+    ]
+
+
+def test_local_marketplace_resolves_enabled_plugin_end_to_end(tmp_path, monkeypatch):
+    """The registered marketplace path, the ``marketplace.json``, and the
+    rendered plugin dir all agree. This is the wiring that was broken when
+    the path pointed at a nonexistent repo dir — the MCPs never loaded."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _seed_settings(tmp_path, {})
+    ClaudeRenderer().render(
+        _bare_manifest(
+            name="global",
+            marketplaces={"local": "~/.claude/plugins/local"},
+            enabled_plugins={"global@local": True},
+        ),
+        tmp_path,
+    )
+
+    settings = json.loads((tmp_path / ".claude/settings.json").read_text())
+    market_path = Path(
+        settings["extraKnownMarketplaces"]["local"]["source"]["path"]
+    )
+    # The registered marketplace path holds the manifest.
+    assert (market_path / ".claude-plugin" / "marketplace.json").is_file()
+    mdata = json.loads(
+        (market_path / ".claude-plugin/marketplace.json").read_text()
+    )
+    assert mdata["name"] == "local"
+    # The manifest advertises a plugin matching the enabled id global@local.
+    plugin = next(p for p in mdata["plugins"] if p["name"] == "global")
+    # Its source resolves to a real rendered plugin dir.
+    assert (market_path / plugin["source"] / ".claude-plugin/plugin.json").is_file()
+
+
+def test_local_marketplace_upserts_and_preserves_siblings(tmp_path):
+    """A second profile installed into the same local marketplace keeps the
+    first's entry; re-rendering the same profile does not duplicate it."""
+    _seed_settings(tmp_path, {})
+    g = _bare_manifest(name="global", enabled_plugins={"global@local": True})
+    r = _bare_manifest(name="review", enabled_plugins={"review@local": True})
+    ClaudeRenderer().render(g, tmp_path)
+    ClaudeRenderer().render(r, tmp_path)
+    ClaudeRenderer().render(g, tmp_path)  # rerun
+
+    data = json.loads(
+        (tmp_path / ".claude/plugins/local/.claude-plugin/marketplace.json").read_text()
+    )
+    assert sorted(p["name"] for p in data["plugins"]) == ["global", "review"]
+
+
+def test_clean_removes_profile_from_local_marketplace(tmp_path):
+    """clean() un-merges the profile's entry; the manifest is deleted only
+    once no plugins remain."""
+    _seed_settings(tmp_path, {})
+    g = _bare_manifest(name="global", enabled_plugins={"global@local": True})
+    r = _bare_manifest(name="review", enabled_plugins={"review@local": True})
+    ClaudeRenderer().render(g, tmp_path)
+    ClaudeRenderer().render(r, tmp_path)
+    mpath = tmp_path / ".claude/plugins/local/.claude-plugin/marketplace.json"
+
+    ClaudeRenderer().clean(g, tmp_path)
+    data = json.loads(mpath.read_text())
+    assert [p["name"] for p in data["plugins"]] == ["review"]
+
+    ClaudeRenderer().clean(r, tmp_path)
+    assert not mpath.exists()
+
+
 def test_claude_renderer_preserves_user_siblings(tmp_path):
     """Pre-existing keys (sandbox, hooks, etc.) survive the merge."""
     settings = _seed_settings(

--- a/agent-profile/tests/test_renderer_claude.py
+++ b/agent-profile/tests/test_renderer_claude.py
@@ -582,6 +582,39 @@ hooks:
     assert not hooks_dir.exists() or not any(hooks_dir.iterdir())
 
 
+def test_hook_matcher_dropped_for_non_matcher_event(env):
+    """A SessionStart entry carrying a matcher (the codex-only source regex,
+    e.g. cheese-flair's "startup|resume") must render WITHOUT a matcher on the
+    Claude side — Claude only consumes matchers for PreToolUse/PostToolUse.
+    Locks parity with `_hook_event_uses_matcher` in agents/hooks/lib.sh so the
+    live `ap` render path doesn't leak a dead matcher field Claude ignores."""
+    yaml_text = """\
+name: matcherhook
+description: SessionStart hook that carries a (codex-only) matcher
+hooks:
+  - event: SessionStart
+    matcher: "startup|resume"
+    command: "echo hi"
+    harnesses: [claude]
+  - event: PreToolUse
+    matcher: "Bash"
+    command: "echo bash"
+    harnesses: [claude]
+"""
+    profile_dir = write_profile(env.profiles, "matcherhook", yaml_text)
+    manifest = parse_manifest(profile_dir)
+    ClaudeRenderer().render(manifest, env.target)
+    data = json.loads(
+        (env.target / ".claude/plugins/local/matcherhook/plugin.json").read_text()
+    )
+    session_block = data["hooks"]["SessionStart"][0]
+    assert "matcher" not in session_block, (
+        "SessionStart matcher should be dropped on the Claude render"
+    )
+    # PreToolUse is a matcher event — its matcher must survive.
+    assert data["hooks"]["PreToolUse"][0]["matcher"] == "Bash"
+
+
 def test_hook_with_nonexistent_script_raises(env):
     yaml_text = """\
 name: ghosthook

--- a/agent-profile/tests/test_renderer_claude.py
+++ b/agent-profile/tests/test_renderer_claude.py
@@ -513,10 +513,10 @@ def test_nobody_tracked_files_exclude_shared_agent(rendered_nobody):
 # ─── failure paths (fail fast and loud — parity with bash `return 1`) ─
 
 
-def test_hook_with_missing_script_field_raises(env):
+def test_hook_with_neither_script_nor_command_raises(env):
     yaml_text = """\
 name: badhook
-description: hook missing script
+description: hook with no execution target
 hooks:
   - event: PreToolUse
     matcher: "Bash"
@@ -524,8 +524,62 @@ hooks:
 """
     profile_dir = write_profile(env.profiles, "badhook", yaml_text)
     manifest = parse_manifest(profile_dir)
-    with pytest.raises(ValueError, match="missing 'script'"):
+    with pytest.raises(ValueError, match="neither 'script' nor 'command'"):
         ClaudeRenderer().render(manifest, env.target)
+
+
+def test_hook_with_both_script_and_command_raises(env):
+    yaml_text = """\
+name: bothhook
+description: hook setting both script and command
+hooks:
+  - event: SessionStart
+    script: hooks/h.sh
+    command: "/usr/bin/true"
+    harnesses: [claude]
+"""
+    profile_dir = write_profile(
+        env.profiles, "bothhook", yaml_text,
+        {"hooks/h.sh": "#!/usr/bin/env bash\nexit 0\n"},
+    )
+    manifest = parse_manifest(profile_dir)
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        ClaudeRenderer().render(manifest, env.target)
+
+
+def test_hook_command_literal_is_used_verbatim(env):
+    """A `command:` hook renders the literal command with async/timeout and
+    no file deploy — the moshi-hook bridge pattern."""
+    yaml_text = """\
+name: cmdhook
+description: literal command hook
+hooks:
+  - event: Stop
+    command: "'/home/paul/.local/bin/moshi-hook' claude-hook"
+    async: true
+    harnesses: [claude]
+  - event: PermissionRequest
+    command: "'/home/paul/.local/bin/moshi-hook' claude-hook"
+    timeout: 300
+    async: false
+    harnesses: [claude]
+"""
+    profile_dir = write_profile(env.profiles, "cmdhook", yaml_text)
+    manifest = parse_manifest(profile_dir)
+    ClaudeRenderer().render(manifest, env.target)
+    data = json.loads(
+        (env.target / ".claude/plugins/local/cmdhook/plugin.json").read_text()
+    )
+    stop = data["hooks"]["Stop"][0]
+    assert "matcher" not in stop
+    assert stop["hooks"][0]["command"] == "'/home/paul/.local/bin/moshi-hook' claude-hook"
+    assert stop["hooks"][0]["async"] is True
+    perm = data["hooks"]["PermissionRequest"][0]["hooks"][0]
+    assert perm["timeout"] == 300
+    assert perm["async"] is False
+    # No script file deployed for a command-literal hook.
+    hooks_dir = env.target / ".claude/plugins/local/cmdhook/hooks"
+    assert not hooks_dir.exists() or not any(hooks_dir.iterdir())
 
 
 def test_hook_with_nonexistent_script_raises(env):

--- a/agents/hooks/lib.sh
+++ b/agents/hooks/lib.sh
@@ -7,11 +7,13 @@
 # hidden environment beyond that.
 #
 # Drift signature (per entry, per harness):
-#   <deployed-script-path>\t<event>\t<matcher>\t<timeout>
-# Comparable across harnesses; recomputed from desired state and from the
-# harness's persisted state, then equality-checked. `event` is part of the
-# signature so two entries pointing at the same script but at different
-# event slots don't collide on drift detection.
+#   <resolved-command>\t<event>\t<matcher>\t<timeout>\t<async>
+# `resolved-command` is the final command string — `bash "<deployed-path>"`
+# for a `script` entry, or the literal `command` verbatim. Comparable across
+# harnesses; recomputed from desired state and from the harness's persisted
+# state, then equality-checked. `event` is part of the signature so two
+# entries pointing at the same command but at different event slots don't
+# collide on drift detection. `async` is claude-only (empty for codex).
 #
 # Claude backend reconciles claude/settings.json (in-repo, jq in-place).
 # Codex backend reconciles ~/.codex/config.toml (yq -p=toml -o=toml).
@@ -34,15 +36,6 @@ set -euo pipefail
 # backend will still happily write the entry if a registry author opts
 # codex in, but at run time codex won't trigger it.
 HOOK_EVENTS_VALID=(SessionStart UserPromptSubmit PreToolUse PostToolUse Stop PermissionRequest)
-
-# Returns 0 iff event is in the supported set.
-_hook_event_valid() {
-    local e="$1" v
-    for v in "${HOOK_EVENTS_VALID[@]}"; do
-        [[ "$v" == "$e" ]] && return 0
-    done
-    return 1
-}
 
 # Returns 0 iff the harness writes a `matcher` field into the outer block
 # for that (event, harness) pair.

--- a/agents/hooks/lib.sh
+++ b/agents/hooks/lib.sh
@@ -7,14 +7,17 @@
 # hidden environment beyond that.
 #
 # Drift signature (per entry, per harness):
-#   <deployed-script-path>\t<matcher>\t<timeout>
+#   <deployed-script-path>\t<event>\t<matcher>\t<timeout>
 # Comparable across harnesses; recomputed from desired state and from the
-# harness's persisted state, then equality-checked.
+# harness's persisted state, then equality-checked. `event` is part of the
+# signature so two entries pointing at the same script but at different
+# event slots don't collide on drift detection.
 #
 # Claude backend reconciles claude/settings.json (in-repo, jq in-place).
 # Codex backend reconciles ~/.codex/config.toml (yq -p=toml -o=toml).
-# Only the SessionStart slot for each registered hook is managed; all
-# other top-level keys and unmanaged hook entries are preserved.
+# Only the event slot named by each registered hook is managed; all other
+# top-level keys and unmanaged hook entries (other events, other commands)
+# are preserved.
 #
 # shellcheck disable=SC2034,SC2329
 #   SC2034: exports consumed by sync-common.sh
@@ -22,17 +25,51 @@
 
 set -euo pipefail
 
+# Supported hook event types. Adding a new event needs:
+#   1) Bats coverage for the new event in tests/agents-hooks-sync.bats.
+#   2) If the harness writes a matcher field into the outer block for the
+#      new event, extend _hook_event_uses_matcher accordingly.
+#
+# PermissionRequest is claude-only — codex doesn't fire it. The codex
+# backend will still happily write the entry if a registry author opts
+# codex in, but at run time codex won't trigger it.
+HOOK_EVENTS_VALID=(SessionStart UserPromptSubmit PreToolUse PostToolUse Stop PermissionRequest)
+
+# Returns 0 iff event is in the supported set.
+_hook_event_valid() {
+    local e="$1" v
+    for v in "${HOOK_EVENTS_VALID[@]}"; do
+        [[ "$v" == "$e" ]] && return 0
+    done
+    return 1
+}
+
+# Returns 0 iff the harness writes a `matcher` field into the outer block
+# for that (event, harness) pair.
+#   claude — PreToolUse / PostToolUse (matcher = tool-name regex).
+#            SessionStart, UserPromptSubmit, Stop have no matcher.
+#   codex  — SessionStart (matcher = source regex: startup|resume|clear) and
+#            PreToolUse / PostToolUse (matcher = tool-name regex).
+# Anything not listed here writes the inner hook entry without a matcher
+# wrapper, and any registry-provided matcher is silently dropped for that
+# (event, harness) pair.
+_hook_event_uses_matcher() {
+    local event="$1" harness="$2"
+    case "$harness:$event" in
+        claude:PreToolUse|claude:PostToolUse) return 0 ;;
+        codex:SessionStart|codex:PreToolUse|codex:PostToolUse) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
 # ─── registry filtering ─────────────────────────────────────────────────
 #
-# Asserts `event == SessionStart` on every entry. The backends below only
-# wire the SessionStart slot; routing a `PostToolUse` entry through them
-# would silently land in the wrong slot. When a second event type ships,
-# parameterise the slot in the backends and drop this guard at the same
-# time.
+# Validates that every entry declares a known `event`, then filters to the
+# subset that opts into the requested harness.
 
 hook_filter_for_harness() {
     local harness="$1" json="$2"
-    local missing bad
+    local missing bad_name bad_event both_set neither_set
     # Require `event` explicitly — silently defaulting it would let a typo
     # ("evnt: PostToolUse") land in the SessionStart slot.
     missing=$(jq -r <<<"$json" '
@@ -43,13 +80,40 @@ hook_filter_for_harness() {
         echo -e "${RED}hook_filter_for_harness: entry '$missing' is missing the required 'event' field.${NC}" >&2
         return 1
     fi
-    bad=$(jq -r <<<"$json" '
+    # Validate event ∈ supported set. The jq passes the set in as JSON so
+    # the check stays in one place — no per-entry bash loop.
+    local valid_events_json
+    valid_events_json=$(printf '%s\n' "${HOOK_EVENTS_VALID[@]}" | jq -R . | jq -s .)
+    bad_name=$(jq -r --argjson valid "$valid_events_json" <<<"$json" '
         to_entries
-        | map(select(.value.event != "SessionStart"))
+        | map(select((.value.event as $e | $valid | index($e)) == null))
         | .[0].key // ""')
-    if [[ -n "$bad" ]]; then
-        echo -e "${RED}hook_filter_for_harness: entry '$bad' has event != SessionStart;${NC}" >&2
-        echo -e "${RED}  only SessionStart is wired in this sync. Add backend support before registering.${NC}" >&2
+    if [[ -n "$bad_name" ]]; then
+        bad_event=$(jq -r --arg n "$bad_name" '.[$n].event' <<<"$json")
+        echo -e "${RED}hook_filter_for_harness: entry '$bad_name' has unsupported event '$bad_event';${NC}" >&2
+        echo -e "${RED}  supported: ${HOOK_EVENTS_VALID[*]}. Add the event to HOOK_EVENTS_VALID and${NC}" >&2
+        echo -e "${RED}  extend _hook_event_uses_matcher if the harness uses a matcher there.${NC}" >&2
+        return 1
+    fi
+    # `script` and `command` are mutually exclusive (script → deployed path,
+    # command → literal external command). Exactly one must be set.
+    both_set=$(jq -r <<<"$json" '
+        to_entries
+        | map(select((.value.script // "") != "" and (.value.command // "") != ""))
+        | .[0].key // ""')
+    if [[ -n "$both_set" ]]; then
+        echo -e "${RED}hook_filter_for_harness: entry '$both_set' sets both 'script' and 'command';${NC}" >&2
+        echo -e "${RED}  these are mutually exclusive — pick one.${NC}" >&2
+        return 1
+    fi
+    neither_set=$(jq -r <<<"$json" '
+        to_entries
+        | map(select((.value.script // "") == "" and (.value.command // "") == ""))
+        | .[0].key // ""')
+    if [[ -n "$neither_set" ]]; then
+        echo -e "${RED}hook_filter_for_harness: entry '$neither_set' has neither 'script' nor 'command';${NC}" >&2
+        echo -e "${RED}  set 'script: <repo-relative-path>' for a deployed hook, or${NC}" >&2
+        echo -e "${RED}  'command: <literal>' for an external binary.${NC}" >&2
         return 1
     fi
     jq --arg h "$harness" <<<"$json" '
@@ -84,113 +148,205 @@ hook_codex_command() {
     printf 'bash "$HOME/.codex/hooks/%s"\n' "$base"
 }
 
+# Resolve the final command string for a registry entry. Mutually exclusive
+# fields:
+#   script:   repo-relative path. Deployed under $HOME/.<harness>/hooks/;
+#             command is `bash "<deployed-path>"`.
+#   command:  literal command. Used verbatim, no deploy. The string is
+#             written into the hook entry as-is (caller is responsible for
+#             any $HOME-style quoting).
+# If both are set the registry is malformed (caller validates before this
+# point). If neither is set, returns empty — *_apply functions guard.
+# shellcheck disable=SC2016
+#   The literal `$HOME` in the claude command is intentional — it is written
+#   verbatim into settings.json and expanded by Claude at runtime, not bash.
+_hook_resolve_command() {
+    local name="$1" harness="$2"
+    local script command_literal
+    script=$(         jq -r --arg n "$name" '.[$n].script  // ""' <<<"$HARNESS_DESIRED_JSON")
+    command_literal=$(jq -r --arg n "$name" '.[$n].command // ""' <<<"$HARNESS_DESIRED_JSON")
+
+    if [[ -n "$command_literal" ]]; then
+        printf '%s\n' "$command_literal"
+        return 0
+    fi
+    if [[ -n "$script" ]]; then
+        case "$harness" in
+            claude) printf 'bash "$HOME/.claude/hooks/%s"\n' "$(basename "$script")" ;;
+            codex)  hook_codex_command "$script" ;;
+            *)      return 1 ;;
+        esac
+        return 0
+    fi
+    return 1
+}
+
 # ─── drift signature ────────────────────────────────────────────────────
+# Five tab-separated fields: <resolved-command> <event> <matcher> <timeout> <async>.
+# `event` is included so two entries with the same command but different
+# event slots don't collide. `matcher` is preserved verbatim from the
+# registry even when the (event, harness) pair doesn't use one — current
+# signature normalizes the same way (see *_current_signature below) so
+# equality still holds in the irrelevant-matcher case.
+# `async` is claude-only; codex ignores. Empty when unset.
 
 hook_desired_signature() {
-    local name="$1" harness="$2" script matcher timeout deployed
-    script=$( jq -r --arg n "$name" '.[$n].script // ""'      <<<"$HARNESS_DESIRED_JSON")
-    matcher=$(jq -r --arg n "$name" '.[$n].matcher // ""'     <<<"$HARNESS_DESIRED_JSON")
-    timeout=$(jq -r --arg n "$name" '.[$n].timeout // empty' <<<"$HARNESS_DESIRED_JSON")
-    deployed=$(hook_deployed_path "$harness" "$script")
-    printf '%s\t%s\t%s\n' "$deployed" "$matcher" "$timeout"
+    local name="$1" harness="$2" event matcher timeout async_field cmd
+    event=$(    jq -r --arg n "$name" '.[$n].event   // ""'      <<<"$HARNESS_DESIRED_JSON")
+    matcher=$(  jq -r --arg n "$name" '.[$n].matcher // ""'      <<<"$HARNESS_DESIRED_JSON")
+    timeout=$(  jq -r --arg n "$name" '.[$n].timeout // empty'   <<<"$HARNESS_DESIRED_JSON")
+    # jq's `//` operator treats both `null` AND `false` as fallback triggers,
+    # so `.async // empty` silently drops `async: false`. has("async") gates
+    # on key presence so an explicit `false` survives.
+    async_field=$(jq -r --arg n "$name" \
+        '.[$n] as $h | if ($h | has("async")) then $h.async | tostring else "" end' \
+        <<<"$HARNESS_DESIRED_JSON")
+    cmd=$(_hook_resolve_command "$name" "$harness") || cmd=""
+    # async is claude-only — codex never writes it, so normalize to empty
+    # when computing the codex desired signature.
+    [[ "$harness" == "codex" ]] && async_field=""
+    printf '%s\t%s\t%s\t%s\t%s\n' "$cmd" "$event" "$matcher" "$timeout" "$async_field"
 }
 
 # ─── Claude: jq over claude/settings.json ───────────────────────────────
 # The settings file is checked into the repo; sync writes it in place.
 
 hook_claude_current_signature() {
-    local name="$1" script matcher timeout deployed cmd current_cmd current_timeout
-    [[ -f "$CLAUDE_SETTINGS_FILE" ]] || { printf '\t\t\n'; return; }
+    local name="$1" event matcher cmd
+    local current_cmd current_matcher current_timeout current_async
+    [[ -f "$CLAUDE_SETTINGS_FILE" ]] || { printf '\t\t\t\t\n'; return; }
 
-    script=$( jq -r --arg n "$name" '.[$n].script // ""'  <<<"$HARNESS_DESIRED_JSON")
+    event=$(  jq -r --arg n "$name" '.[$n].event   // ""' <<<"$HARNESS_DESIRED_JSON")
     matcher=$(jq -r --arg n "$name" '.[$n].matcher // ""' <<<"$HARNESS_DESIRED_JSON")
-    deployed=$(hook_deployed_path claude "$script")
-    cmd="bash \"$deployed\""
+    cmd=$(_hook_resolve_command "$name" claude) || cmd=""
 
-    # Find the first SessionStart entry whose first hook command matches.
-    current_cmd=$(jq -r --arg c "$cmd" '
-        .hooks.SessionStart // []
-        | map(select((.hooks // [])[0].command == $c))
-        | (.[0].hooks // [])[0].command // ""
+    # Find the outer block whose first hook command matches.
+    local block_json
+    block_json=$(jq --arg e "$event" --arg c "$cmd" '
+        .hooks[$e] // []
+        | map(select(((.hooks // [])[0].command // "") == $c))
+        | .[0] // {}
     ' "$CLAUDE_SETTINGS_FILE")
-    current_timeout=$(jq -r --arg c "$cmd" '
-        .hooks.SessionStart // []
-        | map(select((.hooks // [])[0].command == $c))
-        | (.[0].hooks // [])[0].timeout // empty
-    ' "$CLAUDE_SETTINGS_FILE")
+
+    current_cmd=$(jq -r     '(.hooks // [])[0].command // ""'        <<<"$block_json")
+    current_matcher=$(jq -r '.matcher // ""'                         <<<"$block_json")
+    current_timeout=$(jq -r '(.hooks // [])[0].timeout // empty'     <<<"$block_json")
+    # has("async") to preserve a literal `false` on disk; `//` would drop it.
+    current_async=$(jq -r '
+        (.hooks // [])[0] as $h
+        | if ($h != null) and ($h | has("async")) then $h.async | tostring else "" end
+    ' <<<"$block_json")
 
     if [[ -z "$current_cmd" ]]; then
-        printf '\t\t\n'
+        printf '\t\t\t\t\n'
         return
     fi
-    # Claude has no matcher for SessionStart; reuse the desired matcher
-    # for comparison so signatures stay equal once installed.
-    printf '%s\t%s\t%s\n' "$deployed" "$matcher" "$current_timeout"
+    # For (event, claude) pairs that don't use matcher, normalize current
+    # to the desired matcher so signatures stay equal once installed.
+    if ! _hook_event_uses_matcher "$event" claude; then
+        current_matcher="$matcher"
+    fi
+    printf '%s\t%s\t%s\t%s\t%s\n' "$cmd" "$event" "$current_matcher" "$current_timeout" "$current_async"
 }
 
-# Upsert the SessionStart hook entry in claude/settings.json. Idempotent.
+# Build the inner hook entry — { type: "command", command, [timeout], [async] }.
+# `async` is claude-only — caller must pass empty for codex (the *_apply
+# functions enforce this by reading the registry async field only for claude).
+_hook_build_inner() {
+    local cmd="$1" timeout="$2" async_field="${3:-}"
+    local inner
+    inner=$(jq -n --arg c "$cmd" '{type: "command", command: $c}')
+    if [[ -n "$timeout" ]]; then
+        inner=$(jq --argjson t "$timeout" '. + {timeout: $t}' <<<"$inner")
+    fi
+    if [[ -n "$async_field" ]]; then
+        inner=$(jq --argjson a "$async_field" '. + {async: $a}' <<<"$inner")
+    fi
+    printf '%s\n' "$inner"
+}
+
+# Build the outer block. Includes `matcher` iff matcher is non-empty AND
+# the (event, harness) pair uses a matcher. The optional async_field is
+# threaded into the inner entry (claude-only; codex callers must pass "").
+_hook_build_outer() {
+    local event="$1" harness="$2" cmd="$3" matcher="$4" timeout="$5" async_field="${6:-}"
+    local inner
+    inner=$(_hook_build_inner "$cmd" "$timeout" "$async_field")
+    if [[ -n "$matcher" ]] && _hook_event_uses_matcher "$event" "$harness"; then
+        jq -n --arg m "$matcher" --argjson h "$inner" '{matcher: $m, hooks: [$h]}'
+    else
+        jq -n --argjson h "$inner" '{hooks: [$h]}'
+    fi
+}
+
+# Upsert the hook entry in claude/settings.json. Idempotent. Strips any
+# prior entry under the same event slot whose first command matches, then
+# appends a fresh one.
 hook_claude_apply() {
-    local name="$1" script timeout deployed cmd
-    script=$( jq -r --arg n "$name" '.[$n].script // ""'      <<<"$HARNESS_DESIRED_JSON")
-    timeout=$(jq -r --arg n "$name" '.[$n].timeout // empty' <<<"$HARNESS_DESIRED_JSON")
-    deployed=$(hook_deployed_path claude "$script")
-    cmd="bash \"$deployed\""
+    local name="$1" event matcher timeout async_field cmd
+    event=$(    jq -r --arg n "$name" '.[$n].event   // ""'     <<<"$HARNESS_DESIRED_JSON")
+    matcher=$(  jq -r --arg n "$name" '.[$n].matcher // ""'     <<<"$HARNESS_DESIRED_JSON")
+    timeout=$(  jq -r --arg n "$name" '.[$n].timeout // empty' <<<"$HARNESS_DESIRED_JSON")
+    # has("async") gates on key presence — `//` would drop async:false (jq
+    # treats false the same as null for the alternative operator).
+    async_field=$(jq -r --arg n "$name" \
+        '.[$n] as $h | if ($h | has("async")) then $h.async | tostring else "" end' \
+        <<<"$HARNESS_DESIRED_JSON")
+    cmd=$(_hook_resolve_command "$name" claude) \
+        || { echo -e "${RED}    hook entry '$name' has neither script nor command${NC}" >&2; return 1; }
 
     [[ -f "$CLAUDE_SETTINGS_FILE" ]] \
         || { echo -e "${RED}    claude settings file not found: $CLAUDE_SETTINGS_FILE${NC}" >&2; return 1; }
 
+    local outer
+    outer=$(_hook_build_outer "$event" claude "$cmd" "$matcher" "$timeout" "$async_field")
+
     local tmp
     tmp=$(mktemp "${TMPDIR:-/tmp}/hook-sync.XXXXXX.json")
-    # Strip any prior entry for this command, then append a fresh one.
-    if [[ -n "$timeout" ]]; then
-        jq --arg c "$cmd" --argjson t "$timeout" '
-            .hooks //= {}
-            | .hooks.SessionStart //= []
-            | .hooks.SessionStart |= (map(select(((.hooks // [])[0].command // "") != $c)))
-            | .hooks.SessionStart += [{ "hooks": [{ "type": "command", "command": $c, "timeout": $t }] }]
-        ' "$CLAUDE_SETTINGS_FILE" > "$tmp"
-    else
-        jq --arg c "$cmd" '
-            .hooks //= {}
-            | .hooks.SessionStart //= []
-            | .hooks.SessionStart |= (map(select(((.hooks // [])[0].command // "") != $c)))
-            | .hooks.SessionStart += [{ "hooks": [{ "type": "command", "command": $c }] }]
-        ' "$CLAUDE_SETTINGS_FILE" > "$tmp"
-    fi
+    jq --arg e "$event" --arg c "$cmd" --argjson b "$outer" '
+        .hooks //= {}
+        | .hooks[$e] //= []
+        | .hooks[$e] |= (map(select(((.hooks // [])[0].command // "") != $c)))
+        | .hooks[$e] += [$b]
+    ' "$CLAUDE_SETTINGS_FILE" > "$tmp"
     mv "$tmp" "$CLAUDE_SETTINGS_FILE"
 }
 
 # ─── Codex: yq over ~/.codex/config.toml ────────────────────────────────
 # Preserves every other top-level key (approval_policy, sandbox_mode,
-# [mcp_servers], …). Only the entries under [[hooks.SessionStart]] with a
-# matching command get rewritten.
+# [mcp_servers], …) and every other event slot. Only the entry under the
+# named event with a matching command gets rewritten.
 
 hook_codex_current_signature() {
-    local name="$1" script matcher timeout deployed cmd current_cmd current_matcher current_timeout
-    [[ -f "$CODEX_CONFIG_FILE" ]] || { printf '\t\t\n'; return; }
+    local name="$1" event matcher cmd
+    local current_cmd current_matcher current_timeout
+    [[ -f "$CODEX_CONFIG_FILE" ]] || { printf '\t\t\t\t\n'; return; }
 
-    script=$( jq -r --arg n "$name" '.[$n].script // ""'  <<<"$HARNESS_DESIRED_JSON")
+    event=$(  jq -r --arg n "$name" '.[$n].event   // ""' <<<"$HARNESS_DESIRED_JSON")
     matcher=$(jq -r --arg n "$name" '.[$n].matcher // ""' <<<"$HARNESS_DESIRED_JSON")
-    cmd=$(hook_codex_command "$script")
-    deployed=$(hook_deployed_path codex "$script")
+    cmd=$(_hook_resolve_command "$name" codex) || cmd=""
 
-    # yq toml→json then jq finds the SessionStart block whose inner hook
-    # command matches.
+    # yq toml→json (scoped to the event slot) then jq finds the matching
+    # block. env() keeps the event name out of the yq path-injection space.
     local block_json
-    block_json=$(yq -p=toml -o=json '.hooks.SessionStart // []' "$CODEX_CONFIG_FILE" 2>/dev/null \
+    block_json=$(HOOK_EVENT="$event" yq -p=toml -o=json '.hooks[env(HOOK_EVENT)] // []' "$CODEX_CONFIG_FILE" 2>/dev/null \
                  | jq --arg c "$cmd" '
                      map(select(((.hooks // [])[0].command // "") == $c))
-                     | .[0] // {}' 2>/dev/null) || { printf '\t\t\n'; return; }
+                     | .[0] // {}' 2>/dev/null) || { printf '\t\t\t\t\n'; return; }
 
-    current_cmd=$(jq -r '(.hooks // [])[0].command // ""'  <<<"$block_json")
-    current_matcher=$(jq -r '.matcher // ""'              <<<"$block_json")
+    current_cmd=$(jq -r     '(.hooks // [])[0].command // ""'    <<<"$block_json")
+    current_matcher=$(jq -r '.matcher // ""'                     <<<"$block_json")
     current_timeout=$(jq -r '(.hooks // [])[0].timeout // empty' <<<"$block_json")
 
     if [[ -z "$current_cmd" ]]; then
-        printf '\t\t\n'
+        printf '\t\t\t\t\n'
         return
     fi
-    printf '%s\t%s\t%s\n' "$deployed" "$current_matcher" "$current_timeout"
+    if ! _hook_event_uses_matcher "$event" codex; then
+        current_matcher="$matcher"
+    fi
+    # async is claude-only — emit empty so codex desired/current signatures match.
+    printf '%s\t%s\t%s\t%s\t\n' "$cmd" "$event" "$current_matcher" "$current_timeout"
 }
 
 # Read the current Codex config and print JSON for the merge step on stdout.
@@ -258,45 +414,31 @@ _hook_codex_validate_writeback() {
     fi
 }
 
-# Build the desired [[hooks.SessionStart]] block as JSON. Branches on
-# matcher/timeout presence because Codex's TOML parser treats `matcher = ""`
-# differently from a missing matcher field.
-_hook_codex_build_session_start_block() {
-    local cmd="$1" matcher="$2" timeout="$3"
-    local inner
-    inner=$(jq -n --arg c "$cmd" '{type: "command", command: $c}')
-    if [[ -n "$timeout" ]]; then
-        inner=$(jq --argjson t "$timeout" '. + {timeout: $t}' <<<"$inner")
-    fi
-    if [[ -n "$matcher" ]]; then
-        jq -n --arg m "$matcher" --argjson h "$inner" '{matcher: $m, hooks: [$h]}'
-    else
-        jq -n --argjson h "$inner" '{hooks: [$h]}'
-    fi
-}
-
 hook_codex_apply() {
-    local name="$1" script matcher timeout cmd
-    script=$( jq -r --arg n "$name" '.[$n].script // ""'      <<<"$HARNESS_DESIRED_JSON")
+    local name="$1" event matcher timeout cmd
+    event=$(  jq -r --arg n "$name" '.[$n].event   // ""'     <<<"$HARNESS_DESIRED_JSON")
     matcher=$(jq -r --arg n "$name" '.[$n].matcher // ""'     <<<"$HARNESS_DESIRED_JSON")
     timeout=$(jq -r --arg n "$name" '.[$n].timeout // empty' <<<"$HARNESS_DESIRED_JSON")
-    cmd=$(hook_codex_command "$script")
+    cmd=$(_hook_resolve_command "$name" codex) \
+        || { echo -e "${RED}    hook entry '$name' has neither script nor command${NC}" >&2; return 1; }
 
     mkdir -p "$(dirname "$CODEX_CONFIG_FILE")"
     [[ -f "$CODEX_CONFIG_FILE" ]] || : > "$CODEX_CONFIG_FILE"
 
-    # Merge plan: TOML → JSON → drop prior entry for this command → append
-    # fresh entry → JSON → TOML. Helpers handle reading the pre-image,
-    # building the desired block, and validating the post-image.
+    # Merge plan: TOML → JSON → drop prior entry for this command (under
+    # the same event slot) → append fresh entry → JSON → TOML. Helpers
+    # handle reading the pre-image, building the desired block, and
+    # validating the post-image. async_field is intentionally "" — codex
+    # doesn't use it.
     local current_json desired_block merged tmp
     current_json=$(_hook_codex_read_current_json) || return 1
-    desired_block=$(_hook_codex_build_session_start_block "$cmd" "$matcher" "$timeout")
+    desired_block=$(_hook_build_outer "$event" codex "$cmd" "$matcher" "$timeout" "")
 
-    merged=$(jq --arg c "$cmd" --argjson b "$desired_block" '
+    merged=$(jq --arg e "$event" --arg c "$cmd" --argjson b "$desired_block" '
         .hooks //= {}
-        | .hooks.SessionStart //= []
-        | .hooks.SessionStart |= (map(select(((.hooks // [])[0].command // "") != $c)))
-        | .hooks.SessionStart += [$b]
+        | .hooks[$e] //= []
+        | .hooks[$e] |= (map(select(((.hooks // [])[0].command // "") != $c)))
+        | .hooks[$e] += [$b]
     ' <<<"$current_json")
 
     tmp=$(mktemp "${TMPDIR:-/tmp}/hook-sync.XXXXXX.toml")

--- a/agents/hooks/registry.yaml
+++ b/agents/hooks/registry.yaml
@@ -3,12 +3,17 @@
 #
 # Per-entry fields:
 #   event          — one of SessionStart, UserPromptSubmit, PreToolUse,
-#                    PostToolUse, Stop. The active set lives in
-#                    HOOK_EVENTS_VALID inside lib.sh;
+#                    PostToolUse, Stop, PermissionRequest. The active set
+#                    lives in HOOK_EVENTS_VALID inside lib.sh;
 #                    hook_filter_for_harness fails loud on anything else
 #                    (catches typos like "evnt: PostToolUse").
+#                    PermissionRequest is claude-only — codex never fires it.
 #   script         — repo-relative path to the hook script (deployed per
-#                    harness into $HOME/.<harness>/hooks/<basename>)
+#                    harness into $HOME/.<harness>/hooks/<basename>).
+#                    Mutually exclusive with `command` — set exactly one.
+#   command        — literal command string, used verbatim with no file
+#                    deploy (e.g. an external binary like moshi-hook).
+#                    Mutually exclusive with `script` — set exactly one.
 #   shared_assets  — optional list of repo-relative paths to data files the
 #                    hook script reads at runtime (libs, banks, …). Each
 #                    asset path must live under agents/<subdir>/<file> and
@@ -33,6 +38,10 @@
 #   timeout        — seconds (verified against
 #                    developers.openai.com/codex/hooks → "timeout is in
 #                    seconds"; Claude uses the same unit)
+#   async          — claude-only boolean. true → Claude fires the hook
+#                    without blocking the turn; false → synchronous. An
+#                    explicit `false` is preserved on write (it is not the
+#                    same as an absent field). Codex ignores it.
 #   description    — human-readable purpose
 hooks:
   session-start-cheese-flair:

--- a/agents/hooks/registry.yaml
+++ b/agents/hooks/registry.yaml
@@ -2,11 +2,11 @@
 # Run `hook-sync` (or `dots sync`) to apply this to every installed harness.
 #
 # Per-entry fields:
-#   event          — must be SessionStart today; the registry shape will
-#                    extend to UserPromptSubmit | PreToolUse | PostToolUse
-#                    | Stop once the backends in lib.sh parameterise the
-#                    event slot. hook_filter_for_harness fails loud on any
-#                    other value.
+#   event          — one of SessionStart, UserPromptSubmit, PreToolUse,
+#                    PostToolUse, Stop. The active set lives in
+#                    HOOK_EVENTS_VALID inside lib.sh;
+#                    hook_filter_for_harness fails loud on anything else
+#                    (catches typos like "evnt: PostToolUse").
 #   script         — repo-relative path to the hook script (deployed per
 #                    harness into $HOME/.<harness>/hooks/<basename>)
 #   shared_assets  — optional list of repo-relative paths to data files the
@@ -17,9 +17,19 @@
 #                    field, so adding a new hook is purely a registry edit.
 #   harnesses      — list of harness names to install into;
 #                    default: [claude, codex]
-#   matcher        — codex-only regex against the event's `source` field
-#                    (SessionStart: startup|resume|clear). Claude ignores;
-#                    its SessionStart entries have no matcher.
+#   matcher        — event-dependent. The (event, harness) pairs that
+#                    actually write a matcher field into the outer block
+#                    are encoded in _hook_event_uses_matcher (lib.sh):
+#                      SessionStart   — codex only (source regex:
+#                                        startup|resume|clear). Claude
+#                                        ignores; matcher is dropped on
+#                                        write.
+#                      PreToolUse,    — both harnesses (tool-name regex).
+#                      PostToolUse
+#                      UserPromptSubmit, Stop — neither harness writes
+#                                        matcher; the field is dropped on
+#                                        write but kept in the registry
+#                                        for documentation if set.
 #   timeout        — seconds (verified against
 #                    developers.openai.com/codex/hooks → "timeout is in
 #                    seconds"; Claude uses the same unit)
@@ -35,3 +45,45 @@ hooks:
     matcher: "startup|resume"
     timeout: 5
     description: Rotating cheese flair sample injected at session start
+
+  # ─── Moshi (rjyo/moshi-hook) ────────────────────────────────────────
+  # Bridge between Claude Code and the Moshi iOS terminal app — sends
+  # session-start, prompt, turn-end, and approval events to the phone
+  # so the user can babysit the agent remotely.
+  #
+  # Wire format captured from `moshi-hook install` (v0.2.8 on linux). The
+  # single quotes around the absolute path are Moshi's own choice — they
+  # let the path tolerate whitespace in $HOME, preserved verbatim.
+  #
+  # Linux-only path: on macOS via brew, moshi-hook lives at
+  # /opt/homebrew/bin/moshi-hook — port this entry when adding the Mac.
+  # claude-only: codex bridge ships via ~/.codex/hooks.json (different
+  # surface), out of scope here.
+  moshi-session-start:
+    event: SessionStart
+    command: "'/home/paul/.local/bin/moshi-hook' claude-hook"
+    async: true
+    harnesses: [claude]
+    description: Moshi bridge — session-start notification to phone
+
+  moshi-user-prompt-submit:
+    event: UserPromptSubmit
+    command: "'/home/paul/.local/bin/moshi-hook' claude-hook"
+    async: true
+    harnesses: [claude]
+    description: Moshi bridge — prompt-submit notification to phone
+
+  moshi-stop:
+    event: Stop
+    command: "'/home/paul/.local/bin/moshi-hook' claude-hook"
+    async: true
+    harnesses: [claude]
+    description: Moshi bridge — turn-end notification to phone
+
+  moshi-permission-request:
+    event: PermissionRequest
+    command: "'/home/paul/.local/bin/moshi-hook' claude-hook"
+    async: false
+    timeout: 300
+    harnesses: [claude]
+    description: Moshi bridge — approval request (synchronous, 5-min phone reach)

--- a/chezmoi/dot_claude/create_settings.json
+++ b/chezmoi/dot_claude/create_settings.json
@@ -138,38 +138,6 @@
             "timeout": 5
           }
         ]
-      },
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "'/home/paul/.local/bin/moshi-hook' claude-hook",
-            "async": true
-          }
-        ]
-      }
-    ],
-    "PermissionRequest": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "'/home/paul/.local/bin/moshi-hook' claude-hook",
-            "timeout": 300,
-            "async": false
-          }
-        ]
-      }
-    ],
-    "UserPromptSubmit": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "'/home/paul/.local/bin/moshi-hook' claude-hook",
-            "async": true
-          }
-        ]
       }
     ]
   },

--- a/chezmoi/dot_claude/create_settings.json
+++ b/chezmoi/dot_claude/create_settings.json
@@ -1,8 +1,7 @@
 {
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
-    "ENABLE_TOOL_SEARCH": "true",
-    "SSL_CERT_FILE": "/etc/ssl/cert.pem"
+    "ENABLE_TOOL_SEARCH": "true"
   },
   "permissions": {
     "allow": [
@@ -137,6 +136,38 @@
             "type": "command",
             "command": "if [ -n \"$TMUX\" ]; then tmux set-option -q @jmux-attention 1; fi",
             "timeout": 5
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "'/home/paul/.local/bin/moshi-hook' claude-hook",
+            "async": true
+          }
+        ]
+      }
+    ],
+    "PermissionRequest": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "'/home/paul/.local/bin/moshi-hook' claude-hook",
+            "timeout": 300,
+            "async": false
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "'/home/paul/.local/bin/moshi-hook' claude-hook",
+            "async": true
           }
         ]
       }

--- a/chezmoi/dot_serena/modify_serena_config.yml
+++ b/chezmoi/dot_serena/modify_serena_config.yml
@@ -50,6 +50,14 @@ fi
 if [ -z "$existing" ] && command -v serena >/dev/null 2>&1; then
     live=$(cat "$HOME/.serena/serena_config.yml" 2>/dev/null || true)
     if [ -z "$live" ] || [ "$live" = "$STUB_MARKER" ]; then
+        # `serena init` loads-then-validates the existing config and aborts
+        # with "`projects` key not found" when the file is present but
+        # incomplete — which is exactly the stub we may have written on a
+        # prior apply. It has no --force, so clear the on-disk file first to
+        # give init a clean slate; from absence it writes a full default
+        # config (incl. `projects: []`). Without this rm the init always
+        # fails here and the script re-emits the stub: a stable broken state.
+        rm -f "$HOME/.serena/serena_config.yml"
         serena init >/dev/null 2>&1 || true
         live=$(cat "$HOME/.serena/serena_config.yml" 2>/dev/null || true)
     fi

--- a/claude/hooks/auto-format.js
+++ b/claude/hooks/auto-format.js
@@ -16,6 +16,11 @@ const FILE_EDITING_TOOLS = new Set([
   'Edit', 'Write', 'MultiEdit', 'mcp__tilth__tilth_write',
 ]);
 
+// Linters that exit non-zero when residual (non-auto-fixable) findings remain
+// after --fix. That exit is expected, not a failure — stay silent so we don't
+// nag on every markdown write (silent fix-only).
+const SILENT_NONZERO_EXIT = new Set(['markdownlint-cli2']);
+
 // Collect every file an edit touched, resolved to absolute paths.
 // Edit/Write/MultiEdit carry a single file_path; tilth_write is a batch and
 // carries tool_input.files[].path.
@@ -45,6 +50,8 @@ function formatterFor(filePath) {
     '.sh': ['shfmt', ['-w', filePath]],
     '.zsh': ['shfmt', ['-w', filePath]],
     '.bash': ['shfmt', ['-w', filePath]],
+    '.md': ['markdownlint-cli2', ['--fix', filePath]],
+    '.markdown': ['markdownlint-cli2', ['--fix', filePath]],
   };
   return FORMATTERS[ext] || null;
 }
@@ -62,6 +69,7 @@ function formatFile(filePath, cwd) {
   try {
     execFileSync(bin, args, { stdio: 'pipe', timeout: 8000, cwd });
   } catch (err) {
+    if (SILENT_NONZERO_EXIT.has(bin)) return;
     const msg = err.stderr ? err.stderr.toString().trim() : err.message;
     process.stderr.write(`[auto-format] ${bin} failed on ${path.basename(filePath)}: ${msg}\n`);
   }

--- a/claude/hooks/auto-format.js
+++ b/claude/hooks/auto-format.js
@@ -16,10 +16,13 @@ const FILE_EDITING_TOOLS = new Set([
   'Edit', 'Write', 'MultiEdit', 'mcp__tilth__tilth_write',
 ]);
 
-// Linters that exit non-zero when residual (non-auto-fixable) findings remain
-// after --fix. That exit is expected, not a failure — stay silent so we don't
-// nag on every markdown write (silent fix-only).
-const SILENT_NONZERO_EXIT = new Set(['markdownlint-cli2']);
+// Linters that exit with a specific non-zero code when residual
+// (non-auto-fixable) findings remain after --fix. That exact code is
+// expected, not a failure — stay silent so we don't nag on every markdown
+// write (silent fix-only). Any OTHER exit code (bad config, runtime crash,
+// missing binary) still reports, so real breakage isn't masked.
+// markdownlint-cli2 exits 1 on residual lint findings; 2 on usage/config errors.
+const EXPECTED_NONZERO_EXIT = { 'markdownlint-cli2': 1 };
 
 // Collect every file an edit touched, resolved to absolute paths.
 // Edit/Write/MultiEdit carry a single file_path; tilth_write is a batch and
@@ -69,7 +72,7 @@ function formatFile(filePath, cwd) {
   try {
     execFileSync(bin, args, { stdio: 'pipe', timeout: 8000, cwd });
   } catch (err) {
-    if (SILENT_NONZERO_EXIT.has(bin)) return;
+    if (EXPECTED_NONZERO_EXIT[bin] === err.status) return;
     const msg = err.stderr ? err.stderr.toString().trim() : err.message;
     process.stderr.write(`[auto-format] ${bin} failed on ${path.basename(filePath)}: ${msg}\n`);
   }

--- a/packages/packages.yaml
+++ b/packages/packages.yaml
@@ -22,6 +22,7 @@ packages:
   - fzf
   - gh
   - shellcheck
+  - bats-core: { apt: bats }                  # bats test runner (tests/*.bats); brew formula is bats-core, apt pkg is bats
   - tree
   - htop
   - ripgrep

--- a/profiles/global/profile.yaml
+++ b/profiles/global/profile.yaml
@@ -33,12 +33,13 @@ target_default: $HOME
 #
 # Must match where the renderer actually writes the plugin tree:
 # target_default above is $HOME, so the claude renderer drops the
-# global plugin at $HOME/.claude/plugins/local/global/. Pointing
-# `local` at $HOME/.claude/plugins/local lets Claude resolve
-# `global@local` to that on-disk tree. (Earlier this pointed at
-# ${DOTFILES_DIR}/.claude/plugins/local, which only contained a
-# staged `base/` tree and not the live `global/` — Claude found the
-# plugin via fallback but the wiring was asymmetric.)
+# global plugin at $HOME/.claude/plugins/local/global/ and emits the
+# directory `marketplace.json` alongside it. Pointing `local` at
+# $HOME/.claude/plugins/local lets Claude resolve `global@local` to
+# that on-disk tree via the marketplace.json (an explicit registration,
+# not just fallback). (Earlier this pointed at
+# ${DOTFILES_DIR}/.claude/plugins/local, which only contained a staged
+# `base/` tree and not the live `global/`.)
 marketplaces:
   local: $HOME/.claude/plugins/local
 

--- a/tests/agents-hooks-sync.bats
+++ b/tests/agents-hooks-sync.bats
@@ -63,8 +63,13 @@ teardown() {
     local c x
     c=$(hook_filter_for_harness claude "$REGISTRY_JSON")
     x=$(hook_filter_for_harness codex  "$REGISTRY_JSON")
-    [[ "$(jq -r 'keys[]' <<<"$c")" == "session-start-cheese-flair" ]]
-    [[ "$(jq -r 'keys[]' <<<"$x")" == "session-start-cheese-flair" ]]
+    # cheese-flair is registered for both harnesses.
+    [[ "$(jq -r '.["session-start-cheese-flair"].event' <<<"$c")" == "SessionStart" ]]
+    [[ "$(jq -r '.["session-start-cheese-flair"].event' <<<"$x")" == "SessionStart" ]]
+    # The claude-only moshi entries appear for claude but are filtered out for
+    # codex — proves the per-entry `harnesses` filter, not just inclusion.
+    [[ "$(jq -r 'has("moshi-session-start")' <<<"$c")" == "true"  ]]
+    [[ "$(jq -r 'has("moshi-session-start")' <<<"$x")" == "false" ]]
 }
 
 # ── deployed-path resolver ─────────────────────────────────────────────
@@ -86,9 +91,12 @@ teardown() {
     local c x
     c=$(hook_desired_signature session-start-cheese-flair claude)
     x=$(hook_desired_signature session-start-cheese-flair codex)
-    # Claude path differs from codex; matcher + timeout match.
-    [[ "$c" == *"/.claude/hooks/session-start-cheese-flair.sh"$'\t'"startup|resume"$'\t'"5" ]]
-    [[ "$x" == *"/.codex/hooks/session-start-cheese-flair.sh"$'\t'"startup|resume"$'\t'"5"  ]]
+    # Signature shape: <resolved-command> <event> <matcher> <timeout> <async>.
+    # event so two entries pointing at the same script/command but different
+    # event slots don't collide; async claude-only (empty for codex). The
+    # cheese-flair entry has no async, so the final field is empty for both.
+    [[ "$c" == 'bash "$HOME/.claude/hooks/session-start-cheese-flair.sh"'$'\t'"SessionStart"$'\t'"startup|resume"$'\t'"5"$'\t' ]]
+    [[ "$x" == 'bash "$HOME/.codex/hooks/session-start-cheese-flair.sh"'$'\t'"SessionStart"$'\t'"startup|resume"$'\t'"5"$'\t' ]]
 }
 
 # ── claude backend: idempotent upsert ──────────────────────────────────
@@ -149,14 +157,14 @@ JSON
     rm -f "$CLAUDE_SETTINGS_FILE"
     local sig
     sig=$(hook_claude_current_signature session-start-cheese-flair)
-    [[ "$sig" == $'\t\t' ]]
+    [[ "$sig" == $'\t\t\t\t' ]]
 }
 
 @test "hook_claude_current_signature reports empty when entry missing" {
     echo '{}' > "$CLAUDE_SETTINGS_FILE"
     local sig
     sig=$(hook_claude_current_signature session-start-cheese-flair)
-    [[ "$sig" == $'\t\t' ]]
+    [[ "$sig" == $'\t\t\t\t' ]]
 }
 
 @test "hook_claude_current_signature reports drift when timeout differs" {
@@ -173,10 +181,16 @@ JSON
     cur=$(hook_claude_current_signature session-start-cheese-flair)
     des=$(hook_desired_signature       session-start-cheese-flair claude)
     [[ "$cur" != "$des" ]]
-    [[ "$cur" == *$'\t'"99" ]]
+    # 5-field signature ends in <timeout> <async>; cheese-flair has no
+    # async on disk, so the trailing field is empty (final tab).
+    [[ "$cur" == *$'\t'"99"$'\t' ]]
 }
 
+# Scope detection to the single cheese-flair entry so the assertions stay
+# decoupled from the registry's entry count (it also carries claude-only
+# moshi-* command hooks, which would otherwise show as drift here).
 @test "hook_detect_changes (claude): empty when in sync" {
+    HARNESS_DESIRED_JSON=$(jq '{"session-start-cheese-flair": .["session-start-cheese-flair"]}' <<<"$HARNESS_DESIRED_JSON")
     echo '{}' > "$CLAUDE_SETTINGS_FILE"
     hook_claude_apply session-start-cheese-flair
     local changed
@@ -185,6 +199,7 @@ JSON
 }
 
 @test "hook_detect_changes (claude): names entry when missing" {
+    HARNESS_DESIRED_JSON=$(jq '{"session-start-cheese-flair": .["session-start-cheese-flair"]}' <<<"$HARNESS_DESIRED_JSON")
     rm -f "$CLAUDE_SETTINGS_FILE"
     echo '{}' > "$CLAUDE_SETTINGS_FILE"
     local changed
@@ -300,8 +315,10 @@ TOML
     run bash "$REAL_DOTFILES_DIR/agents/hooks/sync.sh" --harness=claude
     assert_success
 
-    # Claude side upserted.
-    [[ "$(jq '.hooks.SessionStart | length' "$CLAUDE_SETTINGS_FILE")" == "1" ]]
+    # Claude side upserted — the cheese-flair SessionStart entry is present.
+    # (Asserted by content, not count: the registry also carries a claude-only
+    # moshi-session-start entry, so SessionStart now holds more than one block.)
+    [[ "$(jq '[.hooks.SessionStart[] | select((.hooks[0].command // "") | test("session-start-cheese-flair"))] | length' "$CLAUDE_SETTINGS_FILE")" == "1" ]]
     # Codex side untouched (file still empty).
     [[ ! -s "$CODEX_CONFIG_FILE" ]]
 }
@@ -322,6 +339,273 @@ JSON
     after=$(shasum -a 256 "$CLAUDE_SETTINGS_FILE" | awk '{print $1}')
     [[ "$before" == "$after" ]]
     grep -qF '[[hooks.SessionStart]]' "$CODEX_CONFIG_FILE"
+}
+
+# ── multi-event support (UserPromptSubmit / PreToolUse / PostToolUse / Stop)
+# These tests exercise the parameterized event slot in lib.sh by synthesizing
+# a HARNESS_DESIRED_JSON for each new event type. The cheese-flair registry
+# entry stays SessionStart-only; these synthetic registries are scoped to
+# the tests below so the real registry contract is unchanged.
+
+@test "claude upsert writes UserPromptSubmit slot (no matcher in outer block)" {
+    HARNESS_DESIRED_JSON='{"prompt-stamp":{"event":"UserPromptSubmit","script":"agents/hooks/prompt-stamp.sh","timeout":3}}'
+    echo '{}' > "$CLAUDE_SETTINGS_FILE"
+    hook_claude_apply prompt-stamp
+
+    local cmd timeout matcher
+    cmd=$(jq -r     '.hooks.UserPromptSubmit[0].hooks[0].command' "$CLAUDE_SETTINGS_FILE")
+    timeout=$(jq -r '.hooks.UserPromptSubmit[0].hooks[0].timeout' "$CLAUDE_SETTINGS_FILE")
+    matcher=$(jq -r '.hooks.UserPromptSubmit[0].matcher // "MISSING"' "$CLAUDE_SETTINGS_FILE")
+    [[ "$cmd"     == 'bash "$HOME/.claude/hooks/prompt-stamp.sh"' ]]
+    [[ "$timeout" == "3" ]]
+    # UserPromptSubmit on claude has no outer matcher — must be absent.
+    [[ "$matcher" == "MISSING" ]]
+    # SessionStart slot must NOT have grown.
+    [[ "$(jq '.hooks.SessionStart // [] | length' "$CLAUDE_SETTINGS_FILE")" == "0" ]]
+}
+
+@test "claude upsert writes PreToolUse slot WITH matcher in outer block" {
+    HARNESS_DESIRED_JSON='{"tool-audit":{"event":"PreToolUse","script":"agents/hooks/tool-audit.sh","matcher":"Bash|Edit","timeout":10}}'
+    echo '{}' > "$CLAUDE_SETTINGS_FILE"
+    hook_claude_apply tool-audit
+
+    local cmd matcher timeout
+    cmd=$(jq -r     '.hooks.PreToolUse[0].hooks[0].command' "$CLAUDE_SETTINGS_FILE")
+    matcher=$(jq -r '.hooks.PreToolUse[0].matcher'          "$CLAUDE_SETTINGS_FILE")
+    timeout=$(jq -r '.hooks.PreToolUse[0].hooks[0].timeout' "$CLAUDE_SETTINGS_FILE")
+    [[ "$cmd"     == 'bash "$HOME/.claude/hooks/tool-audit.sh"' ]]
+    [[ "$matcher" == "Bash|Edit" ]]
+    [[ "$timeout" == "10" ]]
+}
+
+@test "claude upsert writes Stop slot (no matcher)" {
+    HARNESS_DESIRED_JSON='{"turn-end":{"event":"Stop","script":"agents/hooks/turn-end.sh"}}'
+    echo '{}' > "$CLAUDE_SETTINGS_FILE"
+    hook_claude_apply turn-end
+
+    local cmd matcher
+    cmd=$(jq -r     '.hooks.Stop[0].hooks[0].command' "$CLAUDE_SETTINGS_FILE")
+    matcher=$(jq -r '.hooks.Stop[0].matcher // "MISSING"' "$CLAUDE_SETTINGS_FILE")
+    [[ "$cmd"     == 'bash "$HOME/.claude/hooks/turn-end.sh"' ]]
+    [[ "$matcher" == "MISSING" ]]
+}
+
+@test "claude upserts in different event slots coexist (one entry per slot)" {
+    HARNESS_DESIRED_JSON='{
+      "ss":     {"event":"SessionStart",     "script":"agents/hooks/ss.sh"},
+      "ups":    {"event":"UserPromptSubmit", "script":"agents/hooks/ups.sh"},
+      "pre":    {"event":"PreToolUse",       "script":"agents/hooks/pre.sh",  "matcher":".*"},
+      "post":   {"event":"PostToolUse",      "script":"agents/hooks/post.sh", "matcher":".*"},
+      "stop":   {"event":"Stop",             "script":"agents/hooks/stop.sh"}
+    }'
+    echo '{}' > "$CLAUDE_SETTINGS_FILE"
+    hook_claude_apply ss
+    hook_claude_apply ups
+    hook_claude_apply pre
+    hook_claude_apply post
+    hook_claude_apply stop
+
+    # Each event slot has exactly one entry.
+    for evt in SessionStart UserPromptSubmit PreToolUse PostToolUse Stop; do
+        local n
+        n=$(jq --arg e "$evt" '.hooks[$e] | length' "$CLAUDE_SETTINGS_FILE")
+        [[ "$n" == "1" ]] || { echo "event $evt has $n entries, expected 1" >&2; return 1; }
+    done
+}
+
+@test "claude apply at one event slot does not disturb other event slots" {
+    HARNESS_DESIRED_JSON='{"ups":{"event":"UserPromptSubmit","script":"agents/hooks/ups.sh"}}'
+    cat > "$CLAUDE_SETTINGS_FILE" <<'JSON'
+{
+  "hooks": {
+    "SessionStart": [
+      { "hooks": [{ "type": "command", "command": "bash $HOME/.claude/hooks/keep-me.sh" }] }
+    ],
+    "Stop": [
+      { "hooks": [{ "type": "command", "command": "bash $HOME/.claude/hooks/turn-end.sh" }] }
+    ]
+  }
+}
+JSON
+    hook_claude_apply ups
+
+    # Untouched slots still have their pre-existing entries.
+    [[ "$(jq -r '.hooks.SessionStart[0].hooks[0].command' "$CLAUDE_SETTINGS_FILE")" == 'bash $HOME/.claude/hooks/keep-me.sh' ]]
+    [[ "$(jq -r '.hooks.Stop[0].hooks[0].command'         "$CLAUDE_SETTINGS_FILE")" == 'bash $HOME/.claude/hooks/turn-end.sh' ]]
+    # New slot has the upserted entry.
+    [[ "$(jq -r '.hooks.UserPromptSubmit[0].hooks[0].command' "$CLAUDE_SETTINGS_FILE")" == 'bash "$HOME/.claude/hooks/ups.sh"' ]]
+}
+
+@test "codex upsert writes PreToolUse slot WITH matcher" {
+    HARNESS_DESIRED_JSON='{"tool-audit":{"event":"PreToolUse","script":"agents/hooks/tool-audit.sh","matcher":"Bash|Edit","timeout":10}}'
+    : > "$CODEX_CONFIG_FILE"
+    hook_codex_apply tool-audit
+
+    grep -qF '[[hooks.PreToolUse]]'                                                  "$CODEX_CONFIG_FILE"
+    grep -qF 'matcher = "Bash|Edit"'                                                 "$CODEX_CONFIG_FILE"
+    grep -qF 'command = "bash \"$HOME/.codex/hooks/tool-audit.sh\""'                 "$CODEX_CONFIG_FILE"
+    grep -qF 'timeout = 10'                                                          "$CODEX_CONFIG_FILE"
+    # SessionStart slot must NOT have been written.
+    ! grep -qF '[[hooks.SessionStart]]' "$CODEX_CONFIG_FILE"
+}
+
+@test "codex upsert writes Stop slot without matcher (matcher field dropped)" {
+    # Registry sets matcher but Stop on codex doesn't use one. The matcher
+    # field must NOT land in the TOML — that's the contract enforced by
+    # _hook_event_uses_matcher.
+    HARNESS_DESIRED_JSON='{"turn-end":{"event":"Stop","script":"agents/hooks/turn-end.sh","matcher":"ignored","timeout":2}}'
+    : > "$CODEX_CONFIG_FILE"
+    hook_codex_apply turn-end
+
+    grep -qF '[[hooks.Stop]]'                                                        "$CODEX_CONFIG_FILE"
+    grep -qF 'command = "bash \"$HOME/.codex/hooks/turn-end.sh\""'                   "$CODEX_CONFIG_FILE"
+    grep -qF 'timeout = 2'                                                           "$CODEX_CONFIG_FILE"
+    ! grep -qF 'matcher = "ignored"' "$CODEX_CONFIG_FILE"
+}
+
+@test "codex multi-event upserts coexist and survive a second sync pass" {
+    HARNESS_DESIRED_JSON='{
+      "ups":  {"event":"UserPromptSubmit", "script":"agents/hooks/ups.sh"},
+      "pre":  {"event":"PreToolUse",       "script":"agents/hooks/pre.sh",  "matcher":"Bash"},
+      "stop": {"event":"Stop",             "script":"agents/hooks/stop.sh"}
+    }'
+    : > "$CODEX_CONFIG_FILE"
+    hook_codex_apply ups
+    hook_codex_apply pre
+    hook_codex_apply stop
+    # Second pass — re-running any apply must be a no-op (idempotent).
+    hook_codex_apply ups
+    hook_codex_apply pre
+    hook_codex_apply stop
+
+    for evt in UserPromptSubmit PreToolUse Stop; do
+        local n
+        n=$(yq -p=toml -o=json ".hooks.${evt} | length" "$CODEX_CONFIG_FILE")
+        [[ "$n" == "1" ]] || { echo "event $evt has $n entries, expected 1 after idempotent re-apply" >&2; return 1; }
+    done
+}
+
+@test "drift detection (claude): catches event slot mismatch" {
+    # Registry says UserPromptSubmit, but the on-disk state has the entry
+    # under SessionStart with the same command. Drift must be reported so
+    # the next apply re-homes the entry. (The misplaced SessionStart entry
+    # stays put — clearing arbitrary other-slot entries is out of scope.)
+    HARNESS_DESIRED_JSON='{"prompt-stamp":{"event":"UserPromptSubmit","script":"agents/hooks/prompt-stamp.sh"}}'
+    cat > "$CLAUDE_SETTINGS_FILE" <<'JSON'
+{
+  "hooks": {
+    "SessionStart": [
+      { "hooks": [{ "type": "command", "command": "bash \"$HOME/.claude/hooks/prompt-stamp.sh\"" }] }
+    ]
+  }
+}
+JSON
+    local changed
+    changed=$(hook_detect_changes claude)
+    [[ "$changed" == "prompt-stamp" ]]
+}
+
+# ── command-style (external binary) hooks — Moshi pattern ─────────────
+# These entries bypass the deploy path: command is used verbatim and async
+# (claude-only) is threaded into the inner hook entry. jq's `//` operator
+# treats `false` as a fallback trigger, so async:false would silently drop
+# without the has("async") guard in lib.sh — these tests pin that.
+
+@test "claude command-style entry writes literal command (no deploy path)" {
+    # Build the desired JSON via jq so the literal command — including its
+    # embedded single quotes and absolute path (the Moshi registry shape) —
+    # round-trips without shell-quoting hazards. The lib must write it verbatim.
+    local cmd_literal="'/home/paul/.local/bin/moshi-hook' claude-hook"
+    HARNESS_DESIRED_JSON=$(jq -nc --arg c "$cmd_literal" \
+        '{"moshi-ss":{event:"SessionStart",command:$c,async:true,harnesses:["claude"]}}')
+    echo '{}' > "$CLAUDE_SETTINGS_FILE"
+    hook_claude_apply moshi-ss
+
+    local cmd async
+    cmd=$(jq -r   '.hooks.SessionStart[0].hooks[0].command' "$CLAUDE_SETTINGS_FILE")
+    async=$(jq -r '.hooks.SessionStart[0].hooks[0].async'   "$CLAUDE_SETTINGS_FILE")
+    [[ "$cmd"   == "$cmd_literal" ]]
+    [[ "$async" == "true" ]]
+    # No `bash` wrapper, no $HOME/.claude/hooks deployed path.
+    [[ "$cmd" != bash* ]]
+    [[ "$cmd" != *".claude/hooks"* ]]
+}
+
+@test "claude command-style entry preserves async:false (jq // bug regression)" {
+    # async: false is the canary for the has("async") guard. jq's `// empty`
+    # would drop it; has("async") preserves it. The PermissionRequest case
+    # synchronous approval, must be `false` on the wire.
+    HARNESS_DESIRED_JSON='{"moshi-pr":{"event":"PermissionRequest","command":"/bin/true","async":false,"timeout":300,"harnesses":["claude"]}}'
+    echo '{}' > "$CLAUDE_SETTINGS_FILE"
+    hook_claude_apply moshi-pr
+
+    [[ "$(jq -r '.hooks.PermissionRequest[0].hooks[0].async'   "$CLAUDE_SETTINGS_FILE")" == "false" ]]
+    [[ "$(jq -r '.hooks.PermissionRequest[0].hooks[0].timeout' "$CLAUDE_SETTINGS_FILE")" == "300" ]]
+    [[ "$(jq -r '.hooks.PermissionRequest[0].hooks[0].type'    "$CLAUDE_SETTINGS_FILE")" == "command" ]]
+}
+
+@test "claude command-style entry omits async when registry doesn't set it" {
+    HARNESS_DESIRED_JSON='{"bare":{"event":"SessionStart","command":"/bin/true","harnesses":["claude"]}}'
+    echo '{}' > "$CLAUDE_SETTINGS_FILE"
+    hook_claude_apply bare
+
+    [[ "$(jq -r '.hooks.SessionStart[0].hooks[0].async // "ABSENT"' "$CLAUDE_SETTINGS_FILE")" == "ABSENT" ]]
+}
+
+@test "codex command-style entry writes literal command (no $HOME wrapper)" {
+    # Codex doesn't carry async, but otherwise the command-vs-script
+    # branch must work the same way.
+    HARNESS_DESIRED_JSON='{"ext":{"event":"SessionStart","command":"/usr/local/bin/external-hook codex","matcher":"startup","timeout":5,"harnesses":["codex"]}}'
+    : > "$CODEX_CONFIG_FILE"
+    hook_codex_apply ext
+
+    grep -qF 'command = "/usr/local/bin/external-hook codex"' "$CODEX_CONFIG_FILE"
+    grep -qF 'matcher = "startup"' "$CODEX_CONFIG_FILE"
+    grep -qF 'timeout = 5' "$CODEX_CONFIG_FILE"
+    # No "bash \"$HOME..." prefix.
+    ! grep -qF 'bash' "$CODEX_CONFIG_FILE"
+}
+
+@test "command-style entry: signature stable across desired+current after apply" {
+    HARNESS_DESIRED_JSON='{"moshi-pr":{"event":"PermissionRequest","command":"/bin/true","async":false,"timeout":300,"harnesses":["claude"]}}'
+    echo '{}' > "$CLAUDE_SETTINGS_FILE"
+    hook_claude_apply moshi-pr
+    local des cur
+    des=$(hook_desired_signature       moshi-pr claude)
+    cur=$(hook_claude_current_signature moshi-pr)
+    [[ "$des" == "$cur" ]]
+    # Resolved command in field 1 is the literal command, not a bash wrapper.
+    [[ "$des" == /bin/true$'\t'"PermissionRequest"$'\t'$'\t'"300"$'\t'"false" ]]
+}
+
+@test "drift detection (claude): same script, different events => both reported" {
+    # The signature includes `event`, so a script duplicated across event
+    # slots is two distinct entries — drift must fire for both, not one.
+    HARNESS_DESIRED_JSON='{
+      "a": {"event":"SessionStart",     "script":"agents/hooks/dup.sh"},
+      "b": {"event":"UserPromptSubmit", "script":"agents/hooks/dup.sh"}
+    }'
+    echo '{}' > "$CLAUDE_SETTINGS_FILE"
+    local changed
+    changed=$(hook_detect_changes claude | sort)
+    [[ "$(echo "$changed" | wc -l | tr -d ' ')" == "2" ]]
+    [[ "$changed" == *"a"* ]]
+    [[ "$changed" == *"b"* ]]
+}
+
+@test "drift detection (codex): catches event slot mismatch" {
+    HARNESS_DESIRED_JSON='{"tool-audit":{"event":"PreToolUse","script":"agents/hooks/tool-audit.sh","matcher":"Bash"}}'
+    cat > "$CODEX_CONFIG_FILE" <<'TOML'
+[[hooks.SessionStart]]
+matcher = "startup"
+
+[[hooks.SessionStart.hooks]]
+type = "command"
+command = "bash \"$HOME/.codex/hooks/tool-audit.sh\""
+TOML
+    local changed
+    changed=$(hook_detect_changes codex)
+    [[ "$changed" == "tool-audit" ]]
 }
 
 # ── chezmoi installer ──────────────────────────────────────────────────
@@ -396,15 +680,53 @@ SH
     [[ "$(jq -r 'keys | length' <<<"$for_codex")"  == "1" ]]
 }
 
-@test "hook_filter_for_harness fails loud when an entry has event != SessionStart" {
-    # Asserts the only-SessionStart-wired guard in lib.sh. Adding a hook
-    # with event: PostToolUse without first wiring backends for that slot
-    # would silently land it under SessionStart — this test catches that.
-    local reg='{"future":{"event":"PostToolUse","script":"x.sh"}}'
+@test "hook_filter_for_harness fails loud when an entry has an unsupported event" {
+    # The whitelist HOOK_EVENTS_VALID gates what events the backends know
+    # how to write. Anything outside that set must abort the sync, not
+    # silently fall through to SessionStart.
+    local reg='{"future":{"event":"NotAnEvent","script":"x.sh"}}'
     run hook_filter_for_harness claude "$reg"
     [[ "$status" -ne 0 ]]
-    [[ "$output" == *"event != SessionStart"* ]]
+    [[ "$output" == *"unsupported event"* ]]
+    [[ "$output" == *"NotAnEvent"* ]]
     [[ "$output" == *"future"* ]]
+}
+
+@test "hook_filter_for_harness accepts every event in the whitelist" {
+    # Locks the contract that all six whitelisted events round-trip
+    # through the filter without erroring. Adding a seventh event needs
+    # both HOOK_EVENTS_VALID and this test updated together.
+    for evt in SessionStart UserPromptSubmit PreToolUse PostToolUse Stop PermissionRequest; do
+        local reg
+        reg=$(jq -n --arg e "$evt" '{(("entry-" + $e)): {event: $e, script: "x.sh"}}')
+        run hook_filter_for_harness claude "$reg"
+        assert_success
+        [[ "$(jq -r 'keys | length' <<<"$output")" == "1" ]]
+    done
+}
+
+@test "hook_filter_for_harness rejects entries with both script and command" {
+    # Mutually exclusive: script → deployed path; command → literal external.
+    local reg='{"bad":{"event":"SessionStart","script":"x.sh","command":"/bin/true"}}'
+    run hook_filter_for_harness claude "$reg"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"both 'script' and 'command'"* ]]
+    [[ "$output" == *"bad"* ]]
+}
+
+@test "hook_filter_for_harness rejects entries with neither script nor command" {
+    local reg='{"empty":{"event":"SessionStart"}}'
+    run hook_filter_for_harness claude "$reg"
+    [[ "$status" -ne 0 ]]
+    [[ "$output" == *"neither 'script' nor 'command'"* ]]
+    [[ "$output" == *"empty"* ]]
+}
+
+@test "hook_filter_for_harness accepts a command-only entry" {
+    local reg='{"moshi":{"event":"SessionStart","command":"/usr/local/bin/moshi-hook claude-hook"}}'
+    run hook_filter_for_harness claude "$reg"
+    assert_success
+    [[ "$(jq -r '.moshi.command' <<<"$output")" == "/usr/local/bin/moshi-hook claude-hook" ]]
 }
 
 @test "hook_filter_for_harness fails loud when the event field is missing" {
@@ -463,7 +785,7 @@ TOML
     rm -f "$CODEX_CONFIG_FILE"
     local sig
     sig=$(hook_codex_current_signature session-start-cheese-flair)
-    [[ "$sig" == $'\t\t' ]]
+    [[ "$sig" == $'\t\t\t\t' ]]
 }
 
 @test "hook_codex_current_signature reports empty when SessionStart entry missing" {
@@ -473,7 +795,7 @@ approval_policy = "on-request"
 TOML
     local sig
     sig=$(hook_codex_current_signature session-start-cheese-flair)
-    [[ "$sig" == $'\t\t' ]]
+    [[ "$sig" == $'\t\t\t\t' ]]
 }
 
 @test "hook_codex_current_signature reports drift when matcher differs" {
@@ -491,7 +813,9 @@ TOML
     cur=$(hook_codex_current_signature session-start-cheese-flair)
     des=$(hook_desired_signature       session-start-cheese-flair codex)
     [[ "$cur" != "$des" ]]
-    [[ "$cur" == *$'\t'"something-else"$'\t'"5" ]]
+    # Signature ends in: <event> <current-matcher> <timeout> <async>.
+    # async is empty for codex (claude-only); ends with a trailing tab.
+    [[ "$cur" == *$'\t'"SessionStart"$'\t'"something-else"$'\t'"5"$'\t' ]]
 }
 
 @test "hook_detect_changes (codex): names entry on matcher drift" {
@@ -596,7 +920,7 @@ YAML
         to_entries[]
         | .value as $h
         | ($h.harnesses // ["claude","codex"])[] as $harness
-        | ([$h.script] + ($h.shared_assets // []))[] as $asset
+        | (($h.script // empty), ($h.shared_assets // [])[]) as $asset
         | "\($asset)\t\($harness)"
     ' | LC_ALL=C sort -u)
 
@@ -757,7 +1081,7 @@ STUB
         to_entries[]
         | .value as $h
         | ($h.harnesses // ["claude","codex"])[] as $harness
-        | ([$h.script] + ($h.shared_assets // []))[] as $asset
+        | (($h.script // empty), ($h.shared_assets // [])[]) as $asset
         | "\($asset)\t\($harness)"
     ' | LC_ALL=C sort -u)
     deployed_count=0
@@ -804,7 +1128,12 @@ STUB
     [[ "$timeout" == "5" ]]
 
     # Claude side mirror — the sync wrote a SessionStart entry into the fake
-    # settings file pointing at the deployed hook.
-    [[ "$(jq -r '.hooks.SessionStart[0].hooks[0].command' "$fake_claude")" == 'bash "$HOME/.claude/hooks/session-start-cheese-flair.sh"' ]]
-    [[ "$(jq -r '.hooks.SessionStart[0].hooks[0].timeout' "$fake_claude")" == "5" ]]
+    # settings file pointing at the deployed hook. Select by content, not
+    # index: claude SessionStart also holds the claude-only moshi entry, so
+    # position [0] is not guaranteed to be cheese-flair.
+    local ss_cmd ss_timeout
+    ss_cmd=$(jq -r '.hooks.SessionStart[] | select((.hooks[0].command // "") | test("session-start-cheese-flair.sh")) | .hooks[0].command' "$fake_claude")
+    ss_timeout=$(jq -r '.hooks.SessionStart[] | select((.hooks[0].command // "") | test("session-start-cheese-flair.sh")) | .hooks[0].timeout' "$fake_claude")
+    [[ "$ss_cmd"     == 'bash "$HOME/.claude/hooks/session-start-cheese-flair.sh"' ]]
+    [[ "$ss_timeout" == "5" ]]
 }

--- a/tests/chezmoi-wiring.bats
+++ b/tests/chezmoi-wiring.bats
@@ -978,6 +978,63 @@ SH
     [[ "$hash_before" == "$hash_after" ]]
 }
 
+# Regression: real `serena init` loads-then-validates the existing config and
+# aborts with "`projects` key not found" when the on-disk file is the stub.
+# The script must remove the stub before calling init so init bootstraps from
+# absence. Without the rm, init crashes on the stub, the live read yields the
+# stub, and the script emits the stub forever — the exact stable-broken state
+# the user hit on a fresh box. The shim here mimics serena's real behaviour
+# (init fails if a projects-less config already exists); this test fails if the
+# rm is removed.
+@test "serena: modify_ script clears the stub so serena init can bootstrap over it" {
+    command -v chezmoi >/dev/null 2>&1 || skip "chezmoi not installed"
+    command -v yq      >/dev/null 2>&1 || skip "yq not installed"
+    setup_serena_chezmoi_env
+
+    mkdir -p "$HOME/.serena"
+    cat > "$HOME/.serena/serena_config.yml" <<'YAML'
+# serena not initialized; run `serena init`, then `chezmoi apply` again
+YAML
+
+    # Shim mimics real serena: `init` aborts if a config already exists
+    # without a `projects` key, and only writes a fresh config from absence.
+    local shim_dir="$HOME/bin"
+    mkdir -p "$shim_dir"
+    cat > "$shim_dir/serena" <<'SH'
+#!/bin/sh
+case "$1" in
+  init)
+    cfg="$HOME/.serena/serena_config.yml"
+    if [ -f "$cfg" ] && ! grep -q '^projects:' "$cfg"; then
+      echo "projects key not found" >&2
+      exit 1
+    fi
+    cat > "$cfg" <<'YAML'
+language_backend: LSP
+web_dashboard: true
+web_dashboard_open_on_launch: true
+excluded_tools: []
+projects: []
+YAML
+    ;;
+esac
+SH
+    chmod +x "$shim_dir/serena"
+
+    local chezmoi_dir yq_dir minimal_path
+    chezmoi_dir=$(dirname "$(command -v chezmoi)")
+    yq_dir=$(dirname "$(command -v yq)")
+    minimal_path="$shim_dir:/usr/bin:/bin:$chezmoi_dir:$yq_dir"
+
+    PATH="$minimal_path" run chezmoi apply --force "$HOME/.serena/serena_config.yml"
+    assert_success
+
+    # Healed: stub gone, projects present, overrides applied.
+    ! grep -qF '# serena not initialized' "$HOME/.serena/serena_config.yml"
+    [[ "$(yq '.projects | length'  "$HOME/.serena/serena_config.yml")" == "0" ]]
+    [[ "$(yq '.web_dashboard'      "$HOME/.serena/serena_config.yml")" == "false" ]]
+}
+
 # Regression: if `serena init` fails after the stub-on-disk gate fires,
 # the script must fall through gracefully — the bootstrap branch swallows
 # the failure with `|| true`, the live-file read still yields the stub,


### PR DESCRIPTION
## Why

On a fresh Linux box, the migrated `global` profile rendered but its MCPs and hooks never loaded. This branch fixes the load path end-to-end and folds in the Moshi hook bridge + serena self-heal that the same fresh-box exposed.

Builds on the recent `main` fixes (`ac9255b` agent-profile skip-list, `370203a` marketplace path, `/cursor/*` gitignore) — this adds the pieces those didn't cover.

## What

**`fix(ap): deploy global-profile hooks and load its MCPs`**
- ap claude renderer `_write_hooks` only understood `script:` entries and raised on `command:`/`async:` hooks, aborting the whole render. Now supports command-literal hooks, `async`, `timeout`, and matcher-less event slots (SessionStart/Stop/UserPromptSubmit/PermissionRequest).
- The `global@local` directory marketplace had no `marketplace.json`, so Claude couldn't resolve the plugin and never read its `.mcp.json`. The renderer now emits a schema-valid `marketplace.json` (incl. the required `owner`). Verified: without this, `claude plugin marketplace add` fails with `owner: expected object` and the MCPs stay unloaded.
- Moshi multi-event hook bridge: registry entries + bash backend, merged into the chezmoi settings seed.

**`fix(chezmoi): self-heal serena config over a stub + add bats runner`**
- `serena init` loads-then-validates the existing config and aborts with `` `projects` key not found `` when the file is the "not initialized" stub — a stable broken state that left the serena MCP unable to start. Clear the stub before `serena init` so it bootstraps from absence.
- Add the `bats` test runner to the package registry so `tests/*.bats` run on every box.

**`feat(hooks): auto-format markdown writes with markdownlint-cli2`**
- Run `markdownlint-cli2 --fix` on `.md`/`.markdown` edits; treat its non-zero "residual findings" exit as expected (silent).

## Verification

- All 8 MCP servers connect (tilth, serena, context7, code-review-graph, tavily, hallouminate, todoist, playwright).
- `374` agent-profile pytest pass; serena chezmoi-wiring bats 7/7; `agents-hooks-sync` bats 68/68.
- `dots sync` clean; working tree clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)