### PR TITLE
Fix skill sync with unsupported harnesses

### DIFF
--- a/chezmoi/dot_config/git/ignore
+++ b/chezmoi/dot_config/git/ignore
@@ -1,0 +1,19 @@
+# Global git ignore (XDG: $XDG_CONFIG_HOME/git/ignore).
+# Git reads this for every repo automatically when core.excludesFile is unset.
+# Uncommitted by design — keeps personal coding-agent tooling out of every
+# repo's tracked tree and out of upstream PRs.
+
+# Cheese-flow ephemeral per-phase reports (NOT .cheese/specs/, which is a
+# durable artifact worth tracking per-repo).
+.cheese/affinage/
+.cheese/cure/
+.cheese/press/
+.cheese/pasteurize/
+.cheese/hard/
+.cheese/notes/
+
+# Serena LSP project state
+.serena/
+
+# Per-task git worktrees created by the /worktree skill
+.worktrees/

--- a/chezmoi/lib/install-external.sh
+++ b/chezmoi/lib/install-external.sh
@@ -120,15 +120,33 @@ fi
 KNOWN_AGENTS=$(awk -F= '/^[[:space:]]*#/ {next} NF==2 {gsub(/[[:space:]]/, "", $2); print $2}' "$SKILL_AGENTS_FILE" | tr '\n' ' ')
 
 AGENT_FLAGS=()
+SKIPPED_AGENTS=()
+SUPPORTED_HARNESSES=""
 for harness in $HARNESSES; do
     if [[ " $KNOWN_AGENTS" != *" $harness "* ]]; then
-        echo -e "${RED}Error: unknown SKILL_HARNESSES agent '$harness' (valid: $KNOWN_AGENTS)${NC}" >&2
-        echo "  The 'skills' CLI exits 0 having installed nothing for a bad --agent, so this is checked here." >&2
-        echo "  Canonical set: $SKILL_AGENTS_FILE" >&2
-        exit 1
+        SKIPPED_AGENTS+=("$harness")
+        continue
     fi
     AGENT_FLAGS+=(--agent "$harness")
+    SUPPORTED_HARNESSES+="${SUPPORTED_HARNESSES:+ }$harness"
 done
+
+# Filter, don't fail: SKILL_HARNESSES is shared with agents the `skills` CLI
+# doesn't support (e.g. crush, antigravity — valid install targets elsewhere,
+# but the CLI only knows the set in skill_agents.txt). Skipping them with a
+# loud warning lets the supported agents still get their skills, instead of a
+# single unsupported entry aborting the whole refresh. The original silent-
+# no-op masking risk is still covered — we warn explicitly per skipped agent.
+if (( ${#SKIPPED_AGENTS[@]} > 0 )); then
+    echo -e "${YELLOW}Skipping SKILL_HARNESSES agents the 'skills' CLI doesn't support: ${SKIPPED_AGENTS[*]}${NC}" >&2
+    echo "  Supported: $KNOWN_AGENTS" >&2
+    echo "  (canonical set: $SKILL_AGENTS_FILE — add an agent there to enable it)" >&2
+fi
+
+if (( ${#AGENT_FLAGS[@]} == 0 )); then
+    echo -e "${YELLOW}No supported SKILL_HARNESSES agents to install into — nothing to do.${NC}" >&2
+    exit 0
+fi
 
 # Repeated `--skill` flags for a source: the explicit registry list (one flag
 # per name), or `--skill '*'` to install every skill in the repo (the CLI's
@@ -172,9 +190,9 @@ install_source() {
 
     local output
     if output=$(npx "${args[@]}" 2>&1); then
-        echo -e "    ${GREEN}✓${NC} $repo → $HARNESSES"
+        echo -e "    ${GREEN}✓${NC} $repo → $SUPPORTED_HARNESSES"
     else
-        echo -e "    ${RED}✗${NC} $repo → $HARNESSES"
+        echo -e "    ${RED}✗${NC} $repo → $SUPPORTED_HARNESSES"
         echo x >> "$FAIL_COUNTER"
         if [[ -n "$output" ]]; then
             echo "$output" | tail -5 | sed -e "s/^/      /"

--- a/tests/skills-external.bats
+++ b/tests/skills-external.bats
@@ -118,19 +118,38 @@ run_sync() {
     assert_output_contains "SKILL_HARNESSES is empty"
 }
 
-@test "skill sync: unknown SKILL_HARNESSES agent fails before invoking npx" {
-    # The `skills` CLI silently exits 0 having installed nothing for a bad
-    # --agent value. Without an allowlist, that masks the misconfig and the
-    # cache below still gets written as if the run worked. install-external.sh
-    # must validate the agent IDs up-front (mirroring agent_profile/fetch.py's
-    # SKILL_AGENT) and abort before npx is reached.
+@test "skill sync: unsupported SKILL_HARNESSES agent is skipped, supported ones still install" {
+    # SKILL_HARNESSES is shared with agents the `skills` CLI doesn't support
+    # (e.g. crush, antigravity — valid install targets elsewhere). An
+    # unsupported entry must be skipped with a loud warning, NOT abort the
+    # whole refresh: the supported agents should still get their skills. The
+    # silent-no-op masking risk the old hard-fail guarded is covered by the
+    # explicit per-skip warning.
     write_registry
     write_env "claude-code bogus-agent"
 
     run_sync
-    assert_failure
-    assert_output_contains "unknown SKILL_HARNESSES agent 'bogus-agent'"
-    # Nothing reached npx — no `skills add` invocation logged.
+    assert_success
+    assert_output_contains "Skipping SKILL_HARNESSES agents"
+    assert_output_contains "bogus-agent"
+    # The supported agent still reached npx with its --agent flag.
+    run grep -c -- '--agent claude-code' "$NPX_LOG"
+    [[ "$output" != "0" ]]
+    # The unsupported agent was never passed to npx.
+    run grep -c 'bogus-agent' "$NPX_LOG"
+    [[ "$output" == "0" ]]
+}
+
+@test "skill sync: all-unsupported SKILL_HARNESSES is a no-op (warn, exit 0, no npx)" {
+    # When every configured agent is unsupported, there is nothing to install
+    # into — warn and exit 0 (matching empty-SKILL_HARNESSES), don't fail the
+    # caller (the `dots upgrade` skills-refresh step).
+    write_registry
+    write_env "bogus-agent another-bogus"
+
+    run_sync
+    assert_success
+    assert_output_contains "No supported SKILL_HARNESSES agents"
     run grep -c 'skills add' "$NPX_LOG"
     [[ "$output" == "0" ]]
 }


### PR DESCRIPTION
## Summary
- Filter SKILL_HARNESSES against the supported skills CLI agent map before invoking npx skills add
- Warn and continue when unsupported agents are present; exit successfully when all configured agents are unsupported
- Add a chezmoi-managed global git ignore for local agent artifacts

## Tests
- bats tests/skills-external.bats