### PR TITLE
chore(skills): shorten local skill descriptions

### DIFF
--- a/skills/claude-local/SKILL.md
+++ b/skills/claude-local/SKILL.md
@@ -3,20 +3,9 @@ name: claude-local
 model: sonnet
 allowed-tools: Read, Write, Edit, Bash(git:*), Bash(grep:*), Bash(test:*), Bash(touch:*), Bash(mkdir:*), Bash(printf:*), Glob
 description: >
-  Distill the user's global ~/.claude/CLAUDE.md into a project-scoped
-  CLAUDE.local.md (gitignored) for repos they're contributing to but
-  don't own. Detects the project's languages and build system, keeps
-  only the relevant subset of global preferences (coding principles,
-  complexity budget, skill delegation table, self-eval checklist,
-  language-gated style notes), drops the personal-flair sections and
-  architectural opinions that shouldn't bleed into a contributed repo.
-  Ensures CLAUDE.local.md is covered by the user's GLOBAL gitignore —
-  never the project's .gitignore — so the contribution stays clean. Use
-  when the user says "set up CLAUDE.local", "scaffold local claude
-  config", "drop my preferences in this repo", "I'm contributing to
-  this repo and want my preferences applied", "claude-local.md", or
-  invokes /claude-local. Also use proactively when the user opens a
-  shell in an unfamiliar repo and says they want to start contributing.
+  Create a gitignored CLAUDE.local.md from the user's global Claude
+  preferences, keeping only repo-relevant instructions. Use for outside
+  repos that need local agent guidance without committing personal config.
 ---
 
 # claude-local

--- a/skills/claude-local/SKILL.md
+++ b/skills/claude-local/SKILL.md
@@ -3,9 +3,13 @@ name: claude-local
 model: sonnet
 allowed-tools: Read, Write, Edit, Bash(git:*), Bash(grep:*), Bash(test:*), Bash(touch:*), Bash(mkdir:*), Bash(printf:*), Glob
 description: >
-  Create a gitignored CLAUDE.local.md from the user's global Claude
-  preferences, keeping only repo-relevant instructions. Use for outside
-  repos that need local agent guidance without committing personal config.
+  Distill the user's global ~/.claude/CLAUDE.md into a gitignored
+  CLAUDE.local.md for repos they contribute to but don't own — keeping only
+  repo-relevant instructions and dropping personal flair. Use when the user
+  says "set up CLAUDE.local", "scaffold local claude config", "drop my
+  preferences in this repo", "I'm contributing and want my preferences
+  applied", "claude-local.md", or invokes /claude-local. Also use proactively
+  when they open an unfamiliar repo and want to start contributing.
 ---
 
 # claude-local

--- a/skills/de-slop/SKILL.md
+++ b/skills/de-slop/SKILL.md
@@ -1,14 +1,9 @@
 ---
 name: de-slop
 description: >
-  Detect and fix AI-generated code anti-patterns ("slop") across Rust, Python,
-  TypeScript, Go, and Shell. Use this skill whenever you generate or edit code,
-  when the user says "de-slop", "clean up AI code", "remove AI slop", or during
-  /simplify and /cook flows. Also use as a mental checklist before committing
-  any code — AI assistants produce systematically predictable mistakes and this
-  skill is the antidote. Trigger proactively on code review, post-generation
-  cleanup, and pre-commit checks. If code was just written or modified by an AI
-  (including you), this skill applies.
+  Find and fix common AI-generated code bloat across Rust, Python,
+  TypeScript, Go, and Shell. Use after generating or editing code, or when
+  asked to de-slop, simplify, clean up, or review AI-written changes.
 model: sonnet
 allowed-tools: Read, Edit, Grep, Glob, Bash(rg:*), Bash(sg:*)
 ---

--- a/skills/de-slop/SKILL.md
+++ b/skills/de-slop/SKILL.md
@@ -1,9 +1,12 @@
 ---
 name: de-slop
 description: >
-  Find and fix common AI-generated code bloat across Rust, Python,
-  TypeScript, Go, and Shell. Use after generating or editing code, or when
-  asked to de-slop, simplify, clean up, or review AI-written changes.
+  Detect and fix AI-generated code anti-patterns ("slop") across Rust, Python,
+  TypeScript, Go, and Shell. Use whenever you generate or edit code, when the
+  user says "de-slop", "clean up AI code", "remove AI slop", or during /simplify
+  and /cook flows. Also trigger proactively as a pre-commit checklist on
+  AI-written changes. Do NOT use for correctness or bug review — use /age or
+  /code-review.
 model: sonnet
 allowed-tools: Read, Edit, Grep, Glob, Bash(rg:*), Bash(sg:*)
 ---

--- a/skills/ghostbuster/SKILL.md
+++ b/skills/ghostbuster/SKILL.md
@@ -6,9 +6,12 @@ context: fork
 argument-hint: "[directory to scope, or leave blank for full codebase]"
 allowed-tools: Read, Glob, Grep, Bash(git log:*), Bash(git diff:*), Bash(git blame:*), Bash(wc:*), Agent, mcp__serena__*
 description: >
-  Find dead code and stale spec references. Classifies unreachable,
-  orphaned, missing, or dormant code paths as DEAD, ZOMBIE, GHOST, or
-  DORMANT. Use for dead-code cleanup and stale-spec checks.
+  Dead-code forensics and spec cross-reference. Finds unreachable, orphaned,
+  missing, or dormant code and classifies it DEAD, ZOMBIE, GHOST, or DORMANT.
+  Use when the user says "find dead code", "what's unused", "what can I delete",
+  "stale specs", "spec drift", "orphaned implementations", "find zombie code",
+  or asks what's wired up vs sitting unused. Do NOT use for code-quality review
+  (/age) or NIH/reinvented-wheel detection (/nih-audit).
 ---
 
 # /ghostbuster — Dead Code Forensics

