### PR TITLE
feat(hooks): add git-guard PreToolUse hook — block destructive git ops against a dirty tree

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,20 +230,34 @@ hooks:
 
 **Per-entry fields:**
 
-- `event` — Claude / Codex event name. Only `SessionStart` is currently wired; the backends in `agents/hooks/lib.sh` fail loud on any other value. Extend the backends before registering `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, or `Stop` entries.
-- `script` — repo-relative path; chezmoi deploys to `~/.<harness>/hooks/<basename>`.
+- `event` — Claude / Codex event name. The supported set lives in `HOOK_EVENTS_VALID` (`agents/hooks/lib.sh`): `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `Stop`, `PermissionRequest` (claude-only). `hook_filter_for_harness` fails loud on anything else (catches typos like `evnt:`).
+- `script` — repo-relative path; chezmoi deploys to `~/.<harness>/hooks/<basename>`. Runs via the harness's shebang under `ap` (the live plugin-tree path) but is wrapped as `bash "<path>"` by the legacy `lib.sh` path — so a non-bash script (e.g. a Node hook) must ship as a `.sh` bridge that `exec`s its interpreter (see `git-guard.sh` → `lib/git-guard.js`), or it breaks under the legacy path.
 - `shared_assets` (optional) — list of repo-relative paths under `agents/<subdir>/<file>` that the hook script reads at runtime (libs, banks, …). Each is deployed to `~/.<harness>/<subdir>/<file>`. Adding a new hook is a pure registry edit — the chezmoi installer iterates `hooks` and copies every `(script ∪ shared_assets) × harnesses` pair.
 - `harnesses` (optional) — list; default `[claude, codex]`.
-- `matcher` — codex-only regex against the event's `source` field (`startup|resume|clear` for SessionStart). Claude SessionStart entries do not use matchers and the field is ignored there.
+- `matcher` — event- and harness-dependent (see `_hook_event_uses_matcher` in `lib.sh`). For `SessionStart` it is a codex-only regex against the event's `source` field (`startup|resume|clear`); claude ignores it. For `PreToolUse`/`PostToolUse` it is a tool-name regex written for **both** harnesses. Events that don't use a matcher drop the field on write.
 - `timeout` — seconds (verified against `developers.openai.com/codex/hooks` — "timeout is in seconds"; Claude uses the same unit).
 - `description` — human-readable purpose.
 
 **Workflow:**
 
 1. Edit registry: `hook-edit`
-2. Apply changes: `hook-sync` (= `dots profile install base`) or let `dots sync` drive it via chezmoi's `run_onchange_after_install-base-profile.sh.tmpl`. The hook + its `shared_assets` (lib/bank) deploy through `ap`'s claude/codex renderers, which copy the self-locating SessionStart script alongside its assets under the harness layout.
+2. Apply changes: `hook-sync` (= `dots profile install base`) or let `dots sync` drive it via chezmoi's `run_onchange_after_install-base-profile.sh.tmpl`. The hook + its `shared_assets` (lib/bank) deploy through `ap`'s claude/codex renderers, which copy the self-locating script alongside its assets under the harness layout.
 
 The hook script is self-locating: it resolves its lib and bank from `$SCRIPT_DIR/../lib` and `$SCRIPT_DIR/../reference`, so the same file runs identically under each harness. (The standalone `agents/hooks/sync.sh` lib remains for the legacy upsert path but no longer runs on `dots sync`.)
