### PR TITLE
feat(skills): analytics-skill evolution + serena initial_instructions exclusion

### DIFF
--- a/agents/registry.yaml
+++ b/agents/registry.yaml
@@ -14,6 +14,8 @@ agents:
     description: Complexity and structure reviewer. Enforces complexity budgets (line counts, params, nesting) and Sliced Bread file organization. Does NOT cover encapsulation, dead code, or bugs.
     models:
       claude: sonnet
+      codex: gpt-5-codex
+      cursor: claude-sonnet
     disallowedTools:
     - Edit
     - NotebookEdit
@@ -27,6 +29,8 @@ agents:
     description: Git history analyst. Produces per-file risk scores that the orchestrator uses to adjust sibling findings. Does NOT find bugs or architecture issues — only outputs score modifiers.
     models:
       claude: haiku
+      codex: gpt-5-mini
+      cursor: claude-haiku
     disallowedTools:
     - Edit
     - Write
@@ -43,6 +47,8 @@ agents:
     description: PR review comment responder. Triages both inline review threads AND PR-level review body comments with 0-100 confidence scoring — fixes high-confidence items, pushes back on bad suggestions, asks about uncertain ones. Named for the strong cheese made from leftover scraps — it takes leftover review comments and turns them into something useful. Spawnable as a parallel agent for move-my-cheese and cheese-convoy workflows.
     models:
       claude: sonnet
+      codex: gpt-5-codex
+      cursor: claude-sonnet
     tools:
     - Read
     - Write
@@ -60,6 +66,8 @@ agents:
     description: Security and dependency health auditor. Scans for vulnerabilities, unused/overweight deps, stdlib alternatives, and OWASP issues. Read-only. Returns stake-grouped findings (high/medium) with file:line citations and one-line recommendations — ~2 KB digest, no severity rewriting, no auto-fixes. Used as an easy-cheese fork target when /age needs evidence on the security dimension.
     models:
       claude: sonnet
+      codex: gpt-5-codex
+      cursor: claude-sonnet
     disallowedTools:
     - Write
     - Edit
@@ -73,6 +81,8 @@ agents:
     description: Forensic examination of expired cheese — finds code that's gone off, specs pointing at empty shelves, and curds that never set. Dead code detector + spec cross-referencer. Categorizes findings as DEAD, ZOMBIE, GHOST, or DORMANT with 0-100 confidence scoring. Read-only — never modifies code. Returns a categorized findings digest (~2 KB). Suitable as an easy-cheese fork target when /age needs evidence on the deslop dimension.
     models:
       claude: sonnet
+      codex: gpt-5-codex
+      cursor: claude-sonnet
     disallowedTools:
     - Edit
     - NotebookEdit
@@ -85,6 +95,8 @@ agents:
     description: Structural NIH pattern scanner. Uses Serena MCP and ast-grep to find code that reinvents well-known library functionality. Returns JSON candidate list (~2 KB digest) with usage counts and categories. Does not judge — the orchestrator scores and filters. Suitable as an easy-cheese fork target when /age needs evidence on the NIH dimension.
     models:
       claude: sonnet
+      codex: gpt-5-codex
+      cursor: claude-sonnet
     disallowedTools:
     - Edit
     - Write
@@ -99,6 +111,8 @@ agents:
     description: Code simplification and distillation agent. Strips genAI bloat, speculative abstractions, and unnecessary documentation. Produces a simplification report categorized by DELETE, INLINE, UNDOCUMENT, and DECOUPLE with 0-100 confidence scoring. Analysis and detection only — never adds code (de-slop runs in scan mode, not auto-fix).
     models:
       claude: sonnet
+      codex: gpt-5-codex
+      cursor: claude-sonnet
     tools:
     - Read
     - Grep
@@ -114,6 +128,8 @@ agents:
     description: Writes and executes unit, integration, or other tests for new or modified code. Use PROACTIVELY to validate code functionality and find bugs. Adversarial approach with 0-100 confidence scoring per finding.
     models:
       claude: haiku
+      codex: gpt-5-mini
+      cursor: claude-haiku
     tools:
     - Read
     - Write
@@ -129,6 +145,7 @@ agents:
     models:
       claude: haiku
       codex: gpt-5-mini