--- a/skills/ghostbuster/SKILL.md
+++ b/skills/ghostbuster/SKILL.md
@@ -6,17 +6,9 @@ context: fork
 argument-hint: "[directory to scope, or leave blank for full codebase]"
 allowed-tools: Read, Glob, Grep, Bash(git log:*), Bash(git diff:*), Bash(git blame:*), Bash(wc:*), Agent, mcp__serena__*
 description: >
-  Dead code forensics and spec cross-reference. Finds unreachable functions,
-  orphaned implementations, specs pointing at deleted code, and transitive dead
-  code chains. Categorizes as DEAD (safe to delete), ZOMBIE (in spec but unwired),
-  GHOST (spec references nonexistent code), or DORMANT (entry point is dead,
-  taking dependents with it). Use when the user says "find dead code", "what's
-  unused", "clean up unused functions", "are there stale specs", "what code can
-  I delete", "check for orphaned implementations", "spec drift", "what's
-  incomplete", "find zombie code", or asks about code that was started but never
-  finished. Also use when reviewing a module and wanting to know what's wired up
-  vs what's just sitting there. Do NOT use for code quality review (/age) or
-  NIH/reinvented-wheel detection (/nih-audit).
+  Find dead code and stale spec references. Classifies unreachable,
+  orphaned, missing, or dormant code paths as DEAD, ZOMBIE, GHOST, or
+  DORMANT. Use for dead-code cleanup and stale-spec checks.
 ---
 
 # /ghostbuster — Dead Code Forensics

--- a/skills/git-hygiene/SKILL.md
+++ b/skills/git-hygiene/SKILL.md
@@ -3,12 +3,9 @@ name: git-hygiene
 model: haiku
 user-invocable: false
 description: >
-  Guardrail for proper git tool usage. Prevents reading file contents via
-  git show <ref>:<path> or git cat-file, which bypass the Read tool and file
-  access controls. Triggers when planning git commands that read file contents
-  from other branches or commits, or when colon syntax appears in git commands.
-  Use when about to construct "git show ref:path" or "git cat-file" commands.
-  Do NOT use for normal git operations like commit, push, log, or diff.
+  Prevent git commands that read file contents outside normal file-access
+  tools, especially git show <ref>:<path> and git cat-file. Use only for
+  those risky read patterns, not ordinary git status, log, diff, commit, or push.
 ---
 
 # git-hygiene

--- a/skills/git-hygiene/SKILL.md
+++ b/skills/git-hygiene/SKILL.md
@@ -3,9 +3,11 @@ name: git-hygiene
 model: haiku
 user-invocable: false
 description: >
-  Prevent git commands that read file contents outside normal file-access
-  tools, especially git show <ref>:<path> and git cat-file. Use only for
-  those risky read patterns, not ordinary git status, log, diff, commit, or push.
+  Guardrail against git commands that read file contents outside the Read tool —
+  especially `git show <ref>:<path>` and `git cat-file`, which bypass file-access
+  controls. Triggers when constructing git commands with colon ref:path syntax or
+  cat-file to read another branch or commit. Do NOT use for normal git operations
+  like status, log, diff, commit, or push.
 ---
 
 # git-hygiene

--- a/skills/grok-codebase/SKILL.md
+++ b/skills/grok-codebase/SKILL.md
@@ -1,9 +1,13 @@
 ---
 name: grok-codebase
 description: >
-  Build lasting understanding of an unfamiliar repo using the four-pillar
-  model and an adaptive quiz. Use for grokking, onboarding, memorizing,
-  studying, or being quizzed on a codebase.
+  Build lasting understanding of an unfamiliar codebase via a four-pillar model
+  (Building Blocks, Entry Points, Infrastructure, Egress) plus an adaptive
+  Socratic quiz, orchestrating code-review-graph, Serena, tilth, and Context7.
+  Use when the user says "help me understand this codebase", "grok this repo",
+  "onboard me", "learn this project", "memorize this codebase", "study this
+  code", "walk me through this code", or "quiz me on this repo". Do NOT use for
+  single-file scripts, repos under 500 LOC, or editing tasks — understanding only.
 argument-hint: <optional focus area, e.g. "auth flow" or "payments">
 allowed-tools: Read, Write, TodoWrite, Skill, Bash(git:*), Bash(ls:*), Bash(cat:*), Bash(jq:*), Bash(yq:*), Bash(tokei:*), Bash(code-review-graph:*), mcp__serena__find_symbol, mcp__serena__find_referencing_symbols, mcp__serena__find_implementations, mcp__serena__find_declaration, mcp__serena__get_symbols_overview, mcp__serena__search_for_pattern, mcp__tilth__*, mcp__code-review-graph__*, mcp__context7__*
 metadata:

--- a/skills/grok-codebase/SKILL.md
+++ b/skills/grok-codebase/SKILL.md
@@ -1,21 +1,9 @@
 ---
 name: grok-codebase
 description: >
