### PR TITLE
docs(agents): clarify phase-agent handback and /wheypoint use

### DIFF
--- a/.hallouminate/wiki/architecture/agents-dir.md
+++ b/.hallouminate/wiki/architecture/agents-dir.md
@@ -61,6 +61,8 @@ The cheese sub-agents. Metadata lives in the registry; instruction bodies live a
 
 Two tiers live here: narrow specialists (`fromage-*`, `ghostbuster`, `nih-scanner`, `ricotta-reducer`, `roquefort-wrecker`, `duckdb-expert`, `whey-drainer`, `worktree-triage`) used as fork targets, and four general phase agents (`explorer`/`researcher`/`reviewer`/`coder`) modelling the explore→research→review→code loop. Planning is intentionally *not* an agent: it owns the human-approval loop and a level-1 sub-agent can't fan out, so it stays an orchestrator concern.
 
+The four phase agents hand results back through their **final message**, which the harness returns to the orchestrator as the tool result; each opens that message with the four-field handoff block (`status` / `next` / `artifact` / one-line orientation) defined in `agents/preamble.md`'s *Cross-phase handoff* section. That block is the deliberate in-session twin of the `/wheypoint` slug — same four fields, `blocked:` where wheypoint uses `halt:`. The agents do **not** call `/wheypoint` on clean completion: `/wheypoint` is the cross-session baton and explicitly disclaims per-phase handoffs. The one sanctioned exception is context exhaustion mid-task — an agent that can't finish in its own window returns `status: blocked: out of context` with `artifact:` pointing at a partial slug (`.cheese/notes/<slug>.md` for the coder, its own `.cheese/<phase>/` artifact for the read-only three) so the orchestrator re-dispatches a fresh agent instead of losing progress.
+
 ### Skills — `skills/` tree + `skills/_registry.yaml`
 
 Two sources unioned at ingest (`ingest._expand_skills`):

--- a/agents/agent_definitions/coder.md
+++ b/agents/agent_definitions/coder.md
@@ -36,7 +36,7 @@ You are the Coder — the one phase agent that mutates the tree. You take an app
 
 ## Handoff
 
-Prefix your Output Format report with the shared handoff block so the orchestrator can machine-read where you landed:
+Your final message *is* the handback — the orchestrator reads it as the tool result, not the user. Lead with the shared four-field block so it can machine-read where you landed, then the Output Format report:
 
 ```
 status: ok | blocked: <one-line reason>
@@ -45,7 +45,9 @@ artifact: <path to fuller output, if any>
 <one-line orientation>
 ```
 
-`/cook` writes the report to `.cheese/cook/<slug>.md`; hand back the digest, not the full trace.
+This block is the in-session twin of the `/wheypoint` slug (same four fields). `/cook` writes the full report to `.cheese/cook/<slug>.md`; hand back the digest, not the full trace.
+
+If you run out of context before finishing, that is the one time to write a `/wheypoint`-format slug yourself: drop resumable state (goal, what is done and verified, what is left) to `.cheese/notes/<slug>.md` via `cheez-write`, then return `status: blocked: out of context`, `artifact: .cheese/notes/<slug>.md`, `next: cook` so the parent resumes with a fresh coder. On clean completion, do not write a wheypoint — the digest above is the baton.
 
 ## Rules
 

--- a/agents/agent_definitions/explorer.md
+++ b/agents/agent_definitions/explorer.md
@@ -32,7 +32,7 @@ You are the Explorer — a read-only investigator. The parent dispatches you to 
 
 ## Handoff
 
-Prefix your Output Format digest with the shared handoff block so the orchestrator can machine-read where you landed:
+Your final message *is* the handback — the orchestrator reads it as the tool result, not the user. Lead with the shared four-field block (the in-session twin of the `/wheypoint` slug) so it can machine-read where you landed, then the Output Format digest:
 
 ```
 status: ok | blocked: <one-line reason>
@@ -41,7 +41,7 @@ artifact: <path to fuller output, if any>
 <one-line orientation>
 ```
 
-Default to the inline digest. Only when your findings genuinely exceed a digest, write them to `.cheese/explore/<slug>.md` and return that path as `artifact:` — never dump the full investigation into your reply.
+Default to the inline digest. Only when your findings genuinely exceed a digest, write them to `.cheese/explore/<slug>.md` and return that path as `artifact:` — never dump the full investigation into your reply. If you run out of context before finishing, return `status: blocked: out of context` and point `artifact:` at a partial `.cheese/explore/<slug>.md` so the parent re-dispatches rather than losing your progress.
 
 ## Rules
 