+      cursor: claude-haiku
     tools:
     - Bash
     - Read
@@ -146,6 +163,8 @@ agents:
     description: Runs existing tests and returns only failures and summary counts (~2 KB digest). Use this agent to validate code without flooding the parent context with verbose test output. Fits easy-cheese's small/fast read-only sub-agent contract — call from /cook taste-test, /press, or /cure post-fix to gate the next step on test pass. Does NOT write tests.
     models:
       claude: haiku
+      codex: gpt-5-mini
+      cursor: claude-haiku
     tools:
     - Bash
     - Read
@@ -158,6 +177,8 @@ agents:
     description: Analyzes WARN/DIRTY worktrees to recommend keep, archive, or remove. Checks commit content, diffs, PR status, and staleness to make informed triage decisions. Interviews the user on DIRTY worktrees with unique changes.
     models:
       claude: sonnet
+      codex: gpt-5-codex
+      cursor: claude-sonnet
     tools:
     - Bash
     - Read

--- a/agents/registry.yaml
+++ b/agents/registry.yaml
@@ -125,7 +125,7 @@ agents:
     - scout
     body_path: agents/agent_definitions/roquefort-wrecker.md
   duckdb-expert:
-    description: Read-only DuckDB analyst for the coding-agent session-analytics database. Spawned with ONE analytics pack pointer (skills/<skill>/references/<domain>.md) plus a target and a harness filter; runs that single domain's queries and returns one structured ~2 KB digest. Reads queries from the caller's pack and the canonical schema from session-analytics. Built for context isolation — consumer skills fan out one parallel spawn per owned domain. Used by skill-improver, tool-efficiency, prompts, and work-recovery.
+    description: Read-only DuckDB analyst for the coding-agent session-analytics database. Spawned with ONE analytics pack pointer (skills/<skill>/references/<domain>.md) plus a target and a harness filter; runs that single domain's queries and returns one structured ~2 KB digest. Reads queries from the caller's pack and the canonical schema from session-analytics. Built for context isolation — consumer skills fan out one parallel spawn per owned domain. Used by skill-improver, tool-efficiency, prompt-analytics, and work-recovery.
     models:
       claude: haiku
       codex: gpt-5-mini

--- a/chezmoi/dot_serena/modify_serena_config.yml
+++ b/chezmoi/dot_serena/modify_serena_config.yml
@@ -6,13 +6,17 @@
 # Source-of-truth defaults are Serena's. We only override:
 #   web_dashboard                 → false  (no auto-browser tab)
 #   web_dashboard_open_on_launch  → false  (and no tray icon noise)
-#   excluded_tools                → memory + onboarding tools
+#   excluded_tools                → memory + onboarding + initial_instructions tools
 #       Rationale: Serena's parallel memory system (~/.serena/memories/)
 #       collides with our MEMORY.md auto-memory under
 #       ~/.claude/projects/-Users-paul-Dev-dotfiles/memory/. Scope serena
 #       to its LSP-grounded retrieval + symbol-edit surface only.
 #       `onboarding` exists solely to bootstrap memory files, so it goes
-#       with the rest.
+#       with the rest. `initial_instructions` is excluded too: the
+#       connection_prompt prods the model to call it, the claude-code
+#       context doesn't strip it, and it fails on an ungranted permission
+#       ~88% of the time (serena's own agent/oaicompat-agent contexts
+#       already exclude it).
 
 set -eu
 
@@ -81,6 +85,7 @@ printf '%s' "$existing" | yq '
         "delete_memory",
         "rename_memory",
         "edit_memory",
-        "onboarding"
+        "onboarding",
+        "initial_instructions"
     ]
 '

--- a/skills/prompt-analytics/SKILL.md
+++ b/skills/prompt-analytics/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: prompts
+name: prompt-analytics
 model: opus
 effort: high
 description: >
@@ -7,7 +7,7 @@ description: >
   produce calibrated recommendations — prompt-pattern analysis, routing accuracy,
   and knowledge gaps. Use when the user says "analyze my prompts", "prompt
   patterns", "is routing working", "which skill should have fired", "knowledge
-  gaps", "what do I keep asking", or invokes /prompts. Do NOT use for auditing a
+  gaps", "what do I keep asking", or invokes /prompt-analytics. Do NOT use for auditing a
   single skill/agent definition (that is /skill-improver), tool/MCP efficiency
   (that is /tool-efficiency), or one-off interactive log queries (that is
   /session-analytics).