-  ALWAYS use this skill when the user wants to deeply understand, memorize, or
-  onboard onto an unfamiliar codebase. Loads a repo into long-term understanding
-  using a four-pillar model — Building Blocks, Entry Points, Infrastructure,
-  Egress — then runs an adaptive Socratic quiz that probes weak spots and eases
-  off strong areas. Orchestrates code-review-graph (Tree-sitter graph + blast
-  radius), Serena (LSP symbols), tilth (token-efficient reads + structural
-  diff), and Context7 (framework docs). Trigger on any of: "help me understand
-  this codebase", "grok this repo", "onboard me", "learn this project",
-  "memorize this codebase", "load this repo into memory", "study this code",
-  "explain this project to me", "walk me through this code", "quiz me on this
-  repo", or whenever the user opens an unfamiliar TypeScript, JavaScript,
-  Python, Go, Rust, or Java project and asks for orientation. Especially tuned
-  for TS/JS monorepos and Next.js / Express / NestJS / Fastify apps; methodology
-  is stack-agnostic. Do NOT use for single-file scripts, repos under 500 LOC,
-  or editing tasks — this skill is for understanding only.
+  Build lasting understanding of an unfamiliar repo using the four-pillar
+  model and an adaptive quiz. Use for grokking, onboarding, memorizing,
+  studying, or being quizzed on a codebase.
 argument-hint: <optional focus area, e.g. "auth flow" or "payments">
 allowed-tools: Read, Write, TodoWrite, Skill, Bash(git:*), Bash(ls:*), Bash(cat:*), Bash(jq:*), Bash(yq:*), Bash(tokei:*), Bash(code-review-graph:*), mcp__serena__find_symbol, mcp__serena__find_referencing_symbols, mcp__serena__find_implementations, mcp__serena__find_declaration, mcp__serena__get_symbols_overview, mcp__serena__search_for_pattern, mcp__tilth__*, mcp__code-review-graph__*, mcp__context7__*
 metadata:

--- a/skills/nih-audit/SKILL.md
+++ b/skills/nih-audit/SKILL.md
@@ -6,20 +6,9 @@ context: fork
 argument-hint: "[directory to scope, or leave blank for full codebase]"
 allowed-tools: Read, Glob, Grep, Bash(sg:*), Bash(git log:*), Bash(git blame:*), Bash(jq:*), Bash(yq:*), Bash(wc:*), Agent, mcp__serena__*
 description: >
-  Scan a codebase for custom code that duplicates what open-source libraries
-  already do, then recommend which libraries to adopt. Detects hand-rolled
-  utility functions, custom retry logic, manual validation, DIY date handling,
-  home-grown argument parsers, and other reinvented wheels. Cross-checks against
-  installed dependencies and open specs. Returns scored migration recommendations
-  with effort estimates. Use this skill when the user mentions reinventing the
-  wheel, asks if there's a library for something they built, wants a build vs buy
-  audit, says "what are we maintaining that we shouldn't be", asks about library
-  alternatives for custom code, wonders if their utils/ folder has redundant
-  implementations, or wants to find dependency opportunities. Also use when the
-  user asks to compare their custom implementation against existing packages, or
-  says things like "should we just use lodash for this" or "is there a crate
-  that does what our helper does". Do NOT use for code quality review (/age) or
-  dead code removal (/simplify).
+  Find custom code that duplicates well-supported libraries, then recommend
+  migrations with effort estimates. Use for NIH checks, hand-rolled utilities,
+  retry logic, validation, date handling, parsers, or dependency replacement.
 ---
 
 # /nih-audit — Not Invented Here Audit

--- a/skills/nih-audit/SKILL.md
+++ b/skills/nih-audit/SKILL.md
@@ -6,9 +6,13 @@ context: fork
 argument-hint: "[directory to scope, or leave blank for full codebase]"
 allowed-tools: Read, Glob, Grep, Bash(sg:*), Bash(git log:*), Bash(git blame:*), Bash(jq:*), Bash(yq:*), Bash(wc:*), Agent, mcp__serena__*
 description: >
-  Find custom code that duplicates well-supported libraries, then recommend
-  migrations with effort estimates. Use for NIH checks, hand-rolled utilities,
-  retry logic, validation, date handling, parsers, or dependency replacement.
+  Scan for custom code that duplicates well-supported libraries, then recommend
+  migrations with effort estimates. Detects hand-rolled utilities, retry logic,
+  validation, date handling, and DIY parsers. Use when the user mentions
+  reinventing the wheel, asks "is there a library/crate for this", wants a build
+  vs buy audit, says "what are we maintaining that we shouldn't be", or "should
+  we just use lodash for this". Do NOT use for code-quality review (/age) or
+  dead-code removal (/simplify or /ghostbuster).
 ---
 
 # /nih-audit — Not Invented Here Audit

--- a/skills/scout/SKILL.md
+++ b/skills/scout/SKILL.md
@@ -3,8 +3,11 @@ name: scout
 model: haiku
 allowed-tools: Skill, Bash(ls:*)
 description: >
-  Explore the filesystem with concise tree views and git status. Use for
-  directory listings, file search, metadata search, and scout requests.
+  Filesystem exploration with human-friendly eza tree views and git status;
+  delegates content/code search to cheez-search (AST-aware via tilth). Use when
+  the user says "search files", "find by metadata", "tree view", "list directory
+  with git status", or invokes /scout. Do NOT use for symbol, usage, or
+  structural code search — that's cheez-search.
 ---
 
 # scout

--- a/skills/scout/SKILL.md
+++ b/skills/scout/SKILL.md
@@ -3,12 +3,8 @@ name: scout
 model: haiku
 allowed-tools: Skill, Bash(ls:*)
 description: >
-  Filesystem exploration. Delegates content/code search to cheese-flow's
-  cheez-search (AST-aware via tilth MCP). Keeps eza directory listings for
-  human-friendly tree views with git status. Use when the user says "search
-  files", "find by metadata", "tree view", "list directory with git status",
-  or invokes /scout. For symbol/usage/structural search, the work is done by
-  cheez-search — this skill is a thin pointer.
+  Explore the filesystem with concise tree views and git status. Use for
+  directory listings, file search, metadata search, and scout requests.
 ---
 
 # scout

