### PR TITLE
build(prek): exclude golden fixtures from whitespace/eof fixers

### DIFF
--- a/prek.toml
+++ b/prek.toml
@@ -5,8 +5,11 @@
 [[repos]]
 repo = "builtin"
 hooks = [
-  { id = "trailing-whitespace", args = ["--markdown-linebreak-ext=md"], exclude = "vimrc" },
-  { id = "end-of-file-fixer" },
+  # Golden fixtures are byte-exact expected renderer output (compared with `==`),
+  # so they must never be auto-normalized — e.g. bare-agent.md legitimately ends
+  # in `---\n\n`, which end-of-file-fixer would otherwise collapse to `---\n`.
+  { id = "trailing-whitespace", args = ["--markdown-linebreak-ext=md"], exclude = "vimrc|agent-profile/tests/fixtures/golden/" },
+  { id = "end-of-file-fixer", exclude = "agent-profile/tests/fixtures/golden/" },
   { id = "check-yaml" },
   { id = "check-toml" },
   { id = "check-json" },


### PR DESCRIPTION
Golden fixtures under `agent-profile/tests/fixtures/golden/` are byte-exact expected renderer output (compared with `==` in the renderer tests). The two *mutating* prek hooks — `end-of-file-fixer` and `trailing-whitespace` — were rewriting them.

Concretely: `claude/nobody/plugin/agents/bare-agent.md` is the only golden ending in `---\n\n` (the renderer emits a trailing blank line for an empty-body agent — verified: `test_renderer_claude.py:491` compares it byte-exact and passes). `end-of-file-fixer` collapsed it to `---\n`, which both corrupts the golden and forced every recent commit touching this tree to use `--no-verify`.

Fix: exclude the golden tree from both mutating hooks. The validators (`check-yaml/toml/json`) don't rewrite files, so they stay in force.

Verified: both hooks now `Skip` the golden (`no files to check`), the file is byte-identical (same sha, `\n\n` preserved), and this commit itself passed prek with no `--no-verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)