@@ -44,7 +44,7 @@ Three analytics packs under `references/`:
    (one-domain-per-spawn):
 
    ```
-   spawn duckdb-expert "Run analytics pack prompts/references/<domain>.md for target {TARGET}. harness={HARNESS}"
+   spawn duckdb-expert "Run analytics pack prompt-analytics/references/<domain>.md for target {TARGET}. harness={HARNESS}"
    ```
 
 3. **Collect** the digests.

--- a/skills/prompt-analytics/references/knowledge-gaps.md
+++ b/skills/prompt-analytics/references/knowledge-gaps.md
@@ -4,7 +4,7 @@
 
 # harness: respects harness=<all|claude|codex|opencode>
 
-# owner: prompts
+# owner: prompt-analytics
 
 # signal: MEDIUM — a recurring topic is not proof of a missing capability
 

--- a/skills/prompt-analytics/references/prompt-analysis.md
+++ b/skills/prompt-analytics/references/prompt-analysis.md
@@ -4,7 +4,7 @@
 
 # harness: respects harness=<all|claude|codex|opencode>
 
-# owner: prompts
+# owner: prompt-analytics
 
 Recurring user-prompt shapes, repeated asks, and session openers. A "user
 prompt" is a user message whose content is plain text (not a tool_result

--- a/skills/prompt-analytics/references/routing-accuracy.md
+++ b/skills/prompt-analytics/references/routing-accuracy.md
@@ -4,7 +4,7 @@
 
 # harness: respects harness; skill_invocations is claude-dominant
 
-# owner: prompts
+# owner: prompt-analytics
 
 # signal: LOW — no intent ground-truth. Findings are correlational at most
 

--- a/skills/session-analytics/SKILL.md
+++ b/skills/session-analytics/SKILL.md
@@ -20,7 +20,7 @@ This skill is **two things**:
 1. **An interactive query tool** (you, inline) — translate a user question into
    SQL and answer it. The catalog below covers the common cases.
 2. **A data layer** for the analytics platform — a multi-harness ingest plus a
