### PR TITLE
feat(ap): register global MCPs at user scope for claude

### DIFF
--- a/agent-profile/agent_profile/cli.py
+++ b/agent-profile/agent_profile/cli.py
@@ -413,6 +413,7 @@ def cmd_uninstall(
         commands=merged.get("commands", []),
         hooks=merged.get("hooks", []),
         settings=merged.get("settings", {}),
+        mcp_scope=merged.get("mcp_scope", "plugin"),
     )
 
     for h in ALL_HARNESSES:

--- a/agent-profile/agent_profile/parse.py
+++ b/agent-profile/agent_profile/parse.py
@@ -151,6 +151,13 @@ def parse_one(profile_dir: Path) -> dict[str, Any]:
         if s:
             _validate_relpath("script", str(s), str(manifest_path))
 
+    scope = raw.get("mcp_scope")
+    if scope is not None and scope not in ("plugin", "user"):
+        raise ParseError(
+            f"ap_parse_one: {manifest_path} has invalid mcp_scope "
+            f"{scope!r} (expected 'plugin' or 'user')"
+        )
+
     sd = str(profile_dir)
 
     def _decorate(items: list[Any]) -> list[dict[str, Any]]:

--- a/agent-profile/agent_profile/parse.py
+++ b/agent-profile/agent_profile/parse.py
@@ -77,6 +77,14 @@ class Manifest:
     # expand at use-time, not parse-time.
     target_default: str | None = None
     marketplaces: dict[str, str] = field(default_factory=dict)
+    # MCP registration scope (claude renderer only). ``"plugin"`` (default)
+    # writes the bundled plugin's ``.mcp.json`` (plugin-scoped tool names
+    # ``mcp__plugin_<profile>_<server>__*``). ``"user"`` registers each
+    # server at user scope via ``claude mcp add --scope user`` (bare tool
+    # names ``mcp__<server>__*``) and skips the plugin ``.mcp.json``. Other
+    # harnesses already write a single bare user-level config and ignore
+    # this field. Outer-profile only, like the install fields above.
+    mcp_scope: str = "plugin"
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize to the same JSON shape parse.sh emits (used for the
@@ -90,6 +98,7 @@ class Manifest:
             "settings": self.settings,
             "name": self.name,
             "description": self.description,
+            "mcp_scope": self.mcp_scope,
         }
 
 
@@ -176,6 +185,7 @@ def parse_one(profile_dir: Path) -> dict[str, Any]:
         "extra_args": list(raw.get("extra_args") or []),
         "target_default": raw.get("target_default") or None,
         "marketplaces": dict(raw.get("marketplaces") or {}),
+        "mcp_scope": raw.get("mcp_scope") or "plugin",
         # Registry-derived items come first; inline items append (matching
         # the include "outer last" convention so an inline override on a
         # name-collision wins on scalar/object merges downstream).
@@ -302,6 +312,7 @@ def _parse_with_includes(
         "extra_args",
         "target_default",
         "marketplaces",
+        "mcp_scope",
     ):
         merged[key] = self_[key]
     return merged
@@ -340,4 +351,5 @@ def parse_manifest(profile_dir: Path, find_profile_dir: Any = None) -> Manifest:
         extra_args=merged["extra_args"],
         target_default=merged["target_default"],
         marketplaces=merged["marketplaces"],
+        mcp_scope=merged["mcp_scope"],
     )

--- a/agent-profile/agent_profile/renderers/claude.py
+++ b/agent-profile/agent_profile/renderers/claude.py
@@ -33,6 +33,7 @@ import json
 import os
 import shutil
 import stat
+import subprocess
 from pathlib import Path
 
 from agent_profile import shared