+
+### Cross-harness guards (`git-guard`)
+
+`git-guard` blocks destructive git ops that silently discard uncommitted work — `git checkout -- <path>` / `git checkout .` / `git checkout -f`, `git restore <path>`, `git reset --hard`, `git clean -f` — but **only** when the targeted paths actually have uncommitted changes (a clean tree has nothing to lose, so the op is allowed and the guard never nags). The classifier handles `sudo`/`env` prefixes, `-C`/`-c` global options, `--` pathspec separation, and `&&`/`||`/`;`/`|`/newline command segmentation. It is **fail-open everywhere**: a missing lib, absent `node`, malformed input, or a non-repo `cwd` always allows. Opt out for a session with `CLAUDE_GIT_GUARD=0`.
+
+One classifier (`agents/lib/git-guard.js`, exporting `shouldBlock(command, cwd)` + `denyReason`), five harness adapters that each call it — no detection logic is duplicated:
+
+| Harness | Mechanism | File(s) | Notes |
+|---------|-----------|---------|-------|
+| Claude | `PreToolUse` (matcher `Bash`) | `agents/hooks/git-guard.sh` + `agents/lib/git-guard.js`, registered in `agents/hooks/registry.yaml` | Deny = `hookSpecificOutput.permissionDecision: "deny"` on stdout. |
+| Codex | `PreToolUse` (matcher `Bash`) | same registry entry (`harnesses: [claude, codex]`) | Identical deny schema and shell tool (`Bash`, `tool_input.command`) — one script serves both (verified: developers.openai.com/codex/hooks). |
+| Cursor | `beforeShellExecution` | `cursor/plugins/local/cheese-grok/hooks/git-guard.sh` + `hooks.json` | Payload carries `.command` + `.cwd`; deny = exit 2. Resolves the shared lib via `$DOTFILES_DIR`. |
+| Copilot CLI | `preToolUse` (matcher `bash\|shell`) | `chezmoi/private_dot_copilot/hooks/executable_git-guard.sh` + `git-guard.json.tmpl` → `~/.copilot/hooks/` | `toolArgs` is a JSON *string* (double-parsed for `.command`); deny = `{permissionDecision:"deny",permissionDecisionReason:…}` on stdout, exit 0. Resolves the shared lib via `$DOTFILES_DIR`. |
+| opencode | plugin `tool.execute.before` (on the `bash` tool) | `chezmoi/dot_config/opencode/plugins/git-guard.js` → `~/.config/opencode/plugins/` | opencode has no shell-command *hook* like the others, but its plugin system fires `tool.execute.before` for every tool call. The plugin intercepts the `bash` tool and `throw`s on a destructive-dirty op (opencode's deny path). A static `permission.bash` pattern can't be used here — it would nag on a clean tree, the exact thing the guard avoids; only the plugin can run the `git status` dirty check. ESM plugin that `require()`s the shared CJS lib via `$DOTFILES_DIR`. |
 
 ## Plugin Management
 

--- a/agents/hooks/git-guard.sh
+++ b/agents/hooks/git-guard.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# PreToolUse hook: block destructive git ops (`git checkout -- <path>`,
+# `git restore`, `git reset --hard`, `git clean -f`, `git checkout .`/`-f`)
+# when the targeted paths have uncommitted changes. The detection logic lives
+# in the sibling Node module (lib/git-guard.js); this bridge exists so the
+# entry deploys as a `.sh` that runs correctly whether invoked directly via
+# shebang (the `ap` plugin-tree path) or as `bash <path>` (the legacy sync
+# path) — a `.js` script entry would break under the latter.
+#
+# Self-locating (same rationale as session-start-cheese-flair.sh): anchor to
+# the deployed path so the same file works under ~/.claude and the plugin
+# tree. `ap` deploys this script alongside lib/git-guard.js via the registry's
+# `shared_assets`.
+#
+# Fail-open: a missing logic file or absent node must never block a git op —
+# the guard hardens, it must not become a denial-of-service.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HARNESS_ROOT="$(dirname "$SCRIPT_DIR")"  # e.g. ~/.claude or the plugin root
+LOGIC="$HARNESS_ROOT/lib/git-guard.js"
+
+[[ -f "$LOGIC" ]] || exit 0
+command -v node >/dev/null 2>&1 || exit 0
+
+# exec so the PreToolUse stdin/stdout flow straight through to Node.
+exec node "$LOGIC"

--- a/agents/hooks/registry.yaml
+++ b/agents/hooks/registry.yaml
@@ -55,6 +55,31 @@ hooks:
     timeout: 5
     description: Rotating cheese flair sample injected at session start
 
+  # ─── Destructive-git protection ─────────────────────────────────────
+  # Blocks destructive git ops that silently discard uncommitted work —
+  # `git checkout -- <path>` / `git checkout .` / `git checkout -f`,
+  # `git restore <path>`, `git reset --hard`, `git clean -f` — but ONLY when
+  # the targeted paths actually have uncommitted changes (clean tree → never
+  # nags). The script dispatches on tool_name == Bash, so the matcher is just
+  # the shell tool, which is `Bash` for both Claude and Codex.
+  # Both harnesses share the identical PreToolUse deny schema
+  # (hookSpecificOutput.permissionDecision: "deny") and route shell through
+  # `tool_input.command` — one script serves both (verified against
+  # developers.openai.com/codex/hooks). Cursor + Copilot are covered
+  # separately (different mechanisms): a Cursor beforeShellExecution hook in
+  # cursor/plugins/local/cheese-grok, and a Copilot preToolUse hook under
+  # chezmoi/private_dot_copilot/hooks. opencode has no shell-command hook, so
+  # it is N/A (see AGENTS.md → Hook Management).
+  git-guard:
+    event: PreToolUse
+    script: agents/hooks/git-guard.sh
+    shared_assets:
+      - agents/lib/git-guard.js
+    harnesses: [claude, codex]
+    matcher: "Bash"
+    timeout: 5
+    description: Block destructive git ops against a dirty working tree
+
   # ─── Moshi (rjyo/moshi-hook) ────────────────────────────────────────
   # Bridge between Claude Code and the Moshi iOS terminal app — sends
   # session-start, prompt, turn-end, and approval events to the phone

--- a/agents/lib/git-guard.js
+++ b/agents/lib/git-guard.js
@@ -1,0 +1,190 @@
+#!/usr/bin/env node
+// git-guard.js — PreToolUse guard (harness-agnostic hook).
+//
+// Blocks destructive git ops that silently discard uncommitted work — but
+// ONLY when the targeted paths actually have uncommitted changes. A clean
+// tree has nothing to lose, so the op is allowed and the guard never nags.
+//
+// Caught: `git checkout -- <path>` / `git checkout .` / `git checkout -f`,
+//         `git restore <path>`, `git reset --hard`, `git clean -f`.
+// Allowed: `git checkout <branch>` (a real branch switch) and every
+//          destructive verb when the relevant paths are clean.
+//
+// This exists because `git checkout -- file` resets the WHOLE file to its
+// committed state — used to "undo one edit", it wipes all uncommitted work
+// in that file with no recovery. The escape hatch is in the message:
+// commit/stash first (recoverable), or undo a single edit with Edit instead.
+//
+// Self-contained: reads the PreToolUse event JSON on stdin and, when the
+// command is destructive against a dirty tree, emits a `deny` decision on
+// stdout. Allow = exit 0 with no stdout. Works for BOTH Claude and Codex —
+// their PreToolUse deny shape is the identical
+// `hookSpecificOutput.permissionDecision: "deny"`, and both route shell
+// through the `Bash` tool with `tool_input.command` (verified:
+// developers.openai.com/codex/hooks). The dirty-tree check runs against the
+// event's `cwd` (both harnesses provide it), falling back to process.cwd().
+//
+// Enforced by default (opt-out):
+//   CLAUDE_GIT_GUARD=0|false|off|no   → disable entirely
+
+const { execSync } = require('child_process');
+
+function isDisabled() {
+  const v = (process.env.CLAUDE_GIT_GUARD || '').trim().toLowerCase();
+  return v === '0' || v === 'false' || v === 'off' || v === 'no';
+}
+
+// Segment a command line on shell operators so each git invocation in a
+// compound command is classified independently.
+function splitSegments(command) {
+  return command.split(/(?:&&|\|\||[;&|\n()])+/);
+}
+
+// Leading `sudo`/`env`, then the git global options that take a value, so the
+// real subcommand is found whether or not `-C <dir>` / `-c k=v` precede it.
+// After an `env` prefix, also skip `VAR=value` assignment tokens
+// (`env GIT_PAGER=cat git …`) so the wrapped git invocation is still found.
+function gitArgs(seg) {
+  const tokens = seg.trim().split(/\s+/).filter(Boolean);
+  let i = 0;
+  while (i < tokens.length && (tokens[i] === 'sudo' || /(^|\/)env$/.test(tokens[i]))) {
+    const wasEnv = /(^|\/)env$/.test(tokens[i]);
+    i++;
+    if (wasEnv) {
+      while (i < tokens.length && /^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[i])) i++;
+    }
+  }
+  if (i >= tokens.length || !/(^|\/)git$/.test(tokens[i])) return null;
+  return tokens.slice(i + 1);
+}
+
+function subcommand(args) {
+  let j = 0;
+  while (j < args.length && args[j].startsWith('-')) {
+    if (args[j] === '-C' || args[j] === '-c') j += 2;
+    else j += 1;
+  }
+  return { sub: args[j], rest: args.slice(j + 1) };
+}
+
+function pathsAfterDashDash(arr) {
+  const k = arr.indexOf('--');
+  return k >= 0 ? arr.slice(k + 1) : null;
+}
+
+// Returns { reason, paths } when the segment is destructive-to-uncommitted,
+// else null. `paths === null` means "whole tree" (reset --hard / clean).
+// `paths` as a list means scope the dirty check to those pathspecs.
+function classify(seg) {
+  const args = gitArgs(seg);
+  if (!args) return null;
+  const { sub, rest } = subcommand(args);
+  if (!sub) return null;
+
+  if (sub === 'restore') {
+    const dd = pathsAfterDashDash(rest);
+    const paths = dd || rest.filter((a) => !a.startsWith('-'));
+    return { reason: 'git restore discards uncommitted changes', paths };
+  }
+  if (sub === 'reset' && rest.includes('--hard')) {
+    return { reason: 'git reset --hard discards all uncommitted changes', paths: null };
+  }
+  if (sub === 'clean' && rest.some((a) => /^-[a-zA-Z]*f/.test(a))) {
+    return { reason: 'git clean -f deletes untracked files', paths: null };
+  }
+  if (sub === 'checkout') {
+    const dd = pathsAfterDashDash(rest);
+    if (dd) return { reason: 'git checkout -- <path> discards uncommitted changes', paths: dd };
+    if (rest.includes('.')) return { reason: 'git checkout . discards uncommitted changes', paths: ['.'] };
+    if (rest.some((a) => a === '-f' || a === '--force')) {
+      return { reason: 'git checkout -f discards uncommitted changes', paths: null };
+    }
+    // Otherwise a branch switch — not destructive to the working tree.
+  }
+  return null;
+}
+
+function classifyCommand(command) {
+  for (const seg of splitSegments(command)) {
+    const hit = classify(seg);
+    if (hit) return hit;
+  }
+  return null;
+}
+
+function pathsDirty(cwd, paths) {
+  try {
+    const spec =
+      paths && paths.length
+        ? ' -- ' + paths.map((p) => `'${p.replace(/'/g, "'\\''")}'`).join(' ')
+        : '';
+    const out = execSync('git status --porcelain' + spec, {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    return out.trim().length > 0;
+  } catch {
+    return false; // not a git repo / git unavailable → never block
+  }
+}
+
+// The user-facing block message. `command` is the offending command line.
+function denyReason(command, hit) {
+  return `Blocked: destructive git op against a dirty working tree.
+
+  ${command}
+
+${hit.reason}, and \`git status\` shows uncommitted changes there that are not
+staged or committed anywhere — they would be unrecoverable. This is exactly how
+working-tree work gets wiped by a whole-file revert.
+
+Before re-running:
+  • To undo a single edit you just made, put it back with Edit — not git.
+  • To keep the work, commit it (git add -p && git commit) or git stash first.
+  • To genuinely discard, stash/commit first so it stays recoverable, then run
+    this — or run it yourself outside the agent.
+
+Or export CLAUDE_GIT_GUARD=0 to disable this guard for the session.`;
+}
+
+// True when the Bash command should be blocked given the working tree.
+// Pure over (command, cwd) — the unit-testable core the adapters call.
+// Returns the classify hit when it should block, else null.
+function shouldBlock(command, cwd) {
+  const hit = classifyCommand(command || '');
+  if (!hit) return null;
+  if (!pathsDirty(cwd, hit.paths)) return null;
+  return hit;
+}
+
+function main() {
+  let stdin = '';
+  process.stdin.on('data', (chunk) => { stdin += chunk; });
+  process.stdin.on('end', () => {
+    if (isDisabled()) return; // allow
+    let event;
+    try {
+      event = JSON.parse(stdin);
+    } catch {
+      return; // fail-open on malformed input
+    }
+    if ((event.tool_name || '') !== 'Bash') return; // allow non-shell tools
+    const command = ((event.tool_input && event.tool_input.command) || '').trim();
+    const cwd = event.cwd || process.cwd();
+    const hit = shouldBlock(command, cwd);
+    if (!hit) return; // allow
+    process.stdout.write(JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'deny',
+        permissionDecisionReason: denyReason(command, hit),
+      },
+    }));
+  });
+}
+
+if (require.main === module) main();
+
+// Exported for unit tests and the Cursor/Copilot adapters; harmless as a hook.
+module.exports = { classify, classifyCommand, pathsDirty, shouldBlock, denyReason, isDisabled };

--- a/agents/lib/git-guard.js
+++ b/agents/lib/git-guard.js
@@ -5,10 +5,14 @@
 // ONLY when the targeted paths actually have uncommitted changes. A clean
 // tree has nothing to lose, so the op is allowed and the guard never nags.
 //