-   canonical schema that consumer skills (`skill-improver`, `prompts`,
+   canonical schema that consumer skills (`skill-improver`, `prompt-analytics`,
    `tool-efficiency`, `work-recovery`) query through their own domain *packs*,
    fanned out via the `duckdb-expert` agent (one spawn per domain).
 

--- a/skills/session-analytics/references/calibration.md
+++ b/skills/session-analytics/references/calibration.md
@@ -1,7 +1,7 @@
 # Calibration — Shared Reference
 
 **Shared by every judgment skill in the analytics platform.** `skill-improver`,
-`prompts`, and `tool-efficiency` import this one file rather than each redefining
+`prompt-analytics`, and `tool-efficiency` import this one file rather than each redefining
 confidence/severity; `work-recovery` is report-only and does not score. Origin:
 PR #212 (qualitative model over 0-100 scoring).
 

--- a/skills/tool-efficiency/SKILL.md
+++ b/skills/tool-efficiency/SKILL.md
@@ -5,12 +5,13 @@ effort: high
 description: >
   Audit how a tool, command, or MCP server is actually used across coding-agent
   sessions and produce calibrated recommendations — tool-vs-task fit, error
-  forensics, permission friction, MCP health, and token economics. Use when the
-  user says "tool efficiency", "am I using X efficiently", "audit tool usage",
-  "why does X keep failing", "permission friction", "is this MCP worth it",
-  "tool error rate", or invokes /tool-efficiency. Do NOT use for auditing a skill
-  or agent definition (that is /skill-improver) or for one-off interactive log
-  queries (that is /session-analytics).
+  forensics, fix recommendations, permission friction, MCP health, and token
+  economics. Use when the user says "tool efficiency", "am I using X
+  efficiently", "audit tool usage", "why does X keep failing", "how do I fix
+  this error", "what should I change", "permission friction", "is this MCP worth
+  it", "tool error rate", "fix recommendations", or invokes /tool-efficiency. Do
+  NOT use for auditing a skill or agent definition (that is /skill-improver) or
+  for one-off interactive log queries (that is /session-analytics).
 allowed-tools: Read, Agent, Bash
 ---
 
@@ -28,12 +29,13 @@ harness filter (`all` default, or `claude`/`codex`/`opencode`).
 
 ## Owned domains
 
-This skill owns five analytics packs under `references/`:
+This skill owns six analytics packs under `references/`:
 
 | Domain | Pack | What it surfaces |
 |--------|------|------------------|
 | tool-usage | `tool-usage.md` | Frequency, project spread, tool-vs-task fit |
 | error-forensics | `error-forensics.md` | Error rate vs baseline, recurring failures |
+| fix-recommendations | `fix-recommendations.md` | Turns errors/friction into concrete fixes (allowlist adds, tool swaps, MCP repair/retire) — advisory only |
 | permission-friction | `permission-friction.md` | Denials, allowlist gaps, compound-command friction |
 | mcp-health | `mcp-health.md` | Per-MCP call volume, error rate, idle servers |
 | token-economics | `token-economics.md` | Token/cost where logged — degrades to "insufficient signal" |
@@ -50,8 +52,9 @@ This skill owns five analytics packs under `references/`:
    ```
 
    Pick the domains that fit the target: MCP targets → `mcp-health` +
-   `error-forensics`; a Bash command → `tool-usage` + `permission-friction` +
-   `error-forensics`; broad audit → all five.
+   `error-forensics` + `fix-recommendations`; a Bash command → `tool-usage` +
+   `permission-friction` + `error-forensics`; "how do I fix X" / high error rate
+   → `error-forensics` + `fix-recommendations`; broad audit → all six.
 3. **Collect** the ~2 KB digests.
 4. **Calibrate** each finding with the shared model in
    `../session-analytics/references/calibration.md` — confidence
@@ -85,7 +88,10 @@ N findings were `<don't know>` or insufficient-signal (not shown).
 - Score with a 0-100 number — it uses the shared qualitative model.
 - Surface `<don't know>` findings or fabricate when a domain returns empty.
 - Run more than one domain per `duckdb-expert` spawn.
-- Modify tools, settings, or allowlists — it recommends; the human decides.
+- Modify tools, settings, or allowlists — it recommends; the human decides. The
+  `fix-recommendations` domain names the fix (allowlist entry, tool swap, MCP
+  retirement); it never applies it. Hand the surfaced fixes to `/cure` or
+  `/settings-clean` if the user wants them applied.
 
 ## Gotchas
 

--- a/skills/tool-efficiency/references/fix-recommendations.md
+++ b/skills/tool-efficiency/references/fix-recommendations.md
@@ -1,0 +1,111 @@
+# Pack: fix-recommendations
+
+# target_param: {TOOL}        (a tool name; '%' to scan all tools)
+
+# harness: allowlist/denial queries are claude-dominant; tool-error queries span all harnesses
+
+# owner: tool-efficiency
+
+Turns the raw error/friction signal into concrete, actionable fixes for `{TOOL}`
+— allowlist entries to add, raw-bash to route to a dedicated tool, and MCP
+servers to repair or retire. Advisory only: it recommends the fix, it never
+applies it. Run by `duckdb-expert`, one spawn. Schema:
+`skills/session-analytics/references/canonical-schema.md`.
+
+> Denials and allowlist gaps are recorded almost exclusively for claude. On a
+> codex/opencode filter, expect those sections empty — report "insufficient
+> signal", not "nothing to fix". The high-error-tool and MCP queries span all
+> harnesses.
+
+## 1. High-error tools — swap or fix the call shape
+
+Tools failing ≥40% of the time with ≥3 calls. A 100% rate usually means a
+malformed/stale tool name (e.g. `tilth_read` instead of `mcp__tilth__tilth_read`).
+
+```sql
+SELECT tu.tool_name, count(*) AS calls,
+       sum(CASE WHEN tr.is_error='true' THEN 1 ELSE 0 END) AS errors,
+       round(sum(CASE WHEN tr.is_error='true' THEN 1 ELSE 0 END)*100.0/count(*),1) AS error_pct
+FROM tool_uses tu JOIN tool_results tr ON tu.tool_use_id = tr.tool_use_id
+WHERE tu.tool_name LIKE '{TOOL}'
+GROUP BY tu.tool_name
+HAVING count(*) >= 3
+   AND sum(CASE WHEN tr.is_error='true' THEN 1 ELSE 0 END)*100.0/count(*) >= 40
+ORDER BY error_pct DESC, calls DESC LIMIT 15;
+```
+
+## 2. Allowlist adds (high-use prefixes that keep getting denied)
+
+```sql
+SELECT split_part(bash_cmd, ' ', 1) AS cmd_prefix, count(*) AS uses,
+       sum(CASE WHEN tr.is_error='true' AND tr.content LIKE 'Permission%' THEN 1 ELSE 0 END) AS denied
+FROM tool_uses tu JOIN tool_results tr ON tu.tool_use_id = tr.tool_use_id
+WHERE tu.tool_name = 'Bash' AND tu.bash_cmd IS NOT NULL
+GROUP BY cmd_prefix
+HAVING sum(CASE WHEN tr.is_error='true' AND tr.content LIKE 'Permission%' THEN 1 ELSE 0 END) >= 2
+ORDER BY denied DESC LIMIT 15;
+```
+
+→ For each row, recommend `Bash(<prefix>:*)` in the allowlist (only when the
+prefix is a safe, read-mostly command — never blanket-allow destructive verbs).
+
+## 3. Raw-bash that should route to a dedicated tool/skill
+
+```sql
+SELECT
+    CASE
+        WHEN bash_cmd LIKE 'find %' OR bash_cmd LIKE '% find %' THEN 'find -> Glob / cheez-search'
+        WHEN bash_cmd LIKE 'grep %' OR bash_cmd LIKE 'egrep %' OR bash_cmd LIKE 'rg %' THEN 'grep/rg -> cheez-search'
+        WHEN bash_cmd LIKE 'cat %' AND bash_cmd NOT LIKE '%>%' THEN 'cat -> cheez-read'
+        WHEN bash_cmd LIKE 'sed %' OR bash_cmd LIKE '%sed -i%' THEN 'sed -> cheez-write / Edit'
+        WHEN bash_cmd LIKE '%python3%json%' THEN 'python3 json -> jq'
+        WHEN bash_cmd LIKE '%git add%' AND bash_cmd LIKE '%git commit%' THEN 'git add+commit -> /commit'
+        ELSE NULL
+    END AS swap,
+    count(*) AS uses
+FROM tool_uses tu
+WHERE tu.tool_name = 'Bash' AND tu.bash_cmd IS NOT NULL
+GROUP BY swap HAVING swap IS NOT NULL
+ORDER BY uses DESC;
+```
+
+## 4. MCP servers — repair (high error) or retire (idle)
+
+```sql
+SELECT split_part(mc.tool_name, '__', 2) AS server,
+       count(*) AS calls,
+       sum(CASE WHEN tr.is_error='true' THEN 1 ELSE 0 END) AS errors,
+       round(sum(CASE WHEN tr.is_error='true' THEN 1 ELSE 0 END)*100.0/count(*),1) AS error_pct
+FROM mcp_calls mc JOIN tool_results tr ON mc.tool_use_id = tr.tool_use_id
+GROUP BY server ORDER BY error_pct DESC, calls ASC LIMIT 20;
+```
+
+→ High error_pct = repair candidate (broken call shape / dead server). Very low
+`calls` across all sessions = retire candidate (paying context cost for nothing).
+
+## Output Format
+
+```
+## Fix Recommendations: {TOOL}
+
+### Swap / Fix Call Shape (high-error tools)
+| Tool | Calls | Errors | Error % | Suggested fix |
+|------|-------|--------|---------|---------------|
+
+### Allowlist Adds
+| Prefix | Uses | Denied | Suggested entry |
+|--------|------|--------|-----------------|
+
+### Route Raw-Bash to a Tool
+| Pattern | Uses | Route to |
+|---------|------|----------|
+
+### MCP Repair / Retire
+| Server | Calls | Error % | Action |
+|--------|-------|---------|--------|
+
+### Findings
+- Concrete, ranked fixes. Each cites the metric above.
+- "Insufficient signal" for any section with <2 supporting rows.
+- Advisory only — names the fix; the human applies it.
+```

--- a/skills/work-recovery/SKILL.md
+++ b/skills/work-recovery/SKILL.md
@@ -8,7 +8,7 @@ description: >
   session", "reconstruct where I left off", "resume my last session", "what did
   that session change", "rebuild context from logs", or invokes /work-recovery.
   Report-only — it never scores or judges. Do NOT use for usage scoring (that is
-  /skill-improver, /tool-efficiency, /prompts) or one-off interactive log queries
+  /skill-improver, /tool-efficiency, /prompt-analytics) or one-off interactive log queries
   (that is /session-analytics).
 allowed-tools: Read, Agent, Bash
 ---

