### PR TITLE
fix(packages): exclude self-updating casks from greedy upgrade

### DIFF
--- a/packages/packages.yaml
+++ b/packages/packages.yaml
@@ -82,7 +82,7 @@ packages:
   - pyenv: { dev: true }
   - uv
   - rustup: { dev: true }
-  - docker: { source: cask, dev: true, platform: mac }
+  - docker-desktop: { source: cask, dev: true, platform: mac, greedy: false } # self-updates in-app; greedy upgrade triggers repeated sudo prompts
   - npm: { platform: linux, dev: true }       # On mac, npm comes with `brew install node`
 
   # LSP servers (for Claude Code LSP plugins)

--- a/packages/sync.sh
+++ b/packages/sync.sh
@@ -142,7 +142,10 @@ upgrade_casks_greedy() {
     fi
 
     local outdated to_upgrade=()
-    outdated=$(brew outdated --cask --greedy-auto-updates --quiet 2>/dev/null || true)
+    if ! outdated=$(brew outdated --cask --greedy-auto-updates --quiet 2>/dev/null); then
+        log_warning "brew outdated --cask failed; skipping greedy cask upgrade"
+        return 0
+    fi
     while IFS= read -r cask; do
         [[ -z "$cask" ]] && continue
         if grep -qxF "$cask" <<< "$excluded"; then

--- a/packages/sync.sh
+++ b/packages/sync.sh
@@ -99,6 +99,13 @@ get_source_pkgs() {
 
 ########## Brew
 
+# Cask names flagged `greedy: false` — excluded from the greedy upgrade pass
+# because they self-update in-app and their cask reinstall triggers repeated
+# sudo/admin prompts (e.g. docker-desktop).
+get_no_greedy_casks() {
+    yq -r ".packages[] | select(kind == \"map\") | to_entries[0] | select(.value.source == \"cask\" and .value.greedy == false) | .key" "$PACKAGES_FILE" 2>/dev/null
+}
+
 # Install brew packages from a list, skipping already-installed ones
 # Usage: brew_install_pkgs <label> <pkg_list> <installed_list> [--cask]
 brew_install_pkgs() {
@@ -119,6 +126,35 @@ brew_install_pkgs() {
             fi
         fi
     done <<< "$pkg_list"
+}
+
+# Greedy-upgrade auto_updates casks, skipping any flagged `greedy: false`.
+# With no exclusions, defer to the cheap one-shot `brew upgrade --cask
+# --greedy-auto-updates`. Otherwise enumerate the greedy-outdated set and
+# upgrade only the casks not on the exclude list.
+upgrade_casks_greedy() {
+    local excluded
+    excluded=$(get_no_greedy_casks)
+
+    if [[ -z "$excluded" ]]; then
+        brew upgrade --cask --greedy-auto-updates </dev/null || log_warning "brew cask upgrade failed"
+        return 0
+    fi
+
+    local outdated to_upgrade=()
+    outdated=$(brew outdated --cask --greedy-auto-updates --quiet 2>/dev/null || true)
+    while IFS= read -r cask; do
+        [[ -z "$cask" ]] && continue
+        if grep -qxF "$cask" <<< "$excluded"; then
+            echo "  + $cask (self-updates; excluded from greedy upgrade)"
+            continue
+        fi
+        to_upgrade+=("$cask")
+    done <<< "$outdated"
+
+    if ((${#to_upgrade[@]})); then
+        brew upgrade --cask "${to_upgrade[@]}" </dev/null || log_warning "brew cask upgrade failed"
+    fi
 }
 
 sync_brew() {
@@ -170,7 +206,12 @@ sync_brew() {
         # `brew upgrade`; --greedy-auto-updates version-checks them and reinstalls
         # only on a diff. Excludes `version :latest` casks (no version to compare,
         # would reinstall every run).
-        brew upgrade --cask --greedy-auto-updates </dev/null || log_warning "brew cask upgrade failed"
+        #
+        # Casks flagged `greedy: false` (e.g. docker-desktop) are excluded from
+        # the greedy pass: they self-update in-app and their cask reinstall
+        # prompts for sudo/admin multiple times. There's no `brew upgrade`
+        # exclude flag, so enumerate the greedy-outdated set and drop them.
+        upgrade_casks_greedy
     fi
 
     log_success "Brew sync complete"

--- a/tests/packages.bats
+++ b/tests/packages.bats
@@ -35,9 +35,9 @@ teardown() {
 
 # --- Mock helpers ---
 
-# Usage: write_mock_brew [installed_formulae] [installed_casks] [fail_pkg]
+# Usage: write_mock_brew [installed_formulae] [installed_casks] [fail_pkg] [outdated_greedy_casks]
 write_mock_brew() {
-    local formulae="${1:-}" casks="${2:-}" fail_pkg="${3:-}"
+    local formulae="${1:-}" casks="${2:-}" fail_pkg="${3:-}" outdated_casks="${4:-}"
     cat > "$MOCK_BIN/brew" << MOCKBREW
 #!/bin/bash
 echo "brew \$*" >> "$BREW_LOG"
@@ -48,6 +48,11 @@ case "\$1" in
         else
             echo "$casks"
         fi
+        ;;
+    outdated)
+        # Only the greedy-cask probe returns names here; bare \`brew outdated\`
+        # in other contexts is unused by sync.sh.
+        echo "$outdated_casks"
         ;;
     tap)
         if [[ \$# -eq 1 ]]; then echo ""; fi
@@ -117,7 +122,7 @@ packages:
   - node: { apt: nodejs }
   - mas: { platform: mac }
   - xclip: { platform: linux }
-  - docker: { source: cask, dev: true, platform: mac }
+  - docker-desktop: { source: cask, dev: true, platform: mac, greedy: false }
   - npm: { platform: linux, dev: true }
   - pyenv: { dev: true }
   - cargo-llvm-cov: { source: cargo }
@@ -507,6 +512,23 @@ MOCKRUSTUP
     assert_success
     grep -q "brew update" "$BREW_LOG"
     grep -q "brew upgrade" "$BREW_LOG"
+}
+
+@test "UPGRADE_MODE excludes greedy:false casks (docker-desktop) from greedy upgrade" {
+    [[ "$(uname)" == "Darwin" ]] || skip "macOS only (sync_brew not invoked on Linux)"
+
+    # Both docker-desktop (greedy:false) and cursor (greedy default) report as
+    # greedy-outdated. cursor must be upgraded; docker-desktop must not.
+    write_mock_brew "" "docker-desktop" "" $'docker-desktop\ncursor'
+    write_test_yaml
+    UPGRADE_MODE=true run bash "$SYNC_SCRIPT"
+    assert_success
+
+    # No blanket greedy upgrade — the exclusion path enumerates instead.
+    ! grep -q "brew upgrade --cask --greedy-auto-updates" "$BREW_LOG"
+    # cursor gets upgraded explicitly; docker-desktop is never passed to upgrade.
+    grep -q "brew upgrade --cask cursor" "$BREW_LOG"
+    ! grep -qE "brew upgrade --cask .*docker-desktop" "$BREW_LOG"
 }
 
 @test "UPGRADE_MODE runs cargo-install-update --all --git instead of per-package --force" {

--- a/tests/packages.bats
+++ b/tests/packages.bats
@@ -531,6 +531,31 @@ MOCKRUSTUP
     ! grep -qE "brew upgrade --cask .*docker-desktop" "$BREW_LOG"
 }
 
+@test "UPGRADE_MODE warns + skips greedy cask upgrade when brew outdated fails" {
+    [[ "$(uname)" == "Darwin" ]] || skip "macOS only (sync_brew not invoked on Linux)"
+
+    # brew outdated failing must NOT be silently swallowed as "nothing to
+    # upgrade" — emit a warning and skip the pass, like the other brew ops.
+    cat > "$MOCK_BIN/brew" << 'MOCKBREW'
+#!/bin/bash
+echo "brew $*" >> "$BREW_LOG"
+case "$1" in
+    list)   [[ "$2" == "--formulae" ]] && echo "" || echo "docker-desktop" ;;
+    outdated) exit 1 ;;
+    tap)    [[ $# -eq 1 ]] && echo "" ;;
+esac
+exit 0
+MOCKBREW
+    chmod +x "$MOCK_BIN/brew"
+
+    write_test_yaml
+    UPGRADE_MODE=true run bash "$SYNC_SCRIPT"
+    assert_success
+    assert_output_contains "brew outdated --cask failed; skipping greedy cask upgrade"
+    # No filtered cask upgrade is attempted when the probe failed.
+    ! grep -qE "brew upgrade --cask [a-z]" "$BREW_LOG"
+}
+
 @test "UPGRADE_MODE runs cargo-install-update --all --git instead of per-package --force" {
     # New idempotent contract (PR #197): the install pass only handles
     # *missing* packages, and the upgrade pass delegates to


### PR DESCRIPTION
## Problem

`dots up` repeatedly prompts for the sudo/admin password while upgrading Docker. The upgrade pass runs `brew upgrade --cask --greedy-auto-updates`, which forces a full cask reinstall of Docker Desktop even though it self-updates in-app. Docker's cask upgrade runs several privileged steps (killing the old app, replacing the `com.docker.*` helpers), each firing a password prompt.

## Fix

- Add a per-cask `greedy: false` flag in `packages.yaml`. When set, the upgrade pass enumerates the greedy-outdated set (`brew outdated --cask --greedy-auto-updates`) and upgrades everything *except* the flagged casks. Homebrew has no exclude flag for `brew upgrade`, hence enumerate-and-filter. Casks that genuinely benefit from greedy (e.g. Cursor) are unaffected.
- Rename the entry `docker` → `docker-desktop` to match the token Homebrew renamed the cask to. The old name never matched `brew list --cask` (which reports `docker-desktop`), so a plain `dots sync` would retry `brew install --cask docker` every run — a latent bug fixed here.

Docker self-updates anyway, so nothing is lost — the repeated prompts just go away.

## Tests

- Taught the mock `brew` in `tests/packages.bats` to answer `outdated`.
- New test proves Cursor still gets greedy-upgraded while `docker-desktop` is excluded.
- Full `tests/packages.bats` suite (33 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)