@@ -116,6 +117,8 @@ class ClaudeRenderer:
         entries (mirroring how :class:`OpencodeRenderer.clean` un-merges
         ``opencode.json``)."""
         base = Path(str(target).rstrip("/"))
+        if manifest.mcp_scope == "user":
+            self._unregister_user_mcps(manifest)
         self._clean_local_marketplace(base, manifest.name)
         settings = base / ".claude" / "settings.json"
         if not settings.is_file():
@@ -336,10 +339,72 @@ class ClaudeRenderer:
         mine = mcps_for(manifest, "claude", _MCP_DEFAULT)
         if not mine:
             return
+        if manifest.mcp_scope == "user":
+            # User-scope install (the `global` profile): register each server
+            # via `claude mcp add --scope user` so the tool names stay bare
+            # (`mcp__<server>__*`) and land in ~/.claude.json. No plugin
+            # .mcp.json is written, so its file is dropped from the install
+            # manifest and swept on the next render.
+            self._register_user_mcps(mine)
+            return
         servers = {mcp["name"]: mcp_server_entry(mcp) for mcp in mine}
         out_path = plugin_dir / ".mcp.json"
         _dump_json(out_path, {"mcpServers": servers})
         self._track(out, base, out_path)
+
+    @staticmethod
+    def _claude_cli() -> str:
+        """Resolve the ``claude`` CLI used for user-scope MCP registration.
+
+        Fail loud when absent: a user-scope render targets the live
+        ``~/.claude.json``, which only the CLI writes safely, so silently
+        skipping would leave the MCPs unregistered."""
+        cli = shutil.which("claude")
+        if cli is None:
+            raise FileNotFoundError(
+                "claude_render: mcp_scope='user' needs the `claude` CLI on "
+                "PATH to register MCP servers at user scope, but it was not "
+                "found."
+            )
+        return cli
+
+    def _register_user_mcps(self, mcps: list[dict]) -> None:
+        """Register each MCP at user scope via the ``claude`` CLI.
+
+        ``remove`` then ``add`` per server makes re-runs idempotent (``add``
+        errors on a duplicate name). ``${VAR}`` refs in env values are passed
+        through literally — the CLI stores them verbatim and Claude expands
+        them at runtime, so secrets stay in ``.env`` and never land in
+        ``~/.claude.json``."""
+        cli = self._claude_cli()
+        for mcp in mcps:
+            name = mcp["name"]
+            entry = mcp_server_entry(mcp)
+            subprocess.run(
+                [cli, "mcp", "remove", name, "--scope", "user"],
+                capture_output=True,
+                check=False,
+            )
+            cmd = [cli, "mcp", "add", name, "--scope", "user"]
+            for key, val in (entry.get("env") or {}).items():
+                cmd += ["-e", f"{key}={val}"]
+            cmd += ["--", entry["command"], *entry.get("args", [])]
+            subprocess.run(cmd, check=True)
+
+    def _unregister_user_mcps(self, manifest: Manifest) -> None:
+        """Remove this profile's user-scope MCP registrations (clean path)."""
+        mine = mcps_for(manifest, "claude", _MCP_DEFAULT)
+        if not mine:
+            return
+        cli = shutil.which("claude")
+        if cli is None:
+            return
+        for mcp in mine:
+            subprocess.run(
+                [cli, "mcp", "remove", mcp["name"], "--scope", "user"],
+                capture_output=True,
+                check=False,
+            )
 
     def _write_settings(
         self,

--- a/agent-profile/agent_profile/renderers/claude.py
+++ b/agent-profile/agent_profile/renderers/claude.py
@@ -392,13 +392,16 @@ class ClaudeRenderer:
             subprocess.run(cmd, check=True)
 
     def _unregister_user_mcps(self, manifest: Manifest) -> None:
-        """Remove this profile's user-scope MCP registrations (clean path)."""
+        """Remove this profile's user-scope MCP registrations (clean path).
+
+        Fail loud when the ``claude`` CLI is absent — parity with the render
+        path. The registrations live in the live ``~/.claude.json`` that only
+        the CLI edits safely; returning silently would leave them behind while
+        clean reports success."""
         mine = mcps_for(manifest, "claude", _MCP_DEFAULT)
         if not mine:
             return
-        cli = shutil.which("claude")
-        if cli is None:
-            return
+        cli = self._claude_cli()
         for mcp in mine:
             subprocess.run(
                 [cli, "mcp", "remove", mcp["name"], "--scope", "user"],

--- a/agent-profile/tests/test_core.py
+++ b/agent-profile/tests/test_core.py
@@ -119,6 +119,24 @@ def test_parse_one_skill_path_traversal_fails(env):
         parse_one(env.profiles / "skilltraverse")
 
 
+def test_parse_one_invalid_mcp_scope_fails(env):
+    # A typo like `mcp_scope: usr` must fail loud, not silently fall through
+    # to plugin behavior (the renderer only matches exactly "user").
+    write_profile(env.profiles, "badscope", "name: badscope\nmcp_scope: usr\n")
+    with pytest.raises(ParseError, match="invalid mcp_scope"):
+        parse_one(env.profiles / "badscope")
+
+
+def test_parse_one_valid_mcp_scopes_pass(env):
+    write_profile(env.profiles, "userscope", "name: userscope\nmcp_scope: user\n")
+    assert parse_one(env.profiles / "userscope")["mcp_scope"] == "user"
+    write_profile(env.profiles, "pluginscope", "name: pluginscope\nmcp_scope: plugin\n")
+    assert parse_one(env.profiles / "pluginscope")["mcp_scope"] == "plugin"
+    # Absent -> defaults to plugin.
+    write_profile(env.profiles, "noscope", "name: noscope\n")
+    assert parse_one(env.profiles / "noscope")["mcp_scope"] == "plugin"
+
+
 def test_parse_one_dots_substring_name_passes(env):
     # 'a..b' has a '..' substring but no '..' path *component* — must pass.
     write_profile(

--- a/agent-profile/tests/test_renderer_claude.py
+++ b/agent-profile/tests/test_renderer_claude.py
@@ -22,6 +22,7 @@ Two profiles cover the renderer's surface:
 from __future__ import annotations
 
 import json
+import os
 import stat
 from pathlib import Path
 
@@ -712,3 +713,81 @@ def test_render_is_idempotent_on_rerun(env):
     }
     assert first == second
     assert snapshot == after
+
+
+# ─── user-scope MCP registration (mcp_scope: user) ───────────────────
+
+_MCPTEST_USER_YAML = """\
+name: mcpuser
+description: user-scope mcp registration
+mcp_scope: user
+mcps:
+  - name: context7
+    command: npx
+    args: ["-y", "@upstash/context7-mcp"]
+    env:
+      KEY: VAL
+    harnesses: [claude, codex]
+  - name: codexonly
+    command: foo
+    harnesses: [codex]
+"""
+
+
+def _install_fake_claude(tmp_path: Path, monkeypatch) -> Path:
+    """Put a fake ``claude`` binary first on PATH that logs each invocation's
+    args (one line per call) to a file, and returns that log path."""
+    bindir = tmp_path / "fakebin"
+    bindir.mkdir()
+    log = tmp_path / "claude-calls.log"
+    shim = bindir / "claude"
+    shim.write_text(
+        '#!/bin/sh\nprintf "%s\\n" "$*" >> "$AP_TEST_CLAUDE_LOG"\nexit 0\n'
+    )
+    shim.chmod(shim.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    monkeypatch.setenv("AP_TEST_CLAUDE_LOG", str(log))
+    monkeypatch.setenv("PATH", f"{bindir}:{os.environ['PATH']}")
+    return log
+
+
+def test_user_scope_skips_plugin_mcp_json(env, monkeypatch):
+    _install_fake_claude(env.tmp, monkeypatch)
+    profile_dir = write_profile(env.profiles, "mcpuser", _MCPTEST_USER_YAML)
+    manifest = parse_manifest(profile_dir)
+    assert manifest.mcp_scope == "user"
+    written = ClaudeRenderer().render(manifest, env.target)
+    # No plugin .mcp.json, and it is not tracked in the install manifest.
+    assert not (
+        env.target / ".claude/plugins/local/mcpuser/.mcp.json"
+    ).exists()
+    assert not any(".mcp.json" in w for w in written)
+
+
+def test_user_scope_registers_bare_via_cli(env, monkeypatch):
+    log = _install_fake_claude(env.tmp, monkeypatch)
+    profile_dir = write_profile(env.profiles, "mcpuser", _MCPTEST_USER_YAML)
+    ClaudeRenderer().render(parse_manifest(profile_dir), env.target)
+    lines = log.read_text().splitlines()
+    # remove-then-add per server, idempotent; context7 only (codexonly dropped).
+    assert lines == [
+        "mcp remove context7 --scope user",
+        "mcp add context7 --scope user -e KEY=VAL -- npx -y @upstash/context7-mcp",
+    ]
+
+
+def test_user_scope_clean_removes_via_cli(env, monkeypatch):
+    log = _install_fake_claude(env.tmp, monkeypatch)
+    profile_dir = write_profile(env.profiles, "mcpuser", _MCPTEST_USER_YAML)
+    manifest = parse_manifest(profile_dir)
+    ClaudeRenderer().clean(manifest, env.target)
+    assert "mcp remove context7 --scope user" in log.read_text().splitlines()
+
+
+def test_user_scope_missing_cli_fails_loud(env, monkeypatch):
+    # PATH with no `claude` -> user-scope render must raise, not silently skip.
+    emptybin = env.tmp / "emptybin"
+    emptybin.mkdir()
+    monkeypatch.setenv("PATH", str(emptybin))
+    profile_dir = write_profile(env.profiles, "mcpuser", _MCPTEST_USER_YAML)
+    with pytest.raises(FileNotFoundError):
+        ClaudeRenderer().render(parse_manifest(profile_dir), env.target)

--- a/agent-profile/tests/test_renderer_claude.py
+++ b/agent-profile/tests/test_renderer_claude.py
@@ -791,3 +791,14 @@ def test_user_scope_missing_cli_fails_loud(env, monkeypatch):
     profile_dir = write_profile(env.profiles, "mcpuser", _MCPTEST_USER_YAML)
     with pytest.raises(FileNotFoundError):
         ClaudeRenderer().render(parse_manifest(profile_dir), env.target)
+
+
+def test_user_scope_clean_missing_cli_fails_loud(env, monkeypatch):
+    # Clean must fail loud too — a silent return would report success while
+    # leaving the user-scope registrations behind in ~/.claude.json.
+    emptybin = env.tmp / "emptybin"
+    emptybin.mkdir()
+    monkeypatch.setenv("PATH", str(emptybin))
+    profile_dir = write_profile(env.profiles, "mcpuser", _MCPTEST_USER_YAML)
+    with pytest.raises(FileNotFoundError):
+        ClaudeRenderer().clean(parse_manifest(profile_dir), env.target)

--- a/profiles/global/profile.yaml
+++ b/profiles/global/profile.yaml
@@ -57,3 +57,16 @@ marketplaces:
 # entry must match — if you rename this profile, update both.
 enabled_plugins:
   global@local: true
+
+# mcp_scope (claude only — other harnesses already write a single bare
+# user-level config and ignore this). "user" makes the claude renderer
+# register each MCP via `claude mcp add --scope user` (into ~/.claude.json,
+# bare tool names `mcp__<server>__*`) instead of writing the plugin's
+# .mcp.json (which produces plugin-scoped names
+# `mcp__plugin_global_<server>__*`). The plugin tree is still rendered +
+# enabled above — it carries the skills, commands, hooks, and agents; only
+# MCP registration moves to user scope. Bare names mean the existing
+# settings.json allowlist matches with no per-plugin namespacing. Default
+# elsewhere is "plugin" (closed-world / staged renders keep their bundled
+# .mcp.json).
+mcp_scope: user


### PR DESCRIPTION
## What

Makes `ap` register the `global` profile's MCPs at **claude user scope** (`~/.claude.json`, bare tool names `mcp__<server>__*`) instead of writing the bundled plugin's `.mcp.json` (plugin-scoped names `mcp__plugin_global_<server>__*`).

Adds an outer-profile **`mcp_scope`** field (default `"plugin"`); `profiles/global/profile.yaml` sets `mcp_scope: user`. The claude renderer branches on it:

- `user` → `claude mcp remove <name> --scope user` then `claude mcp add <name> --scope user [-e K=V ...] -- <cmd> <args>` per server (idempotent), and writes **no** plugin `.mcp.json`.
- `plugin` (everything else — staged/isolated/closed-world renders) → unchanged.

## Why

The plugin route produced `mcp__plugin_global_*` tool names that don't match the bare-name `settings.json` allowlist, causing per-session permission prompts after the recent MCP dedup. User scope restores bare names → the existing allowlist matches with **no per-plugin namespacing** and no allowlist widening.

This is the root-cause fix for the dedup follow-up: same single-registration invariant, on the surface the allowlist already expects.

## Notes

- **Secrets safe**: `${VAR}` env refs pass through literally — verified the CLI stores `${CONTEXT7_API_KEY}` verbatim in `~/.claude.json` (expanded at runtime), so nothing is baked.
- **Plugin tree stays**: it still carries skills/commands/hooks/agents and remains enabled; only MCP registration moves out. The orphaned `.mcp.json` is swept by `diff_and_clean` on the next install.
- **claude-only**: codex/opencode/cursor/copilot already write a single bare user-level config and ignore `mcp_scope`.
- Fail-loud if the `claude` CLI is absent in user-scope mode (the live `~/.claude.json` is only safely written by the CLI).

## Tests

4 new renderer tests (PATH-shimmed fake `claude`): skips plugin `.mcp.json`, registers bare via remove-then-add, `clean` un-registers, fail-loud when CLI missing. Full ap suite green (423 passed).

## Rollout

After merge + `dots sync`: the 7 base MCPs land in `~/.claude.json` user scope, the plugin `.mcp.json` is removed, restart Claude → bare names match the allowlist → zero prompts. The previously-blocked allowlist-twin edit is dropped (no longer needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)