### PR TITLE
feat(local-llm): opt-in local LLM stack (llama.cpp + LiteLLM)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -325,6 +325,32 @@ MCP entries are managed by `agents/mcp/registry.yaml` (see [MCP Management](#mcp
 
 **Migrating from a hand-rolled `opencode.jsonc`:** the scaffold writes to `opencode.json`, not `.jsonc`. If you already have a non-trivial `~/.config/opencode/opencode.jsonc`, merge its contents into `opencode.json` and delete the `.jsonc` (opencode reads either, having both is just confusing).
 
+## Local LLM Stack
+
+A bespoke local-LLM stack (`~/local-llm/`) — llama.cpp workers behind a LiteLLM proxy at `http://127.0.0.1:4000/v1` (dummy key `sk-local`) exposing OpenAI-compatible model names (`local-sonnet`, `local-haiku`, `local-coder`, `local-opus`, `local-vision`, `local-classifier`). It is **per-machine and opt-in**, gated by the chezmoi `localLLM` flag.
+
+**Enable on a machine:** `dots sync` prompts `Manage local LLM stack on this machine?` on first init (persisted to `~/.config/chezmoi/chezmoi.toml`; re-prompt by deleting that file). When **off**, `.chezmoiignore` skips the whole tree so nothing deploys.
+
+**What's managed (in-repo):**
+
+- `chezmoi/local-llm/configs/litellm.yaml` → `~/local-llm/configs/litellm.yaml` (proxy routing + fallbacks).
+- `chezmoi/local-llm/scripts/{aliases,install-npu,healthcheck,download-models}.sh` → `~/local-llm/scripts/`.
+- `chezmoi/dot_config/systemd/user/{litellm,local-llm.target,worker-*}` → `~/.config/systemd/user/` (verbatim; `%h`-portable, no secrets). Unit *files* only — enablement stays a runtime action.
+- opencode `local-llm` provider — `chezmoi/lib/install-local-llm.sh` jq-merges the `.provider` block into `~/.config/opencode/opencode.json` (mirrors the MCP `.mcp` sync), driven by `run_onchange_after_install-local-llm.sh.tmpl`, which also runs `systemctl --user daemon-reload`. Edit models/endpoint there, not in the live file.
+
+**What's NOT managed (runtime / prerequisites):** the 85G `~/local-llm/models/`, the built `~/local-llm/bin/` (llama.cpp + lemonade), `~/local-llm/logs/`, and the `~/.local/bin/litellm` install. The sync never auto-enables or starts workers — that stays explicit (`llm-up`).
+
+**Commands** (aliases from `scripts/aliases.sh`) — these require a manual one-time `echo 'source ~/local-llm/scripts/aliases.sh' >> ~/.zshrc` (per `local-llm/README.md`); the managed `zshrc` does not source them, mirroring how `bin/` and the litellm install are manual prerequisites:
+
+- `llm-up` / `llm-down` / `llm-status` — start/stop/inspect via systemd.
+- `llm-test` (`= healthcheck.sh`) — smoke test: hard tiers (litellm + worker-igpu + worker-cpu) must answer with non-empty completions; optional tiers are informational and flagged when served by a LiteLLM fallback. `llm-test --opencode` adds an end-to-end probe through the wired provider.
+- `llm-download` (`= download-models.sh`) — on-demand, idempotent GGUF fetch (skips present files). Never run by sync.
+- `dots doctor` runs `healthcheck.sh --quiet` automatically when the stack is deployed (presence-gated on `~/local-llm/scripts/healthcheck.sh`).
+
+**Add/tune a model:** add a worker unit under `chezmoi/dot_config/systemd/user/` → add the route to `litellm.yaml` → add the model name to the provider block in `chezmoi/lib/install-local-llm.sh` → `chezmoi apply` (runs `daemon-reload`) → `llm-test`.
+
+> The three Qwen3 repo IDs in `download-models.sh` (sonnet/haiku/coder) are `<unverified>` — they follow the unsloth `<Model>-GGUF` convention of the confirmed opus repo but weren't recorded on the source machine. Confirm on huggingface.co before a fresh-machine download (`hf download` fails loud on a wrong repo).
+
 ## Profile System
 
 Profiles are scoped sessions declared as `profiles/<name>/profile.yaml` (repo root) and owned end-to-end by the harness-agnostic `ap` tool (`dots profile`). The retired `ccp` zsh launcher is gone — `dots profile launch` is the single path.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -334,7 +334,7 @@ A bespoke local-LLM stack (`~/local-llm/`) — llama.cpp workers behind a LiteLL
 **What's managed (in-repo):**
 
 - `chezmoi/local-llm/configs/litellm.yaml` → `~/local-llm/configs/litellm.yaml` (proxy routing + fallbacks).
-- `chezmoi/local-llm/scripts/{aliases,install-npu,healthcheck,download-models}.sh` → `~/local-llm/scripts/`.
+- `chezmoi/local-llm/scripts/executable_{aliases,install-npu,healthcheck,download-models}.sh` → `~/local-llm/scripts/{aliases,install-npu,healthcheck,download-models}.sh` (the `executable_` prefix is stripped on render).
 - `chezmoi/dot_config/systemd/user/{litellm,local-llm.target,worker-*}` → `~/.config/systemd/user/` (verbatim; `%h`-portable, no secrets). Unit *files* only — enablement stays a runtime action.
 - opencode `local-llm` provider — `chezmoi/lib/install-local-llm.sh` jq-merges the `.provider` block into `~/.config/opencode/opencode.json` (mirrors the MCP `.mcp` sync), driven by `run_onchange_after_install-local-llm.sh.tmpl`, which also runs `systemctl --user daemon-reload`. Edit models/endpoint there, not in the live file.
 

--- a/bin/dots
+++ b/bin/dots
@@ -312,6 +312,16 @@ do_doctor() {
         issues=$((issues + 1))
     fi
 
+    # Check local LLM stack (only when the localLLM flag deployed the healthcheck)
+    if [[ -x "$HOME/local-llm/scripts/healthcheck.sh" ]]; then
+        echo -e "${BLUE}Checking local LLM stack...${NC}"
+        if "$HOME/local-llm/scripts/healthcheck.sh" --quiet; then
+            : # healthcheck prints its own per-line ✓/✗
+        else
+            issues=$((issues + 1))
+        fi
+    fi
+
     # Summary
     echo
     if [[ $issues -eq 0 ]]; then

--- a/chezmoi/.chezmoi.toml.tmpl
+++ b/chezmoi/.chezmoi.toml.tmpl
@@ -14,3 +14,4 @@ sourceDir = "{{ .chezmoi.sourceDir }}"
 
 [data]
 email = {{ promptStringOnce . "email" "Git email" "paulnsorensen@gmail.com" | quote }}
+localLLM = {{ promptBoolOnce . "localLLM" "Manage local LLM stack on this machine?" false }}

--- a/chezmoi/.chezmoiignore
+++ b/chezmoi/.chezmoiignore
@@ -42,3 +42,8 @@ local-llm/**
 .config/systemd/user/worker-vision.service
 .config/systemd/user/worker-npu.service
 {{ end }}
+{{ if (get . "localLLM") }}
+# Stack enabled: the global README*/*.md rules above would otherwise skip
+# local-llm/README.md, which local-llm.target's Documentation= points at.
+!local-llm/README.md
+{{ end }}

--- a/chezmoi/.chezmoiignore
+++ b/chezmoi/.chezmoiignore
@@ -20,3 +20,25 @@ README*
 # They live inside the source dir for colocation, but chezmoi must not apply
 # them as $HOME files.
 lib/
+{{- /*
+Local LLM stack is per-machine, opt-in. When the localLLM flag is false,
+ignore the whole stack tree + its systemd units so non-LLM machines stay
+clean. (.chezmoiignore is rendered as a template, so this conditional works
+even though the rest of the file is static.)
+
+`get` (not bare `.localLLM`) is deliberate: chezmoi renders templates with
+missingkey=error, so a bare reference would fail `chezmoi apply` on any
+machine whose chezmoi.toml predates this flag. `get . "localLLM"` returns
+"" for an absent key, so the stack stays ignored by default.
+*/ -}}
+{{ if not (get . "localLLM") }}
+local-llm/**
+.config/systemd/user/litellm.service
+.config/systemd/user/local-llm.target
+.config/systemd/user/worker-cpu.service
+.config/systemd/user/worker-igpu.service
+.config/systemd/user/worker-coder.service
+.config/systemd/user/worker-opus.service
+.config/systemd/user/worker-vision.service
+.config/systemd/user/worker-npu.service
+{{ end }}

--- a/chezmoi/.chezmoiscripts/run_onchange_after_install-local-llm.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/run_onchange_after_install-local-llm.sh.tmpl
@@ -4,10 +4,14 @@
 # flag is false the body collapses to a no-op, so non-LLM machines do nothing.
 #
 # Hash strategy mirrors run_onchange_after_install-cursor-plugins: shasum the
-# provider lib so chezmoi re-runs whenever its contents change. Toggling the
-# flag also changes the rendered body, which re-triggers on its own.
+# inputs whose changes must re-trigger this script — the provider lib AND the
+# systemd unit files. Hashing the units is what makes `daemon-reload` actually
+# fire after a unit edit: the unit files deploy verbatim, so without them in the
+# hash a `.service`/`.target` change leaves this script's rendered body identical
+# and systemd keeps the stale definition. Toggling the flag also changes the
+# rendered body, which re-triggers on its own.
 #
-# install-local-llm.sh hash: {{ output "sh" "-c" (printf "shasum -a 256 %q/lib/install-local-llm.sh 2>/dev/null | cut -d' ' -f1" .chezmoi.sourceDir) }}
+# sources hash (provider lib + systemd units): {{ output "sh" "-c" (printf "cat %q/lib/install-local-llm.sh %q/dot_config/systemd/user/*.service %q/dot_config/systemd/user/*.target 2>/dev/null | shasum -a 256 | cut -d' ' -f1" .chezmoi.sourceDir .chezmoi.sourceDir .chezmoi.sourceDir) }}
 
 set -euo pipefail
 {{/* `get` (not bare `.localLLM`): chezmoi renders with missingkey=error, so a
@@ -30,6 +34,8 @@ echo "✓ opencode local-llm provider wired ($OPENCODE_CFG)"
 # enabling/starting workers stays explicit (llm-up), since a flag-on machine may
 # not yet have the 85G models or the built llama.cpp/lemonade binaries.
 if command -v systemctl &>/dev/null; then
-    systemctl --user daemon-reload 2>/dev/null || true
+    if ! systemctl --user daemon-reload; then
+        echo "⚠ systemctl --user daemon-reload failed — newly-deployed units may be stale. Re-run 'systemctl --user daemon-reload' once a user session/bus is available." >&2
+    fi
 fi
 {{ end }}

--- a/chezmoi/.chezmoiscripts/run_onchange_after_install-local-llm.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/run_onchange_after_install-local-llm.sh.tmpl
@@ -1,0 +1,35 @@
+#!/bin/bash
+# run_onchange — wires the local-llm opencode provider when the localLLM flag is
+# set, and reloads systemd user units. Gated entirely by `.localLLM`: when the
+# flag is false the body collapses to a no-op, so non-LLM machines do nothing.
+#
+# Hash strategy mirrors run_onchange_after_install-cursor-plugins: shasum the
+# provider lib so chezmoi re-runs whenever its contents change. Toggling the
+# flag also changes the rendered body, which re-triggers on its own.
+#
+# install-local-llm.sh hash: {{ output "sh" "-c" (printf "shasum -a 256 %q/lib/install-local-llm.sh 2>/dev/null | cut -d' ' -f1" .chezmoi.sourceDir) }}
+
+set -euo pipefail
+{{/* `get` (not bare `.localLLM`): chezmoi renders with missingkey=error, so a
+     bare reference fails `chezmoi apply` on any machine whose chezmoi.toml
+     predates this flag. `get . "localLLM"` returns "" (falsy → no-op) when absent. */}}
+{{ if (get . "localLLM") }}
+SOURCE_DIR="{{ .chezmoi.sourceDir }}"
+OPENCODE_CFG="${OPENCODE_CONFIG:-${XDG_CONFIG_HOME:-$HOME/.config}/opencode/opencode.json}"
+
+if ! command -v jq &>/dev/null; then
+    echo "Error: jq not found. Install with: brew install jq" >&2
+    exit 1
+fi
+
+# Idempotently merge the local-llm provider block into opencode.json.
+bash "$SOURCE_DIR/lib/install-local-llm.sh" "$OPENCODE_CFG"
+echo "✓ opencode local-llm provider wired ($OPENCODE_CFG)"
+
+# Pick up newly-deployed ~/.config/systemd/user units. daemon-reload ONLY —
+# enabling/starting workers stays explicit (llm-up), since a flag-on machine may
+# not yet have the 85G models or the built llama.cpp/lemonade binaries.
+if command -v systemctl &>/dev/null; then
+    systemctl --user daemon-reload 2>/dev/null || true
+fi
+{{ end }}

--- a/chezmoi/dot_config/systemd/user/litellm.service
+++ b/chezmoi/dot_config/systemd/user/litellm.service
@@ -1,10 +1,11 @@
 [Unit]
 Description=LiteLLM proxy (unified OpenAI-compatible front for all workers)
-After=network.target worker-igpu.service worker-cpu.service
+After=worker-igpu.service worker-cpu.service
 PartOf=local-llm.target
 
 [Service]
 Type=simple
+ExecStartPre=/bin/mkdir -p %h/local-llm/logs
 ExecStart=%h/.local/bin/litellm \
   --config %h/local-llm/configs/litellm.yaml \
   --port 4000 \

--- a/chezmoi/dot_config/systemd/user/litellm.service
+++ b/chezmoi/dot_config/systemd/user/litellm.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=LiteLLM proxy (unified OpenAI-compatible front for all workers)
+After=network.target worker-igpu.service worker-cpu.service
+PartOf=local-llm.target
+
+[Service]
+Type=simple
+ExecStart=%h/.local/bin/litellm \
+  --config %h/local-llm/configs/litellm.yaml \
+  --port 4000 \
+  --host 127.0.0.1
+Restart=on-failure
+RestartSec=5
+StandardOutput=append:%h/local-llm/logs/litellm.log
+StandardError=append:%h/local-llm/logs/litellm.log
+
+[Install]
+WantedBy=local-llm.target

--- a/chezmoi/dot_config/systemd/user/local-llm.target
+++ b/chezmoi/dot_config/systemd/user/local-llm.target
@@ -1,0 +1,8 @@
+[Unit]
+Description=Local LLM stack (always-on workers + LiteLLM proxy)
+Documentation=file://%h/local-llm/README.md
+Wants=worker-igpu.service worker-cpu.service litellm.service
+After=worker-igpu.service worker-cpu.service litellm.service
+
+[Install]
+WantedBy=default.target

--- a/chezmoi/dot_config/systemd/user/worker-coder.service
+++ b/chezmoi/dot_config/systemd/user/worker-coder.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=Coder-tier worker (Qwen3-Coder-30B-A3B-Instruct on iGPU — displaces Sonnet)
+After=network.target
+# Mutual exclusion with Sonnet (same iGPU slot, same arch)
+Conflicts=worker-igpu.service
+ConditionPathExists=%h/local-llm/models/Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf
+
+[Service]
+Type=simple
+Environment="LD_LIBRARY_PATH=%h/local-llm/bin/llama.cpp"
+ExecStart=%h/local-llm/bin/llama.cpp/llama-server \
+  --model %h/local-llm/models/Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf \
+  --host 127.0.0.1 --port 8085 \
+  --ctx-size 65536 \
+  --parallel 4 --cont-batching \
+  --batch-size 2048 --ubatch-size 512 \
+  --cache-type-k q8_0 --cache-type-v q8_0 \
+  --n-gpu-layers 99 \
+  --alias local-coder \
+  --log-file %h/local-llm/logs/worker-coder.log
+Restart=on-failure
+RestartSec=5
+Nice=5
+
+# Not enabled by default — start manually: systemctl --user start worker-coder

--- a/chezmoi/dot_config/systemd/user/worker-coder.service
+++ b/chezmoi/dot_config/systemd/user/worker-coder.service
@@ -1,12 +1,12 @@
 [Unit]
 Description=Coder-tier worker (Qwen3-Coder-30B-A3B-Instruct on iGPU — displaces Sonnet)
-After=network.target
 # Mutual exclusion with Sonnet (same iGPU slot, same arch)
 Conflicts=worker-igpu.service
 ConditionPathExists=%h/local-llm/models/Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf
 
 [Service]
 Type=simple
+ExecStartPre=/bin/mkdir -p %h/local-llm/logs
 Environment="LD_LIBRARY_PATH=%h/local-llm/bin/llama.cpp"
 ExecStart=%h/local-llm/bin/llama.cpp/llama-server \
   --model %h/local-llm/models/Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf \

--- a/chezmoi/dot_config/systemd/user/worker-cpu.service
+++ b/chezmoi/dot_config/systemd/user/worker-cpu.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=Haiku-tier worker (Qwen3-8B on CPU, Zen 5c cores)
+After=network.target
+PartOf=local-llm.target
+
+[Service]
+Type=simple
+Environment="LD_LIBRARY_PATH=%h/local-llm/bin/llama.cpp"
+# Pin to Zen 5c efficiency cores (4-11) + their SMT siblings (16-23) — leaves Zen 5 perf cores free for foreground
+ExecStart=/usr/bin/taskset -c 4-11,16-23 %h/local-llm/bin/llama.cpp/llama-server \
+  --model %h/local-llm/models/Qwen3-8B-Q4_K_M.gguf \
+  --host 127.0.0.1 --port 8081 \
+  --ctx-size 16384 \
+  --parallel 4 --cont-batching \
+  --batch-size 1024 --ubatch-size 256 \
+  --threads 12 \
+  --device none \
+  --reasoning off \
+  --alias local-haiku \
+  --log-file %h/local-llm/logs/worker-cpu.log
+Restart=on-failure
+RestartSec=5
+Nice=10
+
+[Install]
+WantedBy=local-llm.target

--- a/chezmoi/dot_config/systemd/user/worker-cpu.service
+++ b/chezmoi/dot_config/systemd/user/worker-cpu.service
@@ -1,10 +1,11 @@
 [Unit]
 Description=Haiku-tier worker (Qwen3-8B on CPU, Zen 5c cores)
-After=network.target
 PartOf=local-llm.target
+ConditionPathExists=%h/local-llm/models/Qwen3-8B-Q4_K_M.gguf
 
 [Service]
 Type=simple
+ExecStartPre=/bin/mkdir -p %h/local-llm/logs
 Environment="LD_LIBRARY_PATH=%h/local-llm/bin/llama.cpp"
 # Pin to Zen 5c efficiency cores (4-11) + their SMT siblings (16-23) — leaves Zen 5 perf cores free for foreground
 ExecStart=/usr/bin/taskset -c 4-11,16-23 %h/local-llm/bin/llama.cpp/llama-server \

--- a/chezmoi/dot_config/systemd/user/worker-igpu.service
+++ b/chezmoi/dot_config/systemd/user/worker-igpu.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=Sonnet-tier worker (Qwen3-30B-A3B on iGPU via Vulkan)
+After=network.target
+PartOf=local-llm.target
+
+[Service]
+Type=simple
+Environment="LD_LIBRARY_PATH=%h/local-llm/bin/llama.cpp"
+ExecStart=%h/local-llm/bin/llama.cpp/llama-server \
+  --model %h/local-llm/models/Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf \
+  --host 127.0.0.1 --port 8080 \
+  --ctx-size 32768 \
+  --parallel 8 --cont-batching \
+  --batch-size 2048 --ubatch-size 512 \
+  --cache-type-k q8_0 --cache-type-v q8_0 \
+  --n-gpu-layers 99 \
+  --alias local-sonnet \
+  --log-file %h/local-llm/logs/worker-igpu.log
+Restart=on-failure
+RestartSec=5
+Nice=5
+
+[Install]
+WantedBy=local-llm.target

--- a/chezmoi/dot_config/systemd/user/worker-igpu.service
+++ b/chezmoi/dot_config/systemd/user/worker-igpu.service
@@ -1,10 +1,11 @@
 [Unit]
 Description=Sonnet-tier worker (Qwen3-30B-A3B on iGPU via Vulkan)
-After=network.target
 PartOf=local-llm.target
+ConditionPathExists=%h/local-llm/models/Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf
 
 [Service]
 Type=simple
+ExecStartPre=/bin/mkdir -p %h/local-llm/logs
 Environment="LD_LIBRARY_PATH=%h/local-llm/bin/llama.cpp"
 ExecStart=%h/local-llm/bin/llama.cpp/llama-server \
   --model %h/local-llm/models/Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf \

--- a/chezmoi/dot_config/systemd/user/worker-npu.service
+++ b/chezmoi/dot_config/systemd/user/worker-npu.service
@@ -1,18 +1,18 @@
 [Unit]
 Description=NPU classifier worker (Lemonade Server + FastFlowLM on XDNA 2)
-After=network.target
 PartOf=local-llm.target
 # Requires: ~/local-llm/scripts/install-npu.sh has been run successfully
 ConditionPathExists=/usr/lib/x86_64-linux-gnu/libxrt_npu2.so
 
 [Service]
 Type=simple
+ExecStartPre=/bin/mkdir -p %h/local-llm/logs
 Environment="LEMONADE_HOST=127.0.0.1"
 Environment="LEMONADE_PORT=8000"
 ExecStart=%h/local-llm/bin/lemonade/lemond --port 8000 --host 127.0.0.1
 Restart=on-failure
 RestartSec=5
-Nice=0
+Nice=5
 StandardOutput=append:%h/local-llm/logs/worker-npu.log
 StandardError=append:%h/local-llm/logs/worker-npu.log
 

--- a/chezmoi/dot_config/systemd/user/worker-npu.service
+++ b/chezmoi/dot_config/systemd/user/worker-npu.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=NPU classifier worker (Lemonade Server + FastFlowLM on XDNA 2)
+After=network.target
+PartOf=local-llm.target
+# Requires: ~/local-llm/scripts/install-npu.sh has been run successfully
+ConditionPathExists=/usr/lib/x86_64-linux-gnu/libxrt_npu2.so
+
+[Service]
+Type=simple
+Environment="LEMONADE_HOST=127.0.0.1"
+Environment="LEMONADE_PORT=8000"
+ExecStart=%h/local-llm/bin/lemonade/lemond --port 8000 --host 127.0.0.1
+Restart=on-failure
+RestartSec=5
+Nice=0
+StandardOutput=append:%h/local-llm/logs/worker-npu.log
+StandardError=append:%h/local-llm/logs/worker-npu.log
+
+[Install]
+WantedBy=local-llm.target

--- a/chezmoi/dot_config/systemd/user/worker-opus.service
+++ b/chezmoi/dot_config/systemd/user/worker-opus.service
@@ -1,12 +1,12 @@
 [Unit]
 Description=Opus-tier worker (Llama 3.3 70B on iGPU — displaces Sonnet)
-After=network.target
 # Mutual exclusion with Sonnet — systemd stops worker-igpu when this starts
 Conflicts=worker-igpu.service
 ConditionPathExists=%h/local-llm/models/Llama-3.3-70B-Instruct-Q4_K_M.gguf
 
 [Service]
 Type=simple
+ExecStartPre=/bin/mkdir -p %h/local-llm/logs
 Environment="LD_LIBRARY_PATH=%h/local-llm/bin/llama.cpp"
 ExecStart=%h/local-llm/bin/llama.cpp/llama-server \
   --model %h/local-llm/models/Llama-3.3-70B-Instruct-Q4_K_M.gguf \

--- a/chezmoi/dot_config/systemd/user/worker-opus.service
+++ b/chezmoi/dot_config/systemd/user/worker-opus.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=Opus-tier worker (Llama 3.3 70B on iGPU — displaces Sonnet)
+After=network.target
+# Mutual exclusion with Sonnet — systemd stops worker-igpu when this starts
+Conflicts=worker-igpu.service
+ConditionPathExists=%h/local-llm/models/Llama-3.3-70B-Instruct-Q4_K_M.gguf
+
+[Service]
+Type=simple
+Environment="LD_LIBRARY_PATH=%h/local-llm/bin/llama.cpp"
+ExecStart=%h/local-llm/bin/llama.cpp/llama-server \
+  --model %h/local-llm/models/Llama-3.3-70B-Instruct-Q4_K_M.gguf \
+  --host 127.0.0.1 --port 8090 \
+  --ctx-size 16384 \
+  --parallel 1 --cont-batching \
+  --batch-size 1024 --ubatch-size 256 \
+  --cache-type-k q8_0 --cache-type-v q8_0 \
+  --n-gpu-layers 99 \
+  --alias local-opus \
+  --log-file %h/local-llm/logs/worker-opus.log
+Restart=on-failure
+RestartSec=5
+Nice=15
+
+# Not enabled by default — start manually: systemctl --user start worker-opus

--- a/chezmoi/dot_config/systemd/user/worker-vision.service
+++ b/chezmoi/dot_config/systemd/user/worker-vision.service
@@ -1,11 +1,11 @@
 [Unit]
 Description=Vision worker (Qwen2.5-VL-7B on CPU, separate Zen 5c pin)
-After=network.target
 ConditionPathExists=%h/local-llm/models/Qwen2.5-VL-7B-Instruct-Q4_K_M.gguf
 ConditionPathExists=%h/local-llm/models/mmproj-Qwen2.5-VL-7B-Instruct-Q8_0.gguf
 
 [Service]
 Type=simple
+ExecStartPre=/bin/mkdir -p %h/local-llm/logs
 Environment="LD_LIBRARY_PATH=%h/local-llm/bin/llama.cpp"
 # Pin to upper Zen 5c cores so it competes less with worker-cpu (which uses 4-11,16-23)
 ExecStart=/usr/bin/taskset -c 8-11,20-23 %h/local-llm/bin/llama.cpp/llama-server \

--- a/chezmoi/dot_config/systemd/user/worker-vision.service
+++ b/chezmoi/dot_config/systemd/user/worker-vision.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=Vision worker (Qwen2.5-VL-7B on CPU, separate Zen 5c pin)
+After=network.target
+ConditionPathExists=%h/local-llm/models/Qwen2.5-VL-7B-Instruct-Q4_K_M.gguf
+ConditionPathExists=%h/local-llm/models/mmproj-Qwen2.5-VL-7B-Instruct-Q8_0.gguf
+
+[Service]
+Type=simple
+Environment="LD_LIBRARY_PATH=%h/local-llm/bin/llama.cpp"
+# Pin to upper Zen 5c cores so it competes less with worker-cpu (which uses 4-11,16-23)
+ExecStart=/usr/bin/taskset -c 8-11,20-23 %h/local-llm/bin/llama.cpp/llama-server \
+  --model %h/local-llm/models/Qwen2.5-VL-7B-Instruct-Q4_K_M.gguf \
+  --mmproj %h/local-llm/models/mmproj-Qwen2.5-VL-7B-Instruct-Q8_0.gguf \
+  --host 127.0.0.1 --port 8082 \
+  --ctx-size 8192 \
+  --parallel 2 --cont-batching \
+  --batch-size 1024 --ubatch-size 256 \
+  --threads 8 \
+  --device none \
+  --alias local-vision \
+  --log-file %h/local-llm/logs/worker-vision.log
+Restart=on-failure
+RestartSec=5
+Nice=15
+
+# Not enabled by default — start manually: systemctl --user start worker-vision

--- a/chezmoi/lib/install-local-llm.sh
+++ b/chezmoi/lib/install-local-llm.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+#
+# install-local-llm.sh — write the `local-llm` opencode provider block idempotently.
+#
+# opencode talks to the local LiteLLM proxy (http://127.0.0.1:4000/v1, dummy key
+# sk-local) as an OpenAI-compatible provider. There is no non-interactive
+# `opencode provider add`, so — exactly like the MCP sync jq-edits the `.mcp`
+# block (agents/mcp/lib.sh:mcp_opencode_add) — we jq-merge the `.provider`
+# block in place. Idempotent: re-running produces a byte-identical file.
+#
+# Usage: install-local-llm.sh <opencode_json_path>
+#
+# Run as a subprocess (the run_onchange template execs it; bats runs it too),
+# never sourced, so top-level `set -euo pipefail` is safe here.
+
+set -euo pipefail
+
+# Endpoint is overridable for tests / non-default proxies; defaults to the
+# stack's LiteLLM front.
+LOCAL_LLM_BASE_URL="${LOCAL_LLM_BASE_URL:-http://127.0.0.1:4000/v1}"
+
+install_local_llm_opencode_provider() {
+    local cfg="${1:?usage: install-local-llm.sh <opencode_json_path>}"
+    local tmp entry
+
+    if ! command -v jq &>/dev/null; then
+        echo "Error: jq not found." >&2
+        return 1
+    fi
+
+    # Scaffold a minimal opencode.json if absent, mirroring chezmoi's
+    # create_opencode.json scaffold (so a sync-before-chezmoi run still works).
+    if [[ ! -f "$cfg" ]]; then
+        mkdir -p "$(dirname "$cfg")"
+        # shellcheck disable=SC2016  # literal $schema JSON key, not a shell variable
+        echo '{"$schema": "https://opencode.ai/config.json", "formatter": true}' > "$cfg"
+    fi
+
+    entry=$(jq -n --arg base "$LOCAL_LLM_BASE_URL" '{
+        npm: "@ai-sdk/openai-compatible",
+        name: "Local (LiteLLM)",
+        options: { baseURL: $base, apiKey: "sk-local" },
+        models: {
+            "local-sonnet":     { name: "Local Sonnet — Qwen3-30B-A3B (iGPU)" },
+            "local-haiku":      { name: "Local Haiku — Qwen3-8B (CPU)" },
+            "local-coder":      { name: "Local Coder — Qwen3-Coder-30B-A3B (iGPU)" },
+            "local-opus":       { name: "Local Opus — Llama-3.3-70B (iGPU)" },
+            "local-vision":     { name: "Local Vision — Qwen2.5-VL-7B (CPU)" },
+            "local-classifier": { name: "Local Classifier — Llama-3.2-3B (NPU)" }
+        }
+    }')
+
+    tmp=$(mktemp)
+    jq --argjson entry "$entry" \
+        '.provider = ((.provider // {}) | .["local-llm"] = $entry)' "$cfg" > "$tmp" \
+        && mv "$tmp" "$cfg"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    install_local_llm_opencode_provider "${1:-}"
+fi

--- a/chezmoi/local-llm/README.md
+++ b/chezmoi/local-llm/README.md
@@ -1,0 +1,115 @@
+# Local LLM stack — `~/local-llm/`
+
+Worker-pool architecture behind a frontier reasoning agent. All endpoints OpenAI-compatible.
+
+## Topology
+
+```
+  NPU  (XDNA 2)   :8000  local-classifier   Llama 3.2 3B INT4 (FastFlowLM, optional)
+  iGPU (890M)     :8080  local-sonnet       Qwen3-30B-A3B-Instruct-2507 Q4_K_M (Vulkan)
+  CPU  (Zen 5c)   :8081  local-haiku        Qwen3-8B Q4_K_M (--reasoning off)
+  iGPU (890M)     :8085  local-coder        Qwen3-Coder-30B-A3B-Instruct Q4 (optional, displaces Sonnet)
+  iGPU (890M)     :8090  local-opus         Llama 3.3 70B Q4 (optional, displaces Sonnet)
+  CPU  (Zen 5c)   :8082  local-vision      Qwen2.5-VL-7B Q4 (optional)
+                  :4000  LiteLLM proxy      unified front; fallbacks configured
+```
+
+## Quick start
+
+```bash
+# Source aliases (once):
+echo 'source ~/local-llm/scripts/aliases.sh' >> ~/.zshrc
+
+# Always-on stack auto-starts on login (linger enabled, default.target):
+llm-status                       # check what's up
+llm-ping                         # quick port probe
+llm-models                       # list models LiteLLM serves
+llm-chat local-sonnet "hello"    # one-shot chat
+
+# Optional tiers:
+llm-coder-on                     # Qwen3-Coder-30B-A3B, auto-stops Sonnet
+llm-coder-off                    # back to Sonnet
+llm-opus-on                      # 70B, auto-stops Sonnet
+llm-opus-off                     # back to Sonnet
+llm-vision-on                    # adds vision worker on CPU
+llm-vision-off
+
+# NPU (needs sudo block first):
+bash ~/local-llm/scripts/install-npu.sh
+llm-npu-on
+```
+
+## Resource budget
+
+| State | Resident | Peak bandwidth (~120 GB/s avail) |
+|---|---|---|
+| Always-on only (Sonnet + Haiku + LiteLLM) | ~23 GB | ~70 GB/s |
+| + NPU classifier | ~25 GB | ~73 GB/s |
+| + Vision (CPU) | ~28 GB | ~80 GB/s |
+| Opus mode (Sonnet stopped, 70B running) | ~45 GB | ~70 GB/s |
+
+## Layout
+
+```
+~/local-llm/
+├── bin/
+│   ├── llama.cpp/         # Vulkan-build llama-server (b9391)
+│   └── lemonade/          # Lemonade Server v10.6.0 (NPU)
+├── configs/
+│   └── litellm.yaml
+├── logs/                  # all worker + LiteLLM logs
+├── models/
+│   ├── Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf
+│   └── Qwen3-8B-Q4_K_M.gguf
+├── scripts/
+│   ├── aliases.sh
+│   └── install-npu.sh
+└── systemd/               # (unit files actually live in ~/.config/systemd/user/)
+```
+
+## Frontier agent integration
+
+```python
+# OpenAI-compatible client pointed at LiteLLM:
+from openai import OpenAI
+client = OpenAI(base_url="http://127.0.0.1:4000/v1", api_key="sk-local")
+
+# Use model names by tier:
+resp = client.chat.completions.create(
+    model="local-sonnet",            # main worker
+    # model="local-haiku",           # cheap/fast
+    # model="local-classifier",      # tiny/NPU (falls back to haiku if NPU off)
+    # model="local-opus",            # 70B (falls back to sonnet if not running)
+    # model="local-vision",          # VLM (no fallback)
+    messages=[{"role": "user", "content": "..."}],
+)
+```
+
+## Fallbacks (in `litellm.yaml`)
+
+- `local-opus` → `local-sonnet`
+- `local-classifier` → `local-haiku`
+- `local-vision` → no fallback (fails loudly so the agent can adapt)
+
+## Adding the optional models
+
+```bash
+# Opus — Llama 3.3 70B Q4_K_M (42.52 GB):
+hf download unsloth/Llama-3.3-70B-Instruct-GGUF \
+  Llama-3.3-70B-Instruct-Q4_K_M.gguf --local-dir ~/local-llm/models
+
+# Vision — Qwen2.5-VL-7B + mmproj (5.53 GB total, ggml-org = llama.cpp team's official repo):
+hf download ggml-org/Qwen2.5-VL-7B-Instruct-GGUF \
+  Qwen2.5-VL-7B-Instruct-Q4_K_M.gguf --local-dir ~/local-llm/models
+hf download ggml-org/Qwen2.5-VL-7B-Instruct-GGUF \
+  mmproj-Qwen2.5-VL-7B-Instruct-Q8_0.gguf --local-dir ~/local-llm/models
+```
+
+The systemd units gate on file presence (`ConditionPathExists=`), so once the file is there, the unit starts cleanly.
+
+## Tuning notes
+
+- iGPU worker `--ctx-size 32768 --parallel 8` → 4096 tokens/slot. Increase for long-context tasks; decrease parallelism to give each slot more.
+- CPU worker pinned to Zen 5c efficiency cores (4-11, 16-23) to leave Zen 5 perf cores free for foreground work.
+- KV cache quantized to Q8_0 on Sonnet + Opus (`--cache-type-k q8_0 --cache-type-v q8_0`) — halves KV memory.
+- All workers run with `Nice` ≥ 5 so foreground work isn't crushed.

--- a/chezmoi/local-llm/configs/litellm.yaml
+++ b/chezmoi/local-llm/configs/litellm.yaml
@@ -47,7 +47,11 @@ model_list:
       api_key: none
 
 router_settings:
-  num_retries: 0
+  # One retry lets a worker still cold-loading answer on the second attempt
+  # (e.g. local-opus's 70B). NOTE: local-opus's fallback to local-sonnet below
+  # can't fire while Sonnet is stopped by Conflicts=, so a cold local-opus may
+  # still 5xx during its load window — after `llm-opus-on`, wait for readiness.
+  num_retries: 1
   timeout: 120
   fallbacks:
     # If Opus isn't running, fall back to Sonnet

--- a/chezmoi/local-llm/configs/litellm.yaml
+++ b/chezmoi/local-llm/configs/litellm.yaml
@@ -1,0 +1,64 @@
+# LiteLLM proxy config — unified OpenAI-compatible front for local workers
+# Endpoint: http://127.0.0.1:4000/v1
+# Frontier agent calls models by name; LiteLLM routes to the right worker.
+
+model_list:
+  # Sonnet-tier — Qwen3-30B-A3B MoE on iGPU (Vulkan)
+  - model_name: local-sonnet
+    litellm_params:
+      model: openai/local-sonnet
+      api_base: http://127.0.0.1:8080/v1
+      api_key: none
+
+  # Haiku-tier — Qwen3-8B dense on CPU (Zen 5c)
+  - model_name: local-haiku
+    litellm_params:
+      model: openai/local-haiku
+      api_base: http://127.0.0.1:8081/v1
+      api_key: none
+
+  # NPU classifier — Llama 3.2 3B via Lemonade/FastFlowLM (requires install-npu.sh first)
+  - model_name: local-classifier
+    litellm_params:
+      model: openai/local-classifier
+      api_base: http://127.0.0.1:8000/v1
+      api_key: none
+
+  # Coder-tier — Qwen3-Coder-30B-A3B-Instruct on iGPU, displaces Sonnet when started
+  - model_name: local-coder
+    litellm_params:
+      model: openai/local-coder
+      api_base: http://127.0.0.1:8085/v1
+      api_key: none
+
+  # Opus-tier — Llama 3.3 70B on iGPU, displaces Sonnet when started
+  - model_name: local-opus
+    litellm_params:
+      model: openai/local-opus
+      api_base: http://127.0.0.1:8090/v1
+      api_key: none
+      timeout: 600
+
+  # Vision — Qwen2.5-VL-7B on CPU
+  - model_name: local-vision
+    litellm_params:
+      model: openai/local-vision
+      api_base: http://127.0.0.1:8082/v1
+      api_key: none
+
+router_settings:
+  num_retries: 0
+  timeout: 120
+  fallbacks:
+    # If Opus isn't running, fall back to Sonnet
+    - local-opus: ["local-sonnet"]
+    # If Coder isn't running, fall back to Sonnet (still strong at code)
+    - local-coder: ["local-sonnet"]
+    # If the NPU classifier isn't installed, fall back to Haiku
+    - local-classifier: ["local-haiku"]
+    # Vision has no local fallback — agent gets clear 503
+
+litellm_settings:
+  drop_params: true
+  set_verbose: false
+  json_logs: false

--- a/chezmoi/local-llm/scripts/executable_aliases.sh
+++ b/chezmoi/local-llm/scripts/executable_aliases.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Local LLM stack aliases — source from ~/.zshrc:  source ~/local-llm/scripts/aliases.sh
+
+# Always-on stack toggles
+alias llm-up='systemctl --user start  local-llm.target'
+alias llm-down='systemctl --user stop  worker-igpu worker-cpu litellm worker-npu worker-opus worker-vision 2>/dev/null'
+alias llm-status='systemctl --user list-units "worker-*" "litellm*" "local-llm*" --all --no-pager'
+alias llm-logs='journalctl --user -u "worker-*" -u litellm -f'
+
+# Optional tier toggles
+alias llm-opus-on='systemctl --user start worker-opus'      # auto-stops Sonnet (Conflicts=)
+alias llm-opus-off='systemctl --user stop  worker-opus && systemctl --user start worker-igpu'
+alias llm-coder-on='systemctl --user start worker-coder'    # auto-stops Sonnet (Conflicts=)
+alias llm-coder-off='systemctl --user stop  worker-coder && systemctl --user start worker-igpu'
+alias llm-vision-on='systemctl --user start worker-vision'
+alias llm-vision-off='systemctl --user stop  worker-vision'
+alias llm-npu-on='systemctl --user start worker-npu'
+alias llm-npu-off='systemctl --user stop  worker-npu'
+
+# Endpoints
+alias llm-models='curl -s http://127.0.0.1:4000/v1/models | jq'
+# shellcheck disable=SC2154  # p is the for-loop variable inside the alias body
+alias llm-ping='for p in 4000 8080 8081 8000 8085 8090 8082; do printf "port %s: " $p; curl -s --max-time 1 http://127.0.0.1:$p/v1/models >/dev/null && echo UP || echo down; done'
+
+# Health / verify — smoke-test the stack (units + ports + real completions).
+# `llm-test --opencode` also probes the wired opencode provider end-to-end.
+alias llm-test='~/local-llm/scripts/healthcheck.sh'
+alias llm-health='~/local-llm/scripts/healthcheck.sh'
+
+# On-demand model download (never run by dots sync; idempotent).
+alias llm-download='~/local-llm/scripts/download-models.sh'
+
+# Quick chat helper — usage: llm-chat local-sonnet "your prompt"
+llm-chat() {
+  local model="${1:-local-sonnet}"; shift
+  local prompt="$*"
+  curl -s http://127.0.0.1:4000/v1/chat/completions \
+    -H 'Content-Type: application/json' \
+    -H 'Authorization: Bearer sk-local' \
+    -d "$(jq -nc --arg m "$model" --arg p "$prompt" \
+      '{model:$m, messages:[{role:"user", content:$p}], max_tokens: 512}')" \
+    | jq -r '.choices[0].message.content // .error.message'
+}

--- a/chezmoi/local-llm/scripts/executable_aliases.sh
+++ b/chezmoi/local-llm/scripts/executable_aliases.sh
@@ -3,7 +3,7 @@
 
 # Always-on stack toggles
 alias llm-up='systemctl --user start  local-llm.target'
-alias llm-down='systemctl --user stop  worker-igpu worker-cpu litellm worker-npu worker-opus worker-vision 2>/dev/null'
+alias llm-down='systemctl --user stop  worker-igpu worker-cpu litellm worker-npu worker-coder worker-opus worker-vision 2>/dev/null'
 alias llm-status='systemctl --user list-units "worker-*" "litellm*" "local-llm*" --all --no-pager'
 alias llm-logs='journalctl --user -u "worker-*" -u litellm -f'
 

--- a/chezmoi/local-llm/scripts/executable_download-models.sh
+++ b/chezmoi/local-llm/scripts/executable_download-models.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# download-models.sh — fetch the GGUF weights for the local LLM stack on demand.
+#
+# This is NEVER run by `dots sync` — the weights are 85G and machine-specific.
+# Run it by hand (alias `llm-download`) on a box where you want the stack live.
+# Idempotent: any model file already present in ~/local-llm/models is skipped.
+#
+# PREREQUISITES this script does NOT handle (documented in README.md):
+#   - the built llama.cpp + lemonade binaries under ~/local-llm/bin/
+#   - the LiteLLM install at ~/.local/bin/litellm
+#
+# Repo IDs: opus + vision are confirmed from the stack README. The three Qwen3
+# repos below are NOT recorded anywhere on the source machine; they follow the
+# same unsloth naming convention as the confirmed opus repo
+# (unsloth/<Model>-GGUF + <Model>-Q4_K_M.gguf) but are UNVERIFIED — confirm on
+# huggingface.co before a fresh-machine download. `hf download` fails loud if a
+# repo/file is wrong, so a bad guess cannot silently produce a broken stack.
+
+set -euo pipefail
+
+MODELS_DIR="${LLM_MODELS_DIR:-$HOME/local-llm/models}"
+
+# "repo  file  confidence"
+MODELS=(
+    "unsloth/Qwen3-30B-A3B-Instruct-2507-GGUF  Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf  unverified"  # sonnet
+    "unsloth/Qwen3-8B-GGUF                      Qwen3-8B-Q4_K_M.gguf                     unverified"  # haiku
+    "unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF  Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf unverified"  # coder
+    "unsloth/Llama-3.3-70B-Instruct-GGUF        Llama-3.3-70B-Instruct-Q4_K_M.gguf       confirmed"   # opus
+    "ggml-org/Qwen2.5-VL-7B-Instruct-GGUF       Qwen2.5-VL-7B-Instruct-Q4_K_M.gguf       confirmed"   # vision
+    "ggml-org/Qwen2.5-VL-7B-Instruct-GGUF       mmproj-Qwen2.5-VL-7B-Instruct-Q8_0.gguf  confirmed"   # vision mmproj
+)
+
+main() {
+    if ! command -v hf &>/dev/null; then
+        echo "Error: 'hf' (huggingface CLI) not found. Install with: uv tool install huggingface_hub" >&2
+        exit 1
+    fi
+    mkdir -p "$MODELS_DIR"
+
+    local repo file conf skipped=0 fetched=0
+    for entry in "${MODELS[@]}"; do
+        read -r repo file conf <<<"$entry"
+        if [[ -f "$MODELS_DIR/$file" ]]; then
+            echo "✓ present, skipping: $file"
+            skipped=$((skipped + 1))
+            continue
+        fi
+        [[ "$conf" == "unverified" ]] && \
+            echo "⚠ repo '$repo' is UNVERIFIED — confirm on huggingface.co if this fails"
+        echo "↓ downloading: $repo  $file"
+        hf download "$repo" "$file" --local-dir "$MODELS_DIR"
+        fetched=$((fetched + 1))
+    done
+
+    echo
+    echo "done — $fetched fetched, $skipped already present in $MODELS_DIR"
+    echo "Start the stack with: llm-up   (workers gate on model presence via ConditionPathExists)"
+}
+
+main "$@"

--- a/chezmoi/local-llm/scripts/executable_healthcheck.sh
+++ b/chezmoi/local-llm/scripts/executable_healthcheck.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+#
+# healthcheck.sh — verify the local LLM stack is configured and running correctly.
+#
+#   healthcheck.sh             Full smoke test (units + ports + real completions)
+#   healthcheck.sh --quiet     Lightweight subset for `dots doctor` (no completions)
+#   healthcheck.sh --opencode  Also run an opencode end-to-end probe through the provider
+#
+# Source-safe by design: functions are defined at top level WITHOUT enabling
+# errexit, so bats can `source` this file and call the decision functions
+# directly with faked `curl` / `systemctl` on PATH. `set -euo pipefail` lives
+# inside main(), which only runs on direct execution.
+
+# Colors (respect an already-sourced palette; else sane defaults).
+: "${GREEN:=$'\033[0;32m'}"
+: "${YELLOW:=$'\033[1;33m'}"
+: "${RED:=$'\033[0;31m'}"
+: "${BLUE:=$'\033[0;34m'}"
+: "${NC:=$'\033[0m'}"
+
+# Tunables (overridable for tests / non-default proxy).
+LLM_PROXY="${LLM_PROXY:-http://127.0.0.1:4000}"
+LLM_API_KEY="${LLM_API_KEY:-sk-local}"
+LLM_CURL_TIMEOUT="${LLM_CURL_TIMEOUT:-5}"
+
+# Tier table: "unit port model class(hard|opt)". The LiteLLM proxy and the two
+# always-on workers are hard checks; optional tiers are informational.
+LLM_TIERS=(
+    "worker-igpu   8080 local-sonnet     hard"
+    "worker-cpu    8081 local-haiku      hard"
+    "worker-coder  8085 local-coder      opt"
+    "worker-opus   8090 local-opus       opt"
+    "worker-vision 8082 local-vision     opt"
+    "worker-npu    8000 local-classifier opt"
+)
+
+# ─── decision functions (unit-testable) ────────────────────────────────────
+
+# llm_unit_active <unit> — 0 if the systemd --user unit is active.
+llm_unit_active() {
+    systemctl --user is-active --quiet "$1" 2>/dev/null
+}
+
+# llm_port_up <port> — 0 if the worker's /v1/models endpoint answers.
+llm_port_up() {
+    curl -fsS --max-time "$LLM_CURL_TIMEOUT" \
+        "http://127.0.0.1:${1}/v1/models" >/dev/null 2>&1
+}
+
+# _llm_complete <model> — echo the raw chat-completion JSON; curl status propagates.
+_llm_complete() {
+    curl -fsS --max-time "$LLM_CURL_TIMEOUT" \
+        "${LLM_PROXY}/v1/chat/completions" \
+        -H 'Content-Type: application/json' \
+        -H "Authorization: Bearer ${LLM_API_KEY}" \
+        -d "$(jq -nc --arg m "$1" \
+            '{model:$m, messages:[{role:"user", content:"reply with OK"}], max_tokens:16}')" \
+        2>/dev/null
+}
+
+# llm_completion_ok <model> — 0 if the proxy returns non-empty assistant content.
+llm_completion_ok() {
+    local resp; resp=$(_llm_complete "$1") || return 1
+    [[ -n "$(jq -r '.choices[0].message.content // empty' <<<"$resp" 2>/dev/null)" ]]
+}
+
+# llm_served_model <model> — echo the model LiteLLM actually answered with
+# (differs from the request when a fallback fired, e.g. opus→sonnet).
+llm_served_model() {
+    local resp; resp=$(_llm_complete "$1") || return 1
+    jq -r '.model // empty' <<<"$resp" 2>/dev/null
+}
+
+# ─── reports ────────────────────────────────────────────────────────────────
+
+# Lightweight subset for `dots doctor`: hard units active + proxy reachable.
+# A fully-stopped stack is the normal idle state — workers are never
+# auto-started (they gate on 85G models that may be absent), so a clean stop
+# is not a config problem and must not make `dots doctor` fail. Only a
+# partially-up / broken stack (some unit active but a sibling or the proxy
+# down) is a real issue.
+llm_quick_check() {
+    local rc=0 active=0
+    for u in litellm worker-igpu worker-cpu; do
+        llm_unit_active "$u" && active=$((active + 1))
+    done
+    if [[ $active -eq 0 ]]; then
+        echo -e "  ${YELLOW}• local LLM stack not running (start with llm-up)${NC}"
+        return 0
+    fi
+    for u in litellm worker-igpu worker-cpu; do
+        if llm_unit_active "$u"; then
+            echo -e "  ${GREEN}✓ $u active${NC}"
+        else
+            echo -e "  ${RED}✗ $u inactive${NC}"; rc=1
+        fi
+    done
+    if llm_port_up 4000; then
+        echo -e "  ${GREEN}✓ LiteLLM proxy :4000 responding${NC}"
+    else
+        echo -e "  ${RED}✗ LiteLLM proxy :4000 not responding${NC}"; rc=1
+    fi
+    return "$rc"
+}
+
+# opencode end-to-end: prove the wired provider actually reaches a model.
+llm_opencode_e2e() {
+    if ! command -v opencode &>/dev/null; then
+        echo -e "  ${YELLOW}⚠ opencode not installed — skipping e2e${NC}"
+        return 0
+    fi
+    local out
+    if out=$(opencode run --pure -m local-llm/local-haiku "reply with OK" 2>/dev/null) \
+        && [[ -n "$out" ]]; then
+        echo -e "  ${GREEN}✓ opencode reached local-llm/local-haiku${NC}"
+        return 0
+    fi
+    echo -e "  ${RED}✗ opencode could not reach local-llm/local-haiku${NC}"
+    return 1
+}
+
+# Full smoke test. Returns non-zero if any hard tier is unhealthy.
+llm_health_report() {
+    local with_opencode="${1:-false}" hard_fail=0
+
+    echo -e "${BLUE}LiteLLM proxy${NC}"
+    if llm_port_up 4000; then
+        echo -e "  ${GREEN}✓ :4000 responding${NC}"
+    else
+        echo -e "  ${RED}✗ :4000 not responding${NC}"; hard_fail=1
+    fi
+    echo
+
+    printf '%-17s %-14s %-5s %-11s %-8s %s\n' MODEL UNIT PORT COMPLETION LATENCY SERVED-AS
+    local row unit port model class
+    for row in "${LLM_TIERS[@]}"; do
+        read -r unit port model class <<<"$row"
+        local comp served lat note resp rc t0 t1
+        if ! llm_port_up "$port"; then
+            comp="skip"; served="-"; lat="-"
+            [[ "$class" == "hard" ]] && hard_fail=1
+        else
+            t0=$(date +%s.%N 2>/dev/null || echo 0)
+            resp=$(_llm_complete "$model") && rc=0 || rc=1
+            t1=$(date +%s.%N 2>/dev/null || echo 0)
+            lat=$(awk "BEGIN{d=$t1-$t0; if(d>0) printf \"%.1fs\", d; else print \"-\"}" 2>/dev/null || echo "-")
+            if [[ $rc -eq 0 && -n "$(jq -r '.choices[0].message.content // empty' <<<"$resp" 2>/dev/null)" ]]; then
+                comp="ok"
+                served=$(jq -r '.model // empty' <<<"$resp" 2>/dev/null)
+                [[ -z "$served" ]] && served="?"
+            else
+                comp="FAIL"; served="-"
+                [[ "$class" == "hard" ]] && hard_fail=1
+            fi
+        fi
+        # Flag fallback masking (e.g. local-opus actually served by local-sonnet).
+        note=""
+        [[ "$comp" == "ok" && "$served" != "$model" && "$served" != "?" ]] && note="  ${YELLOW}(fallback)${NC}"
+        printf '%-17s %-14s %-5s %-11s %-8s %s' "$model" "$unit" "$port" "$comp" "$lat" "$served"
+        echo -e "$note"
+    done
+
+    if [[ "$with_opencode" == "true" ]]; then
+        echo
+        echo -e "${BLUE}opencode end-to-end${NC}"
+        llm_opencode_e2e || true
+    fi
+
+    echo
+    if [[ $hard_fail -eq 0 ]]; then
+        echo -e "${GREEN}═══ Local LLM stack healthy ═══${NC}"
+    else
+        echo -e "${RED}═══ Local LLM stack: always-on tier unhealthy ═══${NC}"
+    fi
+    return "$hard_fail"
+}
+
+main() {
+    set -euo pipefail
+    local quiet=false opencode=false a
+    for a in "$@"; do
+        case "$a" in
+            --quiet)    quiet=true ;;
+            --opencode) opencode=true ;;
+            -h|--help)
+                echo "usage: healthcheck.sh [--quiet] [--opencode]"
+                return 0 ;;
+            *) echo "unknown arg: $a" >&2; return 2 ;;
+        esac
+    done
+    for dep in curl jq; do
+        command -v "$dep" &>/dev/null || { echo "Error: $dep not found." >&2; return 1; }
+    done
+    if [[ "$quiet" == "true" ]]; then
+        llm_quick_check
+    else
+        llm_health_report "$opencode"
+    fi
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/chezmoi/local-llm/scripts/executable_healthcheck.sh
+++ b/chezmoi/local-llm/scripts/executable_healthcheck.sh
@@ -47,6 +47,14 @@ llm_port_up() {
         "http://127.0.0.1:${1}/v1/models" >/dev/null 2>&1
 }
 
