### PR TITLE
Add RSS sampling and log rotation to serena-mux

### DIFF
--- a/bin/serena-mux
+++ b/bin/serena-mux
@@ -89,6 +89,26 @@ trace() {
 # can confirm the mux is coalescing daemons without enabling DEBUG or digging
 # through the harness's MCP stderr capture. Always on; never fatal.
 log_dir="${SERENA_MUX_LOG_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/dotfiles/logs}"
+# Cap the persistent log to bound disk growth across long-lived setups.
+# Single .1 backup keeps "grep back through last week" while never growing
+# past 2× the cap. Override via SERENA_MUX_LOG_MAX_BYTES (e.g. tests).
+LOG_MAX_BYTES="${SERENA_MUX_LOG_MAX_BYTES:-1048576}"  # 1 MiB
+
+# rss_kb_of <pid> — prints RSS in KB or empty on failure (e.g. sandboxed ps).
+# Useful for spotting #1367-shaped runaway growth on a coalesced daemon.
+rss_kb_of() {
+    ps -o rss= -p "$1" 2>/dev/null | awk 'NR==1{print $1}'
+}
+
+maybe_rotate_log() {
+    local f="$log_dir/serena-mux.log" size
+    [[ -f $f ]] || return 0
+    # BSD stat first (macOS host), GNU stat second (linux CI), zero on neither.
+    size=$(stat -f%z "$f" 2>/dev/null || stat -c%s "$f" 2>/dev/null || echo 0)
+    (( size > LOG_MAX_BYTES )) || return 0
+    mv -f "$f" "$f.1" 2>/dev/null || true
+}
+
 log() { # <event> <detail...>
     local event=$1
     shift
@@ -97,6 +117,9 @@ log() { # <event> <detail...>
         "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$event" "$root" "$harness" "$slug" "$*" \
         >>"$log_dir/serena-mux.log" 2>/dev/null || true
 }
+
+# Rotate once per invocation, before any log line writes — cheap stat check.
+maybe_rotate_log
 
 trace "root=$root harness=$harness slug=$slug"
 
@@ -108,7 +131,7 @@ if [[ -f $pidfile ]]; then
     if [[ -n $pid ]] && kill -0 "$pid" 2>/dev/null; then
         daemon_alive=1
         trace "existing daemon alive at pid=$pid"
-        log reuse "pid=$pid port=$(cat "$portfile" 2>/dev/null || true)"
+        log reuse "pid=$pid port=$(cat "$portfile" 2>/dev/null || true) rss_kb=$(rss_kb_of "$pid")"
     else
         trace "stale pidfile (pid=$pid) — cleaning up"
         log reap "dead_pid=$pid"

--- a/bin/serena-mux
+++ b/bin/serena-mux
@@ -22,10 +22,16 @@
 #   SERENA_MUX_PROXY_VERSION — pin for mcp-proxy (default: 0.12.0)
 #   SERENA_MUX_LOG_DIR  — dir for the persistent decision log
 #                         (default: ${XDG_STATE_HOME:-~/.local/state}/dotfiles/logs)
+#   SERENA_MUX_LOG_MAX_BYTES — rotate the log once it exceeds this size
+#                         (default: 1048576 = 1 MiB)
 #
 # Persistent log: one line per invocation (spawn|reuse|reap) is appended to
 #   <log dir>/serena-mux.log — always on, so you can confirm coalescing is
 #   working without enabling DEBUG or digging through the harness MCP logs.
+#   The reuse line carries rss_kb=<N> (or rss_kb=? when the ps probe fails)
+#   so daemon memory growth is visible at a glance. The log is rotated to a
+#   single <log>.1 backup when it crosses SERENA_MUX_LOG_MAX_BYTES, bounding
+#   on-disk size at 2× the cap.
 #
 # Exit codes:
 #   0   — bridged stdio cleanly

--- a/bin/serena-mux
+++ b/bin/serena-mux
@@ -94,10 +94,15 @@ log_dir="${SERENA_MUX_LOG_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/dotfiles/lo
 # past 2× the cap. Override via SERENA_MUX_LOG_MAX_BYTES (e.g. tests).
 LOG_MAX_BYTES="${SERENA_MUX_LOG_MAX_BYTES:-1048576}"  # 1 MiB
 
-# rss_kb_of <pid> — prints RSS in KB or empty on failure (e.g. sandboxed ps).
+# rss_kb_of <pid> — prints RSS in KB, or "?" when the probe fails (e.g.
+# sandboxed ps). The "?" sentinel keeps the rss_kb= field present and
+# greppable while distinguishing a failed probe from a genuine 0, so
+# downstream parsing never mistakes "no reading" for "RSS was zero".
 # Useful for spotting #1367-shaped runaway growth on a coalesced daemon.
 rss_kb_of() {
-    ps -o rss= -p "$1" 2>/dev/null | awk 'NR==1{print $1}'
+    local kb
+    kb=$(ps -o rss= -p "$1" 2>/dev/null | awk 'NR==1{print $1}')
+    printf '%s' "${kb:-?}"
 }
 
 maybe_rotate_log() {

--- a/tests/serena-mux.bats
+++ b/tests/serena-mux.bats
@@ -276,9 +276,11 @@ teardown() {
     grep -qE '\[serena-mux\] reuse .*pid=[0-9]+' "$MUX_LOG"
     # The reuse line points at the same port the spawn published.
     grep -q "reuse .*$spawn_port" "$MUX_LOG"
-    # And carries an RSS sample so #1367-shaped runaway growth is visible
-    # in the log without enabling DEBUG.
-    grep -qE '\[serena-mux\] reuse .*rss_kb=[0-9]+' "$MUX_LOG"
+    # And carries the RSS sample from the ps stub (pinned to the stub's
+    # literal so a regression that drops or mangles the real value fails
+    # here instead of passing on any stray digit). The "?" failure
+    # sentinel would also fail this, which is what we want.
+    grep -qE '\[serena-mux\] reuse .*rss_kb=12345' "$MUX_LOG"
 }
 
 @test "serena-mux: logs a 'reap' line when a stale daemon is cleaned up" {

--- a/tests/serena-mux.bats
+++ b/tests/serena-mux.bats
@@ -9,6 +9,10 @@
 
 load test_helper
 
+# `run !` (negated assertions below) requires Bats >= 1.5.0; declaring it
+# here silences the BW02 warning and fails loud on an older bats.
+bats_require_minimum_version 1.5.0
+
 setup() {
     setup_test_env
 
@@ -283,6 +287,30 @@ teardown() {
     grep -qE '\[serena-mux\] reuse .*rss_kb=12345' "$MUX_LOG"
 }
 
+@test "serena-mux: reuse line falls back to rss_kb=? when ps probe fails" {
+    # Override the setup() ps stub with one that emits nothing — the shape
+    # of a sandboxed / unavailable ps. rss_kb_of() must then emit the "?"
+    # sentinel rather than a bare empty rss_kb= field, so downstream parsing
+    # can tell "probe failed" apart from "RSS was 0".
+    cat >"$FAKE_BIN/ps" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    chmod +x "$FAKE_BIN/ps"
+
+    run serena-mux
+    [ "$status" -eq 0 ]
+    run serena-mux
+    [ "$status" -eq 0 ]
+
+    grep -qE '\[serena-mux\] reuse .*rss_kb=\?' "$MUX_LOG"
+    # And never a bare empty value — that's the bug the sentinel prevents.
+    # `run !` so the negation actually fails the test (bare ! is a no-op
+    # in Bats — see SC2314).
+    run ! grep -qE '\[serena-mux\] reuse .*rss_kb= ' "$MUX_LOG"
+    run ! grep -qE '\[serena-mux\] reuse .*rss_kb=$' "$MUX_LOG"
+}
+
 @test "serena-mux: logs a 'reap' line when a stale daemon is cleaned up" {
     run serena-mux
     [ "$status" -eq 0 ]
@@ -315,7 +343,9 @@ teardown() {
     # The old contents are now in .1, and the live log only holds this run.
     [ -f "$MUX_LOG.1" ]
     grep -q 'old log line 1' "$MUX_LOG.1"
-    ! grep -q 'old log line 1' "$MUX_LOG"
+    # `run !` so the negation fails the test (bare ! is a no-op in Bats —
+    # see SC2314).
+    run ! grep -q 'old log line 1' "$MUX_LOG"
     # New invocation still logged its spawn line.
     grep -qE '\[serena-mux\] spawn ' "$MUX_LOG"
 }

--- a/tests/serena-mux.bats
+++ b/tests/serena-mux.bats
@@ -27,6 +27,26 @@ setup() {
     mkdir -p "$FAKE_BIN"
     export PATH="$FAKE_BIN:$PATH"
 
+    # Stub ps: serena-mux's rss_kb_of() helper calls `ps -o rss= -p <pid>`.
+    # In sandboxed CI / Claude's bash sandbox the real /bin/ps isn't reachable,
+    # and on the host `ps` may be aliased (e.g. to `procs`) with a different
+    # surface. Hard-pin the response so the rss_kb= field is deterministic.
+    cat >"$FAKE_BIN/ps" <<'EOF'
+#!/usr/bin/env bash
+# Only the `ps -o rss= -p <pid>` shape is exercised by serena-mux. Any other
+# form is unexpected — fall through to silent empty output rather than guess.
+mode=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -o) [[ "$2" == "rss=" ]] && mode=rss; shift 2 ;;
+        -p) shift 2 ;;
+        *)  shift ;;
+    esac
+done
+[[ "$mode" == "rss" ]] && echo "12345"
+EOF
+    chmod +x "$FAKE_BIN/ps"
+
     # Stub uvx: record the args + exit 0. Don't actually bridge.
     export MOCK_UVX_LOG="$TEST_HOME/uvx-args.log"
     cat >"$FAKE_BIN/uvx" <<EOF
@@ -256,6 +276,9 @@ teardown() {
     grep -qE '\[serena-mux\] reuse .*pid=[0-9]+' "$MUX_LOG"
     # The reuse line points at the same port the spawn published.
     grep -q "reuse .*$spawn_port" "$MUX_LOG"
+    # And carries an RSS sample so #1367-shaped runaway growth is visible
+    # in the log without enabling DEBUG.
+    grep -qE '\[serena-mux\] reuse .*rss_kb=[0-9]+' "$MUX_LOG"
 }
 
 @test "serena-mux: logs a 'reap' line when a stale daemon is cleaned up" {
@@ -272,4 +295,25 @@ teardown() {
     run serena-mux
     [ "$status" -eq 0 ]
     grep -qE "\[serena-mux\] reap .*dead_pid=$old_pid" "$MUX_LOG"
+}
+
+@test "serena-mux: rotates the persistent log when it crosses the size cap" {
+    # Tight cap so one pre-existing log fills it; the next invocation rotates.
+    export SERENA_MUX_LOG_MAX_BYTES=200
+
+    mkdir -p "$SERENA_MUX_LOG_DIR"
+    # Seed the log with >200 bytes of junk so the next invocation crosses
+    # the cap on its pre-write rotation check.
+    printf 'old log line %s\n' {1..30} >"$MUX_LOG"
+    [ "$(wc -c <"$MUX_LOG" | tr -d ' ')" -gt 200 ]
+
+    run serena-mux
+    [ "$status" -eq 0 ]
+
+    # The old contents are now in .1, and the live log only holds this run.
+    [ -f "$MUX_LOG.1" ]
+    grep -q 'old log line 1' "$MUX_LOG.1"
+    ! grep -q 'old log line 1' "$MUX_LOG"
+    # New invocation still logged its spawn line.
+    grep -qE '\[serena-mux\] spawn ' "$MUX_LOG"
 }


### PR DESCRIPTION
`serena-mux` coalesces many client sessions onto one long-lived serena daemon, which makes it more exposed to serena's known unbounded-RSS growth ([oraios/serena#1367](https://github.com/oraios/serena/issues/1367)) than the default one-daemon-per-session model. This adds an `rss_kb=` field to every `reuse` log line (via a new `rss_kb_of` helper) so daemon growth is visible without enabling `SERENA_MUX_DEBUG`, and caps the persistent log at `SERENA_MUX_LOG_MAX_BYTES` (1 MiB default) with a single `.1` backup so it can't grow without bound. Tests stub `ps` for deterministic CI, assert the reuse line carries an RSS sample, and add a rotation test under a tight size cap — all 13 bats tests pass, `bash -n` and `shellcheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)