--- a/agents/agent_definitions/researcher.md
+++ b/agents/agent_definitions/researcher.md
@@ -37,7 +37,7 @@ You are the Researcher — you answer questions that live *outside* the codebase
 
 ## Handoff
 
-Prefix your Output Format synthesis with the shared handoff block so the orchestrator can machine-read where you landed:
+Your final message *is* the handback — the orchestrator reads it as the tool result, not the user. Lead with the shared four-field block (the in-session twin of the `/wheypoint` slug) so it can machine-read where you landed, then the Output Format synthesis:
 
 ```
 status: ok | blocked: <one-line reason>
@@ -46,7 +46,7 @@ artifact: <path to fuller output, if any>
 <one-line orientation>
 ```
 
-You always write the durable research slug (`.cheese/research/<slug>/<slug>.md`) — return its path as `artifact:` and your recommended phase as `next:`; the orchestrator threads that reference into the next phase instead of re-reading your fetches.
+You always write the durable research slug (`.cheese/research/<slug>/<slug>.md`) — return its path as `artifact:` and your recommended phase as `next:`; the orchestrator threads that reference into the next phase instead of re-reading your fetches. If you run out of context before finishing, return `status: blocked: out of context` with the partial slug as `artifact:` so the parent re-dispatches rather than losing your progress.
 
 ## Rules
 

--- a/agents/agent_definitions/reviewer.md
+++ b/agents/agent_definitions/reviewer.md
@@ -45,7 +45,7 @@ Cover each dimension. When this review runs at the top level (the orchestrator r
 
 ## Handoff
 
-Prefix your Output Format report with the shared handoff block so the orchestrator can machine-read where you landed:
+Your final message *is* the handback — the orchestrator reads it as the tool result, not the user. Lead with the shared four-field block (the in-session twin of the `/wheypoint` slug) so it can machine-read where you landed, then the Output Format report:
 
 ```
 status: ok | blocked: <one-line reason>
@@ -54,7 +54,7 @@ artifact: <path to fuller output, if any>
 <one-line orientation>
 ```
 
-Default to the inline report. Only when it genuinely exceeds a digest, write it to `.cheese/age/<slug>.md` and return that path as `artifact:` — hand back the severity-grouped findings, not the full trace.
+Default to the inline report. Only when it genuinely exceeds a digest, write it to `.cheese/age/<slug>.md` and return that path as `artifact:` — hand back the severity-grouped findings, not the full trace. If you run out of context before finishing, return `status: blocked: out of context` and point `artifact:` at a partial `.cheese/age/<slug>.md` so the parent re-dispatches rather than losing your progress.
 
 ## Rules
 


### PR DESCRIPTION
## What

The four general phase agents (`coder`, `explorer`, `researcher`, `reviewer`) hand results back to the orchestrator via their **final message** — the harness returns it as the tool result. This PR makes that mechanism explicit in each agent's `## Handoff` section and clarifies the relationship to `/wheypoint`.

Each `## Handoff` now:

1. **States the mechanism** — "Your final message *is* the handback — the orchestrator reads it as the tool result, not the user."
2. **Cross-references the twin** — the four-field block (`status` / `next` / `artifact` / orientation) is the in-session twin of the `/wheypoint` slug (same fields; `blocked:` where wheypoint uses `halt:`).
3. **Defines the one sanctioned in-agent `/wheypoint` use** — context exhaustion mid-task: return `status: blocked: out of context` with an `artifact:` pointer so the parent re-dispatches a fresh agent. The coder writes a full `/wheypoint`-format slug to `.cheese/notes/<slug>.md`; the read-only three point at their existing `.cheese/<phase>/` artifact.

## Why not call `/wheypoint` on clean completion

`/wheypoint` is the **cross-session** baton (writes `.cheese/notes/<slug>.md` for a fresh session via `/cheese --continue`) and its own description disclaims per-phase handoffs. On clean completion the four-field digest already *is* the handback — calling `/wheypoint` would duplicate it and fight the skill's stated scope.

## Scope

- Edited only the four phase-agent bodies. The 11 specialist fork-targets (`fromage-*`, `ghostbuster`, etc.) return bespoke evidence digests, not phase batons, so they were intentionally left alone.
- `preamble.md` left untouched (orchestrator-side; `status: blocked` is already interpretable there).
- Captured the rationale in the wiki (`architecture/agents-dir.md`) so it is not re-litigated.

These are source-of-truth bodies; `dots sync` renders them into the live harness layouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)