+# llm_proxy_up — 0 if the LiteLLM proxy answers /v1/models. Honors the
+# documented LLM_PROXY override (host:port), unlike the per-worker llm_port_up
+# probes, which are correctly pinned to 127.0.0.1 (workers aren't overridable).
+llm_proxy_up() {
+    curl -fsS --max-time "$LLM_CURL_TIMEOUT" \
+        "${LLM_PROXY}/v1/models" >/dev/null 2>&1
+}
+
 # _llm_complete <model> — echo the raw chat-completion JSON; curl status propagates.
 _llm_complete() {
     curl -fsS --max-time "$LLM_CURL_TIMEOUT" \
@@ -95,7 +103,7 @@ llm_quick_check() {
             echo -e "  ${RED}✗ $u inactive${NC}"; rc=1
         fi
     done
-    if llm_port_up 4000; then
+    if llm_proxy_up; then
         echo -e "  ${GREEN}✓ LiteLLM proxy :4000 responding${NC}"
     else
         echo -e "  ${RED}✗ LiteLLM proxy :4000 not responding${NC}"; rc=1
@@ -124,7 +132,7 @@ llm_health_report() {
     local with_opencode="${1:-false}" hard_fail=0
 
     echo -e "${BLUE}LiteLLM proxy${NC}"
-    if llm_port_up 4000; then
+    if llm_proxy_up; then
         echo -e "  ${GREEN}✓ :4000 responding${NC}"
     else
         echo -e "  ${RED}✗ :4000 not responding${NC}"; hard_fail=1

--- a/chezmoi/local-llm/scripts/executable_install-npu.sh
+++ b/chezmoi/local-llm/scripts/executable_install-npu.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Enable the NPU worker (FastFlowLM on AMD XDNA 2).
+#
+# IMPORTANT: `lemonade backends install flm:npu` is Windows-only — on Linux,
+# FastFlowLM must be installed from its own GitHub release as a .deb.
+# Reference: https://lemonade-server.ai/flm_npu_linux.html
+# Reference: https://github.com/FastFlowLM/FastFlowLM/releases
+#
+# Run once, then: systemctl --user start worker-npu
+
+set -euo pipefail
+
+FLM_VERSION="${FLM_VERSION:-0.9.43}"          # override with FLM_VERSION=x.y.z bash install-npu.sh
+UBUNTU_TAG="${UBUNTU_TAG:-ubuntu26.04}"        # override if running a different Ubuntu
+
+if [[ $EUID -eq 0 ]]; then
+  echo "Do not run as root — script uses sudo where needed."
+  exit 1
+fi
+
+echo "=== 1. Add Lemonade PPA (idempotent) ==="
+if ! grep -rq "lemonade-team" /etc/apt/sources.list.d/ 2>/dev/null; then
+  sudo add-apt-repository -y ppa:lemonade-team/stable
+  sudo apt update
+else
+  echo "already added"
+fi
+
+echo ""
+echo "=== 2. Install XRT NPU userspace (libxrt-npu2) ==="
+# amdxdna kernel driver is in-tree on Linux 7.0, no DKMS needed.
+sudo apt install -y libxrt-npu2
+
+echo ""
+echo "=== 3. Bump memlock limits (FastFlowLM uses pinned memory) ==="
+LIMITS=/etc/security/limits.d/99-npu.conf
+if ! sudo grep -q "memlock" "$LIMITS" 2>/dev/null; then
+  sudo tee "$LIMITS" >/dev/null <<'EOF'
+*    soft    memlock    unlimited
+*    hard    memlock    unlimited
+EOF
+  echo "Wrote $LIMITS — re-login needed before non-root processes inherit the new limit."
+else
+  echo "already set"
+fi
+
+echo ""
+echo "=== 4. Download + install FastFlowLM v${FLM_VERSION} for ${UBUNTU_TAG} ==="
+DEB_NAME="fastflowlm_${FLM_VERSION}_${UBUNTU_TAG}_amd64.deb"
+DEB_URL="https://github.com/FastFlowLM/FastFlowLM/releases/download/v${FLM_VERSION}/${DEB_NAME}"
+TMP_DEB="/tmp/${DEB_NAME}"
+
+if ! command -v flm >/dev/null 2>&1; then
+  echo "Downloading from $DEB_URL"
+  curl -fSL -o "$TMP_DEB" "$DEB_URL"
+  sudo apt install -y "$TMP_DEB"
+  rm -f "$TMP_DEB"
+else
+  echo "flm binary already present ($(command -v flm)) — skipping"
+fi
+
+echo ""
+echo "=== 5. Verify Lemonade now sees flm:npu as installed ==="
+~/local-llm/bin/lemonade/lemond --port 8000 --host 127.0.0.1 > /tmp/lemond-verify.log 2>&1 &
+LEMOND_PID=$!
+trap 'kill $LEMOND_PID 2>/dev/null || true' EXIT
+sleep 3
+~/local-llm/bin/lemonade/lemonade backends 2>&1 | grep -E "flm|Recipe" | head -3
+
+echo ""
+echo "=== 6. Pull a small NPU model (Llama-3.2-3B-Instruct via flm recipe) ==="
+~/local-llm/bin/lemonade/lemonade pull Llama-3.2-3B-Instruct-GGUF --recipe flm 2>&1 | tail -10
+
+kill $LEMOND_PID 2>/dev/null || true
+
+echo ""
+echo "=== Done ==="
+echo "Enable + start the NPU worker:"
+echo "  systemctl --user enable --now worker-npu"
+echo ""
+echo "Verify:"
+echo "  curl http://127.0.0.1:8000/v1/models"
+echo "  llm-chat local-classifier 'classify: hello world as greeting or other'"
+echo ""
+if [[ "$(ulimit -l)" != "unlimited" ]]; then
+  echo "NOTE: ulimit -l = $(ulimit -l) — log out and back in for memlock=unlimited to apply"
+  echo "      to your shell + any new systemd user services."
+fi

--- a/tests/chezmoi-wiring.bats
+++ b/tests/chezmoi-wiring.bats
@@ -559,6 +559,28 @@ SH
     grep -qE '^lib(/|$)' "$ignore"
 }
 
+@test ".chezmoiignore localLLM gate renders when the key is absent (missingkey-safe)" {
+    command -v chezmoi >/dev/null 2>&1 || skip "chezmoi not installed"
+    # chezmoi renders templates with missingkey=error. A bare `{{ .localLLM }}`
+    # in .chezmoiignore would fail `chezmoi apply` on every machine whose
+    # chezmoi.toml predates the localLLM flag (the key is simply absent). The
+    # gate must use `get . "localLLM"` so an absent key falls back to ""/ignore.
+    local cfg="$HOME/.config/chezmoi/chezmoi.toml"
+    mkdir -p "$(dirname "$cfg")"
+    cat > "$cfg" <<TOML
+sourceDir = "$REAL_DOTFILES_DIR/chezmoi"
+
+[data]
+email = "test@example.com"
+TOML
+    run chezmoi --config "$cfg" --source "$REAL_DOTFILES_DIR/chezmoi" \
+        execute-template < "$REAL_DOTFILES_DIR/chezmoi/.chezmoiignore"
+    assert_success
+    # With localLLM absent (→ falsy), the stack tree + units must be ignored.
+    assert_output_contains "local-llm/**"
+    assert_output_contains ".config/systemd/user/worker-igpu.service"
+}
+
 @test "skills-install/ directory is gone from the repo" {
     [[ ! -e "$REAL_DOTFILES_DIR/skills-install" ]]
 }
@@ -629,11 +651,17 @@ YAML
     grep -q 'promptStringOnce . "email"' "$toml"
     grep -q '\.chezmoi\.sourceDir' "$toml"
     # The work-machine prompt was removed with the employer git machinery;
-    # per-repo email is native git (`git config user.email`).
-    if grep -q 'promptBoolOnce' "$toml"; then
+    # per-repo email is native git (`git config user.email`). Guard the
+    # *work* prompt specifically — not all promptBoolOnce — so a legitimate
+    # boolean flag (e.g. localLLM) doesn't trip this invariant.
+    if grep -qE 'promptBoolOnce \. "work"' "$toml"; then
         echo ".chezmoi.toml.tmpl still has the removed work prompt" >&2
         return 1
     fi
+    # The localLLM flag must stay a persisted boolean prompt: the .chezmoiignore
+    # gate reads .localLLM, so dropping the prompt would leave the key undefined
+    # and break `chezmoi apply` (missingkey=error).
+    grep -qE 'localLLM = \{\{ promptBoolOnce \. "localLLM"' "$toml"
 }
 
 @test "gitconfig template references .email and carries no employer machinery" {

--- a/tests/local-llm.bats
+++ b/tests/local-llm.bats
@@ -1,0 +1,172 @@
+#!/usr/bin/env bats
+#
+# Tests for the local LLM stack wiring:
+#   - chezmoi/lib/install-local-llm.sh  (opencode provider jq-merge)
+#   - chezmoi/local-llm/scripts/executable_healthcheck.sh  (decision functions)
+#
+# Strategy mirrors skills-external.bats: real jq, fake the external services
+# (curl, systemctl) by putting executables earlier on $PATH. The provider lib is
+# run as a subprocess; the healthcheck functions are sourced (the script is
+# source-safe — main() only runs on direct execution) and called via `run`.
+
+# shellcheck disable=SC1090,SC2016  # $HEALTH = test-resolved source path; JSON fixtures hold literal $schema keys
+load test_helper
+
+LIB="$REAL_DOTFILES_DIR/chezmoi/lib/install-local-llm.sh"
+HEALTH="$REAL_DOTFILES_DIR/chezmoi/local-llm/scripts/executable_healthcheck.sh"
+
+setup() {
+    setup_test_env
+    export MOCK_BIN="$TEST_HOME/bin"
+    mkdir -p "$MOCK_BIN"
+
+    # Fake curl: distinguishes the /v1/models probe from a chat completion.
+    #   FAKE_PORT=up|down           — controls the /v1/models probe
+    #   FAKE_COMPLETION=ok|empty|fail — controls the chat completion
+    #   FAKE_SERVED=<model>         — the `.model` the proxy "answered" with
+    cat > "$MOCK_BIN/curl" << 'MOCK'
+#!/bin/bash
+args="$*"
+if [[ "$args" == *chat/completions* ]]; then
+    case "${FAKE_COMPLETION:-ok}" in
+        fail)  exit 22 ;;
+        empty) printf '{"model":"%s","choices":[{"message":{"content":""}}]}' "${FAKE_SERVED:-local-haiku}"; exit 0 ;;
+        *)     printf '{"model":"%s","choices":[{"message":{"content":"OK"}}]}' "${FAKE_SERVED:-local-haiku}"; exit 0 ;;
+    esac
+elif [[ "$args" == */v1/models* ]]; then
+    [[ "${FAKE_PORT:-up}" == "up" ]] && exit 0 || exit 7
+fi
+exit 0
+MOCK
+    chmod +x "$MOCK_BIN/curl"
+
+    # Fake systemctl: FAKE_ACTIVE is a space-separated list of active units.
+    cat > "$MOCK_BIN/systemctl" << 'MOCK'
+#!/bin/bash
+unit="${!#}"   # last positional arg
+[[ " ${FAKE_ACTIVE:-} " == *" $unit "* ]] && exit 0 || exit 3
+MOCK
+    chmod +x "$MOCK_BIN/systemctl"
+
+    export PATH="$MOCK_BIN:$PATH"
+}
+
+teardown() {
+    teardown_test_env
+}
+
+# ─── provider lib ───────────────────────────────────────────────────────────
+
+@test "provider lib adds local-llm with 6 models and preserves existing .mcp" {
+    local cfg="$TEST_HOME/opencode.json"
+    echo '{"$schema":"x","formatter":true,"mcp":{"tilth":{"type":"local"}}}' > "$cfg"
+
+    run bash "$LIB" "$cfg"
+    assert_success
+
+    run jq -r '.provider["local-llm"].models | keys | length' "$cfg"
+    assert_output_contains "6"
+
+    run jq -r '.provider["local-llm"].options.baseURL' "$cfg"
+    assert_output_contains "http://127.0.0.1:4000/v1"
+
+    run jq -r '.provider["local-llm"].options.apiKey' "$cfg"
+    assert_output_contains "sk-local"
+
+    run jq -r '.provider["local-llm"].npm' "$cfg"
+    assert_output_contains "@ai-sdk/openai-compatible"
+
+    # The pre-existing MCP block must survive untouched.
+    run jq -e '.mcp.tilth.type' "$cfg"
+    assert_success
+    assert_output_contains "local"
+}
+
+@test "provider lib is idempotent (re-run is byte-identical)" {
+    local cfg="$TEST_HOME/opencode.json"
+    echo '{"mcp":{}}' > "$cfg"
+    bash "$LIB" "$cfg"
+    cp "$cfg" "$cfg.first"
+    bash "$LIB" "$cfg"
+    run diff "$cfg.first" "$cfg"
+    assert_success
+}
+
+@test "provider lib scaffolds opencode.json when the file is absent" {
+    local cfg="$TEST_HOME/nested/opencode.json"
+    run bash "$LIB" "$cfg"
+    assert_success
+    assert_file_exists "$cfg"
+    run jq -r '.provider["local-llm"].models["local-coder"].name' "$cfg"
+    assert_output_contains "Coder"
+}
+
+@test "provider lib honours LOCAL_LLM_BASE_URL override" {
+    local cfg="$TEST_HOME/opencode.json"
+    echo '{}' > "$cfg"
+    LOCAL_LLM_BASE_URL="http://127.0.0.1:9999/v1" run bash "$LIB" "$cfg"
+    assert_success
+    run jq -r '.provider["local-llm"].options.baseURL' "$cfg"
+    assert_output_contains "http://127.0.0.1:9999/v1"
+}
+
+# ─── healthcheck decision functions ───────────────────────────────────────────
+
+@test "llm_unit_active reflects systemctl is-active" {
+    source "$HEALTH"
+    export FAKE_ACTIVE="litellm worker-igpu"
+    run llm_unit_active litellm
+    assert_success
+    run llm_unit_active worker-vision
+    assert_failure
+}
+
+@test "llm_port_up follows the /v1/models probe" {
+    source "$HEALTH"
+    FAKE_PORT=up run llm_port_up 4000
+    assert_success
+    FAKE_PORT=down run llm_port_up 8090
+    assert_failure
+}
+
+@test "llm_completion_ok true on non-empty content, false otherwise" {
+    source "$HEALTH"
+    FAKE_COMPLETION=ok run llm_completion_ok local-haiku
+    assert_success
+    FAKE_COMPLETION=empty run llm_completion_ok local-haiku
+    assert_failure
+    FAKE_COMPLETION=fail run llm_completion_ok local-haiku
+    assert_failure
+}
+
+@test "llm_served_model reports the model the proxy actually answered with" {
+    source "$HEALTH"
+    # Ask for opus but the proxy falls back to sonnet — served-as must reflect that.
+    FAKE_SERVED=local-sonnet run llm_served_model local-opus
+    assert_success
+    assert_output_contains "local-sonnet"
+}
+
+@test "llm_quick_check fails when a hard unit is down" {
+    source "$HEALTH"
+    # litellm + worker-cpu active, worker-igpu missing, proxy up.
+    FAKE_ACTIVE="litellm worker-cpu" FAKE_PORT=up run llm_quick_check
+    assert_failure
+    assert_output_contains "worker-igpu inactive"
+}
+
+@test "llm_quick_check passes when all hard units active and proxy up" {
+    source "$HEALTH"
+    FAKE_ACTIVE="litellm worker-igpu worker-cpu" FAKE_PORT=up run llm_quick_check
+    assert_success
+}
+
+@test "llm_quick_check treats a fully-stopped stack as idle, not a failure" {
+    source "$HEALTH"
+    # No units active: the stack is cleanly stopped (workers are never
+    # auto-started). `dots doctor` must NOT count this as an issue, else it
+    # cries wolf on every flag-on machine that hasn't run llm-up.
+    FAKE_ACTIVE="" run llm_quick_check
+    assert_success
+    assert_output_contains "not running"
+}