--- a/skills/self-eval/SKILL.md
+++ b/skills/self-eval/SKILL.md
@@ -2,9 +2,12 @@
 name: self-eval
 model: haiku
 description: >
-  Run the response and change-quality checklist. Use before finishing code
-  edits, when asked to self-evaluate, or when the user questions completeness,
-  testing, confidence, or response quality.
+  Run the Self-Evaluation Checklist against your last response or recent code
+  changes. Use when the user says "self-eval", "self-evaluate", "check my
+  response", "quality check", "evaluate response", or expresses doubt ("did you
+  actually test that?", "are you sure?", "that seems incomplete"), or
+  proactively before finishing code edits. Cross-references /de-slop and
+  /tdd-assertions for items with dedicated tooling.
 allowed-tools: Read, Edit, Glob, Grep, Skill
 ---
 

--- a/skills/self-eval/SKILL.md
+++ b/skills/self-eval/SKILL.md
@@ -2,12 +2,9 @@
 name: self-eval
 model: haiku
 description: >
-  Run the Self-Evaluation Checklist against your last response or recent changes.
-  Use this skill when the user says "self-eval", "self-evaluate", "check my response",
-  "quality check", "evaluate response", or when you want to proactively verify response
-  quality before finishing. Also trigger when the user expresses doubt about your output
-  ("did you actually test that?", "are you sure?", "that seems incomplete"). This skill
-  cross-references with /de-slop and /tdd-assertions for items that have dedicated tooling.
+  Run the response and change-quality checklist. Use before finishing code
+  edits, when asked to self-evaluate, or when the user questions completeness,
+  testing, confidence, or response quality.
 allowed-tools: Read, Edit, Glob, Grep, Skill
 ---
 

--- a/skills/serena-project-config/SKILL.md
+++ b/skills/serena-project-config/SKILL.md
@@ -2,17 +2,9 @@
 name: serena-project-config
 model: haiku
 description: >
-  Per-repo Serena MCP configuration. Use when the user wants to "configure
-  serena for this repo", "set up serena per repo", "serena project config",
-  "tune serena for this codebase", "monorepo serena", "serena wrong language",
-  "serena vendor/node_modules indexing", "review-only serena", or otherwise
-  wants the .serena/project.yml in a specific repo tuned. The skill recognizes
-  the four cases where the auto-bootstrap (--project-from-cwd) is not enough —
-  monorepos, wrong language detection, heavy generated dirs, LSP-specific
-  tuning — and walks through the edit + verification. Do NOT trigger on
-  general "use serena" routing requests; that lives in agents/AGENTS.md's
-  Code-Intelligence Routing section. Do NOT enable memory tools or onboarding
-  — they are intentionally disabled in ~/.serena/serena_config.yml.
+  Tune per-repo Serena MCP config when auto-bootstrap is not enough. Use for
+  monorepos, wrong language detection, generated-dir exclusions, review-only
+  setups, or .serena/project.yml changes.
 ---
 
 # serena-project-config

--- a/skills/serena-project-config/SKILL.md
+++ b/skills/serena-project-config/SKILL.md
@@ -2,9 +2,12 @@
 name: serena-project-config
 model: haiku
 description: >
-  Tune per-repo Serena MCP config when auto-bootstrap is not enough. Use for
-  monorepos, wrong language detection, generated-dir exclusions, review-only
-  setups, or .serena/project.yml changes.
+  Tune per-repo Serena MCP config (.serena/project.yml) when the auto-bootstrap
+  isn't enough — monorepos, wrong language detection, heavy generated dirs, or
+  review-only setups. Use when the user says "configure serena for this repo",
+  "serena project config", "monorepo serena", "serena wrong language", or
+  "review-only serena". Do NOT trigger on general "use serena" routing, and
+  never enable memory tools or onboarding (disabled by design).
 ---
 
 # serena-project-config

--- a/skills/session-analytics/SKILL.md
+++ b/skills/session-analytics/SKILL.md
@@ -1,9 +1,12 @@
 ---
 name: session-analytics
 description: >
-  Analyze Claude Code JSONL session logs with DuckDB. Use for usage patterns,
-  tool counts, permission denials, agent or skill routing, MCP usage, timelines,
-  and session analytics questions.
+  Query Claude Code's own JSONL session logs via DuckDB for usage analytics,
+  tool patterns, error forensics, and routing decisions. Use when the user says
+  "session analytics", "query my logs", "tool usage", "how often do I use",
+  "check my sessions", "analyze my usage", or asks about tool/agent/skill
+  behavior across sessions. Do NOT use for debugging current code, reading a
+  single transcript, or questions about Claude's capabilities.
 model: sonnet
 allowed-tools: Bash(duckdb:*), Bash(python3:*), Read
 ---

--- a/skills/session-analytics/SKILL.md
+++ b/skills/session-analytics/SKILL.md
@@ -1,18 +1,9 @@
 ---
 name: session-analytics
 description: >
-  Query Claude Code's own JSONL session logs via DuckDB for usage analytics,
-  tool patterns, error forensics, and routing decisions. Use when the user asks
-  about their Claude usage patterns, tool frequencies, error rates, permission
-  denials, agent routing, skill invocations, MCP server usage, session timelines,
-  or any question about "how has Claude been working". Also trigger when the user
-  says "session analytics", "query my logs", "tool usage", "how often do I use",
-  "check my sessions", "analyze my usage", or asks about specific tool/agent/skill
-  behavior across sessions. This skill turns ~900MB of raw JSONL into a queryable
-  DuckDB database — use it instead of writing ad-hoc Python scripts to parse logs.
-  Do NOT use for debugging current code issues, reading individual session
-  transcripts, or questions about Claude's capabilities — this skill is for
-  aggregate usage analytics across historical sessions.
+  Analyze Claude Code JSONL session logs with DuckDB. Use for usage patterns,
+  tool counts, permission denials, agent or skill routing, MCP usage, timelines,
+  and session analytics questions.
 model: sonnet
 allowed-tools: Bash(duckdb:*), Bash(python3:*), Read
 ---