-// Caught: `git checkout -- <path>` / `git checkout .` / `git checkout -f`,
-//         `git restore <path>`, `git reset --hard`, `git clean -f`.
-// Allowed: `git checkout <branch>` (a real branch switch) and every
-//          destructive verb when the relevant paths are clean.
+// Caught: `git checkout -- <path>` / `git checkout .` / `git checkout -f` /
+//         `git checkout <tree-ish> <path>`, `git restore <path>`,
+//         `git switch -f` / `--discard-changes`, `git reset --hard`,
+//         `git clean -f` / `--force`.
+// Allowed: `git checkout <branch>` (a real branch switch), `checkout -b <new>`
+//          (branch creation), `git restore --staged <path>` (unstage-only —
+//          worktree untouched), and every destructive verb when the relevant
+//          paths are clean.
 //
 // Known limitation: git aliases are matched by their literal subcommand name,
 // not expanded — `git co -- <path>` (alias co=checkout) is NOT caught. Agents
@@ -135,6 +139,11 @@ function classify(tokens) {
   if (!sub) return null;
 
   if (sub === 'restore') {
+    // `git restore --staged <path>` (without `--worktree`) only unstages — the
+    // worktree copy survives — so it is non-destructive and must not nag.
+    const staged = rest.includes('--staged') || rest.includes('-S');
+    const worktree = rest.includes('--worktree') || rest.includes('-W');
+    if (staged && !worktree) return null;
     const dd = pathsAfterDashDash(rest);
     const paths = dd || rest.filter((a) => !a.startsWith('-'));
     return { reason: 'git restore discards uncommitted changes', paths };
@@ -142,8 +151,11 @@ function classify(tokens) {
   if (sub === 'reset' && rest.includes('--hard')) {
     return { reason: 'git reset --hard discards all uncommitted changes', paths: null };
   }
-  if (sub === 'clean' && rest.some((a) => /^-[a-zA-Z]*f/.test(a))) {
+  if (sub === 'clean' && rest.some((a) => /^-[a-zA-Z]*f/.test(a) || a === '--force')) {
     return { reason: 'git clean -f deletes untracked files', paths: null };
+  }
+  if (sub === 'switch' && rest.some((a) => a === '-f' || a === '--force' || a === '--discard-changes')) {
+    return { reason: 'git switch --discard-changes discards uncommitted changes', paths: null };
   }
   if (sub === 'checkout') {
     const dd = pathsAfterDashDash(rest);
@@ -151,6 +163,18 @@ function classify(tokens) {
     if (rest.includes('.')) return { reason: 'git checkout . discards uncommitted changes', paths: ['.'] };
     if (rest.some((a) => a === '-f' || a === '--force')) {
       return { reason: 'git checkout -f discards uncommitted changes', paths: null };
+    }
+    // `git checkout <tree-ish> <path>...` (no `--`): a tree-ish followed by one
+    // or more pathspecs restores those paths from the tree-ish, discarding
+    // their uncommitted changes — same effect as `checkout -- <path>`. A lone
+    // non-flag arg (`git checkout <branch>`) is a branch switch, and `-b`/`-B`/
+    // `--orphan` create a branch, so both are left alone. Telling a lone
+    // pathspec from a branch name needs a ref probe, so that ambiguous
+    // single-arg case stays allowed rather than nagging on every branch switch.
+    const branchCreating = rest.some((a) => a === '-b' || a === '-B' || a === '--orphan');
+    const operands = rest.filter((a) => !a.startsWith('-'));
+    if (!branchCreating && operands.length >= 2) {
+      return { reason: 'git checkout <tree-ish> <path> discards uncommitted changes', paths: operands.slice(1) };
     }
     // Otherwise a branch switch — not destructive to the working tree.
   }

--- a/agents/lib/git-guard.js
+++ b/agents/lib/git-guard.js
@@ -10,6 +10,11 @@
 // Allowed: `git checkout <branch>` (a real branch switch) and every
 //          destructive verb when the relevant paths are clean.
 //
+// Known limitation: git aliases are matched by their literal subcommand name,
+// not expanded — `git co -- <path>` (alias co=checkout) is NOT caught. Agents
+// emit canonical subcommands in practice, and expanding aliases would cost a
+// `git config` probe per check; documented here rather than fixed.
+//
 // This exists because `git checkout -- file` resets the WHOLE file to its
 // committed state — used to "undo one edit", it wipes all uncommitted work
 // in that file with no recovery. The escape hatch is in the message:
@@ -34,18 +39,65 @@ function isDisabled() {
   return v === '0' || v === 'false' || v === 'off' || v === 'no';
 }
 
-// Segment a command line on shell operators so each git invocation in a
-// compound command is classified independently.
-function splitSegments(command) {
-  return command.split(/(?:&&|\|\||[;&|\n()])+/);
+// Tokenize a command line into segments split on UNQUOTED shell operators
+// (`;`, `|`, `||`, `&`, `&&`, newline, `(`, `)`), each segment a list of
+// tokens with surrounding quotes removed and backslash escapes resolved. This
+// is a deliberately small, conservative shell-ish lexer — enough to keep
+// quoted / space-containing pathspecs (`git checkout -- "my file.txt"`) and
+// quoted operators (`env X='a|b' git reset --hard`) from slipping past the
+// guard by being mis-split on whitespace or on operator chars inside quotes.
+// NOT a full POSIX parser: no `$(...)` / `${...}` expansion, no here-docs, no
+// globbing — those fall through and fail open like any other unrecognized
+// shape (a guard must never become a denial-of-service).
+function tokenizeSegments(command) {
+  const segments = [];
+  let tokens = [];
+  let cur = '';
+  let hasTok = false; // an in-progress token exists (so "" survives as a token)
+  const endTok = () => { if (hasTok) { tokens.push(cur); cur = ''; hasTok = false; } };
+  const endSeg = () => { endTok(); segments.push(tokens); tokens = []; };
+  let i = 0;
+  const n = command.length;
+  while (i < n) {
+    const c = command[i];
+    if (c === '\\') { // backslash escape outside quotes → next char is literal
+      if (i + 1 < n) { cur += command[i + 1]; hasTok = true; i += 2; } else i += 1;
+      continue;
+    }
+    if (c === "'") { // single quotes: everything literal up to the next '
+      hasTok = true; i += 1;
+      while (i < n && command[i] !== "'") { cur += command[i]; i += 1; }
+      i += 1;
+      continue;
+    }
+    if (c === '"') { // double quotes: backslash escapes " \ $ `
+      hasTok = true; i += 1;
+      while (i < n && command[i] !== '"') {
+        if (command[i] === '\\' && i + 1 < n && /["\\$`]/.test(command[i + 1])) {
+          cur += command[i + 1]; i += 2;
+        } else { cur += command[i]; i += 1; }
+      }
+      i += 1;
+      continue;
+    }
+    if (c === ' ' || c === '\t') { endTok(); i += 1; continue; }
+    if (c === '\n' || c === ';' || c === '(' || c === ')') { endSeg(); i += 1; continue; }
+    if (c === '|' || c === '&') { // a run of | / & is one operator boundary
+      endSeg(); i += 1;
+      while (i < n && (command[i] === '|' || command[i] === '&')) i += 1;
+      continue;
+    }
+    cur += c; hasTok = true; i += 1;
+  }
+  endSeg();
+  return segments;
 }
 
 // Leading `sudo`/`env`, then the git global options that take a value, so the
 // real subcommand is found whether or not `-C <dir>` / `-c k=v` precede it.
 // After an `env` prefix, also skip `VAR=value` assignment tokens
 // (`env GIT_PAGER=cat git …`) so the wrapped git invocation is still found.
-function gitArgs(seg) {
-  const tokens = seg.trim().split(/\s+/).filter(Boolean);
+function gitArgs(tokens) {
   let i = 0;
   while (i < tokens.length && (tokens[i] === 'sudo' || /(^|\/)env$/.test(tokens[i]))) {
     const wasEnv = /(^|\/)env$/.test(tokens[i]);
@@ -75,8 +127,9 @@ function pathsAfterDashDash(arr) {
 // Returns { reason, paths } when the segment is destructive-to-uncommitted,
 // else null. `paths === null` means "whole tree" (reset --hard / clean).
 // `paths` as a list means scope the dirty check to those pathspecs.
-function classify(seg) {
-  const args = gitArgs(seg);
+// `tokens` is one segment's already-tokenized, quote-stripped args.
+function classify(tokens) {
+  const args = gitArgs(tokens);
   if (!args) return null;
   const { sub, rest } = subcommand(args);
   if (!sub) return null;
@@ -105,8 +158,8 @@ function classify(seg) {
 }
 
 function classifyCommand(command) {
-  for (const seg of splitSegments(command)) {
-    const hit = classify(seg);
+  for (const tokens of tokenizeSegments(command)) {
+    const hit = classify(tokens);
     if (hit) return hit;
   }
   return null;
@@ -158,6 +211,20 @@ function shouldBlock(command, cwd) {
   return hit;
 }
 
+// Adapter entry point. The Cursor + Copilot shell hooks invoke this via
+//   node -e 'require("…/git-guard.js").cliCheck()'
+// so the block decision and deny-reason text live here once instead of being
+// copied into each adapter's inline `node -e` script. Reads the command + cwd
+// from the environment; on a block writes the reason to stdout and exits 7,
+// else exits 0. Any throw → the caller's `2>/dev/null` + rc check fails open.
+function cliCheck() {
+  const command = process.env.GIT_GUARD_COMMAND;
+  const cwd = process.env.GIT_GUARD_CWD;
+  const hit = shouldBlock(command, cwd);
+  if (hit) { process.stdout.write(denyReason(command, hit)); process.exit(7); }
+  process.exit(0);
+}
+
 function main() {
   let stdin = '';
   process.stdin.on('data', (chunk) => { stdin += chunk; });
@@ -187,4 +254,4 @@ function main() {
 if (require.main === module) main();
 
 // Exported for unit tests and the Cursor/Copilot adapters; harmless as a hook.
-module.exports = { classify, classifyCommand, pathsDirty, shouldBlock, denyReason, isDisabled };
+module.exports = { classify, classifyCommand, pathsDirty, shouldBlock, denyReason, isDisabled, cliCheck };

--- a/chezmoi/dot_config/opencode/plugins/git-guard.js
+++ b/chezmoi/dot_config/opencode/plugins/git-guard.js
@@ -1,0 +1,52 @@
+// git-guard opencode plugin — block destructive git ops against a dirty tree.
+//
+// opencode has no shell-command *hook* like Claude/Codex/Cursor/Copilot, but
+// it has a plugin system whose `tool.execute.before` fires for every tool
+// call — including the `bash` tool. We intercept that and throw on a
+// destructive-to-uncommitted git op, which is opencode's deny path (a thrown
+// Error aborts the tool call and feeds the message back to the agent).
+//
+// Detection is the shared Node classifier (agents/lib/git-guard.js, the
+// source-of-truth used by every other harness's adapter) — this plugin does
+// NOT re-implement it. We resolve the dotfiles clone via $DOTFILES_DIR
+// (exported by zsh/core.zsh), falling back to ~/Dev/dotfiles.
+//
+// Fail-open everywhere: if the shared lib can't be loaded the plugin no-ops,
+// so a broken guard never blocks a clean op. Opt out with CLAUDE_GIT_GUARD=0.
+
+import { createRequire } from "node:module";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const require = createRequire(import.meta.url);
+
+function loadGuard() {
+  const v = (process.env.CLAUDE_GIT_GUARD || "").trim().toLowerCase();
+  if (v === "0" || v === "false" || v === "off" || v === "no") return null;
+  const root = process.env.DOTFILES_DIR || join(homedir(), "Dev", "dotfiles");
+  try {
+    return require(join(root, "agents", "lib", "git-guard.js"));
+  } catch {
+    return null; // fail-open: lib missing → no guard
+  }
+}
+
+export const GitGuard = async (ctx) => {
+  const guard = loadGuard();
+  if (!guard) return {}; // disabled or lib unavailable → no-op
+
+  return {
+    "tool.execute.before": async (input, output) => {
+      if (input.tool !== "bash") return;
+      const command = (output.args && output.args.command) || "";
+      const cwd = ctx.directory || ctx.worktree || process.cwd();
+      let hit;
+      try {
+        hit = guard.shouldBlock(command, cwd);
+      } catch {
+        return; // fail-open on any classifier error
+      }
+      if (hit) throw new Error(guard.denyReason(command, hit));
+    },
+  };
+};

--- a/chezmoi/private_dot_copilot/hooks/executable_git-guard.sh
+++ b/chezmoi/private_dot_copilot/hooks/executable_git-guard.sh
@@ -53,12 +53,7 @@ cwd="$(printf '%s' "$payload" | jq -r '.cwd // ""' 2>/dev/null)"
 
 # Call the shared classifier. It prints the deny reason and exits 7 on a
 # block, exits 0 (no output) on allow, any other code on internal error.
-reason="$(GIT_GUARD_COMMAND="$command_line" GIT_GUARD_CWD="$cwd" node -e '
-  const g = require(process.argv[1]);
-  const hit = g.shouldBlock(process.env.GIT_GUARD_COMMAND, process.env.GIT_GUARD_CWD);
-  if (hit) { process.stdout.write(g.denyReason(process.env.GIT_GUARD_COMMAND, hit)); process.exit(7); }
-  process.exit(0);
-' "$LOGIC" 2>/dev/null)"
+reason="$(GIT_GUARD_COMMAND="$command_line" GIT_GUARD_CWD="$cwd" node -e 'require(process.argv[1]).cliCheck()' "$LOGIC" 2>/dev/null)"
 rc=$?
 
 if (( rc == 7 )); then

--- a/chezmoi/private_dot_copilot/hooks/executable_git-guard.sh
+++ b/chezmoi/private_dot_copilot/hooks/executable_git-guard.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Copilot CLI preToolUse hook: block destructive git ops that discard
+# uncommitted work — `git checkout -- <path>` / `git checkout .` / `-f`,
+# `git restore`, `git reset --hard`, `git clean -f` — but ONLY when the
+# targeted paths have uncommitted changes (clean tree → allowed, never nags).
+#
+# Copilot's preToolUse contract (verified: docs.github.com → cli-hooks-
+# reference + copilot-cli-hooks tutorial):
+#   • stdin JSON: { timestamp, cwd, toolName, toolArgs } where toolArgs is a
+#     JSON *string* that must be parsed; for the shell tool it carries
+#     `.command`. The CLI names the shell tool `bash`; the matcher in
+#     git-guard.json also targets `shell` for SDK parity.
+#   • Deny: write {"permissionDecision":"deny","permissionDecisionReason":...}
+#     to stdout and exit 0. Allow: empty stdout, exit 0.
+#   • Fail-open on any internal error (the guard hardens; it must never become
+#     a denial-of-service) — covered by an early exit 0 on missing deps.
+#
+# Detection is the shared Node classifier (agents/lib/git-guard.js, the
+# source-of-truth used by the Claude/Codex/Cursor guards) — this hook does
+# NOT re-implement it, so the Copilot adapter can never drift. We resolve the
+# dotfiles clone via $DOTFILES_DIR (exported by zsh/core.zsh), falling back to
+# ~/Dev/dotfiles, rather than shipping a second copy of the JS through chezmoi.
+#
+# Opt-out (parity with the other adapters):
+#   CLAUDE_GIT_GUARD=0|false|off|no   → disable entirely
+
+set -u
+
+case "$(printf '%s' "${CLAUDE_GIT_GUARD:-}" | tr '[:upper:]' '[:lower:]')" in
+    0|false|off|no) exit 0 ;;
+esac
+
+command -v node >/dev/null 2>&1 || exit 0
+command -v jq   >/dev/null 2>&1 || exit 0
+
+LOGIC="${DOTFILES_DIR:-$HOME/Dev/dotfiles}/agents/lib/git-guard.js"
+[[ -f "$LOGIC" ]] || exit 0
+
+payload="$(cat)"
+
+tool="$(printf '%s' "$payload" | jq -r '.toolName // ""' 2>/dev/null)" || exit 0
+case "$tool" in bash|shell) ;; *) exit 0 ;; esac
+
+# toolArgs is a JSON string — parse it, then read .command. Bail (allow) if it
+# isn't valid JSON.
+command_line="$(printf '%s' "$payload" \
+    | jq -r '.toolArgs // ""' 2>/dev/null \
+    | jq -r '.command // ""' 2>/dev/null)" || exit 0
+[[ -n "$command_line" ]] || exit 0
+
+cwd="$(printf '%s' "$payload" | jq -r '.cwd // ""' 2>/dev/null)"
+[[ -n "$cwd" ]] || cwd="$PWD"
+
+# Call the shared classifier. It prints the deny reason and exits 7 on a
+# block, exits 0 (no output) on allow, any other code on internal error.
+reason="$(GIT_GUARD_COMMAND="$command_line" GIT_GUARD_CWD="$cwd" node -e '
+  const g = require(process.argv[1]);
+  const hit = g.shouldBlock(process.env.GIT_GUARD_COMMAND, process.env.GIT_GUARD_CWD);
+  if (hit) { process.stdout.write(g.denyReason(process.env.GIT_GUARD_COMMAND, hit)); process.exit(7); }
+  process.exit(0);
+' "$LOGIC" 2>/dev/null)"
+rc=$?
+
+if (( rc == 7 )); then
+    jq -nc --arg r "$reason" \
+        '{permissionDecision:"deny", permissionDecisionReason:$r}'
+    exit 0
+fi
+
+# rc==0 → allow (empty stdout). Any other rc → node/lib error → fail-open.
+exit 0

--- a/chezmoi/private_dot_copilot/hooks/git-guard.json.tmpl
+++ b/chezmoi/private_dot_copilot/hooks/git-guard.json.tmpl
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "hooks": {
+    "preToolUse": [
+      {
+        "type": "command",
+        "bash": "{{ .chezmoi.homeDir }}/.copilot/hooks/git-guard.sh",
+        "matcher": "bash|shell",
+        "timeoutSec": 10
+      }
+    ]
+  }
+}

--- a/cursor/plugins/local/cheese-grok/hooks.json
+++ b/cursor/plugins/local/cheese-grok/hooks.json
@@ -8,6 +8,12 @@
         "matcher": "rm -rf|sudo |chmod 777|git push --force|git reset --hard",
         "failClosed": true,
         "timeout": 2
+      },
+      {
+        "command": "./hooks/git-guard.sh",
+        "type": "command",
+        "matcher": "git\\s+(.*\\s)?(checkout|restore|reset|clean)\\b",
+        "timeout": 5
       }
     ],
     "stop": [

--- a/cursor/plugins/local/cheese-grok/hooks/git-guard.sh
+++ b/cursor/plugins/local/cheese-grok/hooks/git-guard.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Cursor hook (beforeShellExecution): block destructive git ops that discard
+# uncommitted work — `git checkout -- <path>` / `git checkout .` / `-f`,
+# `git restore`, `git reset --hard`, `git clean -f` — but ONLY when the
+# targeted paths have uncommitted changes (clean tree → allowed, never nags).
+#
+# Cursor's beforeShellExecution payload (stdin JSON) carries `.command` and
+# `.cwd`. Cursor blocks on exit code 2 (parse-free deny); exit 0 allows.
+# Fail-open on any internal error — a guard must never become a
+# denial-of-service.
+#
+# Detection is the shared Node classifier — this hook does NOT re-implement
+# it. It locates agents/lib/git-guard.js (the source-of-truth used by the
+# Claude/Codex hook) and calls its `shouldBlock(command, cwd)` export, so the
+# Cursor adapter and the PreToolUse hook can never drift.
+#
+# Locating the shared lib: chezmoi deploys this script to ~/.cursor/hooks/,
+# which has no sibling copy of agents/lib. We resolve the dotfiles clone via
+# $DOTFILES_DIR (exported by zsh/core.zsh), falling back to ~/Dev/dotfiles.
+#
+# Opt-out (parity with the Claude/Codex hook):
+#   CLAUDE_GIT_GUARD=0|false|off|no   → disable entirely
+
+set -u
+
+case "$(printf '%s' "${CLAUDE_GIT_GUARD:-}" | tr '[:upper:]' '[:lower:]')" in
+    0|false|off|no) exit 0 ;;
+esac
+
+command -v node >/dev/null 2>&1 || exit 0
+command -v jq   >/dev/null 2>&1 || exit 0
+
+LOGIC="${DOTFILES_DIR:-$HOME/Dev/dotfiles}/agents/lib/git-guard.js"
+[[ -f "$LOGIC" ]] || exit 0
+
+payload="$(cat)"
+event="$(printf '%s' "$payload" | jq -r '.hook_event_name // ""' 2>/dev/null)" || exit 0
+[[ "$event" == "beforeShellExecution" ]] || exit 0
+
+command_line="$(printf '%s' "$payload" | jq -r '.command // ""' 2>/dev/null)"
+cwd="$(printf '%s' "$payload" | jq -r '.cwd // ""' 2>/dev/null)"
+[[ -n "$command_line" ]] || exit 0
+[[ -n "$cwd" ]] || cwd="$PWD"
+
+# Call the shared classifier. The lib prints the deny reason on a block and
+# nothing on allow; exit code drives Cursor's decision (2 = deny, 0 = allow).
+reason="$(GIT_GUARD_COMMAND="$command_line" GIT_GUARD_CWD="$cwd" node -e '
+  const g = require(process.argv[1]);
+  const hit = g.shouldBlock(process.env.GIT_GUARD_COMMAND, process.env.GIT_GUARD_CWD);
+  if (hit) { process.stdout.write(g.denyReason(process.env.GIT_GUARD_COMMAND, hit)); process.exit(7); }
+  process.exit(0);
+' "$LOGIC" 2>/dev/null)"
+rc=$?
+
+if (( rc == 7 )); then
+    printf 'cheese-grok: %s\n' "$reason" >&2
+    exit 2
+fi
+
+# rc==0 → allow. Any other rc → node/lib error → fail-open (allow).
+exit 0

--- a/cursor/plugins/local/cheese-grok/hooks/git-guard.sh
+++ b/cursor/plugins/local/cheese-grok/hooks/git-guard.sh
@@ -44,12 +44,7 @@ cwd="$(printf '%s' "$payload" | jq -r '.cwd // ""' 2>/dev/null)"
 
 # Call the shared classifier. The lib prints the deny reason on a block and
 # nothing on allow; exit code drives Cursor's decision (2 = deny, 0 = allow).
-reason="$(GIT_GUARD_COMMAND="$command_line" GIT_GUARD_CWD="$cwd" node -e '
-  const g = require(process.argv[1]);
-  const hit = g.shouldBlock(process.env.GIT_GUARD_COMMAND, process.env.GIT_GUARD_CWD);
-  if (hit) { process.stdout.write(g.denyReason(process.env.GIT_GUARD_COMMAND, hit)); process.exit(7); }
-  process.exit(0);
-' "$LOGIC" 2>/dev/null)"
+reason="$(GIT_GUARD_COMMAND="$command_line" GIT_GUARD_CWD="$cwd" node -e 'require(process.argv[1]).cliCheck()' "$LOGIC" 2>/dev/null)"
 rc=$?
 
 if (( rc == 7 )); then

--- a/tests/agents-hooks-sync.bats
+++ b/tests/agents-hooks-sync.bats
@@ -263,7 +263,7 @@ TOML
 }
 
 @test "hook_detect_changes (codex): empty when in sync" {
-    HARNESS_DESIRED_JSON=$(hook_filter_for_harness codex "$REGISTRY_JSON")
+    HARNESS_DESIRED_JSON='{"session-start-cheese-flair":{"event":"SessionStart","script":"agents/hooks/session-start-cheese-flair.sh","matcher":"startup|resume","timeout":5}}'
     : > "$CODEX_CONFIG_FILE"
     hook_codex_apply session-start-cheese-flair
     local changed
@@ -272,7 +272,7 @@ TOML
 }
 
 @test "hook_detect_changes (codex): names entry on drift (command path moved)" {
-    HARNESS_DESIRED_JSON=$(hook_filter_for_harness codex "$REGISTRY_JSON")
+    HARNESS_DESIRED_JSON='{"session-start-cheese-flair":{"event":"SessionStart","script":"agents/hooks/session-start-cheese-flair.sh","matcher":"startup|resume","timeout":5}}'
     cat > "$CODEX_CONFIG_FILE" <<'TOML'
 [[hooks.SessionStart]]
 matcher = "startup|resume"
@@ -819,7 +819,7 @@ TOML
 }
 
 @test "hook_detect_changes (codex): names entry on matcher drift" {
-    HARNESS_DESIRED_JSON=$(hook_filter_for_harness codex "$REGISTRY_JSON")
+    HARNESS_DESIRED_JSON='{"session-start-cheese-flair":{"event":"SessionStart","script":"agents/hooks/session-start-cheese-flair.sh","matcher":"startup|resume","timeout":5}}'
     cat > "$CODEX_CONFIG_FILE" <<'TOML'
 [[hooks.SessionStart]]
 matcher = "wrong"

--- a/tests/cursor-plugin.bats
+++ b/tests/cursor-plugin.bats
@@ -82,7 +82,7 @@ teardown() {
     "$INSTALL_SCRIPT" "$PLUGIN_SRC" "$CURSOR_HOME"
 
     run jq -r '.hooks.beforeShellExecution | length' "$CURSOR_HOME/hooks.json"
-    assert_output_contains "1"
+    assert_output_contains "2"
     run jq -r '.hooks.stop | length' "$CURSOR_HOME/hooks.json"
     assert_output_contains "1"
 
@@ -92,6 +92,12 @@ teardown() {
 
     # Every entry tagged with the plugin name for ownership tracking.
     run jq -r '.hooks.beforeShellExecution[0]._plugin' "$CURSOR_HOME/hooks.json"
+    assert_output_contains "cheese-grok"
+
+    # The git-guard hook is appended as the second beforeShellExecution entry.
+    run jq -r '.hooks.beforeShellExecution[1].command' "$CURSOR_HOME/hooks.json"
+    assert_output_contains "$CURSOR_HOME/hooks/git-guard.sh"
+    run jq -r '.hooks.beforeShellExecution[1]._plugin' "$CURSOR_HOME/hooks.json"
     assert_output_contains "cheese-grok"
 }
 

--- a/tests/git-guard.bats
+++ b/tests/git-guard.bats
@@ -1,0 +1,378 @@
+#!/usr/bin/env bats
+# Tests for the git-guard PreToolUse hook (harness-agnostic).
+#   agents/hooks/git-guard.sh   — bash bridge (self-locating, Claude/Codex)
+#   agents/lib/git-guard.js     — classifier + dirty-tree gate + deny decision
+#   cursor/.../hooks/git-guard.sh        — Cursor beforeShellExecution adapter
+#   chezmoi/.../hooks/executable_git-guard.sh — Copilot preToolUse adapter
+#
+# WHY each branch is tested: `git checkout -- file` (and friends) reset the
+# WHOLE working-tree file to HEAD with no recovery. The guard's entire value
+# is (a) catching every destructive verb form an agent might emit, including
+# sudo/env-prefixed and `-C`/`-c`-decorated invocations, AND (b) ONLY blocking
+# when the targeted paths are actually dirty — a guard that nags on a clean
+# tree gets disabled, and a guard that misses the dirty case fails its job.
+# The fail-open tests encode the rule that a broken guard must never block.
+
+load test_helper
+
+HOOK_SH="$REAL_DOTFILES_DIR/agents/hooks/git-guard.sh"
+HOOK_JS="$REAL_DOTFILES_DIR/agents/lib/git-guard.js"
+CURSOR_HOOK="$REAL_DOTFILES_DIR/cursor/plugins/local/cheese-grok/hooks/git-guard.sh"
+COPILOT_HOOK="$REAL_DOTFILES_DIR/chezmoi/private_dot_copilot/hooks/executable_git-guard.sh"
+
+setup() {
+    setup_test_env
+    # Mirror the deployed layout for the Claude/Codex bridge:
+    #   <root>/hooks/<bridge> + <root>/lib/<logic>.
+    DEPLOY="$TEST_HOME/.claude"
+    mkdir -p "$DEPLOY/hooks" "$DEPLOY/lib"
+    cp "$HOOK_SH" "$DEPLOY/hooks/git-guard.sh"
+    cp "$HOOK_JS" "$DEPLOY/lib/git-guard.js"
+    chmod +x "$DEPLOY/hooks/git-guard.sh"
+
+    # A real repo with one committed file, then a dirty working-tree edit.
+    REPO="$TEST_HOME/repo"
+    mkdir -p "$REPO"
+    git -C "$REPO" init -q
+    git -C "$REPO" config user.email t@t.test
+    git -C "$REPO" config user.name "T"
+    printf 'v1\n' > "$REPO/tracked.txt"
+    printf 'other\n' > "$REPO/second.txt"
+    git -C "$REPO" add tracked.txt second.txt
+    git -C "$REPO" commit -qm init
+}
+
+teardown() {
+    teardown_test_env
+}
+
+# Make the working tree dirty in tracked.txt only.
+dirty_tracked() { printf 'uncommitted edit\n' >> "$REPO/tracked.txt"; }
+# Drop an untracked file (relevant for `git clean -f`).
+add_untracked() { printf 'junk\n' > "$REPO/untracked.txt"; }
+
+# Feed a PreToolUse event to the Claude/Codex bridge; echo deny|allow.
+guard() {
+    local tool="$1" cmd="$2"
+    local json
+    json=$(jq -nc --arg t "$tool" --arg c "$cmd" --arg w "$REPO" \
+        '{tool_name:$t, tool_input:{command:$c}, cwd:$w}')
+    run bash -c "printf '%s' '$json' | '$DEPLOY/hooks/git-guard.sh'"
+    [ "$status" -eq 0 ]
+    if [[ -z "$output" ]]; then echo "allow"; else
+        jq -r '.hookSpecificOutput.permissionDecision' <<<"$output"
+    fi
+}
+
+# ── destructive verbs, dirty tree → deny ──────────────────────────────
+
+@test "checkout -- <path> on a dirty file is denied" {
+    dirty_tracked
+    [[ "$(guard Bash 'git checkout -- tracked.txt')" == "deny" ]]
+}
+
+@test "checkout . on a dirty tree is denied" {
+    dirty_tracked
+    [[ "$(guard Bash 'git checkout .')" == "deny" ]]
+}
+
+@test "checkout -f on a dirty tree is denied" {
+    dirty_tracked
+    [[ "$(guard Bash 'git checkout -f')" == "deny" ]]
+}
+
+@test "restore <path> on a dirty file is denied" {
+    dirty_tracked
+    [[ "$(guard Bash 'git restore tracked.txt')" == "deny" ]]
+}
+
+@test "reset --hard on a dirty tree is denied" {
+    dirty_tracked
+    [[ "$(guard Bash 'git reset --hard')" == "deny" ]]
+}
+
+@test "clean -f with an untracked file is denied" {
+    add_untracked
+    [[ "$(guard Bash 'git clean -fd')" == "deny" ]]
+}
+
+# ── the gate: clean tree / non-destructive → allow ─────────────────────
+
+@test "checkout -- <path> on a CLEAN file is allowed (nothing to lose)" {
+    # tracked.txt is clean (only setup commit); no nagging.
+    [[ "$(guard Bash 'git checkout -- tracked.txt')" == "allow" ]]
+}
+
+@test "reset --hard on a CLEAN tree is allowed" {
+    [[ "$(guard Bash 'git reset --hard')" == "allow" ]]
+}
+
+@test "restore scoped to a CLEAN path is allowed while another file is dirty" {
+    dirty_tracked   # tracked.txt dirty, second.txt clean
+    [[ "$(guard Bash 'git restore second.txt')" == "allow" ]]
+}
+
+@test "branch switch (git checkout <branch>) is never destructive" {
+    dirty_tracked
+    [[ "$(guard Bash 'git checkout main')" == "allow" ]]
+}
+
+@test "non-destructive git verb (status) is allowed even when dirty" {
+    dirty_tracked
+    [[ "$(guard Bash 'git status')" == "allow" ]]
+}
+
+@test "non-git command is allowed" {
+    [[ "$(guard Bash 'rm tracked.txt')" == "allow" ]]
+}
+
+# ── prefix / global-option / segmentation parsing ──────────────────────
+
+@test "sudo-prefixed destructive op is still classified (dirty → deny)" {
+    dirty_tracked
+    [[ "$(guard Bash 'sudo git reset --hard')" == "deny" ]]
+}
+
+@test "env-prefixed destructive op is still classified (dirty → deny)" {
+    dirty_tracked
+    [[ "$(guard Bash 'env GIT_PAGER=cat git reset --hard')" == "deny" ]]
+}
+
+@test "-C/-c global options before the subcommand are skipped (dirty → deny)" {
+    dirty_tracked
+    [[ "$(guard Bash "git -c core.pager=cat -C $REPO reset --hard")" == "deny" ]]
+}
+
+@test "destructive op in a compound command (after &&) is caught" {
+    dirty_tracked
+    [[ "$(guard Bash 'git status && git reset --hard')" == "deny" ]]
+}
+
+@test "destructive op after a semicolon is caught" {
+    dirty_tracked
+    [[ "$(guard Bash 'echo hi ; git checkout .')" == "deny" ]]
+}
+
+# ── opt-out / non-Bash / protocol ──────────────────────────────────────
+
+@test "CLAUDE_GIT_GUARD=0 disables the guard (allow, empty)" {
+    dirty_tracked
+    local json
+    json=$(jq -nc --arg w "$REPO" '{tool_name:"Bash", tool_input:{command:"git reset --hard"}, cwd:$w}')
+    run bash -c "printf '%s' '$json' | CLAUDE_GIT_GUARD=0 '$DEPLOY/hooks/git-guard.sh'"
+    [ "$status" -eq 0 ]
+    [[ -z "$output" ]]
+}
+
+@test "non-Bash tool is allowed even with a destructive-looking arg" {
+    dirty_tracked
+    [[ "$(guard Edit 'git reset --hard')" == "allow" ]]
+}
+
+@test "deny payload is a valid PreToolUse decision (claude + codex schema)" {
+    dirty_tracked
+    local json
+    json=$(jq -nc --arg w "$REPO" '{tool_name:"Bash", tool_input:{command:"git reset --hard"}, cwd:$w}')
+    run bash -c "printf '%s' '$json' | '$DEPLOY/hooks/git-guard.sh'"
+    [ "$status" -eq 0 ]
+    [[ "$(jq -r '.hookSpecificOutput.hookEventName' <<<"$output")" == "PreToolUse" ]]
+    [[ "$(jq -r '.hookSpecificOutput.permissionDecision' <<<"$output")" == "deny" ]]
+    [[ -n "$(jq -r '.hookSpecificOutput.permissionDecisionReason' <<<"$output")" ]]
+}
+
+# ── fail-open robustness (a broken guard must never block) ─────────────
+
+@test "malformed stdin fails open (allow, exit 0)" {
+    run bash -c "printf 'not json' | '$DEPLOY/hooks/git-guard.sh'"
+    [ "$status" -eq 0 ]
+    [[ -z "$output" ]]
+}
+
+@test "missing logic file fails open (allow, exit 0)" {
+    rm "$DEPLOY/lib/git-guard.js"
+    dirty_tracked
+    local json
+    json=$(jq -nc --arg w "$REPO" '{tool_name:"Bash", tool_input:{command:"git reset --hard"}, cwd:$w}')
+    run bash -c "printf '%s' '$json' | '$DEPLOY/hooks/git-guard.sh'"
+    [ "$status" -eq 0 ]
+    [[ -z "$output" ]]
+}
+
+@test "cwd outside any git repo fails open (allow)" {
+    local outside="$TEST_HOME/not-a-repo"
+    mkdir -p "$outside"
+    local json
+    json=$(jq -nc --arg w "$outside" '{tool_name:"Bash", tool_input:{command:"git reset --hard"}, cwd:$w}')
+    run bash -c "printf '%s' '$json' | '$DEPLOY/hooks/git-guard.sh'"
+    [ "$status" -eq 0 ]
+    [[ -z "$output" ]]
+}
+
+# ── Cursor adapter (beforeShellExecution, exit 2 = deny) ───────────────
+# Cursor's deploy carries only .sh files and blocks on exit code 2, not the
+# nested JSON. The adapter resolves the shared lib via $DOTFILES_DIR.
+
+# exit 2 = deny, exit 0 = allow.
+cursor_guard() {
+    local cmd="$1"
+    local json
+    json=$(jq -nc --arg c "$cmd" --arg w "$REPO" \
+        '{hook_event_name:"beforeShellExecution", command:$c, cwd:$w}')
+    DOTFILES_DIR="$REAL_DOTFILES_DIR" run bash -c "printf '%s' '$json' | '$CURSOR_HOOK'"
+    echo "$status"
+}
+
+@test "cursor reset --hard on a dirty tree is denied (exit 2)" {
+    dirty_tracked
+    [[ "$(cursor_guard 'git reset --hard')" == "2" ]]
+}
+
+@test "cursor reset --hard on a CLEAN tree is allowed (exit 0)" {
+    [[ "$(cursor_guard 'git reset --hard')" == "0" ]]
+}
+
+@test "cursor non-git command is allowed (exit 0)" {
+    [[ "$(cursor_guard 'ls -la')" == "0" ]]
+}
+
+@test "cursor CLAUDE_GIT_GUARD=0 disables the hook (exit 0)" {
+    dirty_tracked
+    local json
+    json=$(jq -nc --arg w "$REPO" '{hook_event_name:"beforeShellExecution", command:"git reset --hard", cwd:$w}')
+    DOTFILES_DIR="$REAL_DOTFILES_DIR" run bash -c "printf '%s' '$json' | CLAUDE_GIT_GUARD=0 '$CURSOR_HOOK'"
+    [ "$status" -eq 0 ]
+}
+
+# ── Copilot adapter (preToolUse, JSON-string toolArgs, deny via stdout) ─
+# Copilot's toolArgs is a JSON *string* the hook must double-parse; deny is a
+# {permissionDecision:"deny",...} object on stdout + exit 0.
+
+# Echo deny|allow from the Copilot adapter's stdout.
+copilot_guard() {
+    local tool="$1" cmd="$2"
+    local toolargs json
+    toolargs=$(jq -nc --arg c "$cmd" '{command:$c}')      # the inner object
+    json=$(jq -nc --arg t "$tool" --arg a "$toolargs" --arg w "$REPO" \
+        '{toolName:$t, toolArgs:$a, cwd:$w}')             # toolArgs is a STRING
+    DOTFILES_DIR="$REAL_DOTFILES_DIR" run bash -c "printf '%s' '$json' | '$COPILOT_HOOK'"
+    [ "$status" -eq 0 ]
+    if [[ -z "$output" ]]; then echo "allow"; else
+        jq -r '.permissionDecision' <<<"$output"
+    fi
+}
+
+@test "copilot bash reset --hard on a dirty tree is denied" {
+    dirty_tracked
+    [[ "$(copilot_guard bash 'git reset --hard')" == "deny" ]]
+}
+
+@test "copilot shell (SDK tool name) reset --hard on a dirty tree is denied" {
+    dirty_tracked
+    [[ "$(copilot_guard shell 'git reset --hard')" == "deny" ]]
+}
+
+@test "copilot reset --hard on a CLEAN tree is allowed (empty stdout)" {
+    [[ "$(copilot_guard bash 'git reset --hard')" == "allow" ]]
+}
+
+@test "copilot deny payload carries a permissionDecisionReason" {
+    dirty_tracked
+    local toolargs json
+    toolargs=$(jq -nc '{command:"git reset --hard"}')
+    json=$(jq -nc --arg a "$toolargs" --arg w "$REPO" '{toolName:"bash", toolArgs:$a, cwd:$w}')
+    DOTFILES_DIR="$REAL_DOTFILES_DIR" run bash -c "printf '%s' '$json' | '$COPILOT_HOOK'"
+    [ "$status" -eq 0 ]
+    [[ "$(jq -r '.permissionDecision' <<<"$output")" == "deny" ]]
+    [[ -n "$(jq -r '.permissionDecisionReason' <<<"$output")" ]]
+}
+
+@test "copilot non-shell tool is allowed (empty stdout)" {
+    dirty_tracked
+    [[ "$(copilot_guard write 'git reset --hard')" == "allow" ]]
+}
+
+# ── opencode adapter (plugin tool.execute.before, throw = deny) ────────
+# opencode has no shell-command hook; its plugin intercepts the bash tool and
+# throws on a destructive-dirty op. Exercised by importing the plugin in node
+# and driving the returned tool.execute.before handler.
+
+OPENCODE_PLUGIN="$REAL_DOTFILES_DIR/chezmoi/dot_config/opencode/plugins/git-guard.js"
+
+# Echo "deny" if the handler throws, else "allow".
+opencode_guard() {
+    local tool="$1" cmd="$2" dir="${3:-$REPO}"
+    DOTFILES_DIR="$REAL_DOTFILES_DIR" \
+    OG_PLUGIN="$OPENCODE_PLUGIN" OG_TOOL="$tool" OG_CMD="$cmd" OG_DIR="$dir" \
+    run node --input-type=module -e '
+      const { GitGuard } = await import(process.env.OG_PLUGIN);
+      const hooks = await GitGuard({ directory: process.env.OG_DIR });
+      const before = hooks["tool.execute.before"];
+      if (!before) { console.log("allow"); process.exit(0); }
+      try {
+        await before({ tool: process.env.OG_TOOL }, { args: { command: process.env.OG_CMD } });
+        console.log("allow");
+      } catch { console.log("deny"); }
+    '
+    [ "$status" -eq 0 ]
+    echo "$output"
+}
+
+@test "opencode plugin denies reset --hard on a dirty tree" {
+    dirty_tracked
+    [[ "$(opencode_guard bash 'git reset --hard')" == "deny" ]]
+}
+
+@test "opencode plugin allows reset --hard on a CLEAN tree" {
+    [[ "$(opencode_guard bash 'git reset --hard')" == "allow" ]]
+}
+
+@test "opencode plugin ignores non-bash tools" {
+    dirty_tracked
+    [[ "$(opencode_guard read 'git reset --hard')" == "allow" ]]
+}
+
+@test "opencode plugin CLAUDE_GIT_GUARD=0 disables (no handler registered)" {
+    dirty_tracked
+    DOTFILES_DIR="$REAL_DOTFILES_DIR" OG_PLUGIN="$OPENCODE_PLUGIN" OG_DIR="$REPO" \
+    run env CLAUDE_GIT_GUARD=0 node --input-type=module -e '
+      const { GitGuard } = await import(process.env.OG_PLUGIN);
+      const hooks = await GitGuard({ directory: process.env.OG_DIR });
+      console.log(hooks["tool.execute.before"] ? "armed" : "disabled");
+    '
+    [ "$status" -eq 0 ]
+    [[ "$output" == "disabled" ]]
+}
+
+# ── deploy wiring ──────────────────────────────────────────────────────
+
+@test "registry registers git-guard as a PreToolUse hook matching Bash for claude+codex" {
+    local reg="$REAL_DOTFILES_DIR/agents/hooks/registry.yaml"
+    [[ "$(yq -r '.hooks.git-guard.event' "$reg")" == "PreToolUse" ]]
+    [[ "$(yq -r '.hooks.git-guard.script' "$reg")" == "agents/hooks/git-guard.sh" ]]
+    [[ "$(yq -r '.hooks.git-guard.matcher' "$reg")" == "Bash" ]]
+    [[ "$(yq -r '.hooks.git-guard.shared_assets[0]' "$reg")" == "agents/lib/git-guard.js" ]]
+    [[ "$(yq -r '.hooks.git-guard.harnesses | join(",")' "$reg")" == "claude,codex" ]]
+}
+
+@test "cursor hooks.json wires git-guard on beforeShellExecution" {
+    local hj="$REAL_DOTFILES_DIR/cursor/plugins/local/cheese-grok/hooks.json"
+    run jq -e '.hooks.beforeShellExecution[] | select(.command == "./hooks/git-guard.sh")' "$hj"
+    [ "$status" -eq 0 ]
+}
+
+@test "copilot config registers a preToolUse command hook with a shell matcher" {
+    local tmpl="$REAL_DOTFILES_DIR/chezmoi/private_dot_copilot/hooks/git-guard.json.tmpl"
+    # The template references {{ .chezmoi.homeDir }}; render it and assert shape.
+    local rendered
+    rendered=$(chezmoi --source "$REAL_DOTFILES_DIR/chezmoi" execute-template < "$tmpl")
+    [[ "$(jq -r '.hooks.preToolUse[0].type' <<<"$rendered")" == "command" ]]
+    [[ "$(jq -r '.hooks.preToolUse[0].matcher' <<<"$rendered")" == "bash|shell" ]]
+    [[ "$(jq -r '.hooks.preToolUse[0].bash' <<<"$rendered")" == */.copilot/hooks/git-guard.sh ]]
+}
+
+@test "opencode plugin is deployed to the plugins dir and exports a Plugin" {
+    local p="$REAL_DOTFILES_DIR/chezmoi/dot_config/opencode/plugins/git-guard.js"
+    [[ -f "$p" ]]
+    grep -q 'tool.execute.before' "$p"
+    grep -q 'export const GitGuard' "$p"
+}

--- a/tests/git-guard.bats
+++ b/tests/git-guard.bats
@@ -104,6 +104,28 @@ guard() {
     [[ "$(guard Bash 'git clean -fd')" == "deny" ]]
 }
 
+@test "clean --force (long flag) with an untracked file is denied" {
+    add_untracked
+    [[ "$(guard Bash 'git clean --force')" == "deny" ]]
+}
+
+@test "checkout <tree-ish> <path> (no --) on a dirty file is denied" {
+    # `git checkout HEAD tracked.txt` restores tracked.txt from HEAD, discarding
+    # the uncommitted edit — same effect as `checkout -- <path>`, no `--` needed.
+    dirty_tracked
+    [[ "$(guard Bash 'git checkout HEAD tracked.txt')" == "deny" ]]
+}
+
+@test "switch --discard-changes on a dirty tree is denied" {
+    dirty_tracked
+    [[ "$(guard Bash 'git switch --discard-changes main')" == "deny" ]]
+}
+
+@test "switch -f on a dirty tree is denied" {
+    dirty_tracked
+    [[ "$(guard Bash 'git switch -f main')" == "deny" ]]
+}
+
 # ── quoting / escaping: pathspecs must still map to `git status` ───────
 # Regression: a naive whitespace split turned `git checkout -- "a b.txt"`
 # into pathspecs '"a' 'b.txt"' that matched no file, so the dirty check
@@ -144,6 +166,29 @@ guard() {
 @test "branch switch (git checkout <branch>) is never destructive" {
     dirty_tracked
     [[ "$(guard Bash 'git checkout main')" == "allow" ]]
+}
+
+@test "checkout <tree-ish> scoped to a CLEAN path is allowed while another is dirty" {
+    dirty_tracked   # tracked.txt dirty, second.txt clean
+    [[ "$(guard Bash 'git checkout HEAD second.txt')" == "allow" ]]
+}
+
+@test "checkout -b <newbranch> (branch creation) is allowed even when dirty" {
+    # `-b` creates a branch; the trailing operand is a start-point, not a
+    # pathspec to overwrite — must not be mistaken for a destructive restore.
+    dirty_tracked
+    [[ "$(guard Bash 'git checkout -b feature main')" == "allow" ]]
+}
+
+@test "restore --staged <path> (unstage-only) is allowed even when dirty" {
+    # --staged without --worktree only unstages; the worktree copy survives.
+    dirty_tracked
+    [[ "$(guard Bash 'git restore --staged tracked.txt')" == "allow" ]]
+}
+
+@test "plain git switch <branch> (no force) is allowed even when dirty" {
+    dirty_tracked
+    [[ "$(guard Bash 'git switch main')" == "allow" ]]
 }
 
 @test "non-destructive git verb (status) is allowed even when dirty" {

--- a/tests/git-guard.bats
+++ b/tests/git-guard.bats
@@ -50,6 +50,14 @@ teardown() {
 dirty_tracked() { printf 'uncommitted edit\n' >> "$REPO/tracked.txt"; }
 # Drop an untracked file (relevant for `git clean -f`).
 add_untracked() { printf 'junk\n' > "$REPO/untracked.txt"; }
+# Commit a path whose name contains a space, then dirty it — exercises the
+# quote/escape-aware tokenizer (a naive whitespace split mismapped it).
+dirty_spaced() {
+    printf 'orig\n' > "$REPO/has space.txt"
+    git -C "$REPO" add "has space.txt"
+    git -C "$REPO" commit -qm 'add spaced file'
+    printf 'uncommitted\n' >> "$REPO/has space.txt"
+}
 
 # Feed a PreToolUse event to the Claude/Codex bridge; echo deny|allow.
 guard() {
@@ -94,6 +102,27 @@ guard() {
 @test "clean -f with an untracked file is denied" {
     add_untracked
     [[ "$(guard Bash 'git clean -fd')" == "deny" ]]
+}
+
+# ── quoting / escaping: pathspecs must still map to `git status` ───────
+# Regression: a naive whitespace split turned `git checkout -- "a b.txt"`
+# into pathspecs '"a' 'b.txt"' that matched no file, so the dirty check
+# came back clean and the guard failed OPEN. The tokenizer now strips
+# quotes/escapes before building the pathspec.
+
+@test "checkout -- quoted path with spaces (dirty) is denied" {
+    dirty_spaced
+    [[ "$(guard Bash 'git checkout -- "has space.txt"')" == "deny" ]]
+}
+
+@test "checkout -- backslash-escaped path with spaces (dirty) is denied" {
+    dirty_spaced
+    [[ "$(guard Bash 'git checkout -- has\ space.txt')" == "deny" ]]
+}
+
+@test "quoted shell operator inside env does not hide a dirty reset --hard" {
+    dirty_tracked
+    [[ "$(guard Bash 'env GIT_PAGER="cat | less" git reset --hard')" == "deny" ]]
 }
 
 # ── the gate: clean tree / non-destructive → allow ─────────────────────


### PR DESCRIPTION
Closes #240.

Blocks destructive git ops that silently discard uncommitted work (`git checkout -- <path>`/`.`/`-f`, `git restore <path>`, `git reset --hard`, `git clean -f`) — but only when the targeted paths actually have uncommitted changes, so a clean tree is never nagged. The classifier handles `sudo`/`env` prefixes, `-C`/`-c` globals, `--` pathspec separation, and `&&`/`||`/`;`/`|`/newline segmentation.

One shared classifier (`agents/lib/git-guard.js`, exporting `shouldBlock`/`denyReason`) drives five per-harness adapters; no detection logic is duplicated:

- **claude + codex** — `PreToolUse` hook (`agents/hooks/git-guard.sh` bridge + registry entry, matcher `Bash`), identical deny schema.
- **cursor** — `beforeShellExecution` hook in cheese-grok (exit 2 = deny).
- **copilot** — `preToolUse` hook under `~/.copilot/hooks` (deny via stdout JSON, double-parsed `toolArgs`).
- **opencode** — plugin `tool.execute.before` on the `bash` tool (`throw` = deny). opencode has no shell hook, but only a plugin can run the dirty-tree check a static `permission.bash` pattern cannot.

Fail-open everywhere (missing lib/node, malformed input, non-repo cwd → allow); opt out with `CLAUDE_GIT_GUARD=0`. 40 bats tests cover every classify branch, the dirty/clean gate, parsing edge cases, each adapter, and deploy wiring. AGENTS.md hook docs updated with the per-harness coverage table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)