### PR TITLE
feat(ap): render cheese agents cross-harness via registry

### DIFF
--- a/agent-profile/agent_profile/ingest.py
+++ b/agent-profile/agent_profile/ingest.py
@@ -95,6 +95,26 @@ def _expand_hooks(
     return out
 
 
+def _expand_agents(
+    path: Path, source_dir: str
+) -> list[dict[str, Any]]:
+    """Normalize the agent registry mapping into a profile item list.
+
+    Same name-keyed shape as the MCP/hook registries: each ``<name>: {...}``
+    entry becomes ``{name, ...fields, _source_dir}`` with ``_source_dir`` set
+    to the repo root so ``body_path`` (e.g. ``claude/agents/<name>.md``)
+    resolves against the repo, not the profile dir. No env resolution — agent
+    metadata carries no ``${VAR}`` refs."""
+    data = _load_yaml_mapping(path)
+    agents = data.get("agents") or {}
+    out: list[dict[str, Any]] = []
+    for name, body in agents.items():
+        if not isinstance(body, dict):
+            continue
+        out.append({"name": name, **body, "_source_dir": source_dir})
+    return out
+
+
 def _expand_external_skills(
     path: Path, source_dir: str
 ) -> list[dict[str, Any]]:
@@ -179,8 +199,8 @@ def expand_registries(
     repo_root: Path,
     dotenv: dict[str, str],
 ) -> dict[str, list[dict[str, Any]]]:
-    """Expand a ``registries:`` directive into ``{mcps, skills, hooks}`` item
-    lists, each item carrying ``_source_dir = str(repo_root)``.
+    """Expand a ``registries:`` directive into ``{mcps, agents, skills,
+    hooks}`` item lists, each item carrying ``_source_dir = str(repo_root)``.
 
     ``directive`` maps each section to a registry path (or, for skills, a
     list of paths: the external registry plus the local tree). ``dotenv``
@@ -188,11 +208,20 @@ def expand_registries(
     the directive yield empty lists."""
     repo_root = Path(repo_root)
     source_dir = str(repo_root)
-    out: dict[str, list[dict[str, Any]]] = {"mcps": [], "skills": [], "hooks": []}
+    out: dict[str, list[dict[str, Any]]] = {
+        "mcps": [],
+        "agents": [],
+        "skills": [],
+        "hooks": [],
+    }
 
     mcps_path = directive.get("mcps")
     if mcps_path:
         out["mcps"] = _expand_mcps(repo_root / mcps_path, source_dir, dotenv)
+
+    agents_path = directive.get("agents")
+    if agents_path:
+        out["agents"] = _expand_agents(repo_root / agents_path, source_dir)
 
     hooks_path = directive.get("hooks")
     if hooks_path:

--- a/agent-profile/agent_profile/parse.py
+++ b/agent-profile/agent_profile/parse.py
@@ -180,7 +180,7 @@ def parse_one(profile_dir: Path) -> dict[str, Any]:
         # the include "outer last" convention so an inline override on a
         # name-collision wins on scalar/object merges downstream).
         "mcps": reg["mcps"] + _decorate(raw.get("mcps") or []),
-        "agents": _decorate(raw.get("agents") or []),
+        "agents": reg["agents"] + _decorate(raw.get("agents") or []),
         "skills": reg["skills"] + _decorate(raw.get("skills") or []),
         "commands": _decorate(raw.get("commands") or []),
         "hooks": reg["hooks"] + _decorate(raw.get("hooks") or []),
@@ -207,7 +207,7 @@ def _expand_registries_directive(
     as their ``_source_dir`` (not the profile dir) since their payload files
     live under the repo, not the profile."""
     if not directive:
-        return {"mcps": [], "skills": [], "hooks": []}
+        return {"mcps": [], "agents": [], "skills": [], "hooks": []}
     if not isinstance(directive, dict):
         raise ParseError(
             "ap_parse_one: 'registries' must be a mapping of "

--- a/agent-profile/agent_profile/renderers/base.py
+++ b/agent-profile/agent_profile/renderers/base.py
@@ -49,6 +49,7 @@ from typing import Any, Protocol, runtime_checkable
 
 import tomlkit
 
+from agent_profile._validate import ParseError
 from agent_profile.parse import Manifest
 from agent_profile.shared import track_file
 from agent_profile.templating import render_mcp_for_harness
@@ -223,13 +224,27 @@ def copy_hook_shared_assets(
 def body_abs(item: dict[str, Any], body_key: str = "body_path") -> Path | None:
     """Resolve an item's body file against its ``_source_dir``.
 
-    Returns the absolute path iff the field is set and the file exists,
-    else ``None`` (the bash treats a missing body as "skip the body")."""
+    Returns the absolute path when a body is declared and the file exists.
+    Returns ``None`` when no body is declared — an optional body the renderer
+    legitimately skips (the bash treated a missing ``body_path`` as "skip the
+    body").
+
+    A *declared* ``body_path`` that does not resolve is a registry/profile bug,
+    not an optional body: raise :class:`ParseError` so ``ap install`` fails
+    loud (clean stderr + exit 1 via ``cli.main``) instead of silently shipping
+    a body-less item — e.g. a typo'd agent ``body_path`` would otherwise emit a
+    frontmatter-only file and skip the user-scoped shared write with no error."""
     body_rel = item.get(body_key) or ""
     if not body_rel:
         return None
     candidate = Path(item["_source_dir"]) / body_rel
-    return candidate if candidate.is_file() else None
+    if not candidate.is_file():
+        raise ParseError(
+            f"ap: {item.get('name', '?')!r} declares {body_key} "
+            f"{body_rel!r}, but it does not resolve to a file under "
+            f"{item['_source_dir']}"
+        )
+    return candidate
 
 
 def load_toml(path: Path) -> tomlkit.TOMLDocument:

--- a/agent-profile/agent_profile/renderers/claude.py
+++ b/agent-profile/agent_profile/renderers/claude.py
@@ -180,34 +180,23 @@ class ClaudeRenderer:
     ) -> None:
         for item in manifest.agents:
             name = item["name"]
-            desc = item.get("description") or ""
-            tools = ", ".join(item.get("tools") or [])
-            model = (item.get("models") or {}).get("claude") or ""
             body = body_abs(item)
+            # Single Claude-complete frontmatter for both the plugin-scoped
+            # file and the user-scoped shared file. The user-scoped file wins
+            # (priority 4 > plugin priority 5), so it must carry the full
+            # metadata — model/color/effort/skills — not a neutral subset.
+            fm = shared.claude_agent_frontmatter(item)
 
-            # Plugin-scoped agent file (with optional model frontmatter).
-            lines = ["---", f"name: {name}"]
-            if desc:
-                lines.append(f"description: {desc}")
-            if tools:
-                lines.append(f"tools: {tools}")
-            if model:
-                lines.append(f"model: {model}")
-            lines.append("---")
+            lines = ["---", *(f"{k}: {v}" for k, v in fm.items()), "---"]
             content = "\n".join(lines) + "\n\n"
             if body is not None:
-                content += body.read_text()
+                content += shared.strip_frontmatter(body.read_text())
             out_path = plugin_dir / "agents" / f"{name}.md"
             out_path.write_text(content)
             self._track(out, base, out_path)
 
-            # Cross-harness shared write (neutral body, no model frontmatter).
+            # Cross-harness shared write (Claude + Cursor) — same frontmatter.
             if body is not None:
-                fm: dict[str, str] = {"name": name}
-                if desc:
-                    fm["description"] = desc
-                if tools:
-                    fm["tools"] = tools
                 shared.write_shared_claude_agent(target, name, body, fm, out)
 
     def _write_skills(

--- a/agent-profile/agent_profile/renderers/codex.py
+++ b/agent-profile/agent_profile/renderers/codex.py
@@ -99,12 +99,15 @@ class CodexRenderer:
             body_path = base.body_abs(item)
             if body_path is not None:
                 body = body_path.read_text()
+            body = shared.strip_frontmatter(body)
 
             doc = tomlkit.document()
             doc["name"] = name
             doc["description"] = desc
             if model:
                 doc["model"] = model
+            if shared.agent_is_read_only(item):
+                doc["sandbox_mode"] = "read-only"
             doc["developer_instructions"] = tomlkit.string(body, multiline=True)
 
             rel = f".codex/agents/{name}.toml"

--- a/agent-profile/agent_profile/renderers/copilot.py
+++ b/agent-profile/agent_profile/renderers/copilot.py
@@ -42,7 +42,7 @@ from agent_profile.renderers.base import (
     mcps_for,
     read_json_object,
 )
-from agent_profile.shared import track_file
+from agent_profile.shared import strip_frontmatter, track_file
 
 # Copilot's MCP membership default in the bash select() is claude+codex
 # (narrower than the common claude/codex/opencode triple).
@@ -136,7 +136,7 @@ class CopilotRenderer:
 
             body = body_abs(agent)
             if body is not None:
-                parts.append(body.read_text())
+                parts.append(strip_frontmatter(body.read_text()))
 
             abs_path.write_text("".join(parts))
             track_file(out_files, rel)

--- a/agent-profile/agent_profile/renderers/cursor.py
+++ b/agent-profile/agent_profile/renderers/cursor.py
@@ -271,19 +271,17 @@ def _cursor_model(item: dict[str, Any]) -> str:
 
 
 def _agent_frontmatter(item: dict[str, Any]) -> dict[str, Any]:
-    """Build the shared-agent frontmatter dict, dropping empty/null values.
+    """Build the shared ``.claude/agents/<n>.md`` frontmatter.
 
-    Port of the bash jq object: ``{name, description, tools}`` where
-    ``tools`` becomes a comma-joined string only when non-empty, and any
-    empty/null entry is filtered out (``with_entries(select(...))``)."""
-    fields: dict[str, Any] = {
-        "name": item["name"],
-        "description": item.get("description") or "",
-    }
-    tools = item.get("tools") or []
-    if len(tools) > 0:
-        fields["tools"] = ", ".join(tools)
-    return {k: v for k, v in fields.items() if v != "" and v is not None}
+    Delegates to :func:`shared.claude_agent_frontmatter` so the file Cursor
+    and Claude share is written identically by both renderers (the install
+    runs cursor after claude into the same path — divergent frontmatter would
+    let the later writer clobber the earlier one's metadata). Claude resolves
+    this user-scoped file ahead of any plugin copy, so it carries the full
+    metadata (model/color/effort/skills); Cursor ignores what it doesn't use
+    and overrides the model via ``.cursor/agents/<n>.md`` when ``models.cursor``
+    is set."""
+    return shared.claude_agent_frontmatter(item)
 
 
 def _cursor_mcp_entry(mcp: dict[str, Any]) -> dict[str, Any]:

--- a/agent-profile/agent_profile/renderers/opencode.py
+++ b/agent-profile/agent_profile/renderers/opencode.py
@@ -2,9 +2,9 @@
 
 Behavioral port of agent-profile/renderers/opencode.sh, scoped to the
 ``opencode.json`` merge + surgical clean (the mcp + permission surfaces).
-The agent/skill/command writers route through the shared cross-harness
-paths and are owned elsewhere; this renderer owns the merged
-``opencode.json`` file.
+The skill/command writers route through the shared cross-harness paths and
+are owned elsewhere; this renderer owns the merged ``opencode.json`` file
+plus opencode's native subagent files at ``<target>/agents/<name>.md``.
 
 Substrate: stdlib :mod:`json` only (own your keys; ``del``/``pop`` for
 surgical removal). No ``jq``.
@@ -24,7 +24,8 @@ from pathlib import Path
 from typing import Any
 
 from agent_profile.parse import Manifest
-from agent_profile.renderers.base import mcps_for, read_json_object
+from agent_profile.renderers.base import body_abs, mcps_for, read_json_object
+from agent_profile.shared import agent_is_read_only, strip_frontmatter, track_file
 
 # opencode's MCP membership default (matches the bash select default).
 _OPENCODE_MCP_DEFAULT = ("claude", "codex", "opencode")
@@ -80,16 +81,20 @@ class OpencodeRenderer:
     name = "opencode"
 
     def render(self, manifest: Manifest, target: Path) -> list[str]:
-        """Merge this profile's opencode MCPs and translated permissions
-        into ``<target>/opencode.json``, bootstrapping the schema stub
-        when the file is absent. Returns ``[]`` — the merged file is not
-        a tracked artefact."""
+        """Render opencode's native subagent files (``.opencode/agent/``) and
+        merge this profile's opencode MCPs + translated permissions into
+        ``<target>/opencode.json``, bootstrapping the schema stub when the
+        file is absent. Returns the tracked agent paths; the merged
+        ``opencode.json`` is never listed (it is undone in :meth:`clean`)."""
+        written = self._render_agents(manifest, target)
+
         mcps = mcps_for(manifest, "opencode", _OPENCODE_MCP_DEFAULT)
         allow = _allow_keys(manifest)
 
-        # Bash early-returns when neither surface has anything to add.
+        # Bash early-returns when neither mcp/permission surface has anything
+        # to add; agents are written above regardless.
         if not mcps and not allow:
-            return []
+            return written
 
         cfg = Path(str(target).rstrip("/")) / "opencode.json"
         data: dict[str, Any] = (
@@ -111,7 +116,48 @@ class OpencodeRenderer:
 
         cfg.parent.mkdir(parents=True, exist_ok=True)
         cfg.write_text(json.dumps(data, indent=2) + "\n")
-        return []
+        return written
+
+    def _render_agents(self, manifest: Manifest, target: Path) -> list[str]:
+        """Write each agent to ``<target>/agents/<name>.md`` — opencode's
+        native subagent path (Markdown with ``mode: subagent`` frontmatter),
+        not the shared ``.claude/agents/`` tree, which opencode does not read.
+
+        The path is root-relative to ``target`` (the opencode config dir),
+        mirroring how this renderer writes ``opencode.json`` at the target
+        root. The installer points ``target`` at ``~/.config/opencode``, whose
+        global agent dir is ``~/.config/opencode/agents/`` (plural, no extra
+        ``.opencode/`` prefix — that prefix is the *project*-local convention,
+        ``<project>/.opencode/agents/``, not the global config dir). Singular
+        ``agent/`` only works via opencode's legacy backwards-compat alias.
+
+        Read-only intent (see :func:`agent_is_read_only`) becomes a
+        ``permission.edit: deny`` block. Returns the tracked rel paths."""
+        base = Path(str(target).rstrip("/"))
+        written: list[str] = []
+        for item in manifest.agents:
+            body_path = body_abs(item)
+            if body_path is None:
+                continue
+            name = item["name"]
+            fm = [
+                f"description: {item.get('description') or ''}",
+                "mode: subagent",
+            ]
+            model = (item.get("models") or {}).get("opencode") or ""
+            if model and model != "inherit":
+                fm.append(f"model: {model}")
+            if agent_is_read_only(item):
+                fm.append("permission:")
+                fm.append("  edit: deny")
+            body = strip_frontmatter(body_path.read_text())
+            content = "---\n" + "\n".join(fm) + "\n---\n" + body
+            rel = f"agents/{name}.md"
+            abs_path = base / rel
+            abs_path.parent.mkdir(parents=True, exist_ok=True)
+            abs_path.write_text(content)
+            track_file(written, rel)
+        return written
 
     def clean(self, manifest: Manifest, target: Path) -> None:
         """Surgically remove this profile's mcp + permission entries from

--- a/agent-profile/agent_profile/renderers/opencode.py
+++ b/agent-profile/agent_profile/renderers/opencode.py
@@ -81,7 +81,7 @@ class OpencodeRenderer:
     name = "opencode"
 
     def render(self, manifest: Manifest, target: Path) -> list[str]:
-        """Render opencode's native subagent files (``.opencode/agent/``) and
+        """Render opencode's native subagent files (``<target>/agents/``) and
         merge this profile's opencode MCPs + translated permissions into
         ``<target>/opencode.json``, bootstrapping the schema stub when the
         file is absent. Returns the tracked agent paths; the merged
@@ -140,10 +140,12 @@ class OpencodeRenderer:
             if body_path is None:
                 continue
             name = item["name"]
-            fm = [
-                f"description: {item.get('description') or ''}",
-                "mode: subagent",
-            ]
+            fm = ["mode: subagent"]
+            desc = item.get("description")
+            if desc:
+                # Omit an empty description, matching claude_agent_frontmatter
+                # — avoids emitting a null-valued ``description:`` key.
+                fm.insert(0, f"description: {desc}")
             model = (item.get("models") or {}).get("opencode") or ""
             if model and model != "inherit":
                 fm.append(f"model: {model}")

--- a/agent-profile/agent_profile/shared.py
+++ b/agent-profile/agent_profile/shared.py
@@ -32,6 +32,89 @@ def _frontmatter_lines(frontmatter: dict[str, Any]) -> list[str]:
     return [f"{k}: {v}" for k, v in frontmatter.items()]
 
 
+def strip_frontmatter(text: str) -> str:
+    """Return ``text`` with a leading ``---``/``---`` YAML frontmatter block
+    removed.
+
+    A block is recognised only when the very first line is exactly ``---``;
+    it ends at the next line that is exactly ``---``. Bodies that do not open
+    with a frontmatter block — or whose opener is never closed — are returned
+    unchanged, so a body that merely starts with a horizontal rule is never
+    truncated. Used to keep already-frontmattered agent bodies from emitting a
+    second frontmatter block (or leaking frontmatter into codex's
+    ``developer_instructions``) when a renderer prepends its own."""
+    if not text.startswith("---"):
+        return text
+    lines = text.splitlines(keepends=True)
+    if lines[0].rstrip("\r\n") != "---":
+        return text
+    for i in range(1, len(lines)):
+        if lines[i].rstrip("\r\n") == "---":
+            return "".join(lines[i + 1:])
+    return text
+
+
+# Tools whose presence means an agent can modify files. Used to derive
+# read-only intent for harnesses that sandbox by capability (codex
+# ``sandbox_mode``, opencode ``permission.edit``) rather than by an explicit
+# tool list.
+_WRITE_TOOLS = frozenset({"Edit", "Write", "MultiEdit", "NotebookEdit"})
+
+
+def agent_is_read_only(item: dict[str, Any]) -> bool:
+    """True when an agent's tool config forbids file writes.
+
+    Read-only when the agent either disallows a write tool
+    (``disallowedTools``) or declares a ``tools`` whitelist that contains no
+    write tool. An agent that declares neither signal is treated as writable
+    (no sandbox imposed)."""
+    if _WRITE_TOOLS & set(item.get("disallowedTools") or ()):
+        return True
+    tools = item.get("tools") or ()
+    return bool(tools) and not (_WRITE_TOOLS & set(tools))
+
+
+def claude_agent_frontmatter(item: dict[str, Any]) -> dict[str, str]:
+    """Build the frontmatter dict for the shared ``.claude/agents/<n>.md`` file.
+
+    This file is read by Claude *and* Cursor, and — critically — Claude
+    resolves it at user scope (``~/.claude/agents/``, priority 4), which wins
+    over the same agent in a plugin tree (priority 5). So the shared file is
+    the one Claude actually honors and must carry the full Claude metadata,
+    not a model-neutral subset: ``model`` (claude), ``color``, ``effort`` and
+    ``skills`` are all honored sub-agent frontmatter fields. Cursor reads the
+    same file and ignores the fields it does not recognise; a Cursor-specific
+    model still overrides via ``.cursor/agents/<n>.md`` when ``models.cursor``
+    is set.
+
+    Values are pre-stringified so :func:`_frontmatter_lines` emits clean YAML:
+    ``tools`` as a CSV string, ``disallowedTools`` / ``skills`` as ``[a, b]``
+    flow sequences, the rest as scalars. Empty fields are omitted."""
+    fm: dict[str, str] = {"name": item["name"]}
+    desc = item.get("description") or ""
+    if desc:
+        fm["description"] = desc
+    tools = item.get("tools") or []
+    if tools:
+        fm["tools"] = ", ".join(tools)
+    disallowed = item.get("disallowedTools") or []
+    if disallowed:
+        fm["disallowedTools"] = f"[{', '.join(disallowed)}]"
+    model = (item.get("models") or {}).get("claude") or ""
+    if model:
+        fm["model"] = model
+    color = item.get("color") or ""
+    if color:
+        fm["color"] = color
+    effort = item.get("effort") or ""
+    if effort:
+        fm["effort"] = effort
+    skills = item.get("skills") or []
+    if skills:
+        fm["skills"] = f"[{', '.join(skills)}]"
+    return fm
+
+
 def write_shared_claude_agent(
     target: Path,
     name: str,
@@ -59,7 +142,7 @@ def write_shared_claude_agent(
         parts.append("---\n")
         parts.append("\n".join(_frontmatter_lines(frontmatter)) + "\n")
         parts.append("---\n")
-    parts.append(body_path.read_text())
+    parts.append(strip_frontmatter(body_path.read_text()))
     abs_path.write_text("".join(parts))
 
     track_file(out_files, rel)
@@ -127,6 +210,8 @@ def render_model_override(
     abs_path = Path(str(target).rstrip("/")) / rel
 
     abs_path.parent.mkdir(parents=True, exist_ok=True)
-    abs_path.write_text(f"---\nmodel: {model}\n---\n" + body_path.read_text())
+    abs_path.write_text(
+        f"---\nmodel: {model}\n---\n" + strip_frontmatter(body_path.read_text())
+    )
 
     track_file(out_files, rel)

--- a/agent-profile/tests/fixtures/golden/claude/mcptest/shared/.claude/agents/modeled-agent.md
+++ b/agent-profile/tests/fixtures/golden/claude/mcptest/shared/.claude/agents/modeled-agent.md
@@ -2,5 +2,6 @@
 name: modeled-agent
 description: has a model
 tools: Read, Bash
+model: opus
 ---
 agent body here

--- a/agent-profile/tests/test_ingest.py
+++ b/agent-profile/tests/test_ingest.py
@@ -12,10 +12,15 @@ per-type edit surface.
 
 from __future__ import annotations
 
+import os
+from pathlib import Path
+
 import pytest
 
+from agent_profile._validate import ParseError
 from agent_profile.env import EnvResolutionError
 from agent_profile.ingest import expand_registries
+from agent_profile.renderers.base import body_abs
 
 
 # ─── fixtures: a miniature dotfiles-shaped repo ───────────────────────
@@ -62,6 +67,20 @@ def repo(tmp_path):
     )
     (tmp_path / "agents" / "lib" / "cheese-flair.sh").write_text("# lib\n")
 
+    (tmp_path / "agents" / "registry.yaml").write_text(
+        "agents:\n"
+        "  ghostbuster:\n"
+        "    description: dead code\n"
+        "    models:\n"
+        "      claude: sonnet\n"
+        "    disallowedTools: [Edit, Write]\n"
+        "    color: red\n"
+        "    effort: high\n"
+        "    skills: [scout]\n"
+        "    body_path: claude/agents/ghostbuster.md\n"
+        "  bad-entry: not-a-mapping\n"
+    )
+
     (tmp_path / "skills" / "_registry.yaml").write_text(
         "sources:\n"
         "  paulnsorensen/easy-cheese:\n"
@@ -78,6 +97,7 @@ def repo(tmp_path):
 
     directive = {
         "mcps": "agents/mcp/registry.yaml",
+        "agents": "agents/registry.yaml",
         "skills": ["skills/_registry.yaml", "skills/"],
         "hooks": "agents/hooks/registry.yaml",
     }
@@ -159,6 +179,82 @@ def test_expand_hooks_become_named_list(repo):
     assert hook["timeout"] == 5
     assert hook["harnesses"] == ["claude", "codex"]
     assert hook["_source_dir"] == str(root)
+
+
+# ─── agent ingestion ──────────────────────────────────────────────────
+
+
+def test_expand_agents_become_named_list(repo):
+    root, directive = repo
+    out = expand_registries(directive, root, _dotenv())
+    names = [a["name"] for a in out["agents"]]
+    # The malformed `bad-entry: not-a-mapping` is skipped (parity with the
+    # MCP/hook readers — trust nothing from the registry file).
+    assert names == ["ghostbuster"]
+
+
+def test_expand_agents_carry_all_metadata(repo):
+    root, directive = repo
+    out = expand_registries(directive, root, _dotenv())
+    gb = out["agents"][0]
+    assert gb["description"] == "dead code"
+    assert gb["models"] == {"claude": "sonnet"}
+    assert gb["disallowedTools"] == ["Edit", "Write"]
+    assert gb["color"] == "red"
+    assert gb["effort"] == "high"
+    assert gb["skills"] == ["scout"]
+    assert gb["body_path"] == "claude/agents/ghostbuster.md"
+
+
+def test_expand_agents_source_dir_is_repo_root(repo):
+    # body_path resolves against the repo root (where claude/agents/ lives),
+    # not the profile dir — the whole reason agents go through a registry.
+    root, directive = repo
+    out = expand_registries(directive, root, _dotenv())
+    assert out["agents"][0]["_source_dir"] == str(root)
+
+
+def test_real_agents_registry_body_paths_resolve():
+    # The shipped agents/registry.yaml is the Phase-2 deliverable. Every entry
+    # carries a body_path that MUST resolve to a real file. body_abs() now
+    # fails loud (raises ParseError) on a declared-but-unresolvable path, so a
+    # typo'd or stale path aborts `ap install` instead of silently shipping a
+    # body-less agent. This locks the deliverable: every body resolves today.
+    repo_root = Path(
+        os.environ.get("DOTFILES_DIR") or Path.home() / "Dev/dotfiles"
+    )
+    registry = repo_root / "agents" / "registry.yaml"
+    if not registry.is_file():
+        pytest.skip(f"agents registry not found at {registry}")
+
+    out = expand_registries(
+        {"agents": "agents/registry.yaml"}, repo_root, _dotenv()
+    )
+    agents = out["agents"]
+    assert agents, "shipped agents/registry.yaml expanded to zero agents"
+    # body_abs raises if any path is unresolvable; assert each is a real file.
+    for a in agents:
+        resolved = body_abs(a)
+        assert resolved is not None and resolved.is_file(), a["name"]
+
+
+def test_body_abs_raises_on_declared_missing_path(tmp_path):
+    # Finding 1: a declared body_path that does not resolve is a registry bug,
+    # not an optional body — fail loud (ParseError → clean exit 1) rather than
+    # silently skip the body. Catches a typo'd/stale agent body_path at install.
+    item = {
+        "name": "ghostbuster",
+        "_source_dir": str(tmp_path),
+        "body_path": "claude/agents/ghostbuster.md",  # never created
+    }
+    with pytest.raises(ParseError, match="ghostbuster"):
+        body_abs(item)
+
+
+def test_body_abs_none_when_no_body_declared(tmp_path):
+    # The optional-body case is preserved: no body_path => None (the renderer
+    # legitimately skips the body), NOT a raise.
+    assert body_abs({"name": "x", "_source_dir": str(tmp_path)}) is None
 
 
 # ─── skill ingestion (external + local tree) ──────────────────────────
@@ -244,10 +340,10 @@ def test_expand_repo_level_external_skill_has_no_name(repo):
 
 def test_expand_registries_absent_sections_yield_empty_lists(repo):
     root, _ = repo
-    # An empty directive returns the three keys, each an empty list — not a
+    # An empty directive returns every section key, each an empty list — not a
     # KeyError downstream, not a missing section.
     out = expand_registries({}, root, _dotenv())
-    assert out == {"mcps": [], "skills": [], "hooks": []}
+    assert out == {"mcps": [], "agents": [], "skills": [], "hooks": []}
 
 
 def test_expand_mcps_skip_non_mapping_entries(repo):

--- a/agent-profile/tests/test_ingest.py
+++ b/agent-profile/tests/test_ingest.py
@@ -12,7 +12,6 @@ per-type edit surface.
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
 
 import pytest
@@ -220,12 +219,12 @@ def test_real_agents_registry_body_paths_resolve():
     # fails loud (raises ParseError) on a declared-but-unresolvable path, so a
     # typo'd or stale path aborts `ap install` instead of silently shipping a
     # body-less agent. This locks the deliverable: every body resolves today.
-    repo_root = Path(
-        os.environ.get("DOTFILES_DIR") or Path.home() / "Dev/dotfiles"
-    )
+    # Derive the repo root from this test file's location (matching
+    # test_overlay.py) so the lock runs hermetically by default — in CI and in
+    # checkouts outside ~/Dev/dotfiles — instead of silently skipping.
+    repo_root = Path(__file__).resolve().parents[2]
     registry = repo_root / "agents" / "registry.yaml"
-    if not registry.is_file():
-        pytest.skip(f"agents registry not found at {registry}")
+    assert registry.is_file(), f"agents registry not found at {registry}"
 
     out = expand_registries(
         {"agents": "agents/registry.yaml"}, repo_root, _dotenv()

--- a/agent-profile/tests/test_registries_directive.py
+++ b/agent-profile/tests/test_registries_directive.py
@@ -36,6 +36,13 @@ def dotfiles(tmp_path, monkeypatch):
         "    script: agents/hooks/flair.sh\n    harnesses: [claude, codex]\n"
     )
     (root / "agents" / "hooks" / "flair.sh").write_text("#!/bin/bash\n")
+    (root / "agents" / "registry.yaml").write_text(
+        "agents:\n"
+        "  ghostbuster:\n    description: dead code\n"
+        "    models:\n      claude: sonnet\n"
+        "    disallowedTools: [Edit, Write]\n"
+        "    body_path: claude/agents/ghostbuster.md\n"
+    )
     (root / "skills" / "de-slop" / "SKILL.md").write_text("# de-slop\n")
     (root / ".env").write_text("TODOIST_API_KEY=secret\n")
 
@@ -59,6 +66,36 @@ def test_parse_one_expands_registries_directive(dotfiles):
     assert "todoist" in mcp_names  # TODOIST_API_KEY set in .env
     assert [h["name"] for h in out["hooks"]] == ["flair"]
     assert [s["name"] for s in out["skills"]] == ["de-slop"]
+
+
+def test_parse_one_expands_agents_registry(dotfiles):
+    write_profile(
+        dotfiles / "profiles",
+        "base",
+        "name: base\nregistries:\n  agents: agents/registry.yaml\n",
+    )
+    out = parse_one(dotfiles / "profiles" / "base")
+    assert [a["name"] for a in out["agents"]] == ["ghostbuster"]
+    gb = out["agents"][0]
+    assert gb["models"] == {"claude": "sonnet"}
+    assert gb["disallowedTools"] == ["Edit", "Write"]
+    # body_path (claude/agents/...) resolves against DOTFILES_DIR, so the
+    # registry item carries the repo root as its _source_dir.
+    assert gb["_source_dir"] == str(dotfiles)
+
+
+def test_registries_agents_union_with_inline_agents(dotfiles):
+    # Registry agents come first; an inline agents: block appends.
+    write_profile(
+        dotfiles / "profiles",
+        "mixed",
+        "name: mixed\n"
+        "registries:\n  agents: agents/registry.yaml\n"
+        "agents:\n  - name: extra\n    description: inline\n",
+    )
+    out = parse_one(dotfiles / "profiles" / "mixed")
+    names = [a["name"] for a in out["agents"]]
+    assert names == ["ghostbuster", "extra"]
 
 
 def test_registries_mcp_env_resolved_from_dotfiles_env(dotfiles):
@@ -154,6 +191,7 @@ def test_no_registries_directive_yields_empty_registry_items(dotfiles):
     )
     out = parse_one(dotfiles / "profiles" / "plain")
     assert [m["name"] for m in out["mcps"]] == ["only"]
+    assert out["agents"] == []
     assert out["hooks"] == []
     assert out["skills"] == []
 

--- a/agent-profile/tests/test_renderer_agents.py
+++ b/agent-profile/tests/test_renderer_agents.py
@@ -1,0 +1,364 @@
+"""test_renderer_agents.py — cross-harness agent rendering (Phase 1).
+
+Covers the behaviour added when the cheese sub-agents began rendering through
+``ap`` into every harness instead of reaching Claude via a legacy symlink:
+
+  - a leading YAML frontmatter block is stripped from agent bodies, so no
+    harness emits a double frontmatter block and codex does not leak
+    frontmatter into ``developer_instructions``;
+  - ``disallowedTools`` survives into the claude / cursor / copilot
+    frontmatter (the read-only restriction the cheese agents depend on);
+  - read-only intent maps to codex ``sandbox_mode`` and an opencode
+    ``permission.edit: deny``;
+  - opencode emits a real ``agents/<name>.md`` subagent file (root-relative
+    to its target config dir → ``~/.config/opencode/agents/``).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from agent_profile.parse import Manifest, parse_one
+from agent_profile.renderers.claude import ClaudeRenderer
+from agent_profile.renderers.codex import CodexRenderer
+from agent_profile.renderers.copilot import CopilotRenderer
+from agent_profile.renderers.cursor import CursorRenderer
+from agent_profile.renderers.opencode import OpencodeRenderer
+from agent_profile.shared import agent_is_read_only, strip_frontmatter
+
+_PLAIN_BODY = "You are the ghostbuster.\n"
+_FRONTMATTERED_BODY = (
+    "---\n"
+    "name: ghostbuster\n"
+    "description: stale frontmatter metadata\n"
+    "disallowedTools: [Edit, Write]\n"
+    "---\n"
+    "You are the ghostbuster.\n"
+)
+
+
+def _agent_manifest(
+    tmp_path: Path, *, body: str = _PLAIN_BODY, **agent_over: Any
+) -> Manifest:
+    """A one-agent manifest whose body lives under ``tmp_path/src``."""
+    src = tmp_path / "src"
+    src.mkdir(exist_ok=True)
+    (src / "ghostbuster.md").write_text(body)
+    agent: dict[str, Any] = {
+        "name": "ghostbuster",
+        "description": "Finds dead code",
+        "_source_dir": str(src),
+        "body_path": "ghostbuster.md",
+    }
+    agent.update(agent_over)
+    return Manifest(name="cheese", agents=[agent])
+
+
+def _delims(content: str) -> int:
+    return content.splitlines().count("---")
+
+
+# ── strip_frontmatter unit ────────────────────────────────────────────
+
+
+def test_strip_frontmatter_removes_leading_block() -> None:
+    assert strip_frontmatter("---\na: 1\n---\nbody\n") == "body\n"
+
+
+def test_strip_frontmatter_keeps_plain_body() -> None:
+    text = "body\n---\nnot frontmatter\n"
+    assert strip_frontmatter(text) == text
+
+
+def test_strip_frontmatter_unterminated_is_noop() -> None:
+    text = "---\nopened but never closed\n"
+    assert strip_frontmatter(text) == text
+
+
+# ── read-only intent ──────────────────────────────────────────────────
+
+
+def test_agent_is_read_only_from_disallowed() -> None:
+    assert agent_is_read_only({"disallowedTools": ["Edit", "Write"]})
+
+
+def test_agent_is_read_only_from_whitelist() -> None:
+    assert agent_is_read_only({"tools": ["Read", "Grep"]})
+
+
+def test_agent_writable_when_tools_include_write() -> None:
+    assert not agent_is_read_only({"tools": ["Read", "Edit"]})
+
+
+def test_agent_writable_when_no_signal() -> None:
+    assert not agent_is_read_only({})
+
+
+# ── schema flow-through (parse keeps the field) ────────────────────────
+
+
+def test_parse_carries_disallowed_tools(tmp_path: Path) -> None:
+    (tmp_path / "profile.yaml").write_text(
+        "name: p\nagents:\n  - name: ghostbuster\n"
+        "    disallowedTools: [Edit, Write]\n"
+    )
+    parsed = parse_one(tmp_path)
+    assert parsed["agents"][0]["disallowedTools"] == ["Edit", "Write"]
+
+
+# ── claude ────────────────────────────────────────────────────────────
+
+
+def test_claude_shared_agent_strips_frontmatter(tmp_path: Path) -> None:
+    ClaudeRenderer().render(
+        _agent_manifest(tmp_path, body=_FRONTMATTERED_BODY, tools=["Read"]),
+        tmp_path,
+    )
+    content = (tmp_path / ".claude" / "agents" / "ghostbuster.md").read_text()
+    assert _delims(content) == 2
+    assert "stale frontmatter metadata" not in content
+    assert content.rstrip().endswith("You are the ghostbuster.")
+
+
+def test_claude_plugin_agent_strips_frontmatter(tmp_path: Path) -> None:
+    ClaudeRenderer().render(
+        _agent_manifest(tmp_path, body=_FRONTMATTERED_BODY, tools=["Read"]),
+        tmp_path,
+    )
+    content = (
+        tmp_path / ".claude" / "plugins" / "local" / "cheese" / "agents"
+        / "ghostbuster.md"
+    ).read_text()
+    assert _delims(content) == 2
+    assert "stale frontmatter metadata" not in content
+
+
+def test_claude_agent_disallowed_tools(tmp_path: Path) -> None:
+    ClaudeRenderer().render(
+        _agent_manifest(
+            tmp_path, tools=["Read"], disallowedTools=["Edit", "Write"]
+        ),
+        tmp_path,
+    )
+    shared_file = (
+        tmp_path / ".claude" / "agents" / "ghostbuster.md"
+    ).read_text()
+    plugin_file = (
+        tmp_path / ".claude" / "plugins" / "local" / "cheese" / "agents"
+        / "ghostbuster.md"
+    ).read_text()
+    assert "disallowedTools: [Edit, Write]" in shared_file
+    assert "disallowedTools: [Edit, Write]" in plugin_file
+
+
+def test_claude_shared_agent_carries_model_color_effort_skills(
+    tmp_path: Path,
+) -> None:
+    # The user-scoped shared file wins over the plugin copy (priority 4 > 5),
+    # so it must carry the full claude metadata — a model-neutral shared file
+    # would silently drop the agent's pinned model and its color/effort/skills.
+    ClaudeRenderer().render(
+        _agent_manifest(
+            tmp_path,
+            tools=["Read"],
+            models={"claude": "sonnet"},
+            color="red",
+            effort="high",
+            skills=["scout", "gh"],
+        ),
+        tmp_path,
+    )
+    shared_file = (
+        tmp_path / ".claude" / "agents" / "ghostbuster.md"
+    ).read_text()
+    assert "model: sonnet" in shared_file
+    assert "color: red" in shared_file
+    assert "effort: high" in shared_file
+    assert "skills: [scout, gh]" in shared_file
+
+
+# ── cursor ────────────────────────────────────────────────────────────
+
+
+def test_cursor_shared_agent_strips_frontmatter(tmp_path: Path) -> None:
+    CursorRenderer().render(
+        _agent_manifest(tmp_path, body=_FRONTMATTERED_BODY, tools=["Read"]),
+        tmp_path,
+    )
+    content = (tmp_path / ".claude" / "agents" / "ghostbuster.md").read_text()
+    assert _delims(content) == 2
+    assert "stale frontmatter metadata" not in content
+
+
+def test_cursor_agent_disallowed_tools(tmp_path: Path) -> None:
+    CursorRenderer().render(
+        _agent_manifest(
+            tmp_path, tools=["Read"], disallowedTools=["Edit", "Write"]
+        ),
+        tmp_path,
+    )
+    content = (tmp_path / ".claude" / "agents" / "ghostbuster.md").read_text()
+    assert "disallowedTools: [Edit, Write]" in content
+
+
+# ── codex ─────────────────────────────────────────────────────────────
+
+
+def test_codex_body_excludes_frontmatter(tmp_path: Path) -> None:
+    CodexRenderer().render(
+        _agent_manifest(tmp_path, body=_FRONTMATTERED_BODY), tmp_path
+    )
+    content = (tmp_path / ".codex" / "agents" / "ghostbuster.toml").read_text()
+    assert "stale frontmatter metadata" not in content
+    assert "You are the ghostbuster." in content
+
+
+def test_codex_sandbox_read_only_from_whitelist(tmp_path: Path) -> None:
+    CodexRenderer().render(
+        _agent_manifest(tmp_path, tools=["Read", "Grep"]), tmp_path
+    )
+    content = (tmp_path / ".codex" / "agents" / "ghostbuster.toml").read_text()
+    assert 'sandbox_mode = "read-only"' in content
+
+
+def test_codex_sandbox_read_only_from_disallowed(tmp_path: Path) -> None:
+    CodexRenderer().render(
+        _agent_manifest(tmp_path, disallowedTools=["Edit", "Write"]), tmp_path
+    )
+    content = (tmp_path / ".codex" / "agents" / "ghostbuster.toml").read_text()
+    assert 'sandbox_mode = "read-only"' in content
+
+
+def test_codex_no_sandbox_when_writable(tmp_path: Path) -> None:
+    CodexRenderer().render(
+        _agent_manifest(tmp_path, tools=["Read", "Edit"]), tmp_path
+    )
+    content = (tmp_path / ".codex" / "agents" / "ghostbuster.toml").read_text()
+    assert "sandbox_mode" not in content
+
+
+# ── copilot ───────────────────────────────────────────────────────────
+
+
+def test_copilot_agent_strips_frontmatter(tmp_path: Path) -> None:
+    CopilotRenderer().render(
+        _agent_manifest(tmp_path, body=_FRONTMATTERED_BODY, tools=["Read"]),
+        tmp_path,
+    )
+    content = (
+        tmp_path / ".github" / "agents" / "ghostbuster.agent.md"
+    ).read_text()
+    assert _delims(content) == 2
+    assert "stale frontmatter metadata" not in content
+
+
+def test_copilot_agent_disallowed_tools(tmp_path: Path) -> None:
+    CopilotRenderer().render(
+        _agent_manifest(
+            tmp_path, tools=["Read"], disallowedTools=["Edit", "Write"]
+        ),
+        tmp_path,
+    )
+    content = (
+        tmp_path / ".github" / "agents" / "ghostbuster.agent.md"
+    ).read_text()
+    assert "disallowedTools: [Edit, Write]" in content
+
+
+# ── opencode ──────────────────────────────────────────────────────────
+
+
+def test_opencode_renders_subagent(tmp_path: Path) -> None:
+    written = OpencodeRenderer().render(
+        _agent_manifest(
+            tmp_path, tools=["Read", "Grep"], models={"opencode": "gpt-5.4"}
+        ),
+        tmp_path,
+    )
+    rel = "agents/ghostbuster.md"
+    assert rel in written
+    content = (tmp_path / "agents" / "ghostbuster.md").read_text()
+    assert content.startswith("---\n")
+    assert "mode: subagent" in content
+    assert "description: Finds dead code" in content
+    assert "model: gpt-5.4" in content
+    assert content.rstrip().endswith("You are the ghostbuster.")
+
+
+def test_opencode_subagent_read_only_permission(tmp_path: Path) -> None:
+    OpencodeRenderer().render(
+        _agent_manifest(tmp_path, tools=["Read", "Grep"]), tmp_path
+    )
+    content = (tmp_path / "agents" / "ghostbuster.md").read_text()
+    assert "permission:" in content
+    assert "edit: deny" in content
+
+
+def test_opencode_subagent_writable_omits_permission(tmp_path: Path) -> None:
+    OpencodeRenderer().render(
+        _agent_manifest(tmp_path, tools=["Read", "Edit"]), tmp_path
+    )
+    content = (tmp_path / "agents" / "ghostbuster.md").read_text()
+    assert "edit: deny" not in content
+
+
+def test_opencode_subagent_strips_frontmatter(tmp_path: Path) -> None:
+    OpencodeRenderer().render(
+        _agent_manifest(tmp_path, body=_FRONTMATTERED_BODY), tmp_path
+    )
+    content = (tmp_path / "agents" / "ghostbuster.md").read_text()
+    assert _delims(content) == 2
+    assert "stale frontmatter metadata" not in content
+
+
+def test_opencode_subagent_omits_inherit_model(tmp_path: Path) -> None:
+    OpencodeRenderer().render(
+        _agent_manifest(tmp_path, tools=["Read"], models={"opencode": "inherit"}),
+        tmp_path,
+    )
+    content = (tmp_path / "agents" / "ghostbuster.md").read_text()
+    assert "model:" not in content
+
+
+# ── hardening (press) ─────────────────────────────────────────────────
+
+
+def test_cursor_model_override_strips_frontmatter(tmp_path: Path) -> None:
+    """A cursor model override writes ``.cursor/agents/<n>.md`` via
+    render_model_override, which reads the body itself — its strip must also
+    fire, or a frontmattered body double-frontmatters in that file."""
+    CursorRenderer().render(
+        _agent_manifest(
+            tmp_path,
+            body=_FRONTMATTERED_BODY,
+            models={"cursor": "claude-sonnet"},
+        ),
+        tmp_path,
+    )
+    content = (tmp_path / ".cursor" / "agents" / "ghostbuster.md").read_text()
+    assert _delims(content) == 2
+    assert "stale frontmatter metadata" not in content
+    assert content.rstrip().endswith("You are the ghostbuster.")
+
+
+def test_agent_writable_when_disallowed_is_non_write_only() -> None:
+    assert not agent_is_read_only({"disallowedTools": ["WebSearch", "WebFetch"]})
+
+
+def test_agent_read_only_for_full_write_tool_set() -> None:
+    assert agent_is_read_only({"disallowedTools": ["NotebookEdit"]})
+    assert agent_is_read_only({"disallowedTools": ["MultiEdit"]})
+
+
+def test_strip_frontmatter_preserves_later_horizontal_rule() -> None:
+    text = "---\na: 1\n---\nbefore\n\n---\n\nafter\n"
+    assert strip_frontmatter(text) == "before\n\n---\n\nafter\n"
+
+
+def test_strip_frontmatter_empty_frontmatter_block() -> None:
+    assert strip_frontmatter("---\n---\nbody\n") == "body\n"
+
+
+def test_strip_frontmatter_crlf_block() -> None:
+    assert strip_frontmatter("---\r\na: 1\r\n---\r\nbody\r\n") == "body\r\n"

--- a/agent-profile/tests/test_renderer_claude.py
+++ b/agent-profile/tests/test_renderer_claude.py
@@ -15,7 +15,8 @@ Two profiles cover the renderer's surface:
   "no ``.mcp.json`` when no claude MCPs" path.
 - ``mcptest``: ``.mcp.json`` projection (claude member kept, codex-only
   dropped) and ``models.claude`` frontmatter on agent + command, with the
-  shared agent staying model-neutral.
+  shared agent carrying the same claude model (it is the user-scoped file
+  Claude resolves ahead of the plugin-scoped copy).
 """
 
 from __future__ import annotations
@@ -448,14 +449,18 @@ def test_mcptest_command_model_frontmatter_byte_parity(rendered_mcptest):
     assert "model: haiku" in on_disk
 
 
-def test_mcptest_shared_agent_is_model_neutral(rendered_mcptest):
+def test_mcptest_shared_agent_carries_claude_model(rendered_mcptest):
     target, _ = rendered_mcptest
     on_disk = (target / ".claude/agents/modeled-agent.md").read_text()
     assert on_disk == _read_golden(
         "mcptest/shared/.claude/agents/modeled-agent.md"
     )
-    # Shared cross-harness file must NOT carry the claude model override.
-    assert "model:" not in on_disk
+    # The user-scoped shared file is the one Claude actually resolves — it
+    # wins over the plugin-scoped copy (priority 4 > 5), so it MUST carry the
+    # claude model (and color/effort/skills). A neutral shared file would
+    # silently drop the agent's pinned model. opencode reads its own
+    # .opencode/agent/ path (unaffected); Cursor overrides via .cursor/agents/.
+    assert "model: opus" in on_disk
 
 
 def test_mcptest_plugin_manifest_has_no_hooks_key(rendered_mcptest):

--- a/agents/registry.yaml
+++ b/agents/registry.yaml
@@ -1,0 +1,197 @@
+# agents/registry.yaml — the cheese sub-agent definitions.
+#
+# Single source of truth for the 13 cheese sub-agents. Edited via
+# `agent-edit`; expanded into the `base` profile (and any profile that
+# declares `registries: { agents: agents/registry.yaml }`) by ap's ingest
+# layer, then rendered into every harness by the five renderers.
+#
+# Bodies are instruction-only Markdown at body_path (frontmatter stripped);
+# all metadata lives here. tools/disallowedTools are LISTS (renderers join
+# to CSV for claude/cursor and derive sandbox/permission for codex/opencode).
+# models is per-harness; color/effort/skills are Claude-honored fields.
+agents:
+  fromage-age-arch:
+    description: Complexity and structure reviewer. Enforces complexity budgets (line counts, params, nesting) and Sliced Bread file organization. Does NOT cover encapsulation, dead code, or bugs.
+    models:
+      claude: sonnet
+    disallowedTools:
+    - Edit
+    - NotebookEdit
+    color: red
+    effort: high
+    skills:
+    - scout
+    - cheese-flow:cheez-search
+    body_path: claude/agents/fromage-age-arch.md
+  fromage-age-history:
+    description: Git history analyst. Produces per-file risk scores that the orchestrator uses to adjust sibling findings. Does NOT find bugs or architecture issues — only outputs score modifiers.
+    models:
+      claude: haiku
+    disallowedTools:
+    - Edit
+    - Write
+    - NotebookEdit
+    - WebSearch
+    - WebFetch
+    - Agent
+    color: red
+    effort: high
+    skills:
+    - scout
+    body_path: claude/agents/fromage-age-history.md
+  fromage-fort:
+    description: PR review comment responder. Triages both inline review threads AND PR-level review body comments with 0-100 confidence scoring — fixes high-confidence items, pushes back on bad suggestions, asks about uncertain ones. Named for the strong cheese made from leftover scraps — it takes leftover review comments and turns them into something useful. Spawnable as a parallel agent for move-my-cheese and cheese-convoy workflows.
+    models:
+      claude: sonnet
+    tools:
+    - Read
+    - Write
+    - Edit
+    - Grep
+    - Glob
+    - Bash
+    skills:
+    - gh
+    - scout
+    - cheese-flow:cheez-write
+    - commit
+    body_path: claude/agents/fromage-fort.md
+  fromage-pasteurize:
+    description: Security and dependency health auditor. Scans for vulnerabilities, unused/overweight deps, stdlib alternatives, and OWASP issues. Read-only. Returns stake-grouped findings (high/medium) with file:line citations and one-line recommendations — ~2 KB digest, no severity rewriting, no auto-fixes. Used as an easy-cheese fork target when /age needs evidence on the security dimension.
+    models:
+      claude: sonnet
+    disallowedTools:
+    - Write
+    - Edit
+    - NotebookEdit
+    - AskUserQuestion
+    color: red
+    skills:
+    - scout
+    body_path: claude/agents/fromage-pasteurize.md
+  ghostbuster:
+    description: Forensic examination of expired cheese — finds code that's gone off, specs pointing at empty shelves, and curds that never set. Dead code detector + spec cross-referencer. Categorizes findings as DEAD, ZOMBIE, GHOST, or DORMANT with 0-100 confidence scoring. Read-only — never modifies code. Returns a categorized findings digest (~2 KB). Suitable as an easy-cheese fork target when /age needs evidence on the deslop dimension.
+    models:
+      claude: sonnet
+    disallowedTools:
+    - Edit
+    - NotebookEdit
+    - WebSearch
+    - WebFetch
+    - AskUserQuestion
+    - Write
+    body_path: claude/agents/ghostbuster.md
+  nih-scanner:
+    description: Structural NIH pattern scanner. Uses Serena MCP and ast-grep to find code that reinvents well-known library functionality. Returns JSON candidate list (~2 KB digest) with usage counts and categories. Does not judge — the orchestrator scores and filters. Suitable as an easy-cheese fork target when /age needs evidence on the NIH dimension.
+    models:
+      claude: sonnet
+    disallowedTools:
+    - Edit
+    - Write
+    - NotebookEdit
+    - WebSearch
+    - WebFetch
+    - AskUserQuestion
+    skills:
+    - cheese-flow:cheez-search
+    body_path: claude/agents/nih-scanner.md
+  ricotta-reducer:
+    description: Code simplification and distillation agent. Strips genAI bloat, speculative abstractions, and unnecessary documentation. Produces a simplification report categorized by DELETE, INLINE, UNDOCUMENT, and DECOUPLE with 0-100 confidence scoring. Analysis and detection only — never adds code (de-slop runs in scan mode, not auto-fix).
+    models:
+      claude: sonnet
+    tools:
+    - Read
+    - Grep
+    - Glob
+    - Bash
+    - Agent
+    - mcp__serena__*
+    skills:
+    - scout
+    - de-slop
+    body_path: claude/agents/ricotta-reducer.md
+  roquefort-wrecker:
+    description: Writes and executes unit, integration, or other tests for new or modified code. Use PROACTIVELY to validate code functionality and find bugs. Adversarial approach with 0-100 confidence scoring per finding.
+    models:
+      claude: haiku
+    tools:
+    - Read
+    - Write
+    - Grep
+    - Glob
+    - Bash
+    - mcp__serena__*
+    skills:
+    - scout
+    body_path: claude/agents/roquefort-wrecker.md
+  skill-analytics-friction:
+    description: Skill Friction Analyst — lightweight data-gathering sub-agent for skill-improver. Queries DuckDB session analytics for errors, permission denials, and friction during skill execution.
+    models:
+      claude: sonnet
+    tools:
+    - Bash
+    - Read
+    disallowedTools:
+    - Edit
+    - Write
+    - NotebookEdit
+    - Agent
+    - WebSearch
+    - WebFetch
+    body_path: claude/agents/skill-analytics-friction.md
+  skill-analytics-tools:
+    description: Skill Tool Pattern Analyst — lightweight data-gathering sub-agent for skill-improver. Queries DuckDB session analytics to compare a skill's declared tools against its actual tool usage.
+    models:
+      claude: sonnet
+    tools:
+    - Bash
+    - Read
+    disallowedTools:
+    - Edit
+    - Write
+    - NotebookEdit
+    - Agent
+    - WebSearch
+    - WebFetch
+    body_path: claude/agents/skill-analytics-tools.md
+  skill-analytics-usage:
+    description: Skill Usage Analyst — lightweight data-gathering sub-agent for skill-improver. Queries DuckDB session analytics to measure invocation patterns for a specific skill or agent.
+    models:
+      claude: sonnet
+    tools:
+    - Bash
+    - Read
+    disallowedTools:
+    - Edit
+    - Write
+    - NotebookEdit
+    - Agent
+    - WebSearch
+    - WebFetch
+    body_path: claude/agents/skill-analytics-usage.md
+  whey-drainer:
+    description: Runs existing tests and returns only failures and summary counts (~2 KB digest). Use this agent to validate code without flooding the parent context with verbose test output. Fits easy-cheese's small/fast read-only sub-agent contract — call from /cook taste-test, /press, or /cure post-fix to gate the next step on test pass. Does NOT write tests.
+    models:
+      claude: haiku
+    tools:
+    - Bash
+    - Read
+    - Glob
+    - Grep
+    skills:
+    - scout
+    body_path: claude/agents/whey-drainer.md
+  worktree-triage:
+    description: Analyzes WARN/DIRTY worktrees to recommend keep, archive, or remove. Checks commit content, diffs, PR status, and staleness to make informed triage decisions. Interviews the user on DIRTY worktrees with unique changes.
+    models:
+      claude: sonnet
+    tools:
+    - Bash
+    - Read
+    - Grep
+    - Glob
+    - AskUserQuestion
+    skills:
+    - scout
+    - gh
+    body_path: claude/agents/worktree-triage.md

--- a/chezmoi/.chezmoiscripts/run_once_before_migrate-claude-agents.sh
+++ b/chezmoi/.chezmoiscripts/run_once_before_migrate-claude-agents.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# run_once_before — one-time migration: drop the legacy ~/.claude/agents
+# symlink BEFORE the base-profile installer renders agents into $HOME.
+#
+# Before this change, claude/.sync symlinked $DOTFILES/claude/agents into
+# ~/.claude/agents. The cheese sub-agents have moved to agents/registry.yaml
+# and now render through `ap` (the `base`/`global` profile) as real files at
+# ~/.claude/agents/<name>.md plus the plugin tree. If the symlink were still
+# present when `ap install global` runs (run_onchange_after_install-base-profile),
+# ap would write THROUGH the symlink straight back into the repo's
+# claude/agents/ — clobbering the now-instruction-only source bodies.
+#
+# chezmoi runs run_before_* scripts ahead of run_after_* scripts in a single
+# apply, so removing the symlink here guarantees the installer writes into a
+# real directory. claude/.sync also removes it (belt) for the legacy symlink
+# sync path; this is the chezmoi-ordering guarantee.
+#
+# Idempotent: a no-op once the symlink is gone. run_once_ ensures this never
+# runs again on this host after a clean pass.
+set -euo pipefail
+
+target="$HOME/.claude/agents"
+if [[ -L "$target" ]]; then
+    link_dest=$(readlink "$target")
+    case "$link_dest" in
+        */dotfiles/claude/agents)
+            echo "  Migrating: removing legacy ~/.claude/agents symlink (was $link_dest)"
+            rm -f "$target"
+            ;;
+        *)
+            echo "  Skipping migration: ~/.claude/agents links to $link_dest (not the legacy dotfiles source)"
+            ;;
+    esac
+fi

--- a/chezmoi/.chezmoiscripts/run_onchange_after_install-base-profile.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/run_onchange_after_install-base-profile.sh.tmpl
@@ -25,7 +25,7 @@
 # plain sync. Bytecode (*.pyc / __pycache__) is excluded so the hash tracks
 # source edits, not interpreter artifacts.
 #
-# input hash: {{ output "sh" "-c" (printf "find %q/../profiles/base %q/../profiles/global %q/../agents/mcp/registry.yaml %q/../agents/hooks %q/../agents/lib %q/../agents/reference %q/../skills %q/../agent-profile/agent_profile -type f -not -name .DS_Store -not -name '*.pyc' -not -path '*/__pycache__/*' -print0 2>/dev/null | LC_ALL=C sort -z | xargs -0 shasum -a 256 2>/dev/null | shasum -a 256 | cut -d' ' -f1" .chezmoi.sourceDir .chezmoi.sourceDir .chezmoi.sourceDir .chezmoi.sourceDir .chezmoi.sourceDir .chezmoi.sourceDir .chezmoi.sourceDir .chezmoi.sourceDir) }}
+# input hash: {{ output "sh" "-c" (printf "find %q/../profiles/base %q/../profiles/global %q/../agents/mcp/registry.yaml %q/../agents/registry.yaml %q/../agents/hooks %q/../agents/lib %q/../agents/reference %q/../skills %q/../agent-profile/agent_profile -type f -not -name .DS_Store -not -name '*.pyc' -not -path '*/__pycache__/*' -print0 2>/dev/null | LC_ALL=C sort -z | xargs -0 shasum -a 256 2>/dev/null | shasum -a 256 | cut -d' ' -f1" .chezmoi.sourceDir .chezmoi.sourceDir .chezmoi.sourceDir .chezmoi.sourceDir .chezmoi.sourceDir .chezmoi.sourceDir .chezmoi.sourceDir .chezmoi.sourceDir .chezmoi.sourceDir) }}
 
 set -euo pipefail
 

--- a/claude/.sync
+++ b/claude/.sync
@@ -12,6 +12,11 @@ mkdir -p "$CLAUDE_DIR"
 #   - plugins/  — Claude uses that path as plugin cache
 #   - profiles/ — retired; scoped profiles moved to profiles/<name>/profile.yaml
 #                 (repo root) and deploy/launch via the `ap` tool (dots profile).
+#   - agents/   — the cheese sub-agents now live in agents/registry.yaml and
+#                 render into every harness via the `base` profile (`ap`), the
+#                 same path mcp/hooks/skills take. The legacy ~/.claude/agents
+#                 symlink is removed below; ap writes the real files to
+#                 ~/.claude/agents/<name>.md (user-scoped) + the plugin tree.
 #   - skills/   — copied (not symlinked) by chezmoi; gh-installed skills drop
 #                 real dirs alongside without fighting a directory symlink.
 #   - CLAUDE.md, RTK.md — copied (not symlinked) by chezmoi via
@@ -34,7 +39,6 @@ mkdir -p "$CLAUDE_DIR"
 # ~/.claude/plugins/local/global/hooks/ (deployed by `ap`); no legacy
 # write-through-symlinks happens.
 configs=(
-  agents
   commands
   hooks
   reference
@@ -131,6 +135,14 @@ fi
 if [[ -L "$CLAUDE_DIR/mcp" ]]; then
   rm "$CLAUDE_DIR/mcp"
   echo "  Removed legacy ~/.claude/mcp symlink"
+fi
+
+# Clean up the legacy ~/.claude/agents symlink — agents moved to
+# agents/registry.yaml and now render through `ap` (base profile) as real
+# files. Leaving the symlink would shadow the rendered ~/.claude/agents tree.
+if [[ -L "$CLAUDE_DIR/agents" ]]; then
+  rm "$CLAUDE_DIR/agents"
+  echo "  Removed legacy ~/.claude/agents symlink (agents now render via ap)"
 fi
 
 # Drop stale per-project entries from ~/.claude.json (worktrees that no

--- a/claude/agents/fromage-age-arch.md
+++ b/claude/agents/fromage-age-arch.md
@@ -1,13 +1,3 @@
----
-name: fromage-age-arch
-description: Complexity and structure reviewer. Enforces complexity budgets (line counts, params, nesting) and Sliced Bread file organization. Does NOT cover encapsulation, dead code, or bugs.
-model: sonnet
-effort: high
-skills: [scout, cheese-flow:cheez-search]
-disallowedTools: [Edit, NotebookEdit]
-color: red
----
-
 You are the Architecture reviewer — one of six parallel Age sub-agents. Your sole charter is **Complexity & Structure**. Sibling agents handle safety, encapsulation, dead code, history, and spec adherence.
 
 ## Charter

--- a/claude/agents/fromage-age-history.md
+++ b/claude/agents/fromage-age-history.md
@@ -1,13 +1,3 @@
----
-name: fromage-age-history
-description: Git history analyst. Produces per-file risk scores that the orchestrator uses to adjust sibling findings. Does NOT find bugs or architecture issues — only outputs score modifiers.
-model: haiku
-effort: high
-skills: [scout]
-disallowedTools: [Edit, Write, NotebookEdit, WebSearch, WebFetch, Agent]
-color: red
----
-
 You are the History analyst — one of six parallel Age sub-agents.
 
 ## What You Do

--- a/claude/agents/fromage-fort.md
+++ b/claude/agents/fromage-fort.md
@@ -1,11 +1,3 @@
----
-name: fromage-fort
-description: PR review comment responder. Triages both inline review threads AND PR-level review body comments with 0-100 confidence scoring — fixes high-confidence items, pushes back on bad suggestions, asks about uncertain ones. Named for the strong cheese made from leftover scraps — it takes leftover review comments and turns them into something useful. Spawnable as a parallel agent for move-my-cheese and cheese-convoy workflows.
-model: sonnet
-tools: Read, Write, Edit, Grep, Glob, Bash
-skills: [gh, scout, cheese-flow:cheez-write, commit]
----
-
 You are the Fromage Fort — the strong cheese made from leftover scraps. You handle reviewer feedback on PRs so the Cheese Lord doesn't have to read every bot comment.
 
 Your job: read all unresolved review threads on a PR, score each one, and act based on confidence.

--- a/claude/agents/fromage-pasteurize.md
+++ b/claude/agents/fromage-pasteurize.md
@@ -1,12 +1,3 @@
----
-name: fromage-pasteurize
-description: Security and dependency health auditor. Scans for vulnerabilities, unused/overweight deps, stdlib alternatives, and OWASP issues. Read-only. Returns stake-grouped findings (high/medium) with file:line citations and one-line recommendations — ~2 KB digest, no severity rewriting, no auto-fixes. Used as an easy-cheese fork target when /age needs evidence on the security dimension.
-model: sonnet
-skills: [scout]
-disallowedTools: [Write, Edit, NotebookEdit, AskUserQuestion]
-color: red
----
-
 You are the Pasteurize phase — heat treatment that kills harmful bacteria before the cheese can mature safely. Your job: find vulnerabilities, dependency rot, and security issues before they reach production.
 
 **Reusable agent.** Invoked by `/copilot-review` (security lens).

--- a/claude/agents/ghostbuster.md
+++ b/claude/agents/ghostbuster.md
@@ -1,10 +1,3 @@
----
-name: ghostbuster
-description: Forensic examination of expired cheese — finds code that's gone off, specs pointing at empty shelves, and curds that never set. Dead code detector + spec cross-referencer. Categorizes findings as DEAD, ZOMBIE, GHOST, or DORMANT with 0-100 confidence scoring. Read-only — never modifies code. Returns a categorized findings digest (~2 KB). Suitable as an easy-cheese fork target when /age needs evidence on the deslop dimension.
-model: sonnet
-disallowedTools: [Edit, NotebookEdit, WebSearch, WebFetch, AskUserQuestion, Write]
----
-
 You are the Ghostbuster agent — forensic pathologist of codebases. You examine code that may have expired: functions nobody calls, specs referencing symbols that no longer exist, and implementation chains where the root caller is dead (taking its dependents with it).
 
 Your four categories of finding tell the orchestrator exactly what kind of decay they're dealing with:

--- a/claude/agents/nih-scanner.md
+++ b/claude/agents/nih-scanner.md
@@ -1,11 +1,3 @@
----
-name: nih-scanner
-description: Structural NIH pattern scanner. Uses Serena MCP and ast-grep to find code that reinvents well-known library functionality. Returns JSON candidate list (~2 KB digest) with usage counts and categories. Does not judge — the orchestrator scores and filters. Suitable as an easy-cheese fork target when /age needs evidence on the NIH dimension.
-model: sonnet
-skills: [cheese-flow:cheez-search]
-disallowedTools: [Edit, Write, NotebookEdit, WebSearch, WebFetch, AskUserQuestion]
----
-
 You are the NIH Scanner — a structural analysis agent that finds code reinventing the wheel. You use Serena MCP and ast-grep to detect patterns, not Grep for text.
 
 ## Input

--- a/claude/agents/ricotta-reducer.md
+++ b/claude/agents/ricotta-reducer.md
@@ -1,11 +1,3 @@
----
-name: ricotta-reducer
-description: Code simplification and distillation agent. Strips genAI bloat, speculative abstractions, and unnecessary documentation. Produces a simplification report categorized by DELETE, INLINE, UNDOCUMENT, and DECOUPLE with 0-100 confidence scoring. Analysis and detection only — never adds code (de-slop runs in scan mode, not auto-fix).
-tools: Read, Grep, Glob, Bash, Agent, mcp__serena__*
-skills: [scout, de-slop]
-model: sonnet
----
-
 You are the Ricotta Reducer — named for the cheese made by re-cooking whey down to its purest essence. Like ricotta, you take what remains after the main curds have formed and extract every last drop of value through reduction.
 
 Your job is to make codebases lighter, not heavier. Every line you leave behind must justify its existence. You do not add. You subtract.

--- a/claude/agents/roquefort-wrecker.md
+++ b/claude/agents/roquefort-wrecker.md
@@ -1,11 +1,3 @@
----
-name: roquefort-wrecker
-description: Writes and executes unit, integration, or other tests for new or modified code. Use PROACTIVELY to validate code functionality and find bugs. Adversarial approach with 0-100 confidence scoring per finding.
-model: haiku
-tools: Read, Write, Grep, Glob, Bash, mcp__serena__*
-skills: [scout]
----
-
 You are the 'Roquefort Wrecker' agent, an adversarial testing specialist with the complex, penetrating nature of blue-veined Roquefort. Your mission is to find flaws in code through relentless, systematic assault.
 
 **Standalone test agent.** Use for on-demand adversarial test writing — separate from the easy-cheese `/press` flow.

--- a/claude/agents/skill-analytics-friction.md
+++ b/claude/agents/skill-analytics-friction.md
@@ -1,9 +1,3 @@
----
-model: sonnet
-tools: [Bash, Read]
-disallowedTools: [Edit, Write, NotebookEdit, Agent, WebSearch, WebFetch]
----
-
 # Skill Friction Analyst
 
 Lightweight data-gathering sub-agent for skill-improver. Queries DuckDB session

--- a/claude/agents/skill-analytics-tools.md
+++ b/claude/agents/skill-analytics-tools.md
@@ -1,9 +1,3 @@
----
-model: sonnet
-tools: [Bash, Read]
-disallowedTools: [Edit, Write, NotebookEdit, Agent, WebSearch, WebFetch]
----
-
 # Skill Tool Pattern Analyst
 
 Lightweight data-gathering sub-agent for skill-improver. Queries DuckDB session

--- a/claude/agents/skill-analytics-usage.md
+++ b/claude/agents/skill-analytics-usage.md
@@ -1,9 +1,3 @@
----
-model: sonnet
-tools: [Bash, Read]
-disallowedTools: [Edit, Write, NotebookEdit, Agent, WebSearch, WebFetch]
----
-
 # Skill Usage Analyst
 
 Lightweight data-gathering sub-agent for skill-improver. Queries DuckDB session

--- a/claude/agents/whey-drainer.md
+++ b/claude/agents/whey-drainer.md
@@ -1,11 +1,3 @@
----
-name: whey-drainer
-description: Runs existing tests and returns only failures and summary counts (~2 KB digest). Use this agent to validate code without flooding the parent context with verbose test output. Fits easy-cheese's small/fast read-only sub-agent contract — call from /cook taste-test, /press, or /cure post-fix to gate the next step on test pass. Does NOT write tests.
-model: haiku
-tools: Bash, Read, Glob, Grep
-skills: [scout]
----
-
 You are the Whey Drainer — you run tests and filter out the noise. Your entire purpose is to execute test suites in your own context window and return ONLY what the parent agent needs: pass/fail counts and failure details. All the verbose passing-test output stays trapped in your context, never reaching the caller.
 
 ## What You Do

--- a/claude/agents/worktree-triage.md
+++ b/claude/agents/worktree-triage.md
@@ -1,11 +1,3 @@
----
-name: worktree-triage
-description: Analyzes WARN/DIRTY worktrees to recommend keep, archive, or remove. Checks commit content, diffs, PR status, and staleness to make informed triage decisions. Interviews the user on DIRTY worktrees with unique changes.
-model: sonnet
-tools: Bash, Read, Grep, Glob, AskUserQuestion
-skills: [scout, gh]
----
-
 You are the Worktree Triage agent — you analyze worktrees that `ccw-sweep` couldn't automatically categorize and recommend actions for each one.
 
 ## What You Do

--- a/profiles/base/profile.yaml
+++ b/profiles/base/profile.yaml
@@ -1,11 +1,13 @@
-# base — the union of the three separate registries (mcp, skills, hooks).
+# base — the union of the four separate registries (mcp, agents, skills, hooks).
 # This is the ONLY profile that reads the registries; `mcp-edit` /
-# `hook-edit` / `skill-edit` keep editing them. `ap` expands `registries:`
-# at parse time into the item lists. Specialized profiles `include: [base]`
-# to layer additively (isolated profiles do NOT — they are closed worlds).
+# `agent-edit` / `hook-edit` / `skill-edit` keep editing them. `ap` expands
+# `registries:` at parse time into the item lists. Specialized profiles
+# `include: [base]` to layer additively (isolated profiles do NOT — they are
+# closed worlds, so they reference the agents registry directly instead).
 name: base
-description: Registry-derived union of all MCPs, skills, and hooks
+description: Registry-derived union of all MCPs, agents, skills, and hooks
 registries:
   mcps:   agents/mcp/registry.yaml
+  agents: agents/registry.yaml
   skills: [skills/_registry.yaml, skills/]
   hooks:  agents/hooks/registry.yaml

--- a/profiles/fe/profile.yaml
+++ b/profiles/fe/profile.yaml
@@ -3,6 +3,10 @@
 # plus shadcn (profile-local). Re-enables claude.ai connectors for Figma.
 name: fe
 description: Frontend + shadcn/Figma/Playwright
+# Cheese sub-agents are available in this closed world too
+# (agents are orthogonal to the MCP/skill scope below).
+registries:
+  agents: agents/registry.yaml
 isolated: true
 system_prompt: CLAUDE.md
 # Auto-approve the Figma connector (ccp settings-merge parity).

--- a/profiles/notion/profile.yaml
+++ b/profiles/notion/profile.yaml
@@ -3,6 +3,10 @@
 # launch overlay it becomes a closed world whose single MCP is notion.
 name: notion
 description: Notion HTTP MCP
+# Cheese sub-agents are available in this closed world too
+# (agents are orthogonal to the MCP/skill scope below).
+registries:
+  agents: agents/registry.yaml
 isolated: true
 system_prompt: CLAUDE.md
 # Auto-approve the profile's own MCP (ccp settings-merge parity).

--- a/profiles/plugin/profile.yaml
+++ b/profiles/plugin/profile.yaml
@@ -2,6 +2,10 @@
 # Closed MCP world: AST nav, cross-plugin structural search, Claude/SDK docs.
 name: plugin
 description: Plugin dev — code nav + ecosystem docs
+# Cheese sub-agents are available in this closed world too
+# (agents are orthogonal to the MCP/skill scope below).
+registries:
+  agents: agents/registry.yaml
 isolated: true
 system_prompt: CLAUDE.md
 # Per-profile plugin set (ccp settings-merge parity).

--- a/profiles/review/profile.yaml
+++ b/profiles/review/profile.yaml
@@ -4,6 +4,10 @@
 # whitelist. MCP world is tilth + code-review-graph + context7.
 name: review
 description: Read-only PR review
+# Cheese sub-agents are available in this closed world too
+# (agents are orthogonal to the MCP/skill scope below).
+registries:
+  agents: agents/registry.yaml
 isolated: true
 system_prompt: CLAUDE.md
 tools:

--- a/profiles/rtkonly/profile.yaml
+++ b/profiles/rtkonly/profile.yaml
@@ -2,6 +2,10 @@
 # Closed MCP world of just tilth.
 name: rtkonly
 description: Experimental — tilth + rtk only
+# Cheese sub-agents are available in this closed world too
+# (agents are orthogonal to the MCP/skill scope below).
+registries:
+  agents: agents/registry.yaml
 isolated: true
 system_prompt: CLAUDE.md
 # Auto-approve rtk + tilth (ccp settings-merge parity).

--- a/profiles/spec/profile.yaml
+++ b/profiles/spec/profile.yaml
@@ -3,6 +3,10 @@
 # NotebookEdit denied (spec work doesn't touch notebooks).
 name: spec
 description: Discovery dialogue — research-heavy
+# Cheese sub-agents are available in this closed world too
+# (agents are orthogonal to the MCP/skill scope below).
+registries:
+  agents: agents/registry.yaml
 isolated: true
 system_prompt: CLAUDE.md
 permissions_deny:

--- a/profiles/todo/profile.yaml
+++ b/profiles/todo/profile.yaml
@@ -5,6 +5,10 @@
 # not a --tools whitelist).
 name: todo
 description: Todoist-only — closed world, base stripped
+# Cheese sub-agents are available in this closed world too
+# (agents are orthogonal to the MCP/skill scope below).
+registries:
+  agents: agents/registry.yaml
 isolated: true
 system_prompt: CLAUDE.md
 env:

--- a/zsh/claude.zsh
+++ b/zsh/claude.zsh
@@ -89,6 +89,13 @@ alias hook-sync='base-sync'
 alias hook-edit='${EDITOR:-vim} $AGENTS_DOTFILES/hooks/registry.yaml'
 alias hook-ls='yq -r ".hooks | keys | .[]" $AGENTS_DOTFILES/hooks/registry.yaml'
 
+# ═══════════════════════════════════════════════════════════════════
+# Agent Management (harness-agnostic — edit surface; deploy via `ap`)
+# ═══════════════════════════════════════════════════════════════════
+alias agent-sync='base-sync'
+alias agent-edit='${EDITOR:-vim} $AGENTS_DOTFILES/registry.yaml'
+alias agent-ls='yq -r ".agents | keys | .[]" $AGENTS_DOTFILES/registry.yaml'
+
 # Add user-scoped MCP (available in all projects)
 mcp-add() {
     if [[ -z "$1" || -z "$2" ]]; then


### PR DESCRIPTION
## What

Migrates the 13 cheese sub-agents off the legacy `~/.claude/agents` symlink onto registry-driven `ap` render. Agents now deploy as real files into every harness — Claude (user-scoped + plugin tree), Codex (sandbox TOML), opencode (native subagents), Copilot, Cursor — the same path MCPs / hooks / skills already take.

## Highlights

- **`agents/registry.yaml`** — single source of truth for agent metadata (`description`, `models.claude`, `tools`, `disallowedTools`, `color`, `effort`, `skills`, `body_path`). The 13 `claude/agents/*.md` files are stripped to instruction-only bodies; the registry is authoritative.
- **ingest / parse** — expand a `registries.agents` directive into manifest agents (registry items first, inline append); the empty-directive default includes `agents: []`.
- **User-scope precedence fix** — `shared.claude_agent_frontmatter` makes the user-scoped `~/.claude/agents/<name>.md` file (Claude priority 4, which wins over the plugin copy at priority 5) carry **full** metadata, not a neutral subset. The Claude and Cursor renderers share it so the later writer can't clobber the earlier one's metadata.
- **Read-only intent** — `agent_is_read_only` derives sandbox intent → Codex `sandbox_mode = "read-only"` and opencode `permission.edit: deny`. `strip_frontmatter` removes stale frontmatter at every body-read site.
- **opencode path fix** — native subagents now write to `<target>/agents/<name>.md` (root-relative), fixing a double-nested `.opencode/agent/` bug.
- **Fail-loud `body_abs`** — a *declared* but unresolvable `body_path` now raises `ParseError` (clean exit 1) instead of silently shipping a body-less item; optional bodies (no `body_path`) still return `None`.
- **Symlink drop** — `claude/.sync` removes the legacy symlink; a `run_once_before` chezmoi migration removes it ahead of the installer so `ap` never writes back through it into the repo.
- **profiles + zsh** — `base` declares the agents registry (global inherits) and the 7 specialized/isolated profiles reference it; new `agent-edit` / `agent-sync` / `agent-ls` aliases.

## Testing

- `uv run --directory agent-profile pytest -q` → **414 passed**
- Real `ap install base` render of all 5 harnesses → `✓ Installed`, no `ParseError` (every real `body_path` resolves)
- `bats tests/install-base-profile.bats` (10/10), `tests/sync-claude.bats` (37/37)

## Notes

- Unrelated `skills/*/SKILL.md` description-rewording churn in the working tree is intentionally **excluded** from this PR.
- Live fresh-session read behaviour (Claude honoring the user-scoped file over the plugin copy; opencode `permission.edit: deny`) is verified on disk but only fully confirmable in a live harness session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)