--- a/skills/settings-clean/SKILL.md
+++ b/skills/settings-clean/SKILL.md
@@ -2,7 +2,7 @@
 name: settings-clean
 model: haiku
 context: fork
-description: Clean up bloated .claude/settings.local.json by removing redundant, stale, and junk permission entries, and ensure hook-redirected skills are allowed. Use when the user says "clean settings", "prune settings", "settings cleanup", or invokes /settings-clean. Also trigger proactively when you notice a settings.local.json with more than 30 permission entries, or after extended sessions where many one-off Bash permissions have accumulated. This skill only touches settings.local.json (gitignored), never settings.json (committed).
+description: Clean bloated .claude/settings.local.json permission entries and ensure hook-redirected skills are allowed. Use for settings cleanup or pruning.
 allowed-tools: Read, Write, Bash(jq:*), Bash(cp:*), Bash(mkdir:*), Bash(mv:*), Bash(date:*)
 ---
 

--- a/skills/settings-clean/SKILL.md
+++ b/skills/settings-clean/SKILL.md
@@ -2,7 +2,7 @@
 name: settings-clean
 model: haiku
 context: fork
-description: Clean bloated .claude/settings.local.json permission entries and ensure hook-redirected skills are allowed. Use for settings cleanup or pruning.
+description: Clean a bloated .claude/settings.local.json by removing redundant, stale, and junk permission entries and ensuring hook-redirected skills are allowed. Use when the user says "clean settings", "prune settings", "settings cleanup", or invokes /settings-clean; also proactively when settings.local.json exceeds ~30 entries. Only touches settings.local.json (gitignored), never settings.json (committed).
 allowed-tools: Read, Write, Bash(jq:*), Bash(cp:*), Bash(mkdir:*), Bash(mv:*), Bash(date:*)
 ---
 

--- a/skills/skill-improver/SKILL.md
+++ b/skills/skill-improver/SKILL.md
@@ -3,15 +3,9 @@ name: skill-improver
 model: opus
 effort: high
 description: >
-  Audit and improve agent and skill definitions for better calibration, tool scoping,
-  context management, activation quality, and output format. Use when the user says
-  "improve this skill", "audit this agent", "optimize this agent", "review agent
-  definition", "fix trigger rate", "skill not activating", or invokes /skill-improver
-  with a path. Also trigger when an agent is producing poor results and needs prompt
-  tuning, or when a skill isn't triggering reliably. Covers: calibrated confidence
-  scoring, tool scoping, sub-agent delegation, fork vs inline, context budgets,
-  and activation optimization. Do NOT use for creating new skills from scratch —
-  use /skill-creator for that.
+  Audit and improve skill or agent definitions. Use for prompt tuning,
+  activation quality, tool scope, context budget, output format, and unreliable
+  trigger behavior.
 allowed-tools: Read, Glob, Grep, Agent, Bash
 ---
 

--- a/skills/skill-improver/SKILL.md
+++ b/skills/skill-improver/SKILL.md
@@ -3,9 +3,12 @@ name: skill-improver
 model: opus
 effort: high
 description: >
-  Audit and improve skill or agent definitions. Use for prompt tuning,
-  activation quality, tool scope, context budget, output format, and unreliable
-  trigger behavior.
+  Audit and improve agent and skill definitions — calibration, tool scoping,
+  context budget, activation quality, and output format. Use when the user says
+  "improve this skill", "audit this agent", "optimize this agent", "review agent
+  definition", "fix trigger rate", "skill not activating", or invokes
+  /skill-improver. Do NOT use for creating new skills from scratch — use
+  /skill-creator.
 allowed-tools: Read, Glob, Grep, Agent, Bash
 ---
 

--- a/skills/spec-verify/SKILL.md
+++ b/skills/spec-verify/SKILL.md
@@ -5,13 +5,9 @@ context: fork
 effort: high
 allowed-tools: Read, Glob, Grep, Bash(sg:*), Bash(echo:*), Bash(cargo check:*), Bash(cargo clippy:*), Bash(cargo test:*), Bash(tsc:*), Bash(npm run:*), Bash(pnpm:*), Bash(yarn:*), Bash(go build:*), Bash(go vet:*), Bash(go test:*), Bash(uv run:*), Bash(python -m:*), Bash(pytest:*), Bash(ruff:*), Bash(mypy:*), Bash(prek:*), Bash(rtk:*), Agent, mcp__serena__*
 description: >
-  Verify that a spec's implementation matches its requirements using Serena MCP
-  structural analysis, build verification, and test coverage checking. Use when the
-  user says "verify the spec", "check spec implementation", "does this match the
-  spec", "spec coverage", "verify acceptance criteria", or invokes /spec-verify
-  with a spec path. Also trigger after `/cure` completes to validate the result
-  against the original spec. Do NOT use for writing code — this is verification
-  only. Do NOT use for general code review — use /age for that.
+  Verify an implementation against a spec using structural checks, build gates,
+  and tests. Use for spec coverage, acceptance criteria, and post-cure
+  validation; not for writing code or general review.
 ---
 
 # spec-verify