--- a/tests/chezmoi-wiring.bats
+++ b/tests/chezmoi-wiring.bats
@@ -845,9 +845,9 @@ YAML
 
     [[ "$(yq '.web_dashboard'                 "$HOME/.serena/serena_config.yml")" == "false" ]]
     [[ "$(yq '.web_dashboard_open_on_launch'  "$HOME/.serena/serena_config.yml")" == "false" ]]
-    # excluded_tools is overridden with the managed memory + onboarding list,
-    # replacing whatever was there (here: ["some_tool"]).
-    [[ "$(yq '.excluded_tools | length'       "$HOME/.serena/serena_config.yml")" == "7" ]]
+    # excluded_tools is overridden with the managed memory + onboarding +
+    # initial_instructions list, replacing whatever was there (here: ["some_tool"]).
+    [[ "$(yq '.excluded_tools | length'       "$HOME/.serena/serena_config.yml")" == "8" ]]
     [[ "$(yq '.excluded_tools | .[0]'         "$HOME/.serena/serena_config.yml")" == "write_memory" ]]
     [[ "$(yq '.excluded_tools | contains(["onboarding"])' "$HOME/.serena/serena_config.yml")" == "true" ]]
     [[ "$(yq '.excluded_tools | contains(["some_tool"])'  "$HOME/.serena/serena_config.yml")" == "false" ]]

