### PR TITLE
feat(ap): pass MCP ${VAR} secrets through per-harness instead of baking resolved values

### DIFF
--- a/.hallouminate/wiki/architecture/index.md
+++ b/.hallouminate/wiki/architecture/index.md
@@ -4,5 +4,6 @@ How this dotfiles repo configures AI coding agents. The model is **one harness-a
 
 - [[agents-dir]] — the `agents/` registry system: MCP / hook / sub-agent / skill registries, the system-prompt body, and the shared cheese-flair assets. Declares *what* every agent gets.
 - [[agent-profile]] — the `ap` tool (`agent-profile/`): profiles (base / global / isolated), the five per-harness renderers, install vs launch, and the chezmoi drive path. Decides *where and in what shape*.
+- [[mcp-secret-handling]] — why MCP `${VAR}` env refs are passed through to each harness as a runtime placeholder (claude/copilot `${VAR}`, opencode `{env:VAR}`, cursor `envFile`) instead of baked as resolved secrets, and the ingest validation-vs-substitution split.
 
 For the harness-specific consumption (and official upstream docs for each native config surface), see [[../harnesses/index]].

--- a/.hallouminate/wiki/architecture/mcp-secret-handling.md
+++ b/.hallouminate/wiki/architecture/mcp-secret-handling.md
@@ -45,12 +45,14 @@ The hard part: the `${VAR}` runtime-expansion syntax is **not** uniform.
 | **copilot** | yes (fragile) | `${VAR}` (literal) | chezmoi template, NOT the `ap` renderer |
 
 ### claude — literal passthrough, no code change
+
 `_register_user_mcps` / `mcp_server_entry` already pass `entry["env"]` through;
 with the literal flowing in, the CLI stores `${VAR}` verbatim and Claude expands
 it at launch. Empirically verified: `claude mcp add probe -e PROBE_KEY='${FAKE}'`
 stores `"${FAKE}"` literally.
 
 ### codex — scrub-by-keyname, unchanged
+
 `codex.py` drops any env key present in `$DOTFILES_DIR/.env` from the rendered
 TOML (zsh already exports them; codex is terminal-launched so its MCP children
 inherit at runtime). The registry shape is `KEY: "${KEY}"` (key == varname), so
@@ -59,6 +61,7 @@ or a resolved secret. Neither the placeholder nor a secret lands in
 `config.toml`.
 
 ### opencode — rewrite `${VAR}` → `{env:VAR}`
+
 opencode does **not** understand `${VAR}` — it passes it through verbatim and
 breaks (unset → silent empty string). `opencode._to_opencode_env` rewrites every
 `${VAR}` occurrence to opencode's own `{env:VAR}` token; plain literals (e.g.
@@ -66,6 +69,7 @@ breaks (unset → silent empty string). `opencode._to_opencode_env` rewrites eve
 through untouched.
 
 ### cursor — drop `${VAR}`, add `envFile`
+
 Cursor's `${env:VAR}` resolves against Cursor's *process* env, but a Finder/Dock
 launch inherits **no** shell `.env`. So `_cursor_mcp_entry` splits env into
 `${VAR}`-referencing entries vs plain literals: literals stay in `env`; if any
@@ -77,6 +81,7 @@ path in user config is acceptable — same precedent as the marketplace path in
 `claude.py`'s `_merge_root_settings`.
 
 ### copilot — chezmoi template, not the renderer
+
 copilot is **excluded** from the `ap` MCP default membership
 (`_COPILOT_MCP_DEFAULT = (claude, codex)`), so the `ap` copilot renderer writes
 nothing for context7/tavily. The live `~/.copilot/mcp-config.json` is written by

--- a/.hallouminate/wiki/architecture/mcp-secret-handling.md
+++ b/.hallouminate/wiki/architecture/mcp-secret-handling.md
@@ -1,0 +1,103 @@
+# MCP secret handling — `${VAR}` passthrough per harness
+
+## Why secrets are NOT baked at ingest
+
+`ap` carries MCP `env` values as the **literal `${VAR}`** from ingest all the
+way to each renderer, instead of resolving the secret at sync time. The goal:
+keep real API keys out of the rendered config files on disk
+(`~/.claude.json`, `~/.cursor/mcp.json`, `~/.config/opencode/opencode.json`,
+`~/.copilot/mcp-config.json`). Each harness expands the placeholder itself at
+launch from its process env (zsh exports every `.env` key on shell init, so
+shell-launched CLIs already have the vars).
+
+Before this change, `ingest._expand_mcps` called `resolve_item_env`, so every
+renderer received the resolved secret and wrote it to disk — the keys sat in
+plaintext.
+
+## The ingest split: validate without substituting
+
+`ingest.py:_expand_mcps` decouples **validation** from **substitution**:
+
+- `optional` MCP with an unset `${VAR}` → dropped non-fatally (protects against
+  rendering a server whose credential the user definitely lacks).
+- non-`optional` MCP with an unset `${VAR}` → **fails loud** at ingest (catches
+  a typo'd var name) — but WITHOUT substituting the value.
+- otherwise → the item is appended with its env block **untouched** (the literal
+  `${VAR}` rides through).
+
+The fail-loud has a real blast radius on **claude**: an unset referenced var
+with no default makes Claude fail to parse the *entire* `~/.claude.json`, so
+every MCP dies. The `optional`-drop is what prevents this for credential-gated
+servers (e.g. `todoist` without `TODOIST_API_KEY`). context7/tavily are
+non-optional, so a fresh box with no `.env` will fail the base-profile render
+until the keys are populated — intended, not a bug.
+
+## Per-harness placeholder syntax (they diverge)
+
+The hard part: the `${VAR}` runtime-expansion syntax is **not** uniform.
+
+| Harness | Expands at runtime? | Placeholder emitted | Where written |
+|---|---|---|---|
+| **claude** | yes | `${VAR}` (literal) | `claude mcp add -e K='${VAR}'` (user scope) / plugin `.mcp.json` |
+| **codex** | n/a — inherits shell env | — (scrubbed) | `~/.codex/config.toml` |
+| **opencode** | yes | `{env:VAR}` | `opencode.json` `mcp.*.environment` |
+| **cursor** | yes, but GUI-launched | `envFile` → abs `.env` | `~/.cursor/mcp.json` |
+| **copilot** | yes (fragile) | `${VAR}` (literal) | chezmoi template, NOT the `ap` renderer |
+
+### claude — literal passthrough, no code change
+`_register_user_mcps` / `mcp_server_entry` already pass `entry["env"]` through;
+with the literal flowing in, the CLI stores `${VAR}` verbatim and Claude expands
+it at launch. Empirically verified: `claude mcp add probe -e PROBE_KEY='${FAKE}'`
+stores `"${FAKE}"` literally.
+
+### codex — scrub-by-keyname, unchanged
+`codex.py` drops any env key present in `$DOTFILES_DIR/.env` from the rendered
+TOML (zsh already exports them; codex is terminal-launched so its MCP children
+inherit at runtime). The registry shape is `KEY: "${KEY}"` (key == varname), so
+the scrub stays correct regardless of whether the value is the literal `${VAR}`
+or a resolved secret. Neither the placeholder nor a secret lands in
+`config.toml`.
+
+### opencode — rewrite `${VAR}` → `{env:VAR}`
+opencode does **not** understand `${VAR}` — it passes it through verbatim and
+breaks (unset → silent empty string). `opencode._to_opencode_env` rewrites every
+`${VAR}` occurrence to opencode's own `{env:VAR}` token; plain literals (e.g.
+`SERENA_MUX_HARNESS`, a render-time per-harness value, not a secret) pass
+through untouched.
+
+### cursor — drop `${VAR}`, add `envFile`
+Cursor's `${env:VAR}` resolves against Cursor's *process* env, but a Finder/Dock
+launch inherits **no** shell `.env`. So `_cursor_mcp_entry` splits env into
+`${VAR}`-referencing entries vs plain literals: literals stay in `env`; if any
+`${VAR}`-ref existed, the entry drops those keys and gains an `envFile` field
+pointing at the absolute `.env` (stdio servers only — all ours are stdio).
+The abs path resolves `${DOTFILES_DIR}/.env` via `os.path.expandvars` with the
+`~/Dev/dotfiles` fallback (the `discover.py` pattern). A machine-specific abs
+path in user config is acceptable — same precedent as the marketplace path in
+`claude.py`'s `_merge_root_settings`.
+
+### copilot — chezmoi template, not the renderer
+copilot is **excluded** from the `ap` MCP default membership
+(`_COPILOT_MCP_DEFAULT = (claude, codex)`), so the `ap` copilot renderer writes
+nothing for context7/tavily. The live `~/.copilot/mcp-config.json` is written by
+the chezmoi template `private_dot_copilot/mcp-config.json.tmpl`, which emits the
+literal `${CONTEXT7_API_KEY}` / `${TAVILY_API_KEY}` and always emits the servers
+(the old unset-var warnf + empty-`mcpServers` stub branch is gone — there is no
+apply-time key to resolve now). Copilot's `${VAR}` expansion regressed in CLI
+v0.0.407 (gh#1403) and is thinly documented — if env passthrough breaks on a CLI
+upgrade, that template is where to revisit.
+
+## What was intentionally left alone
+
+- **codex stays on scrub** (already clean — never wrote secrets in the
+  shell-inherited common case).
+- **`overlay.py` (isolated-launch path)** still resolves `${VAR}` to the secret
+  in its **ephemeral** scratch `.mcp.json` — that file is passed directly to the
+  launched `claude` via `--mcp-config` and discarded, never a persistent config.
+  This is `ccp` parity (the retired `gen-profile-mcp.sh` resolved too).
+- **Legacy bash `agents/mcp/lib.sh`** (`mcp_cursor_add` et al.) still bakes
+  secrets at sync time, but that native-CLI path no longer runs on `dots sync`
+  (superseded by the `ap` renderers). Dormant; not in scope.
+
+See also [[agent-profile]] for the renderer architecture, [[cursor]],
+[[opencode]], [[copilot]] for the per-harness config surfaces.

--- a/agent-profile/agent_profile/env.py
+++ b/agent-profile/agent_profile/env.py
@@ -27,7 +27,7 @@ import re
 from pathlib import Path
 from typing import Any
 
-_VAR_RE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
+VAR_RE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
 _IDENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
@@ -80,7 +80,7 @@ def resolve_env_value(value: str, dotenv: dict[str, str]) -> str:
             )
         return dotenv[var]
 