--- a/skills/spec-verify/SKILL.md
+++ b/skills/spec-verify/SKILL.md
@@ -5,9 +5,12 @@ context: fork
 effort: high
 allowed-tools: Read, Glob, Grep, Bash(sg:*), Bash(echo:*), Bash(cargo check:*), Bash(cargo clippy:*), Bash(cargo test:*), Bash(tsc:*), Bash(npm run:*), Bash(pnpm:*), Bash(yarn:*), Bash(go build:*), Bash(go vet:*), Bash(go test:*), Bash(uv run:*), Bash(python -m:*), Bash(pytest:*), Bash(ruff:*), Bash(mypy:*), Bash(prek:*), Bash(rtk:*), Agent, mcp__serena__*
 description: >
-  Verify an implementation against a spec using structural checks, build gates,
-  and tests. Use for spec coverage, acceptance criteria, and post-cure
-  validation; not for writing code or general review.
+  Verify a spec's implementation against its requirements using Serena
+  structural analysis, build verification, and test coverage. Use when the user
+  says "verify the spec", "check spec implementation", "does this match the
+  spec", "spec coverage", "verify acceptance criteria", or invokes /spec-verify;
+  also after /cure to validate the result. Do NOT use for writing code or for
+  general code review — use /age.
 ---
 
 # spec-verify

--- a/skills/steel-thread/SKILL.md
+++ b/skills/steel-thread/SKILL.md
@@ -4,21 +4,9 @@ model: opus
 effort: high
 allowed-tools: Read, Bash(git log:*), Bash(git diff:*), Bash(git status:*), Bash(ls:*), Bash(rg:*), Agent, Skill
 description: >
-  Map a concept end-to-end through a layered codebase using the code-review-graph
-  (CRG) MCP. Always rebuilds and re-embeds the graph before answering so
-  semantic search reflects current code. Prefers CRG's native `Flow` primitive
-  (which IS a steel thread) over hand-rolled traversal. Queries along both
-  behaviour and surface vocabularies when no flow matches, traverses from the
-  densest hub, cross-checks with impact radius, and routes via
-  `get_minimal_context_tool`'s `suggested_tools` array. Use when the user asks
-  to trace a concept, find an entry point, map a feature across layers,
-  estimate blast radius of a planned change, find which contract/route/handler
-  reaches a given service, or asks "did you check whether I just added X".
-  Triggers on: /steel-thread, "trace this through", "map the X flow", "blast
-  radius for Y", "what touches Z", "find the entry point for", "where does X
-  get called from", "is there a new endpoint I added", "what's affected by
-  this change". Do NOT use for single-symbol lookups (use the Serena MCP),
-  filesystem search (use /scout), or dead code detection (use /ghostbuster).
+  Trace a concept end-to-end through a layered codebase with code-review-graph.
+  Use to map features, find entry points, follow behavior across layers, or
+  understand cross-cutting flows.
 license: MIT
 ---
 

--- a/skills/steel-thread/SKILL.md
+++ b/skills/steel-thread/SKILL.md
@@ -4,9 +4,13 @@ model: opus
 effort: high
 allowed-tools: Read, Bash(git log:*), Bash(git diff:*), Bash(git status:*), Bash(ls:*), Bash(rg:*), Agent, Skill
 description: >
-  Trace a concept end-to-end through a layered codebase with code-review-graph.
-  Use to map features, find entry points, follow behavior across layers, or
-  understand cross-cutting flows.
+  Map a concept end-to-end through a layered codebase using the code-review-graph
+  MCP — rebuilding the graph, preferring its Flow primitive, and cross-checking
+  impact radius. Use when the user says "trace this through", "map the X flow",
+  "blast radius for Y", "what touches Z", "find the entry point for", "what's
+  affected by this change", or invokes /steel-thread. Do NOT use for
+  single-symbol lookups (Serena), filesystem search (/scout), or dead-code
+  detection (/ghostbuster).
 license: MIT
 ---
 

--- a/skills/tdd-assertions/SKILL.md
+++ b/skills/tdd-assertions/SKILL.md
@@ -2,13 +2,8 @@
 name: tdd-assertions
 model: sonnet
 description: >
-  Detect and fix weak test assertions that AI generates across Rust, Python,
-  TypeScript, Go, and Shell. Use this skill whenever you write or review tests,
-  when the user says "strengthen assertions", "fix weak tests", or during
-  /wreck, /cook, /press, and /simplify flows. Also use as a mental checklist before
-  committing test code — AI assistants systematically produce assertions that
-  pass when the code is broken, which is the cardinal sin of TDD.
-  Trigger proactively on test generation and test review.
+  Find and fix weak test assertions across Rust, Python, TypeScript, Go, and
+  Shell. Use when writing, reviewing, strengthening, or repairing tests.
 allowed-tools: Read, Edit, Grep, Glob, Bash(rg:*)
 ---
 

--- a/skills/tdd-assertions/SKILL.md
+++ b/skills/tdd-assertions/SKILL.md
@@ -2,8 +2,11 @@
 name: tdd-assertions
 model: sonnet
 description: >
-  Find and fix weak test assertions across Rust, Python, TypeScript, Go, and
-  Shell. Use when writing, reviewing, strengthening, or repairing tests.
+  Detect and fix weak test assertions that pass even when code is broken, across
+  Rust, Python, TypeScript, Go, and Shell. Use whenever you write or review
+  tests, when the user says "strengthen assertions" or "fix weak tests", or
+  during /wreck, /cook, /press, and /simplify flows. Trigger proactively on test
+  generation and review.
 allowed-tools: Read, Edit, Grep, Glob, Bash(rg:*)
 ---
 