--- a/tests/serena-smoke.sh
+++ b/tests/serena-smoke.sh
@@ -2,7 +2,7 @@
 # Serena MCP smoke test — boots the real stdio server and asserts it:
 #   1. starts without a traceback,
 #   2. auto-detects a project from cwd,
-#   3. applies our chezmoi-managed excluded_tools (7 memory/onboarding tools),
+#   3. applies our chezmoi-managed excluded_tools (8 memory/onboarding tools),
 #   4. exposes the LSP edit/read toolset (find_symbol, replace_symbol_body).
 #
 # Run before pushing changes to the serena registry entry
@@ -80,9 +80,9 @@ assert() { # <extended-regex> <description>
 echo "serena smoke test:"
 assert "Starting Serena server"                  "boots without crashing"
 assert "Auto-detected project root:"             "auto-detects project from cwd"
-# Count 7 proves OUR excluded_tools is live — serena ships excluded_tools: [].
-assert "excluded 7 tools:.*write_memory"         "applies managed excluded_tools (memory)"
-assert "excluded 7 tools:.*onboarding"           "  ↳ onboarding excluded too"
+# Count 8 proves OUR excluded_tools is live — serena ships excluded_tools: [].
+assert "excluded 8 tools:.*write_memory"         "applies managed excluded_tools (memory)"
+assert "excluded 8 tools:.*onboarding"           "  ↳ onboarding excluded too"
 assert "Exposed tools:.*find_symbol"             "exposes find_symbol"
 assert "Exposed tools:.*replace_symbol_body"     "exposes replace_symbol_body"
 


### PR DESCRIPTION
## Analytics skills

- Rename the `/prompts` skill to `/prompt-analytics` (SKILL.md + 3 references), updating cross-references in session-analytics, calibration, work-recovery, and `agents/registry.yaml`.
- Add an advisory-only `fix-recommendations` domain to `/tool-efficiency` — the 6th domain, backed by 4 validated DuckDB queries, read-only. It names fixes and hands application off to `/cure` or `/settings-clean` rather than applying them itself.

## Serena fix

- Exclude the `initial_instructions` tool in the serena config template. It failed ~88% of the time (15/17 calls) on an ungranted permission: serena's `connection_prompt` prods the model to call it and the claude-code context doesn't strip the tool. This matches the exclusion serena's own agent/oaicompat-agent contexts already apply.

Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)