--- a/zshrc
+++ b/zshrc
@@ -28,3 +28,6 @@ source "$HOME/Dev/dotfiles/zsh/claude.zsh"
 source "$HOME/Dev/dotfiles/zsh/skhd.zsh"
 
 clear
+
+# opencode
+export PATH=/home/paul/.opencode/bin:$PATH

--- a/zshrc
+++ b/zshrc
@@ -30,4 +30,4 @@ source "$HOME/Dev/dotfiles/zsh/skhd.zsh"
 clear
 
 # opencode
-export PATH=/home/paul/.opencode/bin:$PATH
+[ -d "$HOME/.opencode/bin" ] && export PATH="$HOME/.opencode/bin:$PATH"


### PR DESCRIPTION
## Summary

Adds a per-machine, **opt-in** local LLM stack: llama.cpp workers behind a LiteLLM proxy at `http://127.0.0.1:4000/v1`, exposing OpenAI-compatible model names (`local-sonnet`, `local-haiku`, `local-coder`, `local-opus`, `local-vision`, `local-classifier`) and wired into opencode as a `local-llm` provider.

Gated entirely by the chezmoi `localLLM` flag — machines with the flag off deploy **nothing** (`.chezmoiignore` skips the whole tree). `dots sync` prompts once on first init.

## What's managed (in-repo)