--- a/skills/test-sandbox/SKILL.md
+++ b/skills/test-sandbox/SKILL.md
@@ -4,12 +4,9 @@ model: haiku
 context: fork
 allowed-tools: Read, Write, Bash(python3:*), Bash(uv:*), Bash(pytest:*), Bash(ls:*), Bash(rm:*)
 description: >
-  Run Python test code in an isolated sandbox without polluting the main context.
-  Writes test files to .claude/testing/ (gitignored), runs via sub-agent, and
-  reports only pass/fail counts and assertion details. Use when you want to quickly
-  verify code without writing inline python3 -c scripts. Also supports --sweep to
-  clean stale test files. Use when the user says "run a quick test", "verify this
-  works", "sanity check", "test this snippet", or invokes /test-sandbox.
+  Run quick Python tests in an isolated .claude/testing sandbox and report only
+  pass/fail counts plus assertion details. Use for snippets, sanity checks, and
+  lightweight verification.
 ---
 
 # /test-sandbox — Isolated Test Sandboxing

--- a/skills/test-sandbox/SKILL.md
+++ b/skills/test-sandbox/SKILL.md
@@ -4,9 +4,12 @@ model: haiku
 context: fork
 allowed-tools: Read, Write, Bash(python3:*), Bash(uv:*), Bash(pytest:*), Bash(ls:*), Bash(rm:*)
 description: >
-  Run quick Python tests in an isolated .claude/testing sandbox and report only
-  pass/fail counts plus assertion details. Use for snippets, sanity checks, and
-  lightweight verification.
+  Run Python test code in an isolated .claude/testing sandbox (via sub-agent)
+  without polluting the main context, reporting only pass/fail counts and
+  assertion details. Use when the user says "run a quick test", "verify this
+  works", "sanity check", "test this snippet", or invokes /test-sandbox; supports
+  --sweep to clean stale test files. Do NOT use for the project's real test
+  suite — this is for quick snippets.
 ---
 
 # /test-sandbox — Isolated Test Sandboxing

--- a/skills/tui-design/SKILL.md
+++ b/skills/tui-design/SKILL.md
@@ -4,13 +4,9 @@ model: sonnet
 context: fork
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash(mkdir:*), mcp__context7__resolve-library-id, mcp__context7__query-docs
 description: >
-  Create distinctive, production-grade terminal user interfaces with high usability
-  and professional polish. Use this skill when the user asks to build TUI applications,
-  terminal dashboards, interactive CLI tools, or any full-screen terminal interface
-  (system monitors, git clients, database explorers, log viewers, file managers, REPL
-  wrappers). Supports Rust (ratatui/crossterm) and Python (Textual/Rich).
-  Use when the user says "build a dashboard", "terminal UI", "interactive CLI",
-  "TUI app", "system monitor", "log viewer", or invokes /tui-design.
+  Build polished terminal UIs and full-screen interactive CLI tools. Use for
+  dashboards, log viewers, system monitors, file managers, REPL wrappers, and
+  TUI apps in Rust or Python.
 ---
 
 # tui-design

--- a/skills/tui-design/SKILL.md
+++ b/skills/tui-design/SKILL.md
@@ -4,9 +4,10 @@ model: sonnet
 context: fork
 allowed-tools: Read, Write, Edit, Glob, Grep, Bash(mkdir:*), mcp__context7__resolve-library-id, mcp__context7__query-docs
 description: >
-  Build polished terminal UIs and full-screen interactive CLI tools. Use for
-  dashboards, log viewers, system monitors, file managers, REPL wrappers, and
-  TUI apps in Rust or Python.
+  Create distinctive, production-grade terminal UIs and full-screen interactive
+  CLI tools in Rust (ratatui/crossterm) or Python (Textual/Rich). Use when the
+  user says "build a dashboard", "terminal UI", "interactive CLI", "TUI app",
+  "system monitor", "log viewer", "file manager", or invokes /tui-design.
 ---
 
 # tui-design

--- a/skills/version-doctor/SKILL.md
+++ b/skills/version-doctor/SKILL.md
@@ -1,9 +1,12 @@
 ---
 name: version-doctor
 description: >
-  Diagnose and fix dependency versions, resolution failures, conflicts, and
-  workspace inheritance issues. Use before restructuring build files because of
-  a version-related failure.
+  Diagnose and fix library version mismatches, dependency conflicts, and build
+  file inheritance issues. Use when the user says "fix versions", "version
+  mismatch", "dependency conflict", "why won't this build", or "update
+  dependencies", and proactively when a build fails on version constraints —
+  the fix is almost always a version bump, not restructuring the build. Use this
+  before rewriting a build config or bypassing workspace inheritance.
 allowed-tools: Read, Grep, Glob, Bash, Agent
 ---
 

--- a/skills/version-doctor/SKILL.md
+++ b/skills/version-doctor/SKILL.md
@@ -1,15 +1,9 @@
 ---
 name: version-doctor
 description: >
-  Diagnose and fix library version mismatches, dependency conflicts, and build
-  file inheritance issues. Use this skill when encountering version resolution
-  failures, workspace inheritance problems, or when the user says "fix versions",
-  "version mismatch", "dependency conflict", "why won't this build", or "update
-  dependencies". Also trigger proactively when a build fails due to version
-  constraints — the right fix is almost always updating a version number, not
-  restructuring the build. If you catch yourself about to rewrite a build config
-  or bypass workspace inheritance because of a version error, stop and use this
-  skill instead.
+  Diagnose and fix dependency versions, resolution failures, conflicts, and
+  workspace inheritance issues. Use before restructuring build files because of
+  a version-related failure.
 allowed-tools: Read, Grep, Glob, Bash, Agent
 ---
 