-    return _VAR_RE.sub(_sub, value)
+    return VAR_RE.sub(_sub, value)
 
 
 def first_unset_var(item: dict[str, Any], dotenv: dict[str, str]) -> str | None:
@@ -94,7 +94,7 @@ def first_unset_var(item: dict[str, Any], dotenv: dict[str, str]) -> str | None:
     if not isinstance(env, dict):
         return None
     for val in env.values():
-        for match in _VAR_RE.finditer(str(val)):
+        for match in VAR_RE.finditer(str(val)):
             var = match.group(1)
             if var not in dotenv:
                 return var

--- a/agent-profile/agent_profile/ingest.py
+++ b/agent-profile/agent_profile/ingest.py
@@ -15,9 +15,11 @@ unions them.
 :func:`expand_registries` reads each declared registry relative to the repo
 root, normalizes every entry into a profile *item* (the registry entry IS a
 profile item — no translation layer), stamps ``_source_dir`` so payload
-files resolve against the repo root, resolves ``${VAR}`` env refs at ingest
-time (spec D4), and drops ``optional`` MCPs whose referenced credential is
-unset (parity with the bash ``optional`` skip).
+files resolve against the repo root, **validates** ``${VAR}`` env refs
+without substituting them (MCP-secret-passthrough — the literal ``${VAR}``
+rides through to each renderer so the harness expands it at launch and no
+secret is baked to disk), and drops ``optional`` MCPs whose referenced
+credential is unset (parity with the bash ``optional`` skip).
 
 Registry shapes consumed:
 
@@ -42,7 +44,11 @@ from typing import Any
 
 import yaml
 
-from agent_profile.env import first_unset_var, resolve_item_env
+from agent_profile.env import (
+    EnvResolutionError,
+    first_unset_var,
+    resolve_item_env,
+)
 
 
 def _as_list(value: Any) -> list[str]:
@@ -64,9 +70,12 @@ def _expand_mcps(
     """Normalize the MCP registry mapping into a profile item list.
 
     Each named entry becomes ``{name, ...fields, _source_dir}``. ``env``
-    blocks resolve at ingest. An ``optional`` MCP whose referenced ``${VAR}``
-    is unset is dropped non-fatally; a required MCP with an unset ref fails
-    loud via :func:`resolve_item_env`."""
+    blocks are **validated but not substituted**: the literal ``${VAR}`` is
+    carried through to the renderers so each harness expands it at launch and
+    no secret is baked into a rendered config file (the MCP-secret-passthrough
+    spec). An ``optional`` MCP whose referenced ``${VAR}`` is unset is dropped
+    non-fatally; a non-``optional`` MCP with an unset ref still fails loud at
+    ingest (catches a typo'd var) — without substituting the value."""
     data = _load_yaml_mapping(path)
     mcps = data.get("mcps") or {}
     out: list[dict[str, Any]] = []
@@ -74,9 +83,15 @@ def _expand_mcps(
         if not isinstance(body, dict):
             continue
         item: dict[str, Any] = {"name": name, **body, "_source_dir": source_dir}
-        if item.get("optional") and first_unset_var(item, dotenv) is not None:
-            continue
-        out.append(resolve_item_env(item, dotenv))
+        unset = first_unset_var(item, dotenv)
+        if unset is not None:
+            if item.get("optional"):
+                continue
+            raise EnvResolutionError(
+                f"ap: env var ${{{unset}}} is unset (referenced by MCP "
+                f"'{name}'; set it in .env or mark the item optional)"
+            )
+        out.append(item)
     return out
 
 

--- a/agent-profile/agent_profile/renderers/cursor.py
+++ b/agent-profile/agent_profile/renderers/cursor.py
@@ -50,7 +50,7 @@ from pathlib import Path
 from typing import Any
 
 from agent_profile import shared
-from agent_profile.env import _VAR_RE
+from agent_profile.env import VAR_RE
 from agent_profile.parse import Manifest
 from agent_profile.renderers.base import (
     body_abs,
@@ -299,7 +299,18 @@ def _dotenv_abs_path() -> str:
 
 
 def _has_var_ref(value: str) -> bool:
-    return _VAR_RE.search(value) is not None
+    return VAR_RE.search(value) is not None
+
+
+def _is_self_reference(key: str, value: str) -> bool:
+    """True when ``value`` is exactly ``${key}``.
+
+    The only ``${VAR}`` shape Cursor's ``envFile`` can faithfully reproduce:
+    ``envFile`` loads vars by their own names, so a renamed key
+    (``API_KEY: "${TOKEN}"``) or an embedded reference
+    (``URL: "https://x/${TOKEN}/y"``) would be lost. All current registry MCPs
+    use the self-reference form ``KEY: "${KEY}"``."""
+    return value == f"${{{key}}}"
 
 
 def _cursor_mcp_entry(mcp: dict[str, Any]) -> dict[str, Any]:
@@ -313,13 +324,28 @@ def _cursor_mcp_entry(mcp: dict[str, Any]) -> dict[str, Any]:
     no shell env). Cursor's stdio servers support an ``envFile`` field that
     loads a ``.env`` at launch — so any ``${VAR}``-referencing entry is dropped
     from ``env`` and the abs ``.env`` path is added as ``envFile`` instead.
-    Plain literals (no ``${VAR}``) stay in ``env``."""
+    Plain literals (no ``${VAR}``) stay in ``env``.
+
+    ``envFile`` can only represent the exact self-reference shape
+    ``KEY: "${KEY}"`` (it loads vars by their own names). A renamed key or an
+    embedded reference would be silently lost, so we fail loud on those rather
+    than emit a broken server entry."""
     entry: dict[str, Any] = {
         "command": mcp["command"],
         "args": mcp.get("args") if mcp.get("args") is not None else [],
     }
     env = mcp.get("env")
     if env is not None:
+        for k, v in env.items():
+            sv = str(v)
+            if _has_var_ref(sv) and not _is_self_reference(k, sv):
+                raise ValueError(
+                    f"cursor renderer: env entry {k!r}={sv!r} references a "
+                    "${VAR} that is not an exact self-reference. Cursor's "
+                    "envFile loads vars by their own names and cannot "
+                    'represent a renamed key or an embedded reference. Use the '
+                    'KEY: "${KEY}" form, or handle this MCP explicitly.'
+                )
         literals = {k: v for k, v in env.items() if not _has_var_ref(str(v))}
         has_var_ref = len(literals) != len(env)
         if literals:

--- a/agent-profile/agent_profile/renderers/cursor.py
+++ b/agent-profile/agent_profile/renderers/cursor.py
@@ -43,12 +43,14 @@ the right source dir by construction.
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import sys
 from pathlib import Path
 from typing import Any
 
 from agent_profile import shared
+from agent_profile.env import _VAR_RE
 from agent_profile.parse import Manifest
 from agent_profile.renderers.base import (
     body_abs,
@@ -284,19 +286,46 @@ def _agent_frontmatter(item: dict[str, Any]) -> dict[str, Any]:
     return shared.claude_agent_frontmatter(item)
 
 
+def _dotenv_abs_path() -> str:
+    """Absolute path to the dotfiles ``.env`` Cursor's ``envFile`` points at.
+
+    Resolves ``${DOTFILES_DIR}/.env`` via :func:`os.path.expandvars`, falling
+    back to ``~/Dev/dotfiles`` when ``DOTFILES_DIR`` is unset (the
+    :mod:`discover` pattern). A machine-specific absolute path in user config
+    is acceptable here — it matches the marketplace-path precedent in
+    ``claude.py``'s ``_merge_root_settings``."""
+    dotfiles = os.environ.get("DOTFILES_DIR") or str(Path.home() / "Dev/dotfiles")
+    return str(Path(os.path.expandvars(dotfiles)) / ".env")
+
+
+def _has_var_ref(value: str) -> bool:
+    return _VAR_RE.search(value) is not None
+
+
 def _cursor_mcp_entry(mcp: dict[str, Any]) -> dict[str, Any]:
     """Project one MCP to Cursor's server record.
 
     Unlike the base ``mcp_server_entry``, Cursor's bash always emits
-    ``args`` (defaulting to ``[]``) and appends ``env`` only when present:
-    ``{command, args: (.args // [])} + (if .env then {env:.env} else {} end)``.
-    """
+    ``args`` (defaulting to ``[]``) and appends ``env`` only when present.
+
+    MCP-secret-passthrough: Cursor is GUI-launched, so a ``${VAR}`` in ``env``
+    does NOT resolve against the shell ``.env`` (a Finder/Dock launch inherits
+    no shell env). Cursor's stdio servers support an ``envFile`` field that
+    loads a ``.env`` at launch — so any ``${VAR}``-referencing entry is dropped
+    from ``env`` and the abs ``.env`` path is added as ``envFile`` instead.
+    Plain literals (no ``${VAR}``) stay in ``env``."""
     entry: dict[str, Any] = {
         "command": mcp["command"],
         "args": mcp.get("args") if mcp.get("args") is not None else [],
     }
-    if mcp.get("env") is not None:
-        entry["env"] = mcp["env"]
+    env = mcp.get("env")
+    if env is not None:
+        literals = {k: v for k, v in env.items() if not _has_var_ref(str(v))}
+        has_var_ref = len(literals) != len(env)
+        if literals:
+            entry["env"] = literals
+        if has_var_ref:
+            entry["envFile"] = _dotenv_abs_path()
     return entry
 
 

--- a/agent-profile/agent_profile/renderers/opencode.py
+++ b/agent-profile/agent_profile/renderers/opencode.py
@@ -23,6 +23,7 @@ import re
 from pathlib import Path
 from typing import Any
 
+from agent_profile.env import _VAR_RE
 from agent_profile.parse import Manifest
 from agent_profile.renderers.base import body_abs, mcps_for, read_json_object
 from agent_profile.shared import agent_is_read_only, strip_frontmatter, track_file
@@ -56,17 +57,33 @@ def _allow_keys(manifest: Manifest) -> list[str]:
     ]
 
 
+def _to_opencode_env(value: str) -> str:
+    """Rewrite every ``${VAR}`` in an env value to opencode's ``{env:VAR}``.
+
+    opencode does NOT understand the ``${VAR}`` shell syntax the registry
+    carries — it passes it through verbatim and breaks (MCP-secret-passthrough).
+    Its runtime expansion token is ``{env:VAR}``. Plain literals (no ``${}``)
+    pass through unchanged."""
+    return _VAR_RE.sub(lambda m: f"{{env:{m.group(1)}}}", value)
+
+
 def _mcp_server_record(mcp: dict[str, Any]) -> dict[str, Any]:
     """The opencode mcp-server shape:
     ``{type: "local", enabled: True, command: [cmd, *args], environment?}``.
-    Port of the bash ``{type, enabled, command} + {environment}`` reduce."""
+    Port of the bash ``{type, enabled, command} + {environment}`` reduce.
+
+    Env values carry the literal ``${VAR}`` from ingest; each is rewritten to
+    opencode's ``{env:VAR}`` placeholder so opencode expands it at launch and
+    no secret is baked into ``opencode.json``."""
     record: dict[str, Any] = {
         "type": "local",
         "enabled": True,
         "command": [mcp["command"], *(mcp.get("args") or [])],
     }
     if mcp.get("env") is not None:
-        record["environment"] = mcp["env"]
+        record["environment"] = {
+            k: _to_opencode_env(str(v)) for k, v in mcp["env"].items()
+        }
     return record
 
 

--- a/agent-profile/agent_profile/renderers/opencode.py
+++ b/agent-profile/agent_profile/renderers/opencode.py
@@ -23,7 +23,7 @@ import re
 from pathlib import Path
 from typing import Any
 
-from agent_profile.env import _VAR_RE
+from agent_profile.env import VAR_RE
 from agent_profile.parse import Manifest
 from agent_profile.renderers.base import body_abs, mcps_for, read_json_object
 from agent_profile.shared import agent_is_read_only, strip_frontmatter, track_file
@@ -64,7 +64,7 @@ def _to_opencode_env(value: str) -> str:
     carries — it passes it through verbatim and breaks (MCP-secret-passthrough).
     Its runtime expansion token is ``{env:VAR}``. Plain literals (no ``${}``)
     pass through unchanged."""
-    return _VAR_RE.sub(lambda m: f"{{env:{m.group(1)}}}", value)
+    return VAR_RE.sub(lambda m: f"{{env:{m.group(1)}}}", value)
 
 
 def _mcp_server_record(mcp: dict[str, Any]) -> dict[str, Any]:

--- a/agent-profile/tests/test_ingest.py
+++ b/agent-profile/tests/test_ingest.py
@@ -133,11 +133,16 @@ def test_expand_mcps_source_dir_is_repo_root(repo):
     assert out["mcps"][0]["_source_dir"] == str(root)
 
 
-def test_expand_mcps_env_resolved_at_ingest(repo):
+def test_expand_mcps_env_stays_literal_at_ingest(repo):
+    # MCP-secret-passthrough (criterion 1): even with the var SET in .env, the
+    # env value is carried through as the literal ``${VAR}`` — NOT substituted
+    # to the secret — so renderers emit a runtime placeholder, not plaintext.
     root, directive = repo
     out = expand_registries(directive, root, _dotenv())
     todoist = next(m for m in out["mcps"] if m["name"] == "todoist")
-    assert todoist["env"]["TODOIST_API_KEY"] == "secret"
+    assert todoist["env"]["TODOIST_API_KEY"] == "${TODOIST_API_KEY}"
+    # The secret value must never appear in the rendered item.
+    assert "secret" not in str(todoist["env"])
 
 
 def test_expand_optional_mcp_skipped_when_var_unset(repo):

--- a/agent-profile/tests/test_mcp_secret_passthrough.py
+++ b/agent-profile/tests/test_mcp_secret_passthrough.py
@@ -1,0 +1,109 @@
+"""test_mcp_secret_passthrough.py — criterion 10 regression.
+
+MCP-secret-passthrough: ``ap`` carries the literal ``${VAR}`` from ingest to
+each renderer instead of baking the resolved secret. This module is the
+cross-harness backstop: render a ``${VAR}``-bearing MCP through every
+``ap`` renderer that writes a persistent config (claude plugin-scope, codex,
+opencode, cursor) with real secret values present in the process env, then
+grep the entire rendered tree and assert no secret value leaked to disk.
+
+copilot is excluded from the ``ap`` MCP default membership, so its live
+config is written by the chezmoi template, not a renderer here — that arm is
+covered by ``tests/chezmoi-wiring.bats`` (criterion 9).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent_profile.parse import Manifest
+from agent_profile.renderers.claude import ClaudeRenderer
+from agent_profile.renderers.codex import CodexRenderer
+from agent_profile.renderers.cursor import CursorRenderer
+from agent_profile.renderers.opencode import OpencodeRenderer
+
+SECRET = "sk-real-secret-VALUE-do-not-leak"
+VARNAME = "CONTEXT7_API_KEY"
+
+
+def _manifest() -> Manifest:
+    """A plugin-scope manifest with one ${VAR}-bearing MCP that every
+    persistent-config renderer (claude/codex/opencode/cursor) accepts."""
+    return Manifest(
+        name="secrets",
+        mcps=[
+            {
+                "name": "context7",
+                "command": "npx",
+                "args": ["-y", "@upstash/context7-mcp"],
+                "env": {VARNAME: f"${{{VARNAME}}}"},
+                # Default membership = [claude, codex, opencode, cursor].
+                "_source_dir": ".",
+            }
+        ],
+    )
+
+
+def _tree_text(root: Path) -> str:
+    """Concatenate every rendered file's text under ``root`` (config files
+    only — skip nothing; a leak anywhere is a failure)."""
+    parts: list[str] = []
+    for p in sorted(root.rglob("*")):
+        if p.is_file():
+            try:
+                parts.append(p.read_text())
+            except UnicodeDecodeError:
+                continue
+    return "\n".join(parts)
+
+
+def test_no_renderer_bakes_the_secret(tmp_path, monkeypatch):
+    # Real secret live in the process env (as it would be after zsh sources
+    # .env) — the renderers must NOT resolve ${VAR} to it on disk.
+    monkeypatch.setenv(VARNAME, SECRET)
+    # codex scrub keys off $DOTFILES_DIR/.env containing the key name.
+    dotfiles = tmp_path / "df"
+    dotfiles.mkdir()
+    (dotfiles / ".env").write_text(f"{VARNAME}={SECRET}\n")
+    monkeypatch.setenv("DOTFILES_DIR", str(dotfiles))
+    monkeypatch.delenv("AP_CODEX_INHERIT_ENV", raising=False)
+
+    target = tmp_path / "target"
+    target.mkdir()
+
+    for renderer in (
+        ClaudeRenderer(),
+        CodexRenderer(),
+        OpencodeRenderer(),
+        CursorRenderer(),
+    ):
+        renderer.render(_manifest(), target)
+
+    rendered = _tree_text(target)
+    assert rendered, "no files were rendered — test would vacuously pass"
+    assert SECRET not in rendered
+
+
+def test_claude_user_scope_does_not_bake_secret(tmp_path, monkeypatch):
+    # The user-scope path shells out to `claude mcp add`; capture its argv via
+    # a fake CLI and assert the secret never reaches it.
+    monkeypatch.setenv(VARNAME, SECRET)
+    bindir = tmp_path / "fakebin"
+    bindir.mkdir()
+    log = tmp_path / "claude-calls.log"
+    shim = bindir / "claude"
+    shim.write_text(
+        '#!/bin/sh\nprintf "%s\\n" "$*" >> "$AP_TEST_CLAUDE_LOG"\nexit 0\n'
+    )
+    shim.chmod(0o755)
+    monkeypatch.setenv("AP_TEST_CLAUDE_LOG", str(log))
+    monkeypatch.setenv("PATH", f"{bindir}:{Path('/usr/bin')}")
+
+    m = _manifest()
+    m.mcp_scope = "user"
+    ClaudeRenderer().render(m, tmp_path / "t")
+    text = log.read_text()
+    assert f"-e {VARNAME}=${{{VARNAME}}}" in text
+    assert SECRET not in text

--- a/agent-profile/tests/test_mcp_secret_passthrough.py
+++ b/agent-profile/tests/test_mcp_secret_passthrough.py
@@ -16,8 +16,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 from agent_profile.parse import Manifest
 from agent_profile.renderers.claude import ClaudeRenderer
 from agent_profile.renderers.codex import CodexRenderer

--- a/agent-profile/tests/test_registries_directive.py
+++ b/agent-profile/tests/test_registries_directive.py
@@ -98,7 +98,12 @@ def test_registries_agents_union_with_inline_agents(dotfiles):
     assert names == ["ghostbuster", "extra"]
 
 
-def test_registries_mcp_env_resolved_from_dotfiles_env(dotfiles):
+def test_registries_mcp_env_stays_literal_not_resolved(dotfiles):
+    # MCP-secret-passthrough: even with TODOIST_API_KEY=secret in DOTFILES_DIR/.env,
+    # the ingest validates-but-does-not-substitute — the env value rides through
+    # as the literal ${VAR} so renderers emit a runtime placeholder, not the
+    # secret. The presence check still keeps the (optional) entry because the
+    # var IS set.
     write_profile(
         dotfiles / "profiles",
         "base",
@@ -106,7 +111,8 @@ def test_registries_mcp_env_resolved_from_dotfiles_env(dotfiles):
     )
     out = parse_one(dotfiles / "profiles" / "base")
     todoist = next(m for m in out["mcps"] if m["name"] == "todoist")
-    assert todoist["env"]["TODOIST_API_KEY"] == "secret"
+    assert todoist["env"]["TODOIST_API_KEY"] == "${TODOIST_API_KEY}"
+    assert "secret" not in str(todoist["env"])
 
 
 def test_registries_source_dir_points_at_dotfiles(dotfiles):

--- a/agent-profile/tests/test_renderer_claude.py
+++ b/agent-profile/tests/test_renderer_claude.py
@@ -802,3 +802,59 @@ def test_user_scope_clean_missing_cli_fails_loud(env, monkeypatch):
     profile_dir = write_profile(env.profiles, "mcpuser", _MCPTEST_USER_YAML)
     with pytest.raises(FileNotFoundError):
         ClaudeRenderer().clean(parse_manifest(profile_dir), env.target)
+
+
+# ─── MCP-secret-passthrough: ${VAR} reaches claude as a literal ──────
+
+_SECRET_USER_YAML = """\
+name: secretuser
+description: literal ${VAR} passthrough at user scope
+mcp_scope: user
+mcps:
+  - name: context7
+    command: npx
+    args: ["-y", "@upstash/context7-mcp"]
+    env:
+      CONTEXT7_API_KEY: "${CONTEXT7_API_KEY}"
+    harnesses: [claude]
+"""
+
+_SECRET_PLUGIN_YAML = """\
+name: secretplugin
+description: literal ${VAR} passthrough at plugin scope
+mcps:
+  - name: context7
+    command: npx
+    args: ["-y", "@upstash/context7-mcp"]
+    env:
+      CONTEXT7_API_KEY: "${CONTEXT7_API_KEY}"
+    harnesses: [claude]
+"""
+
+
+def test_user_scope_passes_literal_var_not_secret(env, monkeypatch):
+    # Criterion 4: the `claude mcp add` argv carries `-e KEY=${VAR}` literally,
+    # never a resolved secret. A real value in the process env must NOT leak
+    # into the stored registration — Claude expands ${VAR} itself at launch.
+    monkeypatch.setenv("CONTEXT7_API_KEY", "sk-real-secret-123")
+    log = _install_fake_claude(env.tmp, monkeypatch)
+    profile_dir = write_profile(env.profiles, "secretuser", _SECRET_USER_YAML)
+    ClaudeRenderer().render(parse_manifest(profile_dir), env.target)
+    text = log.read_text()
+    assert "-e CONTEXT7_API_KEY=${CONTEXT7_API_KEY}" in text
+    assert "sk-real-secret-123" not in text
+
+
+def test_plugin_scope_mcp_json_env_is_literal_var(env, monkeypatch):
+    # Criterion 5: the plugin-scope `.mcp.json` env value is the literal
+    # ${VAR}; Claude expands it at launch. No secret on disk.
+    monkeypatch.setenv("CONTEXT7_API_KEY", "sk-real-secret-123")
+    profile_dir = write_profile(env.profiles, "secretplugin", _SECRET_PLUGIN_YAML)
+    ClaudeRenderer().render(parse_manifest(profile_dir), env.target)
+    mcp_json = (
+        env.target / ".claude/plugins/local/secretplugin/.mcp.json"
+    ).read_text()
+    data = json.loads(mcp_json)
+    env_block = data["mcpServers"]["context7"]["env"]
+    assert env_block["CONTEXT7_API_KEY"] == "${CONTEXT7_API_KEY}"
+    assert "sk-real-secret-123" not in mcp_json

--- a/agent-profile/tests/test_renderer_codex.py
+++ b/agent-profile/tests/test_renderer_codex.py
@@ -468,6 +468,39 @@ def test_mcp_env_block_omitted_when_fully_scrubbed(renderer, src, target, monkey
     assert "env" not in doc["mcp_servers"]["todoist"]
 
 
+def test_mcp_literal_var_is_scrubbed_no_placeholder_or_secret(
+    renderer, src, target, monkeypatch, tmp_path
+):
+    """Criterion 6: with the MCP-secret-passthrough flow the manifest now
+    carries the literal ``${VAR}`` (not a resolved secret). Codex's
+    scrub-by-keyname must still drop the `.env`-keyed entry, so neither the
+    `${VAR}` placeholder NOR any secret lands in config.toml — codex inherits
+    the value from the shell env at runtime."""
+    dotfiles = tmp_path / "df"
+    dotfiles.mkdir()
+    (dotfiles / ".env").write_text("CONTEXT7_API_KEY=ctx7sk-real-secret\n")
+    monkeypatch.setenv("DOTFILES_DIR", str(dotfiles))
+    monkeypatch.delenv("AP_CODEX_INHERIT_ENV", raising=False)
+
+    m = _manifest(
+        src,
+        mcps=[
+            {
+                "name": "context7",
+                "command": "npx",
+                "env": {"CONTEXT7_API_KEY": "${CONTEXT7_API_KEY}"},
+                "harnesses": ["codex"],
+            }
+        ],
+    )
+    renderer.render(m, target)
+    raw = (target / ".codex" / "config.toml").read_text()
+    assert "${CONTEXT7_API_KEY}" not in raw
+    assert "ctx7sk-real-secret" not in raw
+    doc = tomllib.loads(raw)
+    assert "env" not in doc["mcp_servers"]["context7"]
+
+
 # ─── commands deprecated, AGENTS.md never touched ─────────────────────────
 
 

--- a/agent-profile/tests/test_renderer_cursor.py
+++ b/agent-profile/tests/test_renderer_cursor.py
@@ -388,6 +388,48 @@ def test_mcp_envfile_falls_back_to_home_dotfiles_when_dotfiles_dir_unset(
     assert entry["envFile"] == "/home/user/Dev/dotfiles/.env"
 
 
+def test_mcp_renamed_var_ref_fails_loud(tmp_path, monkeypatch):
+    """A ``${VAR}`` env value that is NOT an exact self-reference — a renamed
+    key (``API_KEY: "${TOKEN}"``) — cannot be represented by Cursor's
+    ``envFile`` (which loads vars by their own names), so the renderer fails
+    loud rather than silently dropping the key and emitting a broken server
+    entry."""
+    monkeypatch.setenv("DOTFILES_DIR", "/abs/dots")
+    m, target, _ = _manifest(
+        tmp_path,
+        mcps=[
+            {
+                "name": "renamed",
+                "command": "npx",
+                "env": {"API_KEY": "${TODOIST_API_KEY}"},
+                "harnesses": ["cursor"],
+            }
+        ],
+    )
+    with pytest.raises(ValueError, match="not an exact self-reference"):
+        CursorRenderer().render(m, target)
+
+
+def test_mcp_embedded_var_ref_fails_loud(tmp_path, monkeypatch):
+    """An embedded ``${VAR}`` (surrounded by other text) is likewise
+    unrepresentable by ``envFile`` and fails loud rather than silently
+    dropping the key."""
+    monkeypatch.setenv("DOTFILES_DIR", "/abs/dots")
+    m, target, _ = _manifest(
+        tmp_path,
+        mcps=[
+            {
+                "name": "embedded",
+                "command": "npx",
+                "env": {"URL": "https://x/${TOKEN}/y"},
+                "harnesses": ["cursor"],
+            }
+        ],
+    )
+    with pytest.raises(ValueError, match="not an exact self-reference"):
+        CursorRenderer().render(m, target)
+
+
 def test_mcp_merge_preserves_user_entries(tmp_path):
     m, target, _ = _manifest(
         tmp_path,

--- a/agent-profile/tests/test_renderer_cursor.py
+++ b/agent-profile/tests/test_renderer_cursor.py
@@ -276,6 +276,118 @@ def test_mcp_entry_args_default_empty_and_env_preserved(tmp_path):
     assert entry == {"command": "uvx", "args": [], "env": {"K": "v"}}
 
 
+def test_mcp_secret_var_dropped_and_envfile_added(tmp_path, monkeypatch):
+    """Criterion 8: Cursor is GUI-launched, so a ``${VAR}`` in ``env`` does not
+    resolve against the shell. A secret-bearing (``${VAR}``-referencing) server
+    drops the ``${VAR}`` env entry and gains ``envFile`` = abs ``.env``; plain
+    literals remain in ``env``. No secret on disk."""
+    monkeypatch.setenv("DOTFILES_DIR", "/abs/dots")
+    m, target, _ = _manifest(
+        tmp_path,
+        mcps=[
+            {
+                "name": "context7",
+                "command": "npx",
+                "args": ["-y", "@upstash/context7-mcp"],
+                "env": {
+                    "CONTEXT7_API_KEY": "${CONTEXT7_API_KEY}",
+                    "SERENA_MUX_HARNESS": "cursor",
+                },
+                "harnesses": ["cursor"],
+            }
+        ],
+    )
+    CursorRenderer().render(m, target)
+    import json
+
+    raw = (target / ".cursor" / "mcp.json").read_text()
+    entry = json.loads(raw)["mcpServers"]["context7"]
+    # The ${VAR} entry is gone; the plain literal stays.
+    assert entry["env"] == {"SERENA_MUX_HARNESS": "cursor"}
+    assert entry["envFile"] == "/abs/dots/.env"
+    assert "${CONTEXT7_API_KEY}" not in raw
+
+
+def test_mcp_no_var_ref_keeps_env_no_envfile(tmp_path, monkeypatch):
+    """A server whose env has NO ``${VAR}`` reference keeps its plain ``env``
+    and gains no ``envFile`` — envFile is added only when a ${VAR} entry was
+    dropped."""
+    monkeypatch.setenv("DOTFILES_DIR", "/abs/dots")
+    m, target, _ = _manifest(
+        tmp_path,
+        mcps=[
+            {
+                "name": "plain",
+                "command": "uvx",
+                "env": {"SERENA_MUX_HARNESS": "cursor"},
+                "harnesses": ["cursor"],
+            }
+        ],
+    )
+    CursorRenderer().render(m, target)
+    import json
+
+    entry = json.loads((target / ".cursor" / "mcp.json").read_text())[
+        "mcpServers"
+    ]["plain"]
+    assert entry["env"] == {"SERENA_MUX_HARNESS": "cursor"}
+    assert "envFile" not in entry
+
+
+def test_mcp_all_env_vars_dropped_omits_env_key(tmp_path, monkeypatch):
+    """When every env entry is a ${VAR} ref, ``env`` is omitted entirely (no
+    empty ``env: {}`` left dangling) and ``envFile`` carries the lookup."""
+    monkeypatch.setenv("DOTFILES_DIR", "/abs/dots")
+    m, target, _ = _manifest(
+        tmp_path,
+        mcps=[
+            {
+                "name": "tavily",
+                "command": "npx",
+                "env": {"TAVILY_API_KEY": "${TAVILY_API_KEY}"},
+                "harnesses": ["cursor"],
+            }
+        ],
+    )
+    CursorRenderer().render(m, target)
+    import json
+
+    entry = json.loads((target / ".cursor" / "mcp.json").read_text())[
+        "mcpServers"
+    ]["tavily"]
+    assert "env" not in entry
+    assert entry["envFile"] == "/abs/dots/.env"
+
+
+def test_mcp_envfile_falls_back_to_home_dotfiles_when_dotfiles_dir_unset(
+    tmp_path, monkeypatch
+):
+    """Boundary: with ``DOTFILES_DIR`` UNSET, ``envFile`` resolves to the
+    ``~/Dev/dotfiles/.env`` fallback (the discover.py pattern) — never an
+    empty or ``/.env`` path. A broken ``or`` fallback would silently point
+    Cursor at the wrong .env and the secret would never load."""
+    monkeypatch.delenv("DOTFILES_DIR", raising=False)
+    monkeypatch.setenv("HOME", "/home/user")
+    m, target, _ = _manifest(
+        tmp_path,
+        mcps=[
+            {
+                "name": "tavily",
+                "command": "npx",
+                "env": {"TAVILY_API_KEY": "${TAVILY_API_KEY}"},
+                "harnesses": ["cursor"],
+            }
+        ],
+    )
+    CursorRenderer().render(m, target)
+    import json
+
+    entry = json.loads((target / ".cursor" / "mcp.json").read_text())[
+        "mcpServers"
+    ]["tavily"]
+    assert entry["envFile"] == "/home/user/Dev/dotfiles/.env"
+
+
 def test_mcp_merge_preserves_user_entries(tmp_path):
     m, target, _ = _manifest(
         tmp_path,

--- a/agent-profile/tests/test_renderer_opencode.py
+++ b/agent-profile/tests/test_renderer_opencode.py
@@ -179,6 +179,87 @@ def test_mcp_env_maps_to_environment(tmp_path: Path):
     }
 
 
+def test_mcp_env_rewrites_var_to_opencode_placeholder(tmp_path: Path):
+    """Criterion 7: opencode does not understand ``${VAR}`` (it passes it
+    through verbatim and breaks). Each ``${VAR}`` occurrence is rewritten to
+    opencode's ``{env:VAR}`` syntax; a plain literal (e.g. SERENA_MUX_HARNESS,
+    which is render-time, not a secret) passes through untouched. No resolved
+    secret on disk — opencode expands ``{env:VAR}`` from its process env."""
+    m = Manifest(
+        name="withvar",
+        mcps=[
+            {
+                "name": "withvar",
+                "command": "foo",
+                "env": {
+                    "CONTEXT7_API_KEY": "${CONTEXT7_API_KEY}",
+                    "SERENA_MUX_HARNESS": "opencode",
+                },
+                "harnesses": ["opencode"],
+            }
+        ],
+    )
+    OpencodeRenderer().render(m, tmp_path)
+    raw = (tmp_path / "opencode.json").read_text()
+    server = json.loads(raw)["mcp"]["withvar"]
+    assert server["environment"] == {
+        "CONTEXT7_API_KEY": "{env:CONTEXT7_API_KEY}",
+        "SERENA_MUX_HARNESS": "opencode",
+    }
+    assert "${CONTEXT7_API_KEY}" not in raw
+
+
+def test_mcp_env_rewrites_embedded_var(tmp_path: Path):
+    """A ``${VAR}`` embedded in a larger value is rewritten in place; only the
+    ``${VAR}`` token is touched, surrounding text is preserved."""
+    m = Manifest(
+        name="embed",
+        mcps=[
+            {
+                "name": "embed",
+                "command": "foo",
+                "env": {"URL": "https://x/${TOKEN}/y"},
+                "harnesses": ["opencode"],
+            }
+        ],
+    )
+    OpencodeRenderer().render(m, tmp_path)
+    server = json.loads((tmp_path / "opencode.json").read_text())["mcp"]["embed"]
+    assert server["environment"]["URL"] == "https://x/{env:TOKEN}/y"
+
+
+def test_mcp_env_bare_dollar_and_multi_var_boundaries(tmp_path: Path):
+    """Boundary: only the ``${IDENT}`` form is rewritten. A bare ``$VAR``
+    (no braces), a literal ``$`` (e.g. a price), and a malformed ``${}`` must
+    pass through UNTOUCHED — the rewrite must not broaden into shell-style
+    expansion or it would corrupt non-secret literals. Multiple ``${VAR}``
+    tokens in one value are each rewritten (``re.sub`` is global)."""
+    m = Manifest(
+        name="bounds",
+        mcps=[
+            {
+                "name": "bounds",
+                "command": "foo",
+                "env": {
+                    "BARE": "$NOT_A_REF",
+                    "PRICE": "costs $5.00 USD",
+                    "MALFORMED": "${}",
+                    "MULTI": "${A}-${B}",
+                },
+                "harnesses": ["opencode"],
+            }
+        ],
+    )
+    OpencodeRenderer().render(m, tmp_path)
+    env = json.loads((tmp_path / "opencode.json").read_text())["mcp"]["bounds"][
+        "environment"
+    ]
+    assert env["BARE"] == "$NOT_A_REF"
+    assert env["PRICE"] == "costs $5.00 USD"
+    assert env["MALFORMED"] == "${}"
+    assert env["MULTI"] == "{env:A}-{env:B}"
+
+
 def test_mcp_without_env_omits_environment(tmp_path: Path):
     """No ``env`` -> no ``environment`` key (the bash ``else {}`` branch)."""
     m = Manifest(

--- a/chezmoi/private_dot_copilot/mcp-config.json.tmpl
+++ b/chezmoi/private_dot_copilot/mcp-config.json.tmpl
@@ -1,26 +1,24 @@
 {{- /*
-Renders ~/.copilot/mcp-config.json with API keys at apply time.
+Renders ~/.copilot/mcp-config.json.
 
-Today: keys come from $CONTEXT7_API_KEY / $TAVILY_API_KEY (sourced from
-dotfiles/.env on shell init). To swap to 1Password instead, replace the
-two `env "..."` calls below with `onepasswordRead "op://<vault>/<item>/credential"`
-and add `op` to packages/packages.yaml. See references/secrets.md.
+MCP-secret-passthrough: the API-key env values are emitted as the LITERAL
+runtime placeholders ${CONTEXT7_API_KEY} / ${TAVILY_API_KEY}, NOT the resolved
+secret. Copilot CLI expands ${VAR} from its process env at launch (the user's
+shell already exports every dotfiles/.env key via zsh/core.zsh), so the secret
+stays in .env and never lands in this file on disk.
 
-If either key is missing (fresh box, no .env populated yet), render an
-empty mcpServers object and emit a chezmoi warning instead of failing the
-whole `chezmoi apply`. The keyed MCPs simply won't work until the user
-copies .env.example → .env and fills in the keys, but the rest of the
-sync (base-profile install, run_onchange installers) proceeds.
+Because the value is now a runtime placeholder, there is no apply-time key to
+resolve — the servers are always emitted, even on a fresh box with no .env yet
+(they simply won't work until the user populates .env). This is why the old
+unset-var warnf/empty-stub branch is gone.
+
+To swap to 1Password instead, the renderer would inject the secret at launch
+via a wrapper; that path is tracked in references/secrets.md.
+
+Fragility note: Copilot CLI's ${VAR} expansion regressed in v0.0.407 (gh#1403)
+and is thinly documented. If env passthrough breaks on a CLI upgrade, this is
+the place to revisit.
 */ -}}
-{{- $context7 := env "CONTEXT7_API_KEY" -}}
-{{- $tavily   := env "TAVILY_API_KEY" -}}
-{{- if or (eq $context7 "") (eq $tavily "") -}}
-{{   warnf "copilot mcp-config: CONTEXT7_API_KEY and/or TAVILY_API_KEY unset — emitting empty mcpServers. Fill keys in dotfiles/.env and re-run `dots sync` to enable." -}}
-{
-  "_comment": "Stub written by chezmoi: CONTEXT7_API_KEY and/or TAVILY_API_KEY were unset at apply time. Populate dotfiles/.env and re-run `dots sync`.",
-  "mcpServers": {}
-}
-{{- else -}}
 {
   "mcpServers": {
     "code-review-graph": {
@@ -42,7 +40,7 @@ sync (base-profile install, run_onchange installers) proceeds.
         "@upstash/context7-mcp"
       ],
       "env": {
-        "CONTEXT7_API_KEY": {{ $context7 | quote }}
+        "CONTEXT7_API_KEY": "${CONTEXT7_API_KEY}"
       },
       "tools": [
         "*"
@@ -56,7 +54,7 @@ sync (base-profile install, run_onchange installers) proceeds.
         "tavily-mcp@latest"
       ],
       "env": {
-        "TAVILY_API_KEY": {{ $tavily | quote }}
+        "TAVILY_API_KEY": "${TAVILY_API_KEY}"
       },
       "tools": [
         "*"
@@ -75,4 +73,3 @@ sync (base-profile install, run_onchange installers) proceeds.
     }
   }
 }
-{{- end -}}

--- a/tests/chezmoi-wiring.bats
+++ b/tests/chezmoi-wiring.bats
@@ -652,20 +652,33 @@ YAML
     fi
 }
 
-@test "copilot template warns on missing env vars and renders both keys" {
-    # Behavior change: prior to the linux-bootstrap PR (commit 5369aa3) the
-    # template hard-failed `chezmoi apply` with `{{ fail "... is not set" }}`
-    # whenever either API key was unset. That was hostile to fresh-box
-    # bootstraps where the user has not yet copied .env.example → .env, so
-    # the template now `warnf`s and emits an empty `mcpServers: {}` stub
-    # instead. The MCPs simply won't work until the keys are populated, but
-    # the rest of `dots sync` proceeds.
+@test "copilot template emits literal \${VAR} placeholders, never resolved secrets" {
+    # MCP-secret-passthrough: the template emits the LITERAL ${CONTEXT7_API_KEY}
+    # / ${TAVILY_API_KEY} so Copilot expands them at launch — the secret stays
+    # in .env and never lands in ~/.copilot/mcp-config.json. Render with real
+    # secrets in the env and assert they do NOT appear in the output.
     local tmpl="$REAL_DOTFILES_DIR/chezmoi/private_dot_copilot/mcp-config.json.tmpl"
-    grep -q 'warnf "copilot mcp-config:' "$tmpl"
-    grep -q 'CONTEXT7_API_KEY and/or TAVILY_API_KEY unset' "$tmpl"
-    grep -q '"mcpServers": {}' "$tmpl"
-    grep -q 'env "CONTEXT7_API_KEY"' "$tmpl"
-    grep -q 'env "TAVILY_API_KEY"' "$tmpl"
+    local rendered
+    rendered="$(CONTEXT7_API_KEY=ctx7-real-secret TAVILY_API_KEY=tav-real-secret \
+        chezmoi --source "$REAL_DOTFILES_DIR/chezmoi" execute-template < "$tmpl")"
+    # Valid JSON.
+    jq -e . <<<"$rendered" >/dev/null
+    # Literal placeholders present, both servers emitted unconditionally.
+    # SC2016: intentional literal — the rendered value IS the string ${VAR}.
+    # shellcheck disable=SC2016
+    [[ "$(jq -r '.mcpServers.context7.env.CONTEXT7_API_KEY' <<<"$rendered")" == '${CONTEXT7_API_KEY}' ]]
+    # shellcheck disable=SC2016
+    [[ "$(jq -r '.mcpServers.tavily.env.TAVILY_API_KEY' <<<"$rendered")" == '${TAVILY_API_KEY}' ]]
+    # No resolved secret leaked onto disk.
+    if grep -qE 'ctx7-real-secret|tav-real-secret' <<<"$rendered"; then
+        echo "copilot template leaked a resolved secret into the rendered config" >&2
+        return 1
+    fi
+    # The removed unset-var guard branch must be gone.
+    if grep -q '"mcpServers": {}' "$tmpl"; then
+        echo "copilot template still carries the removed empty-stub guard" >&2
+        return 1
+    fi
 }
 
 @test "copilot sensitive-file-guard source files exist" {
@@ -782,44 +795,50 @@ TOML
         return 1
     fi
 
-    # The copilot template should render with the env-supplied API keys.
+    # MCP-secret-passthrough: the copilot template renders the LITERAL ${VAR}
+    # placeholders, NOT the resolved keys — Copilot expands them at launch, so
+    # the secret stays in .env and never lands in this file on disk.
     assert_file_exists "$HOME/.copilot/mcp-config.json"
-    grep -qF '"CONTEXT7_API_KEY": "test-context7-key"' "$HOME/.copilot/mcp-config.json"
-    grep -qF '"TAVILY_API_KEY": "test-tavily-key"' "$HOME/.copilot/mcp-config.json"
+    # SC2016: the single quotes are intentional — we assert the LITERAL ${VAR}
+    # placeholder text is present, not its expansion.
+    # shellcheck disable=SC2016
+    grep -qF '"CONTEXT7_API_KEY": "${CONTEXT7_API_KEY}"' "$HOME/.copilot/mcp-config.json"
+    # shellcheck disable=SC2016
+    grep -qF '"TAVILY_API_KEY": "${TAVILY_API_KEY}"' "$HOME/.copilot/mcp-config.json"
+    # The supplied secret values must NOT be baked into the rendered file.
+    if grep -qE 'test-context7-key|test-tavily-key' "$HOME/.copilot/mcp-config.json"; then
+        echo "copilot mcp-config baked a resolved secret instead of a placeholder" >&2
+        return 1
+    fi
 }
 
-@test "copilot template warns + emits empty mcpServers when CONTEXT7_API_KEY is unset" {
+@test "copilot template emits servers with literal placeholders even when keys are unset" {
     command -v chezmoi >/dev/null 2>&1 || skip "chezmoi not installed"
 
-    # Linux-bootstrap PR (5369aa3) softened the template from `{{ fail ... }}`
-    # to `{{ warnf ... }}` + empty-stub render. `chezmoi apply` therefore
-    # SUCCEEDS even when a key is unset, and the rendered file is a stub
-    # carrying `"mcpServers": {}`. The warning still surfaces the missing
-    # key on stderr so the user knows to populate .env.
-    local fake_npx_bin
-    fake_npx_bin=$(make_fake_npx)
-    PATH="$fake_npx_bin:$PATH"
-
-    mkdir -p "$HOME/.config/chezmoi"
-    cat > "$HOME/.config/chezmoi/chezmoi.toml" <<TOML
-sourceDir = "$REAL_DOTFILES_DIR/chezmoi"
-
-[data]
-email = "test@example.com"
-work = false
-TOML
-    unset CONTEXT7_API_KEY
-    export TAVILY_API_KEY="test-tavily-key"
-
-    run chezmoi apply --force
-    assert_success
-    # The warnf message should appear in chezmoi's stderr (combined with
-    # stdout under bats' `run`).
-    assert_output_contains "CONTEXT7_API_KEY and/or TAVILY_API_KEY unset"
-    # The rendered file is the empty-mcpServers stub.
-    assert_file_exists "$HOME/.copilot/mcp-config.json"
-    grep -qF '"mcpServers": {}' "$HOME/.copilot/mcp-config.json"
-    grep -qF 'Stub written by chezmoi' "$HOME/.copilot/mcp-config.json"
+    # MCP-secret-passthrough: because the env values are now runtime ${VAR}
+    # placeholders (Copilot expands them at launch), there is no apply-time key
+    # to resolve. The template therefore always emits the full server set —
+    # even on a fresh box with no .env yet — instead of the old warnf +
+    # empty-mcpServers stub. The MCPs simply won't work until .env is populated.
+    #
+    # Render the template in isolation (execute-template) rather than a full
+    # `chezmoi apply`: with the keys unset, apply would also drive the
+    # base-profile `ap install`, which legitimately fails loud on the
+    # non-optional context7/tavily ${VAR}s (criterion 2). That fail-loud is a
+    # separate, intended behavior — this test pins the copilot template alone.
+    local tmpl="$REAL_DOTFILES_DIR/chezmoi/private_dot_copilot/mcp-config.json.tmpl"
+    local rendered
+    rendered="$(env -u CONTEXT7_API_KEY -u TAVILY_API_KEY \
+        chezmoi --source "$REAL_DOTFILES_DIR/chezmoi" execute-template < "$tmpl")"
+    # Valid JSON; both keyed servers present with literal placeholders.
+    jq -e . <<<"$rendered" >/dev/null
+    # SC2016: intentional literal — the rendered value IS the string ${VAR}.
+    # shellcheck disable=SC2016
+    [[ "$(jq -r '.mcpServers.context7.env.CONTEXT7_API_KEY' <<<"$rendered")" == '${CONTEXT7_API_KEY}' ]]
+    # shellcheck disable=SC2016
+    [[ "$(jq -r '.mcpServers.tavily.env.TAVILY_API_KEY' <<<"$rendered")" == '${TAVILY_API_KEY}' ]]
+    # No empty-mcpServers stub fallback.
+    [[ "$(jq -r '.mcpServers | length' <<<"$rendered")" -ge 4 ]]
 }
 
 # ── serena config (modify_ pattern) ────────────────────────────────────────


### PR DESCRIPTION
## What & why

`ap` resolved `${VAR}` env refs to their **plaintext secret values at ingest** (`ingest._expand_mcps` → `resolve_item_env`), so every renderer wrote real API keys into the rendered config files: `~/.claude.json`, `~/.cursor/mcp.json`, `~/.config/opencode/opencode.json`, `~/.copilot/mcp-config.json`. This also made the #243 commit's "secrets stay in `.env`, never land in `~/.claude.json`" claim false.

This decouples **validation** from **substitution** at ingest: the literal `${VAR}` is carried through to each renderer, which emits the placeholder *its* harness expands at launch — so secrets stay off disk.

## Per-harness placeholder (syntax diverges — verified against official docs + an empirical test)

| Harness | Emits | Notes |
|---|---|---|
| claude | `${VAR}` | `claude mcp add -e K='${VAR}'` stores the literal (verified); Claude expands at launch |
| codex | — | already scrubbed `.env` keys + inherits shell env; **no change** |
| opencode | `{env:VAR}` | `${VAR}` is unsupported there (passes through verbatim) |
| cursor | `envFile` → abs `.env` | GUI launch can't inherit shell env; `${env:VAR}` wouldn't resolve |
| copilot | `${VAR}` | live writer is the **chezmoi template**, not the `ap` renderer |

## Changes

- **`ingest.py`** — validate `${VAR}` without substituting: `optional`+unset → drop; required+unset → fail loud; else carry the literal through.
- **`opencode.py`** — rewrite `${VAR}` → `{env:VAR}`.
- **`cursor.py`** — drop `${VAR}` env entries, add `envFile` = abs `.env` (`${DOTFILES_DIR}` with `~/Dev/dotfiles` fallback).
- **`chezmoi/private_dot_copilot/mcp-config.json.tmpl`** — emit literal `${VAR}`; drop the apply-time unset-stub branch.
- **claude.py / codex.py** — no code change; literal flows through.

## Tests

- 438 pytest pass (was 426 on `main`); new cross-harness `test_mcp_secret_passthrough.py` renders all four persistent-config harnesses with a real secret in env and greps the whole tree (absent).
- Boundary hardening: bare `$VAR` / `${}` / multi-var pass-through; cursor `envFile` `DOTFILES_DIR`-unset fallback (both verified red under mutation).
- `tests/chezmoi-wiring.bats` copilot arm rewritten to assert literal placeholders + no resolved secret.

## Out of scope (flagged, intentional)

- `overlay.py` (isolated `ap launch`) still resolves into an **ephemeral** `/tmp` `.mcp.json` (0700, discarded) — closed-world parity.
- Legacy bash `agents/mcp/lib.sh` still bakes — **dormant** path, doesn't run on `dots sync`. Future cleanup.
- Pre-existing `chezmoi-wiring.bats` #39 failure (fails on `main` too, stash-verified) — unrelated.

## Wiki

Adds `.hallouminate/wiki/architecture/mcp-secret-handling.md` (the *why*: secrets off disk, claude parse-failure blast radius, per-harness syntax divergence, cursor GUI/`envFile`, copilot fragility).

🤖 Generated with [Claude Code](https://claude.com/claude-code)