- `chezmoi/dot_config/systemd/user/{litellm,local-llm.target,worker-*}` — `%h`-portable systemd `--user` units (files only; enablement stays a runtime action).
- `chezmoi/local-llm/configs/litellm.yaml` — proxy routing + fallbacks.
- `chezmoi/lib/install-local-llm.sh` — jq-merges the opencode provider block (mirrors the MCP sync), driven by `run_onchange_after_install-local-llm.sh.tmpl` (also runs `systemctl --user daemon-reload`).
- `chezmoi/local-llm/scripts/{aliases,healthcheck,download-models,install-npu}.sh` — runtime helpers.
- Docs: `AGENTS.md` Local LLM Stack section; `chezmoi/local-llm/README.md`.

## What's NOT managed (runtime prerequisites)

The 85G `~/local-llm/models/`, the built `~/local-llm/bin/`, logs, and the `litellm` install. The sync never auto-enables or starts workers — that stays explicit (`llm-up`).

## Design notes

- **missingkey-safe gating** — the run_onchange template uses `{{ if (get . "localLLM") }}` so machines whose `chezmoi.toml` predates the flag don't crash `chezmoi apply`.
- **`dots doctor` idle detection** — `healthcheck.sh`'s `llm_quick_check` treats a fully-stopped stack as cleanly idle (rc 0) since workers never auto-start; only a partially-up/broken stack returns non-zero. No cry-wolf on flag-on machines that haven't run `llm-up`.

## Testing

- `tests/local-llm.bats` — 11/11 (provider jq-merge + healthcheck decision functions, including the three idle/partial/full branches).
- `tests/chezmoi-wiring.bats` — localLLM gating coverage (absent/false/true template states).
- shellcheck clean across all stack scripts.

> Two pre-existing `chezmoi-wiring.bats` failures (base-profile / `ap` / `uv` render path) are unrelated to this branch and present on a clean base.

> The three Qwen3 repo IDs in `download-models.sh` (sonnet/haiku/coder) are unverified — they follow the confirmed opus repo's `<Model>-GGUF` convention but weren't recorded on the source machine. Flagged in-repo; confirm on huggingface before a fresh-machine download.

🤖 Generated with [Claude Code](https://claude.com/claude-code)