--- a/skills/worktree/SKILL.md
+++ b/skills/worktree/SKILL.md
@@ -3,8 +3,9 @@ name: worktree
 model: haiku
 allowed-tools: Bash(ccw-init:*), Bash(cd:*)
 description: >
-  Create or resume an isolated git worktree for a task. Use for worktree setup
-  requests and /worktree invocations; requires a task slug.
+  Create or resume an isolated git worktree for a Claude Code task, keeping main
+  clean. Use when asked to "create a worktree", "resume a worktree", set up an
+  isolated branch for a task, or when /worktree is invoked. Requires a task slug.
 ---
 
 # worktree

--- a/skills/worktree/SKILL.md
+++ b/skills/worktree/SKILL.md
@@ -3,9 +3,8 @@ name: worktree
 model: haiku
 allowed-tools: Bash(ccw-init:*), Bash(cd:*)
 description: >
-  Create an isolated git worktree for a Claude Code task, keeping main clean.
-  Use when asked to create or resume a worktree, set up an isolated branch for
-  a task, or when the /worktree command is invoked. Requires a task slug.
+  Create or resume an isolated git worktree for a task. Use for worktree setup
+  requests and /worktree invocations; requires a task slug.
 ---
 
 # worktree

--- a/skills/wt-git/SKILL.md
+++ b/skills/wt-git/SKILL.md
@@ -3,9 +3,12 @@ name: wt-git
 model: haiku
 allowed-tools: Bash(git:*), Bash(gh:*), Bash(wt-git:*), Read, Grep, Glob
 description: >
-  Run git and GitHub commands inside another worktree. Use for commits, pushes,
-  PRs, or worktree git operations that would otherwise require cd+git command
-  patterns or heredoc-heavy gh calls.
+  Run git and GitHub operations inside a worktree you're not currently in,
+  without tripping Claude Code's Seatbelt safety heuristics (compound cd+git,
+  heredoc PR bodies). Use whenever you need to commit, push, or create PRs in
+  another worktree — especially from orchestrators, /move-my-cheese, or
+  /cheese-convoy — or when about to write "cd <path> && git" or a heredoc gh PR
+  body.
 ---
 
 # wt-git

--- a/skills/wt-git/SKILL.md
+++ b/skills/wt-git/SKILL.md
@@ -3,14 +3,9 @@ name: wt-git
 model: haiku
 allowed-tools: Bash(git:*), Bash(gh:*), Bash(wt-git:*), Read, Grep, Glob
 description: >
-  Run git and GitHub operations inside a worktree without triggering Claude Code's
-  safety heuristics. Use this skill whenever you need to commit, push, create PRs,
-  or run any git command in a worktree you're not currently inside — especially from
-  orchestrator agents, /move-my-cheese, or /cheese-convoy. Also use when
-  you catch yourself about to write "cd <path> && git" or "gh pr create --body" with
-  a heredoc. This skill exists because Claude Code's Seatbelt sandbox blocks two
-  legitimate patterns: compound cd+git commands ("bare repository attack" heuristic)
-  and heredoc PR bodies with markdown headers ("# hides arguments" heuristic).
+  Run git and GitHub commands inside another worktree. Use for commits, pushes,
+  PRs, or worktree git operations that would otherwise require cd+git command
+  patterns or heredoc-heavy gh calls.
 ---
 
 # wt-git

--- a/skills/xray/SKILL.md
+++ b/skills/xray/SKILL.md
@@ -3,8 +3,12 @@ name: xray
 model: opus
 effort: high
 description: >
-  Verify design and behavior through dependency graph traversal. Use for large
-  module review, spec checks, architecture questions, code audits, and /xray.
+  Interactive design verification via dependency-graph traversal (replaces
+  /notebook) — point it at a module, spec, or PR. Use when reviewing large
+  modules, verifying agent output, or auditing design, or when the user says
+  "review this module", "verify the design", "is this the right architecture",
+  "check this code against the spec", "what does this module actually do", or
+  invokes /xray.
 argument-hint: <module path, spec path, PR number, or concept>
 allowed-tools: Read, Write, Glob, Grep, Bash(sg:*), Bash(git diff:*), Bash(git log:*), Bash(gh:*), Agent
 ---

--- a/skills/xray/SKILL.md
+++ b/skills/xray/SKILL.md
@@ -3,12 +3,8 @@ name: xray
 model: opus
 effort: high
 description: >
-  Interactive design verification via dependency graph traversal. Replaces /notebook.
-  Use when reviewing large modules, verifying agent output, auditing design decisions,
-  or when you need to understand whether code does what it should. Point it at a module,
-  spec, or PR. Triggers on: /xray, "review this module", "verify the design",
-  "is this the right architecture", "check this code against the spec",
-  "what does this module actually do", design review, code audit.
+  Verify design and behavior through dependency graph traversal. Use for large
+  module review, spec checks, architecture questions, code audits, and /xray.
 argument-hint: <module path, spec path, PR number, or concept>
 allowed-tools: Read, Write, Glob, Grep, Bash(sg:*), Bash(git diff:*), Bash(git log:*), Bash(gh:*), Agent
 ---


### PR DESCRIPTION
## What

Shortens the `description` frontmatter of 21 local skills. The descriptions had grown into multi-sentence trigger lists; this tightens each to a one- or two-sentence purpose + trigger summary.

Split out of #232 (cross-harness agent render), where this churn was noted as unrelated and intentionally excluded from that PR's scope.

## Scope

- 21 `skills/*/SKILL.md` files, frontmatter `description` only — no body or behavior changes.
- 57 insertions, 181 deletions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
