### PR TITLE
feat(ap): self-heal pre-ap legacy hooks across harnesses + harness-doctor skill

### DIFF
--- a/.hallouminate/wiki/architecture/config-drift.md
+++ b/.hallouminate/wiki/architecture/config-drift.md
@@ -1,0 +1,91 @@
+# Config Drift & Self-Heal
+
+Why live harness config on a machine can disagree with what `ap` renders from
+the registries, how to tell the kinds of drift apart, and what heals each.
+This is the *why* behind the `/harness-doctor` skill and the renderer-level
+legacy-hook cleanup.
+
+## The root cause: seed-once files nothing prunes
+
+Most live config is fully owned by `ap` — it rewrites the plugin tree,
+`.mcp.json`, codex `[mcp_servers]`, etc. on every `dots sync`. But a few files
+are chezmoi `create_` seeds or otherwise user-owned: written once, then never
+overwritten or pruned. The two that bite:
+
+- `~/.claude/settings.json` — `ap install global` only jq-*merges*
+  `enabledPlugins` + `extraKnownMarketplaces` into it (`claude.py:_merge_root_settings`),
+  preserving every other key.
+- `~/.codex/config.toml` — seeded once, then user-owned; `ap` merges
+  `[mcp_servers]` into it.
+
+That asymmetry is the drift engine. Before the `ap` migration (commit **#217**,
+`feat(ap): add global profile + migrate settings.json to chezmoi seed`), the
+retired `agents/hooks/sync.sh` jq/yq-merged the hook registry **directly into
+those user files** — `settings.json` for Claude, `[[hooks.*]]` in `config.toml`
+for Codex. The migration moved hook wiring into the per-harness render targets
+(Claude's plugin tree `plugin.json`; Codex's `hooks.json`) — but nothing
+removed the old copies. They linger as:
+
+- **Dead hooks** — the script path no longer exists. The pre-ap cheese-flair
+  hook (`bash "$HOME/.claude/hooks/session-start-cheese-flair.sh"`) points at a
+  file deleted when hooks moved into the plugin; it fails (exit 127) silently
+  on every session start.
+- **Double-fired hooks** — byte-identical to a now-managed hook (e.g.
+  `moshi-hook`), and the harness loads both sources at once, so the event fires
+  twice (duplicate phone notifications, etc.).
+
+## Three classes of drift
+
+| Class | Signature | Action |
+|---|---|---|
+| **Stale remnant** | Live, absent from the `ap` render, AND git history shows the repo moved this responsibility elsewhere. | Prune (self-heal). |
+| **Dotfiles bug** | The repo's own source is wrong (registry → missing script, invalid hook `event`, required MCP `${VAR}` not marked `optional`, wiki index won't rebuild). | Open a gh issue. |
+| **Expected local** | Live-only, no repo provenance — a personal hook, an extra permission, the tmux Stop hook, the JS guards under `~/.claude/hooks/`. | Leave alone. |
+
+The Claude-specific JS guards (`bash-guard.js`, `write-guard.js`, …), `rtk`,
+and any tmux hook are **settings-only and legit** — not managed by any render
+target, so they are *not* drift even though they live in `settings.json`.
+
+## The heal lives in the renderers — all harnesses alike
+
+The legacy-hook cleanup is a renderer responsibility, run on every `ap install`
+— not a bolt-on chezmoi script. Each renderer prunes its *own* harness's
+pre-ap leftovers, keyed off the hooks it just wired into that harness's render
+target:
+
+- **claude** — `agent_profile/renderers/claude.py:_clean_legacy_settings_hooks`
+  builds a per-event signature set from the hooks it wired into `plugin.json` —
+  a script basename (for `${CLAUDE_PLUGIN_ROOT}/hooks/<base>`) or the full
+  command string (for command-type hooks like moshi) — and drops any
+  `settings.json` hook whose command duplicates one, pruning at the inner-hook
+  level so a user command sharing a block survives, then pruning emptied events.
+- **codex** — `agent_profile/renderers/codex.py:_clean_legacy_config_toml_hooks`
+  does the equivalent for `[[hooks.*]]` blocks in `config.toml`, matching
+  managed script basenames per event.
+
+Because each cleanup is keyed off the hooks the renderer *just produced*, it
+self-extends: add a hook to `agents/hooks/registry.yaml` → it renders → the
+matching renderer auto-strips any stale user-file copy on the next sync. It
+fails safe — no managed hooks means no signatures, so it can never strip when
+it doesn't know what's managed.
+
+So the heal is simply **`dots sync`** (which runs `ap install global`).
+opencode/cursor/copilot don't receive the cross-harness `agents/hooks/`
+registry hooks (their cursor/copilot guard hooks ship via chezmoi separately),
+so there is no registry-hook drift to heal there — the "all harnesses alike"
+coverage is complete with claude + codex both self-cleaning.
+
+Why renderer-level and not a chezmoi heal script: it's where codex already put
+it, it runs as part of the single `ap install` path (no `run_onchange`
+ordering hacks), and it's unit-tested in-process
+(`tests/test_claude_legacy_hook_cleanup.py`, `tests/test_codex_legacy_hook_cleanup.py`).
+
+## Gotcha: index drift is its own drift class
+
+The hallouminate wiki index (LanceDB) is derived from the markdown on disk. If
+`ground` errors with `missing column chunk_id` (or similar), the index is stale
+vs the schema — run `hallouminate index` to rebuild. A doctor run should treat
+a non-rebuildable index as a dotfiles bug, not just retry.
+
+See [[agent-profile]] for the `ap` render/install model and [[../harnesses/claude]]
+for where each Claude config surface lives.

--- a/.hallouminate/wiki/architecture/config-drift.md
+++ b/.hallouminate/wiki/architecture/config-drift.md
@@ -3,44 +3,47 @@
 Why live harness config on a machine can disagree with what `ap` renders from
 the registries, how to tell the kinds of drift apart, and what heals each.
 This is the *why* behind the `/harness-doctor` skill and the renderer-level
-legacy-hook cleanup.
+self-heal (legacy hooks + dropped MCPs).
 
-## The root cause: seed-once files nothing prunes
+## The root cause: seed-once / merged files nothing prunes
 
 Most live config is fully owned by `ap` — it rewrites the plugin tree,
-`.mcp.json`, codex `[mcp_servers]`, etc. on every `dots sync`. But a few files
-are chezmoi `create_` seeds or otherwise user-owned: written once, then never
-overwritten or pruned. The two that bite:
+claude's plugin `.mcp.json`, etc. wholesale on every `dots sync`. Drift lives
+in the files `ap` **merges into** rather than overwrites: chezmoi `create_`
+seeds and user-owned configs it reads-modifies-writes. The ones that bite:
 
 - `~/.claude/settings.json` — `ap install global` only jq-*merges*
-  `enabledPlugins` + `extraKnownMarketplaces` into it (`claude.py:_merge_root_settings`),
+  `enabledPlugins` + `extraKnownMarketplaces` (`claude.py:_merge_root_settings`),
   preserving every other key.
-- `~/.codex/config.toml` — seeded once, then user-owned; `ap` merges
-  `[mcp_servers]` into it.
+- `~/.codex/config.toml`, `~/.config/opencode/opencode.json`,
+  `~/.cursor/mcp.json`, `~/.copilot/mcp-config.json` — each seeded/user-owned;
+  `ap` merges MCP entries into them per render.
+- `~/.claude.json` — claude user-scope MCP registrations (`claude mcp add`).
 
-That asymmetry is the drift engine. Before the `ap` migration (commit **#217**,
-`feat(ap): add global profile + migrate settings.json to chezmoi seed`), the
-retired `agents/hooks/sync.sh` jq/yq-merged the hook registry **directly into
-those user files** — `settings.json` for Claude, `[[hooks.*]]` in `config.toml`
-for Codex. The migration moved hook wiring into the per-harness render targets
-(Claude's plugin tree `plugin.json`; Codex's `hooks.json`) — but nothing
-removed the old copies. They linger as:
+That merge-not-overwrite asymmetry is the drift engine. Two leftover kinds:
 
-- **Dead hooks** — the script path no longer exists. The pre-ap cheese-flair
-  hook (`bash "$HOME/.claude/hooks/session-start-cheese-flair.sh"`) points at a
-  file deleted when hooks moved into the plugin; it fails (exit 127) silently
-  on every session start.
-- **Double-fired hooks** — byte-identical to a now-managed hook (e.g.
-  `moshi-hook`), and the harness loads both sources at once, so the event fires
-  twice (duplicate phone notifications, etc.).
+**Legacy hooks.** Before the `ap` migration (commit **#217**, `feat(ap): add
+global profile + migrate settings.json to chezmoi seed`), the retired
+`agents/hooks/sync.sh` jq/yq-merged the hook registry **directly into** those
+user files — `settings.json` for Claude, `[[hooks.*]]` in `config.toml` for
+Codex. The migration moved hook wiring into the per-harness render targets
+(Claude's plugin `plugin.json`; Codex's `hooks.json`), but nothing removed the
+old copies. They linger as **dead hooks** (script path deleted → exit 127 every
+session start, e.g. the pre-ap cheese-flair entry) or **double-fired hooks**
+(byte-identical to a now-managed hook like `moshi-hook`; the harness loads both
+sources and fires twice).
+
+**Dropped MCPs.** Remove an MCP from `agents/mcp/registry.yaml` and the next
+render simply stops writing it — but the entry a *prior* render merged into the
+files above is never removed, so it lingers indefinitely.
 
 ## Three classes of drift
 
 | Class | Signature | Action |
 |---|---|---|
-| **Stale remnant** | Live, absent from the `ap` render, AND git history shows the repo moved this responsibility elsewhere. | Prune (self-heal). |
+| **Stale remnant** | Live, absent from the `ap` render, AND git history shows the repo moved this responsibility elsewhere (legacy hook) or dropped it from a registry (MCP). | Prune (self-heal). |
 | **Dotfiles bug** | The repo's own source is wrong (registry → missing script, invalid hook `event`, required MCP `${VAR}` not marked `optional`, wiki index won't rebuild). | Open a gh issue. |
-| **Expected local** | Live-only, no repo provenance — a personal hook, an extra permission, the tmux Stop hook, the JS guards under `~/.claude/hooks/`. | Leave alone. |
+| **Expected local** | Live-only, no repo provenance — a personal hook, an extra permission, the tmux Stop hook, the JS guards under `~/.claude/hooks/`, a hand-added MCP. | Leave alone. |
 
 The Claude-specific JS guards (`bash-guard.js`, `write-guard.js`, …), `rtk`,
 and any tmux hook are **settings-only and legit** — not managed by any render
@@ -48,37 +51,54 @@ target, so they are *not* drift even though they live in `settings.json`.
 
 ## The heal lives in the renderers — all harnesses alike
 
-The legacy-hook cleanup is a renderer responsibility, run on every `ap install`
-— not a bolt-on chezmoi script. Each renderer prunes its *own* harness's
-pre-ap leftovers, keyed off the hooks it just wired into that harness's render
-target:
+Self-heal is a renderer responsibility, run on every `ap install` — not a
+bolt-on chezmoi script. Two reconcile passes:
 
-- **claude** — `agent_profile/renderers/claude.py:_clean_legacy_settings_hooks`
-  builds a per-event signature set from the hooks it wired into `plugin.json` —
-  a script basename (for `${CLAUDE_PLUGIN_ROOT}/hooks/<base>`) or the full
-  command string (for command-type hooks like moshi) — and drops any
-  `settings.json` hook whose command duplicates one, pruning at the inner-hook
-  level so a user command sharing a block survives, then pruning emptied events.
-- **codex** — `agent_profile/renderers/codex.py:_clean_legacy_config_toml_hooks`
-  does the equivalent for `[[hooks.*]]` blocks in `config.toml`, matching
-  managed script basenames per event.
+### Legacy hooks (per-renderer, keyed off what it just wired)
 
-Because each cleanup is keyed off the hooks the renderer *just produced*, it
-self-extends: add a hook to `agents/hooks/registry.yaml` → it renders → the
-matching renderer auto-strips any stale user-file copy on the next sync. It
-fails safe — no managed hooks means no signatures, so it can never strip when
-it doesn't know what's managed.
+- **claude** — `claude.py:_clean_legacy_settings_hooks` builds a per-event
+  signature set from the hooks it wired into `plugin.json` — a script basename
+  (for `${CLAUDE_PLUGIN_ROOT}/hooks/<base>`) or the full command string (moshi)
+  — and drops any `settings.json` hook whose command duplicates one, pruning at
+  the inner-hook level so a user command sharing a block survives, then pruning
+  emptied events.
+- **codex** — `codex.py:_clean_legacy_config_toml_hooks` does the equivalent
+  for `[[hooks.*]]` blocks in `config.toml`, matching managed basenames per
+  event.
 
-So the heal is simply **`dots sync`** (which runs `ap install global`).
-opencode/cursor/copilot don't receive the cross-harness `agents/hooks/`
-registry hooks (their cursor/copilot guard hooks ship via chezmoi separately),
-so there is no registry-hook drift to heal there — the "all harnesses alike"
-coverage is complete with claude + codex both self-cleaning.
+Keyed off the hooks the renderer *just produced*, so it self-extends (add a
+registry hook → it renders → stale copies auto-strip next sync) and fails safe
+(no managed hooks → no signatures → never strips blind). opencode/cursor/
+copilot receive no cross-harness registry hooks, so there's no hook drift there.
 
-Why renderer-level and not a chezmoi heal script: it's where codex already put
-it, it runs as part of the single `ap install` path (no `run_onchange`
-ordering hacks), and it's unit-tested in-process
-(`tests/test_claude_legacy_hook_cleanup.py`, `tests/test_codex_legacy_hook_cleanup.py`).
+### Dropped MCPs (install-level diff → per-renderer `prune_mcps`)
+
+`cli.py:_reconcile_dropped_mcps` snapshots the prior resolved manifest (cached
+as `merged_json` in `manifest.json`) before the render loop overwrites it,
+diffs it against the current manifest, and for each in-scope harness calls
+`renderer.prune_mcps(dropped_manifest, target)` — where `dropped_manifest`
+carries *only* the servers that fell out of the registry. Each renderer
+implements `prune_mcps` (the `Renderer` protocol) by reusing its own MCP-only
+removal:
+
+- **codex/opencode/cursor/copilot** — delegate to their existing MCP-only
+  `clean` path (the `dropped_manifest` has empty non-MCP fields, so clean's
+  other passes no-op); the dropped server is popped from the merged file.
+- **claude** — plugin `.mcp.json` is whole-file (no drift); only user-scope
+  registrations persist, so `prune_mcps` calls `_unregister_user_mcps` to
+  `claude mcp remove` exactly the dropped servers. No-op for plugin scope.
+
+Fires only when a prior install exists AND something dropped, so fresh renders
+stay byte-identical (golden-test safe). User-authored MCP entries survive —
+only servers a prior render wrote (still named in the prior manifest) are
+evicted.
+
+So the heal for **both** classes is just **`dots sync`** (which runs
+`ap install global`). Why renderer-level and not a chezmoi script: it's where
+codex already put the hook cleanup, it runs in the single `ap install` path (no
+`run_onchange` ordering hacks), and it's unit-tested in-process
+(`tests/test_claude_legacy_hook_cleanup.py`, `test_codex_legacy_hook_cleanup.py`,
+`test_mcp_reconcile.py`).
 
 ## Gotcha: index drift is its own drift class
 

--- a/.hallouminate/wiki/architecture/index.md
+++ b/.hallouminate/wiki/architecture/index.md
@@ -5,5 +5,6 @@ How this dotfiles repo configures AI coding agents. The model is **one harness-a
 - [[agents-dir]] — the `agents/` registry system: MCP / hook / sub-agent / skill registries, the system-prompt body, and the shared cheese-flair assets. Declares *what* every agent gets.
 - [[agent-profile]] — the `ap` tool (`agent-profile/`): profiles (base / global / isolated), the five per-harness renderers, install vs launch, and the chezmoi drive path. Decides *where and in what shape*.
 - [[mcp-secret-handling]] — why MCP `${VAR}` env refs are passed through to each harness as a runtime placeholder (claude/copilot `${VAR}`, opencode `{env:VAR}`, cursor `envFile`) instead of baked as resolved secrets, and the ingest validation-vs-substitution split.
+- [[config-drift]] — why live harness config drifts from the `ap` render (seed-once `create_` files nothing prunes), the three drift classes (stale remnant / dotfiles bug / expected local), and the `settings.json` hook self-heal behind `/harness-doctor`.
 
 For the harness-specific consumption (and official upstream docs for each native config surface), see [[../harnesses/index]].

--- a/agent-profile/agent_profile/cli.py
+++ b/agent-profile/agent_profile/cli.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import json
 import os
 import sys
+from dataclasses import replace
 from pathlib import Path
 from typing import Any, NoReturn
 
@@ -239,6 +240,10 @@ def cmd_install(
     merged_dict = manifest.to_dict()
 
     manifest_mod.manifest_init(target)
+    # Snapshot the prior resolved manifest BEFORE the render loop overwrites
+    # it (record_merged_json runs at the end) so the reconcile can diff which
+    # MCPs dropped out of the registry since the last install.
+    prior_merged = manifest_mod.merged_json(target, name)
 
     all_new_files: list[str] = []
     for h in harnesses:
@@ -263,10 +268,49 @@ def cmd_install(
         manifest_mod.diff_and_clean(target, name, new_files, harnesses)
         _union_files(target, name, new_files, harnesses)
 
+    _reconcile_dropped_mcps(prior_merged, manifest, harnesses, target, out, colors)
+
     manifest_mod.record_merged_json(target, name, merged_dict)
 
     print(f"{colors.GREEN}✓ Installed{colors.NC}", file=out)
     return 0
+
+
+def _reconcile_dropped_mcps(
+    prior_merged: dict[str, Any] | None,
+    manifest: Any,
+    harnesses: list[str],
+    target: Path,
+    out: Any,
+    colors: Any,
+) -> None:
+    """Evict MCP servers that fell out of the registry since the last install.
+
+    Renderers MERGE MCPs into persistent/user-owned files (codex config.toml,
+    opencode/cursor/copilot JSON, claude user-scope ~/.claude.json), so a
+    server dropped from the registry lingers — render only writes the current
+    set. Diff the prior resolved manifest against the current one and have
+    each in-scope renderer prune the dropped servers. No prior install, or
+    nothing dropped → no-op (keeps fresh renders byte-identical)."""
+    if not prior_merged:
+        return
+    current_names = {m.get("name") for m in manifest.mcps}
+    dropped = [
+        m
+        for m in (prior_merged.get("mcps") or [])
+        if m.get("name") not in current_names
+    ]
+    if not dropped:
+        return
+
+    dropped_manifest = replace(manifest, mcps=dropped)
+    for h in harnesses:
+        renderer = RENDERERS.get(h)
+        if renderer is not None:
+            renderer.prune_mcps(dropped_manifest, target)
+
+    names = ", ".join(sorted(str(m.get("name", "?")) for m in dropped))
+    print(f"  {colors.BLUE}↺ pruned dropped MCP(s): {names}{colors.NC}", file=out)
 
 
 def _skill_fetch_runner(argv: list[str]) -> int:

--- a/agent-profile/agent_profile/renderers/base.py
+++ b/agent-profile/agent_profile/renderers/base.py
@@ -80,6 +80,17 @@ class Renderer(Protocol):
         """Surgically un-merge this harness's shared/merged-file entries."""
         ...
 
+    def prune_mcps(self, manifest: Manifest, target: Path) -> None:
+        """Evict ``manifest``'s MCP servers from this harness's merged file.
+
+        Called by the install reconcile to remove servers a prior render
+        wrote into a persistent/user-owned file (codex ``config.toml``,
+        opencode/cursor/copilot merged JSON, claude user-scope
+        ``~/.claude.json``) that have since been dropped from the registry.
+        ``manifest`` carries ONLY the dropped MCPs — every other item list is
+        empty — so an implementation must touch nothing but MCP entries."""
+        ...
+
 
 def item_harnesses(item: dict[str, Any], default: tuple[str, ...]) -> list[str]:
     """Return ``item``'s harness membership list, applying ``default`` when

--- a/agent-profile/agent_profile/renderers/claude.py
+++ b/agent-profile/agent_profile/renderers/claude.py
@@ -149,6 +149,16 @@ class ClaudeRenderer:
             return
         settings.write_text(json.dumps(data, indent=2) + "\n")
 
+    def prune_mcps(self, manifest: Manifest, target: Path) -> None:
+        """Evict dropped MCP servers (install reconcile). The plugin-scoped
+        ``.mcp.json`` is rewritten wholesale each render, so a dropped server
+        simply stops appearing — no drift there. Only user-scope
+        registrations in ``~/.claude.json`` persist across renders, so
+        unregister exactly the dropped servers by name. ``manifest`` holds
+        only the dropped MCPs (see the protocol contract)."""
+        if manifest.mcp_scope == "user":
+            self._unregister_user_mcps(manifest)
+
     # ─── helpers ─────────────────────────────────────────────────────
 
     @staticmethod

--- a/agent-profile/agent_profile/renderers/claude.py
+++ b/agent-profile/agent_profile/renderers/claude.py
@@ -36,6 +36,7 @@ import shutil
 import stat
 import subprocess
 from pathlib import Path
+from typing import NamedTuple
 
 from agent_profile import shared
 from agent_profile.parse import Manifest
@@ -598,32 +599,46 @@ class ClaudeRenderer:
         _dump_json(manifest_path, data)
 
 
+class _ManagedSigs(NamedTuple):
+    """Signatures of the plugin-managed hooks for one event, split by hook
+    type so the matcher can apply the right rule (see
+    :func:`_inner_hook_is_managed`): ``basenames`` are script-hook file
+    names matched by path token; ``commands`` are command-type hook strings
+    matched by exact equality."""
+
+    basenames: set[str]
+    commands: set[str]
+
+
 def _managed_signatures_per_event(
     hook_entries: dict[str, list[dict]],
-) -> dict[str, set[str]]:
+) -> dict[str, _ManagedSigs]:
     """Map each event to the signatures of the hooks just wired into the
-    plugin. A signature is the script basename (for a
-    ``${CLAUDE_PLUGIN_ROOT}/hooks/<base>`` command) or the full command
-    string (for a command-type hook like moshi). Keying per-event mirrors
-    the codex cleanup: a user routing the same script through a different
-    event than the registry manages must survive the sweep."""
-    out: dict[str, set[str]] = {}
+    plugin, split by type: the script basename (for a
+    ``${CLAUDE_PLUGIN_ROOT}/hooks/<base>`` command) goes in ``basenames``,
+    the full command string (for a command-type hook like moshi) in
+    ``commands``. Keying per-event mirrors the codex cleanup: a user routing
+    the same script through a different event than the registry manages must
+    survive the sweep. Splitting by type lets the matcher use exact equality
+    for command hooks (a user command that wraps or merely mentions a
+    managed one must not be pruned) rather than the old substring test."""
+    out: dict[str, _ManagedSigs] = {}
     for event, entries in hook_entries.items():
         for entry in entries:
             for inner in entry.get("hooks", []):
                 cmd = inner.get("command", "")
                 if not isinstance(cmd, str) or not cmd:
                     continue
+                sigs = out.setdefault(event, _ManagedSigs(set(), set()))
                 if "${CLAUDE_PLUGIN_ROOT}/hooks/" in cmd:
-                    sig = cmd.split("/hooks/", 1)[1].split()[0]
+                    sigs.basenames.add(cmd.split("/hooks/", 1)[1].split()[0])
                 else:
-                    sig = cmd
-                out.setdefault(event, set()).add(sig)
+                    sigs.commands.add(cmd)
     return out
 
 
 def _prune_settings_blocks(
-    event_array: list, signatures: set[str]
+    event_array: list, signatures: _ManagedSigs
 ) -> "list | None":
     """Rebuild a settings.json event array with managed hooks removed at the
     inner-hook level. Returns ``None`` when nothing matched (the caller
@@ -650,11 +665,27 @@ def _prune_settings_blocks(
     return rebuilt if changed else None
 
 
-def _inner_hook_is_managed(inner: object, signatures: set[str]) -> bool:
-    """An inner hook is managed iff its command contains a managed signature
-    — a script basename embedded in a ``bash "<path>/<base>"`` command, or an
-    exact command-string match (moshi). Substring covers both forms."""
+def _inner_hook_is_managed(inner: object, signatures: _ManagedSigs) -> bool:
+    """An inner hook is managed iff it matches a plugin-written signature by
+    its own type, never by substring:
+
+    - command-type hooks match by **exact command-string equality** — a user
+      hook that wraps a managed command (``bash -lc "<managed> ..."``) or
+      merely mentions it must survive;
+    - script-type hooks match when the command's final token is a path under
+      a ``/hooks/`` segment whose basename is managed (the
+      ``bash "<path>/hooks/<base>"`` form the retired sync.sh wrote),
+      mirroring ``codex.py:_is_managed_legacy_block``.
+    """
     cmd = inner.get("command", "") if isinstance(inner, dict) else ""
-    if not isinstance(cmd, str):
+    if not isinstance(cmd, str) or not cmd:
         return False
-    return any(sig in cmd for sig in signatures)
+    if cmd in signatures.commands:
+        return True
+    tokens = cmd.strip().split()
+    if not tokens:
+        return False
+    script_token = tokens[-1].strip("'").strip('"')
+    if "/hooks/" not in script_token:
+        return False
+    return Path(script_token).name in signatures.basenames

--- a/agent-profile/agent_profile/renderers/claude.py
+++ b/agent-profile/agent_profile/renderers/claude.py
@@ -312,6 +312,16 @@ class ClaudeRenderer:
         if not wrote_any:
             return
 
+        # Strip legacy hook entries from the live .claude/settings.json that
+        # the retired agents/hooks/sync.sh jq-merged there before the ap
+        # migration (#217). Claude merges settings.json hooks with plugin
+        # hooks at load time, so an orphan copy either fires twice (a still-
+        # present command like moshi) or errors (a script path deleted when
+        # hooks moved into the plugin tree). Mirrors the codex renderer's
+        # _clean_legacy_config_toml_hooks; keyed off the hooks we just wired
+        # into the plugin, so it self-extends as the registry changes.
+        self._clean_legacy_settings_hooks(hook_entries, base)
+
         # Merge hook entries into both manifests so the on-disk JSON Claude
         # reads (.claude-plugin/plugin.json) gets the wiring; the root marker
         # stays in sync. Bash sets `.hooks = $h` — the key lands last.
@@ -319,6 +329,54 @@ class ClaudeRenderer:
             data = json.loads(mf.read_text())
             data["hooks"] = hook_entries
             _dump_json(mf, data)
+
+    # ─── legacy settings.json hook cleanup ─────────────────────────────
+    # Pre-#217, agents/hooks/sync.sh jq-merged the hook registry straight
+    # into ~/.claude/settings.json. The ap migration moved hook wiring into
+    # this plugin's plugin.json, but settings.json is a chezmoi create_ seed
+    # nothing prunes — so the old copies linger and Claude fires them
+    # alongside the plugin's (it merges both at load time). For each hook we
+    # just wired into the plugin, drop any settings.json hook whose command
+    # duplicates it. User hooks the plugin doesn't manage (the JS guards,
+    # rtk, a tmux Stop hook) carry no managed signature and survive.
+    def _clean_legacy_settings_hooks(
+        self, hook_entries: dict[str, list[dict]], base: Path
+    ) -> None:
+        settings = base / ".claude" / "settings.json"
+        if not settings.is_file():
+            return
+        managed_per_event = _managed_signatures_per_event(hook_entries)
+        if not managed_per_event:
+            return
+
+        data = read_json_object(settings, ".claude/settings.json")
+        hooks_table = data.get("hooks")
+        if not isinstance(hooks_table, dict):
+            return
+
+        changed = False
+        for event_key in list(hooks_table.keys()):
+            event_managed = managed_per_event.get(event_key)
+            if not event_managed:
+                continue  # not an event we manage — leave user entries alone
+            event_array = hooks_table.get(event_key)
+            if not isinstance(event_array, list):
+                continue
+            rebuilt = _prune_settings_blocks(event_array, event_managed)
+            if rebuilt is None:
+                continue  # nothing stripped for this event
+            changed = True
+            if rebuilt:
+                hooks_table[event_key] = rebuilt
+            else:
+                del hooks_table[event_key]
+
+        if not hooks_table:
+            data.pop("hooks", None)
+            changed = True
+
+        if changed:
+            settings.write_text(json.dumps(data, indent=2) + "\n")
 
     def _write_mcp_json(
         self,
@@ -528,3 +586,65 @@ class ClaudeRenderer:
             return
         data["plugins"] = remaining
         _dump_json(manifest_path, data)
+
+
+def _managed_signatures_per_event(
+    hook_entries: dict[str, list[dict]],
+) -> dict[str, set[str]]:
+    """Map each event to the signatures of the hooks just wired into the
+    plugin. A signature is the script basename (for a
+    ``${CLAUDE_PLUGIN_ROOT}/hooks/<base>`` command) or the full command
+    string (for a command-type hook like moshi). Keying per-event mirrors
+    the codex cleanup: a user routing the same script through a different
+    event than the registry manages must survive the sweep."""
+    out: dict[str, set[str]] = {}
+    for event, entries in hook_entries.items():
+        for entry in entries:
+            for inner in entry.get("hooks", []):
+                cmd = inner.get("command", "")
+                if not isinstance(cmd, str) or not cmd:
+                    continue
+                if "${CLAUDE_PLUGIN_ROOT}/hooks/" in cmd:
+                    sig = cmd.split("/hooks/", 1)[1].split()[0]
+                else:
+                    sig = cmd
+                out.setdefault(event, set()).add(sig)
+    return out
+
+
+def _prune_settings_blocks(
+    event_array: list, signatures: set[str]
+) -> "list | None":
+    """Rebuild a settings.json event array with managed hooks removed at the
+    inner-hook level. Returns ``None`` when nothing matched (the caller
+    short-circuits to avoid a no-op rewrite). A block whose inner hooks are
+    all managed is dropped entirely; a mixed block keeps its unmanaged
+    inner hooks so a user command sharing a block with a managed one
+    survives."""
+    rebuilt: list = []
+    changed = False
+    for block in event_array:
+        inner = block.get("hooks") if isinstance(block, dict) else None
+        if not isinstance(inner, list):
+            rebuilt.append(block)
+            continue
+        kept = [h for h in inner if not _inner_hook_is_managed(h, signatures)]
+        if len(kept) == len(inner):
+            rebuilt.append(block)
+            continue
+        changed = True
+        if kept:
+            new_block = dict(block)
+            new_block["hooks"] = kept
+            rebuilt.append(new_block)
+    return rebuilt if changed else None
+
+
+def _inner_hook_is_managed(inner: object, signatures: set[str]) -> bool:
+    """An inner hook is managed iff its command contains a managed signature
+    — a script basename embedded in a ``bash "<path>/<base>"`` command, or an
+    exact command-string match (moshi). Substring covers both forms."""
+    cmd = inner.get("command", "") if isinstance(inner, dict) else ""
+    if not isinstance(cmd, str):
+        return False
+    return any(sig in cmd for sig in signatures)

--- a/agent-profile/agent_profile/renderers/codex.py
+++ b/agent-profile/agent_profile/renderers/codex.py
@@ -81,6 +81,12 @@ class CodexRenderer:
     def clean(self, manifest: Manifest, target: Path) -> None:
         self._clean_mcps(manifest, Path(target))
 
+    def prune_mcps(self, manifest: Manifest, target: Path) -> None:
+        """Evict dropped MCP servers from config.toml's [mcp_servers]
+        (install reconcile). Codex's clean is MCP-only, so this is the same
+        operation; ``manifest`` holds only the dropped servers."""
+        self._clean_mcps(manifest, Path(target))
+
     # ─── subagents ──────────────────────────────────────────────────────
     # Each agent lands at .codex/agents/<name>.toml with TOML fields:
     #   name, description, optional model, developer_instructions (multiline).

--- a/agent-profile/agent_profile/renderers/copilot.py
+++ b/agent-profile/agent_profile/renderers/copilot.py
@@ -251,3 +251,9 @@ class CopilotRenderer:
             cfg.unlink()
         else:
             cfg.write_text(_dumps(data))
+
+    def prune_mcps(self, manifest: Manifest, target: Path) -> None:
+        """Evict dropped MCP servers from .copilot/mcp-config.json's
+        ``mcpServers`` (install reconcile). Copilot's clean is MCP-only, so
+        this delegates to it; ``manifest`` holds only the dropped servers."""
+        self.clean(manifest, target)

--- a/agent-profile/agent_profile/renderers/cursor.py
+++ b/agent-profile/agent_profile/renderers/cursor.py
@@ -106,6 +106,12 @@ class CursorRenderer:
         else:
             cfg.write_text(json.dumps(data, indent=2) + "\n")
 
+    def prune_mcps(self, manifest: Manifest, target: Path) -> None:
+        """Evict dropped MCP servers from .cursor/mcp.json's ``mcpServers``
+        (install reconcile). Cursor's clean is MCP-only, so this delegates to
+        it; ``manifest`` holds only the dropped servers."""
+        self.clean(manifest, target)
+
     # ── unsupported surfaces ──────────────────────────────────────────
 
     def _warn_unsupported(self, manifest: Manifest) -> None:

--- a/agent-profile/agent_profile/renderers/opencode.py
+++ b/agent-profile/agent_profile/renderers/opencode.py
@@ -220,3 +220,10 @@ class OpencodeRenderer:
             return
 
         cfg.write_text(json.dumps(data, indent=2) + "\n")
+
+    def prune_mcps(self, manifest: Manifest, target: Path) -> None:
+        """Evict dropped MCP servers from opencode.json's ``mcp`` block
+        (install reconcile). Delegates to :meth:`clean`: ``manifest`` holds
+        only the dropped servers and no permission allow-list, so clean's
+        permission pass is a no-op and only the dropped MCPs are removed."""
+        self.clean(manifest, target)

--- a/agent-profile/tests/test_claude_legacy_hook_cleanup.py
+++ b/agent-profile/tests/test_claude_legacy_hook_cleanup.py
@@ -1,0 +1,248 @@
+"""test_claude_legacy_hook_cleanup.py — strip orphan hook entries from
+``~/.claude/settings.json`` that the retired ``agents/hooks/sync.sh``
+jq-merged there before the ap migration (#217).
+
+Claude merges ``settings.json`` hooks with the plugin tree's
+``plugin.json`` hooks at load time, so a machine that migrated from the
+legacy bash sync to ap fires every managed hook twice — or, for a hook
+whose script moved into the plugin and was deleted from
+``~/.claude/hooks/``, errors on a dead path every session. The ap Claude
+renderer is now responsible for cleaning the legacy entries when it wires
+the hooks into the plugin (mirrors the codex renderer's config.toml sweep).
+
+Tests assert: the dead script-hook entry (cheese-flair) is stripped,
+command-type duplicates (moshi) are stripped across every event,
+user-authored hooks the plugin does NOT manage (JS guards, rtk, a tmux
+Stop hook) are preserved, non-hook keys survive, a managed basename
+routed through an unmanaged event survives (cross-event invariant), and
+the sweep is a no-op when settings.json has no orphans.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from agent_profile.parse import Manifest
+from agent_profile.renderers.claude import (
+    ClaudeRenderer,
+    _managed_signatures_per_event,
+    _prune_settings_blocks,
+)
+
+
+def _manifest_with_hooks(src: Path) -> Manifest:
+    """A manifest carrying the two hook shapes the migration left behind:
+    a script hook (cheese-flair, SessionStart) and a command hook (moshi,
+    fanned across SessionStart + Stop)."""
+    hooks_dir = src / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    (hooks_dir / "session-start-cheese-flair.sh").write_text(
+        "#!/bin/bash\n: cheese flair\n"
+    )
+    moshi = "'/home/paul/.local/bin/moshi-hook' claude-hook"
+    return Manifest(
+        name="global",
+        description="t",
+        hooks=[
+            {
+                "name": "session-start-cheese-flair",
+                "event": "SessionStart",
+                "script": "hooks/session-start-cheese-flair.sh",
+                "matcher": "startup|resume",
+                "timeout": 5,
+                "harnesses": ["claude"],
+                "_source_dir": str(src),
+            },
+            {
+                "name": "moshi-session-start",
+                "event": "SessionStart",
+                "command": moshi,
+                "harnesses": ["claude"],
+                "_source_dir": str(src),
+            },
+            {
+                "name": "moshi-stop",
+                "event": "Stop",
+                "command": moshi,
+                "harnesses": ["claude"],
+                "_source_dir": str(src),
+            },
+        ],
+    )
+
+
+def _seed_legacy_settings(target: Path) -> Path:
+    """Pre-seed <target>/.claude/settings.json with pre-ap leftovers PLUS
+    legit settings-only hooks (JS guard, rtk, tmux) the plugin never owns."""
+    moshi = "'/home/paul/.local/bin/moshi-hook' claude-hook"
+    settings = target / ".claude" / "settings.json"
+    settings.parent.mkdir(parents=True, exist_ok=True)
+    settings.write_text(
+        json.dumps(
+            {
+                "model": "sonnet",
+                "hooks": {
+                    "PreToolUse": [
+                        {
+                            "matcher": "Bash",
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": 'node "$HOME/.claude/hooks/hook-runner.js" bash-guard.js',
+                                },
+                                {"type": "command", "command": "rtk hook claude"},
+                            ],
+                        }
+                    ],
+                    "SessionStart": [
+                        {
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": 'bash "$HOME/.claude/hooks/session-start-cheese-flair.sh"',
+                                    "timeout": 5,
+                                }
+                            ]
+                        },
+                        {"hooks": [{"type": "command", "command": moshi, "async": True}]},
+                    ],
+                    "Stop": [
+                        {
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": 'if [ -n "$TMUX" ]; then tmux set-option -q @jmux-attention 1; fi',
+                                    "timeout": 5,
+                                }
+                            ]
+                        },
+                        {"hooks": [{"type": "command", "command": moshi, "async": True}]},
+                    ],
+                },
+            },
+            indent=2,
+        )
+        + "\n"
+    )
+    return settings
+
+
+def _render(tmp_path: Path) -> Path:
+    src = tmp_path / "src"
+    src.mkdir()
+    target = tmp_path / "home"
+    target.mkdir()
+    settings = _seed_legacy_settings(target)
+    ClaudeRenderer().render(_manifest_with_hooks(src), target)
+    return settings
+
+
+# ── full-render integration ──────────────────────────────────────────────────
+
+
+def test_dead_cheese_flair_entry_stripped(tmp_path: Path) -> None:
+    settings = _render(tmp_path)
+    data = json.loads(settings.read_text())
+    # SessionStart held only cheese-flair + moshi → both managed → key gone.
+    assert "SessionStart" not in data["hooks"]
+
+
+def test_moshi_duplicate_stripped_across_events(tmp_path: Path) -> None:
+    settings = _render(tmp_path)
+    assert "moshi-hook" not in settings.read_text()
+
+
+def test_tmux_stop_hook_preserved(tmp_path: Path) -> None:
+    settings = _render(tmp_path)
+    data = json.loads(settings.read_text())
+    assert len(data["hooks"]["Stop"]) == 1
+    assert "jmux-attention" in data["hooks"]["Stop"][0]["hooks"][0]["command"]
+
+
+def test_js_guard_and_rtk_preserved(tmp_path: Path) -> None:
+    settings = _render(tmp_path)
+    text = settings.read_text()
+    assert "bash-guard.js" in text
+    assert "rtk hook claude" in text
+    # The mixed PreToolUse block kept BOTH inner hooks (neither managed).
+    data = json.loads(settings.read_text())
+    assert len(data["hooks"]["PreToolUse"][0]["hooks"]) == 2
+
+
+def test_non_hook_keys_preserved(tmp_path: Path) -> None:
+    settings = _render(tmp_path)
+    data = json.loads(settings.read_text())
+    assert data["model"] == "sonnet"
+
+
+def test_result_is_valid_json(tmp_path: Path) -> None:
+    settings = _render(tmp_path)
+    json.loads(settings.read_text())  # raises on invalid
+
+
+def test_idempotent_second_render(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    src.mkdir()
+    target = tmp_path / "home"
+    target.mkdir()
+    settings = _seed_legacy_settings(target)
+    manifest = _manifest_with_hooks(src)
+    ClaudeRenderer().render(manifest, target)
+    after_first = settings.read_text()
+    ClaudeRenderer().render(manifest, target)
+    assert settings.read_text() == after_first
+
+
+def test_no_settings_file_is_noop(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    src.mkdir()
+    target = tmp_path / "home"
+    target.mkdir()
+    # No settings.json seeded → render must not crash or create one.
+    ClaudeRenderer().render(_manifest_with_hooks(src), target)
+    assert not (target / ".claude" / "settings.json").is_file()
+
+
+# ── helper units ─────────────────────────────────────────────────────────────
+
+
+def test_signatures_split_script_basename_vs_command() -> None:
+    entries = {
+        "SessionStart": [
+            {"hooks": [{"command": "${CLAUDE_PLUGIN_ROOT}/hooks/session-start-cheese-flair.sh"}]},
+            {"hooks": [{"command": "'/x/moshi-hook' claude-hook"}]},
+        ]
+    }
+    sigs = _managed_signatures_per_event(entries)
+    assert sigs["SessionStart"] == {
+        "session-start-cheese-flair.sh",
+        "'/x/moshi-hook' claude-hook",
+    }
+
+
+def test_cross_event_basename_survives() -> None:
+    # A user routing the managed basename through an UNMANAGED event keeps it:
+    # the per-event managed set for PreToolUse is empty, so prune is skipped.
+    sigs = _managed_signatures_per_event(
+        {"SessionStart": [{"hooks": [{"command": "${CLAUDE_PLUGIN_ROOT}/hooks/session-start-cheese-flair.sh"}]}]}
+    )
+    assert "PreToolUse" not in sigs
+
+
+def test_prune_returns_none_when_nothing_matches() -> None:
+    arr = [{"hooks": [{"command": "rtk hook claude"}]}]
+    assert _prune_settings_blocks(arr, {"moshi"}) is None
+
+
+def test_prune_keeps_unmanaged_inner_in_mixed_block() -> None:
+    arr = [
+        {
+            "hooks": [
+                {"command": "'/x/moshi-hook' claude-hook"},
+                {"command": "rtk hook claude"},
+            ]
+        }
+    ]
+    rebuilt = _prune_settings_blocks(arr, {"'/x/moshi-hook' claude-hook"})
+    assert rebuilt == [{"hooks": [{"command": "rtk hook claude"}]}]

--- a/agent-profile/tests/test_claude_legacy_hook_cleanup.py
+++ b/agent-profile/tests/test_claude_legacy_hook_cleanup.py
@@ -26,6 +26,7 @@ from pathlib import Path
 from agent_profile.parse import Manifest
 from agent_profile.renderers.claude import (
     ClaudeRenderer,
+    _ManagedSigs,
     _managed_signatures_per_event,
     _prune_settings_blocks,
 )
@@ -215,10 +216,8 @@ def test_signatures_split_script_basename_vs_command() -> None:
         ]
     }
     sigs = _managed_signatures_per_event(entries)
-    assert sigs["SessionStart"] == {
-        "session-start-cheese-flair.sh",
-        "'/x/moshi-hook' claude-hook",
-    }
+    assert sigs["SessionStart"].basenames == {"session-start-cheese-flair.sh"}
+    assert sigs["SessionStart"].commands == {"'/x/moshi-hook' claude-hook"}
 
 
 def test_cross_event_basename_survives() -> None:
@@ -232,7 +231,7 @@ def test_cross_event_basename_survives() -> None:
 
 def test_prune_returns_none_when_nothing_matches() -> None:
     arr = [{"hooks": [{"command": "rtk hook claude"}]}]
-    assert _prune_settings_blocks(arr, {"moshi"}) is None
+    assert _prune_settings_blocks(arr, _ManagedSigs(set(), {"moshi"})) is None
 
 
 def test_prune_keeps_unmanaged_inner_in_mixed_block() -> None:
@@ -244,5 +243,33 @@ def test_prune_keeps_unmanaged_inner_in_mixed_block() -> None:
             ]
         }
     ]
-    rebuilt = _prune_settings_blocks(arr, {"'/x/moshi-hook' claude-hook"})
+    rebuilt = _prune_settings_blocks(
+        arr, _ManagedSigs(set(), {"'/x/moshi-hook' claude-hook"})
+    )
     assert rebuilt == [{"hooks": [{"command": "rtk hook claude"}]}]
+
+
+def test_user_command_mentioning_managed_basename_survives() -> None:
+    # A user hook whose command merely CONTAINS a managed script basename as
+    # a non-script substring must NOT be pruned. The old substring matcher
+    # (`any(sig in cmd ...)`) wrongly evicted it.
+    arr = [{"hooks": [{"command": "echo session-start-cheese-flair.sh ran"}]}]
+    sigs = _ManagedSigs({"session-start-cheese-flair.sh"}, set())
+    assert _prune_settings_blocks(arr, sigs) is None
+
+
+def test_user_command_wrapping_managed_command_survives() -> None:
+    # A user hook that WRAPS the managed command (extra args / a shell
+    # wrapper) is not the managed command — exact equality, not substring,
+    # so it survives. The old substring matcher wrongly evicted it.
+    managed = "'/x/moshi-hook' claude-hook"
+    arr = [{"hooks": [{"command": f'bash -lc "{managed} --extra"'}]}]
+    sigs = _ManagedSigs(set(), {managed})
+    assert _prune_settings_blocks(arr, sigs) is None
+
+
+def test_managed_command_exact_match_still_pruned() -> None:
+    # The exact managed command IS pruned (the fix must not under-match).
+    managed = "'/x/moshi-hook' claude-hook"
+    arr = [{"hooks": [{"command": managed}]}]
+    assert _prune_settings_blocks(arr, _ManagedSigs(set(), {managed})) == []

--- a/agent-profile/tests/test_mcp_reconcile.py
+++ b/agent-profile/tests/test_mcp_reconcile.py
@@ -1,0 +1,155 @@
+"""test_mcp_reconcile.py — install-time reconcile of MCP servers dropped
+from the registry.
+
+Renderers MERGE MCP entries into persistent/user-owned files (codex
+config.toml, opencode/cursor/copilot JSON, claude user-scope
+~/.claude.json). A server removed from the registry would otherwise
+linger, since render only writes the current set. cmd_install now diffs
+the prior resolved manifest (cached in manifest.json) against the current
+one and has each in-scope renderer prune the dropped servers.
+
+Tests assert: a dropped MCP is evicted from every merge-target harness on
+re-install, the surviving MCP and unrelated user entries are preserved, a
+fresh install (no prior) prunes nothing, and the claude user-scope path
+unregisters exactly the dropped server via the CLI.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+import tomlkit
+
+from agent_profile import cli
+from agent_profile.parse import Manifest
+from agent_profile.renderers.claude import ClaudeRenderer
+from agent_profile.renderers.registry import build_registry
+from tests.conftest import write_profile
+
+
+@pytest.fixture
+def prod_renderers():
+    saved = cli.RENDERERS
+    cli.set_renderers(build_registry())
+    yield
+    cli.set_renderers(saved)
+
+
+def _yaml(name: str, mcp_names: list[str]) -> str:
+    lines = [f"name: {name}", "description: reconcile probe", "mcps:"]
+    for n in mcp_names:
+        lines += [
+            f"  - name: {n}",
+            "    command: /bin/true",
+            "    args: [--flag]",
+            "    harnesses: [codex, opencode, cursor, copilot]",
+        ]
+    return "\n".join(lines) + "\n"
+
+
+def _install(env, name: str) -> int:
+    return cli.main(["install", name, "--target", str(env.target)])
+
+
+# ─── integration: drop one MCP, re-install ───────────────────────────────────
+
+
+def test_dropped_mcp_evicted_from_every_harness(env, capsys, prod_renderers):
+    # Install srv1 + srv2 across the four merge-target harnesses.
+    write_profile(env.profiles, "p", _yaml("p", ["srv1", "srv2"]))
+    assert _install(env, "p") == 0
+    capsys.readouterr()
+    t = env.target
+
+    # A user-authored MCP lands in codex config.toml out of band — it must
+    # survive the reconcile (we only evict servers WE previously wrote).
+    cfg = t / ".codex" / "config.toml"
+    doc = tomlkit.parse(cfg.read_text())
+    doc["mcp_servers"]["user-srv"] = {"command": "/usr/bin/env"}
+    cfg.write_text(tomlkit.dumps(doc))
+
+    # Re-install with srv2 removed from the registry.
+    write_profile(env.profiles, "p", _yaml("p", ["srv1"]))
+    assert _install(env, "p") == 0
+    capsys.readouterr()
+
+    codex = tomlkit.parse((t / ".codex/config.toml").read_text())["mcp_servers"]
+    assert "srv2" not in codex
+    assert "srv1" in codex
+    assert "user-srv" in codex  # user entry preserved
+
+    oc = json.loads((t / "opencode.json").read_text())["mcp"]
+    assert "srv2" not in oc and "srv1" in oc
+
+    cur = json.loads((t / ".cursor/mcp.json").read_text())["mcpServers"]
+    assert "srv2" not in cur and "srv1" in cur
+
+    cop = json.loads((t / ".copilot/mcp-config.json").read_text())["mcpServers"]
+    assert "srv2" not in cop and "srv1" in cop
+
+
+def test_fresh_install_prunes_nothing(env, capsys, prod_renderers):
+    write_profile(env.profiles, "p", _yaml("p", ["srv1", "srv2"]))
+    assert _install(env, "p") == 0
+    capsys.readouterr()
+    t = env.target
+    codex = tomlkit.parse((t / ".codex/config.toml").read_text())["mcp_servers"]
+    assert {"srv1", "srv2"} <= set(codex.keys())
+
+
+def test_reconcile_reports_pruned_names(env, capsys, prod_renderers):
+    write_profile(env.profiles, "p", _yaml("p", ["srv1", "srv2"]))
+    _install(env, "p")
+    capsys.readouterr()
+    write_profile(env.profiles, "p", _yaml("p", ["srv1"]))
+    _install(env, "p")
+    out = capsys.readouterr().out
+    assert "srv2" in out and "pruned" in out
+
+
+# ─── claude user-scope path (CLI-backed, monkeypatched) ──────────────────────
+
+
+def test_claude_prune_unregisters_user_scope(monkeypatch, tmp_path):
+    import agent_profile.renderers.claude as cl
+
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, *a, **k):
+        calls.append(cmd)
+
+        class R:
+            returncode = 0
+
+        return R()
+
+    monkeypatch.setattr(cl.shutil, "which", lambda _: "/usr/bin/claude")
+    monkeypatch.setattr(cl.subprocess, "run", fake_run)
+
+    dropped = Manifest(
+        name="global",
+        description="d",
+        mcps=[{"name": "gone", "command": "/bin/true", "args": []}],
+        mcp_scope="user",
+    )
+    ClaudeRenderer().prune_mcps(dropped, tmp_path)
+
+    removes = [c for c in calls if "remove" in c and "gone" in c]
+    assert removes, f"expected a `claude mcp remove gone`, got {calls}"
+
+
+def test_claude_prune_noop_for_plugin_scope(monkeypatch, tmp_path):
+    import agent_profile.renderers.claude as cl
+
+    def boom(*a, **k):  # would raise if the CLI were touched
+        raise AssertionError("plugin-scope prune must not call the claude CLI")
+
+    monkeypatch.setattr(cl.subprocess, "run", boom)
+    dropped = Manifest(
+        name="p",
+        description="d",
+        mcps=[{"name": "gone", "command": "/bin/true", "args": []}],
+        # default mcp_scope (not "user") → plugin .mcp.json is whole-file
+    )
+    ClaudeRenderer().prune_mcps(dropped, tmp_path)  # must be a no-op

--- a/agent-profile/tests/test_mcp_reconcile.py
+++ b/agent-profile/tests/test_mcp_reconcile.py
@@ -21,9 +21,9 @@ import json
 import pytest
 import tomlkit
 
+import agent_profile.renderers.claude as cl
 from agent_profile import cli
 from agent_profile.parse import Manifest
-from agent_profile.renderers.claude import ClaudeRenderer
 from agent_profile.renderers.registry import build_registry
 from tests.conftest import write_profile
 
@@ -112,8 +112,6 @@ def test_reconcile_reports_pruned_names(env, capsys, prod_renderers):
 
 
 def test_claude_prune_unregisters_user_scope(monkeypatch, tmp_path):
-    import agent_profile.renderers.claude as cl
-
     calls: list[list[str]] = []
 
     def fake_run(cmd, *a, **k):
@@ -133,15 +131,75 @@ def test_claude_prune_unregisters_user_scope(monkeypatch, tmp_path):
         mcps=[{"name": "gone", "command": "/bin/true", "args": []}],
         mcp_scope="user",
     )
-    ClaudeRenderer().prune_mcps(dropped, tmp_path)
+    cl.ClaudeRenderer().prune_mcps(dropped, tmp_path)
 
     removes = [c for c in calls if "remove" in c and "gone" in c]
     assert removes, f"expected a `claude mcp remove gone`, got {calls}"
 
 
-def test_claude_prune_noop_for_plugin_scope(monkeypatch, tmp_path):
-    import agent_profile.renderers.claude as cl
+def _yaml_claude_user(name: str, mcp_names: list[str]) -> str:
+    lines = [
+        f"name: {name}",
+        "description: reconcile probe",
+        "mcp_scope: user",
+        "mcps:",
+    ]
+    for n in mcp_names:
+        lines += [
+            f"  - name: {n}",
+            "    command: /bin/true",
+            "    args: [--flag]",
+            "    harnesses: [claude]",
+        ]
+    return "\n".join(lines) + "\n"
 
+
+def test_dropped_mcp_unregistered_from_claude_user_scope(
+    env, capsys, monkeypatch, prod_renderers
+):
+    # The production `global` profile installs claude MCPs at USER scope into
+    # the live ~/.claude.json (mcp_scope: user) — the only reconcile path that
+    # shells out to the `claude` CLI, and the highest-stakes eviction. The
+    # `_yaml` integration fixture above excludes claude, so without this the
+    # reconcile loop's claude branch is never driven end-to-end through
+    # cli.main. Drive it and assert the dropped server is unregistered.
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, *a, **k):
+        calls.append(cmd)
+
+        class R:
+            returncode = 0
+
+        return R()
+
+    monkeypatch.setattr(cl.shutil, "which", lambda _: "/usr/bin/claude")
+    monkeypatch.setattr(cl.subprocess, "run", fake_run)
+
+    write_profile(env.profiles, "g", _yaml_claude_user("g", ["srv1", "srv2"]))
+    assert _install(env, "g") == 0
+    capsys.readouterr()
+    calls.clear()  # discard first-install register churn
+
+    # Re-install with srv2 dropped from the registry.
+    write_profile(env.profiles, "g", _yaml_claude_user("g", ["srv1"]))
+    assert _install(env, "g") == 0
+    capsys.readouterr()
+
+    # Reconcile must `claude mcp remove srv2` and never re-add it.
+    assert [
+        c for c in calls if "remove" in c and "srv2" in c
+    ], f"expected `claude mcp remove srv2`, got {calls}"
+    assert not [
+        c for c in calls if "add" in c and "srv2" in c
+    ], f"dropped srv2 must not be re-registered, got {calls}"
+    # The survivor is still re-registered.
+    assert [
+        c for c in calls if "add" in c and "srv1" in c
+    ], f"survivor srv1 must stay registered, got {calls}"
+
+
+def test_claude_prune_noop_for_plugin_scope(monkeypatch, tmp_path):
     def boom(*a, **k):  # would raise if the CLI were touched
         raise AssertionError("plugin-scope prune must not call the claude CLI")
 
@@ -152,4 +210,4 @@ def test_claude_prune_noop_for_plugin_scope(monkeypatch, tmp_path):
         mcps=[{"name": "gone", "command": "/bin/true", "args": []}],
         # default mcp_scope (not "user") → plugin .mcp.json is whole-file
     )
-    ClaudeRenderer().prune_mcps(dropped, tmp_path)  # must be a no-op
+    cl.ClaudeRenderer().prune_mcps(dropped, tmp_path)  # must be a no-op

--- a/skills/harness-doctor/SKILL.md
+++ b/skills/harness-doctor/SKILL.md
@@ -1,0 +1,230 @@
+---
+name: harness-doctor
+model: sonnet
+description: >
+  Diagnose and self-heal harness-config drift between what's live on this
+  machine (~/.claude, ~/.codex, ~/.config/opencode, ~/.cursor, ~/.copilot) and
+  what `ap` renders from the registries — the post-migration target state. Use
+  when the user says "harness doctor", "check my harness config", "is my
+  settings drifted", "audit the dotfiles config", "why is this hook firing
+  twice", "diagnose my agent config", or invokes /harness-doctor; also after an
+  `ap`/registry change to verify the live config converged. Grounds the wiki +
+  git history for intended state, diffs live vs `ap` render, classifies each
+  drift (stale remnant / dotfiles bug / expected local), self-heals safe
+  remnants via chezmoi/lib/heal-claude-settings.sh, opens deduped gh issues for
+  confirmed dotfiles bugs, and writes new drift patterns back to the wiki. Do
+  NOT use for general code review (/age), single-file permission cleanup
+  (/settings-clean), or app-level debugging.
+---
+
+# harness-doctor
+
+Audit the gap between **live** harness config on this machine and the
+**target state** the dotfiles repo intends (`ap` rendering the registries into
+each harness). Drift accumulates because some live files are seed-once and
+user-owned — chezmoi never prunes them — so pre-migration leftovers linger
+(dead hooks, double-fired hooks, stale MCP entries).
+
+The doctor's job is to **tell three kinds of drift apart** and act
+differently on each:
+
+| Class | What it is | Action |
+|---|---|---|
+| **Stale remnant** | Live config matching a pattern git history shows the repo migrated *away* from (e.g. registry hooks left in `settings.json` after they moved into the plugin tree). | **Self-heal** — prune it. |
+| **Dotfiles bug** | The repo's own source of truth is wrong/inconsistent (registry points at a missing script, invalid hook event, required MCP var not marked `optional`, wiki index won't rebuild). | **Open a gh issue** (deduped). |
+| **Expected local** | Machine-local user additions not sourced from the repo (a personal hook, an extra permission, a one-off MCP). | **Leave alone** — report only. |
+
+The hard part is the classification, not the diffing. A raw diff between live
+and rendered is noisy; git history + the wiki are what let you say "this is a
+leftover we abandoned" vs "this is a bug" vs "this is the user's own".
+
+## Protocol
+
+### 1. Ground — learn the intended state
+
+Read before judging. The repo's design rationale lives in the wiki; the
+*direction of travel* lives in git history.
+
+- **Wiki** (`repo:dotfiles:wiki`): `list_tree`, then `read_markdown` /
+  `ground` on `architecture/agent-profile.md`, `architecture/agents-dir.md`,
+  and the relevant `harnesses/<harness>.md`. These define what `ap` is
+  *supposed* to produce and where each harness's config lives.
+  - If `ground` errors with a schema/index error (e.g. `missing column
+    chunk_id`), the LanceDB index is stale — run `hallouminate index` (or note
+    it as a dotfiles bug if it won't rebuild) and fall back to `read_markdown`.
+- **Git history** — the migration arc that distinguishes stale from novel:
+
+  ```
+  git -C "$DOTFILES_DIR" log --oneline -20 -- agents/ profiles/ chezmoi/dot_claude/
+  git -C "$DOTFILES_DIR" log --oneline --grep='ap\|migrat\|settings\|hook' -20
+  ```
+
+  Anchor commit: **#217 `feat(ap): add global profile + migrate settings.json
+  to chezmoi seed`** — the point hooks moved from `settings.json` into the
+  plugin tree and `settings.json` became a seed-once `create_` file. Anything
+  in `settings.json` matching a *pre-#217* shape is a stale-remnant candidate.
+
+Key target-state facts to hold:
+
+- Registries (edit surface): `agents/mcp/registry.yaml`,
+  `agents/hooks/registry.yaml`, `agents/registry.yaml`, `skills/`.
+- `base` = registry union (render primitive); `global` = live install overlay
+  (`target_default: $HOME`, `local` marketplace, `enabled_plugins: global@local`).
+- Hook wiring lives in the **plugin tree's** `plugin.json`
+  (`~/.claude/plugins/local/global/.claude-plugin/plugin.json`), **NOT** in
+  `~/.claude/settings.json`. `ap install global` only jq-merges
+  `enabledPlugins` + `extraKnownMarketplaces` into `settings.json`, preserving
+  user keys — it never writes `.hooks` there.
+- The Claude-specific JS guards (`~/.claude/hooks/*.js`), `rtk`, and any tmux
+  hook are **settings-only and legit** — not plugin-managed, so not drift.
+
+### 2. Snapshot live config
+
+Read the live files per harness (use `cheez-read`/`jq`, not blind cat):
+
+| Harness | Live files |
+|---|---|
+| claude | `~/.claude/settings.json`, `~/.claude/plugins/local/global/.claude-plugin/plugin.json`, `~/.claude/plugins/local/global/.mcp.json` |
+| codex | `~/.codex/config.toml` (`[mcp_servers]`, `[[hooks.*]]`) |
+| opencode | `~/.config/opencode/opencode.json` (`mcp`, `provider`) |
+| cursor | `~/.cursor/mcp.json`, `~/.cursor/hooks.json` |
+| copilot | `~/.copilot/mcp-config.json`, `~/.copilot/hooks/` |
+
+### 3. Render the target — diff live vs `ap`
+
+Render `base` into a throwaway target (never touches live config) and diff:
+
+```bash
+TMP="$(mktemp -d)"
+DOTFILES_DIR="$DOTFILES_DIR" ap install base --target "$TMP"
+dots profile describe global          # resolved manifest for the live overlay
+# Compare e.g. rendered plugin.json hooks vs live plugin.json,
+# rendered .mcp.json vs live, codex config_servers vs rendered.
+```
+
+For each difference, ask: *is the live side a superset (extra entries) or does
+it contradict the render?* Extra live-only entries are remnant-or-local;
+contradictions are bugs.
+
+### 4. Classify each drift
+
+Walk every difference and bucket it (first match wins):
+
+1. **Stale remnant** — present live, absent from render, AND git history shows
+   the repo moved this responsibility elsewhere. Canonical case: a hook in
+   `~/.claude/settings.json` whose command duplicates a plugin-managed hook
+   (matched by script basename or exact command), or points at a script path
+   under `~/.claude/hooks/` that no longer exists. Verify the path:
+   `[[ -e <path> ]]` — a dead path is unambiguously stale.
+2. **Dotfiles bug** — the repo source is itself wrong. Checks:
+   - A `script:` in `agents/hooks/registry.yaml` whose file is missing.
+   - A hook `event:` not in `HOOK_EVENTS_VALID` (`agents/hooks/lib.sh`).
+   - An MCP referencing an unset `${VAR}` but not marked `optional: true`.
+   - A skill dir without a `SKILL.md`, or a registry `body_path` that 404s.
+   - The wiki index failing to rebuild (`hallouminate index` errors).
+   - A `run_onchange` hash input list omitting a file the script reads.
+3. **Expected local** — live-only, no repo provenance, plausibly user-added
+   (personal hook, extra permission). Report, never touch.
+
+When unsure between bug and local, **ask the user** (AskUserQuestion) rather
+than guess — opening a spurious issue or healing a wanted local entry both cost
+trust.
+
+### 5. Heal stale remnants
+
+The legacy-hook drift class self-heals **inside the renderers**, not via a
+bolt-on script. Each renderer prunes its own harness's pre-ap hook leftovers on
+every `ap install`:
+
+- **claude** — `agent_profile/renderers/claude.py:_clean_legacy_settings_hooks`
+  strips `settings.json` hooks that duplicate a plugin-managed hook (by script
+  basename or exact command), keyed off the hooks it just wired into
+  `plugin.json`.
+- **codex** — `agent_profile/renderers/codex.py:_clean_legacy_config_toml_hooks`
+  strips legacy `[[hooks.*]]` blocks from `config.toml` the same way.
+
+So the heal is just **`dots profile install global`** (or a full `dots sync`) —
+it re-runs the renderers, which self-clean. opencode/cursor/copilot don't
+receive registry hooks, so there's no hook drift to heal there.
+
+The doctor's value is *explaining why* drift appeared and catching the classes
+the renderers don't auto-heal. For those, propose the precise edit and confirm
+before applying — never hand-roll a jq rewrite of a user-owned file when a
+renderer (or a `dots sync`) does it deterministically.
+
+### 6. File dotfiles bugs as gh issues (deduped)
+
+For each confirmed **dotfiles bug**, open a GitHub issue — but dedup first:
+
+```bash
+gh issue list --repo "$REPO" --state open --label harness-doctor --json number,title
+```
+
+Skip any bug whose title substantially matches an open issue. For novel bugs:
+
+```bash
+gh issue create --repo "$REPO" \
+  --title "harness-doctor: <one-line bug>" \
+  --label harness-doctor \
+  --body "$(cat <<'EOF'
+**Found by** /harness-doctor on <date>.
+
+**Symptom**: <what's wrong, with file:line>
+**Root cause**: <why — cite git history / wiki>
+**Target state**: <what ap/registries should produce>
+**Suggested fix**: <concrete edit>
+EOF
+)"
+```
+
+Create the `harness-doctor` label first if absent (`gh label create
+harness-doctor --color BFD4F2 --description "Drift/bug found by /harness-doctor"`).
+If `gh` is unauthenticated or offline, write the issue bodies to
+`.cheese/harness-doctor/issues-<date>.md` and tell the user to file them.
+
+### 7. Learn — write back to the wiki
+
+When the audit surfaces a *new* drift pattern or a non-obvious root cause a
+future doctor run would otherwise re-derive, persist it via `add_markdown`
+(one topic per file, the *why* not the *what* — follow
+`.hallouminate/wiki/index.md` conventions). Good homes:
+
+- A recurring drift class → extend `harnesses/<harness>.md` § drift, or a new
+  `architecture/config-drift.md`.
+- Don't duplicate `AGENTS.md` or the code; link related pages with `[[name]]`.
+
+After writing, the file reindexes automatically; if you edited via a plain file
+write instead, run `hallouminate index`.
+
+### 8. Report
+
+Emit a compact summary grouped by class:
+
+```
+## harness-doctor — <date>
+
+### Healed (N)
+- <harness>: <what was pruned> — <one-line why>
+
+### Filed as issues (N)
+- #<num> <title>
+
+### Expected-local (ignored, N)
+- <harness>: <entry> — user-added
+
+### Needs your call (N)
+- <ambiguous item> — <question>
+```
+
+Lead with what changed and what needs the user's attention. Keep file dumps out
+of the report — cite `file:line`, don't paste.
+
+## Guard rails
+
+- **Never** rewrite a live config by hand when a tested helper exists.
+- **Never** touch `settings.json`'s non-hook keys, the JS guards, `rtk`, or
+  inline user hooks — those are not plugin-managed.
+- **Never** open an issue without deduping against open issues first.
+- **Never** fabricate git history or a wiki claim — cite the commit / page.
+- Healing edits a user-owned file: always leave the timestamped `.bak` the
+  helper writes, and report the path.

--- a/skills/harness-doctor/SKILL.md
+++ b/skills/harness-doctor/SKILL.md
@@ -132,24 +132,31 @@ trust.
 
 ### 5. Heal stale remnants
 
-The legacy-hook drift class self-heals **inside the renderers**, not via a
-bolt-on script. Each renderer prunes its own harness's pre-ap hook leftovers on
-every `ap install`:
+Two stale-remnant classes self-heal **inside the renderers**, on every
+`ap install` — not via a bolt-on script:
 
-- **claude** — `agent_profile/renderers/claude.py:_clean_legacy_settings_hooks`
-  strips `settings.json` hooks that duplicate a plugin-managed hook (by script
-  basename or exact command), keyed off the hooks it just wired into
-  `plugin.json`.
-- **codex** — `agent_profile/renderers/codex.py:_clean_legacy_config_toml_hooks`
-  strips legacy `[[hooks.*]]` blocks from `config.toml` the same way.
+- **Legacy hooks.** Each renderer prunes its own harness's pre-ap hook
+  leftovers:
+  - **claude** — `claude.py:_clean_legacy_settings_hooks` strips
+    `settings.json` hooks that duplicate a plugin-managed hook (by script
+    basename or exact command), keyed off the hooks it just wired into
+    `plugin.json`.
+  - **codex** — `codex.py:_clean_legacy_config_toml_hooks` strips legacy
+    `[[hooks.*]]` blocks from `config.toml` the same way.
+- **Dropped MCPs.** `cli.py:_reconcile_dropped_mcps` diffs the prior resolved
+  manifest (cached in `manifest.json`) against the current one and calls each
+  renderer's `prune_mcps` to evict servers removed from the registry that a
+  prior render merged into a persistent file (codex `config.toml`,
+  opencode/cursor/copilot JSON, claude user-scope `~/.claude.json`). claude
+  plugin-scoped `.mcp.json` is whole-file so it never drifts.
 
-So the heal is just **`dots profile install global`** (or a full `dots sync`) —
-it re-runs the renderers, which self-clean. opencode/cursor/copilot don't
-receive registry hooks, so there's no hook drift to heal there.
+So the heal for both is just **`dots profile install global`** (or a full
+`dots sync`) — it re-runs the renderers + reconcile. opencode/cursor/copilot
+receive no registry hooks, so there's no hook drift there.
 
 The doctor's value is *explaining why* drift appeared and catching the classes
 the renderers don't auto-heal. For those, propose the precise edit and confirm
-before applying — never hand-roll a jq rewrite of a user-owned file when a
+before applying — never hand-roll a jq/toml rewrite of a user-owned file when a
 renderer (or a `dots sync`) does it deterministically.
 
 ### 6. File dotfiles bugs as gh issues (deduped)

--- a/skills/harness-doctor/SKILL.md
+++ b/skills/harness-doctor/SKILL.md
@@ -11,8 +11,10 @@ description: >
   `ap`/registry change to verify the live config converged. Grounds the wiki +
   git history for intended state, diffs live vs `ap` render, classifies each
   drift (stale remnant / dotfiles bug / expected local), self-heals safe
-  remnants via chezmoi/lib/heal-claude-settings.sh, opens deduped gh issues for
-  confirmed dotfiles bugs, and writes new drift patterns back to the wiki. Do
+  remnants via ap's renderers (ClaudeRenderer._clean_legacy_settings_hooks /
+  CodexRenderer._clean_legacy_config_toml_hooks) during ap install / dots sync,
+  opens deduped gh issues for confirmed dotfiles bugs, and writes new drift
+  patterns back to the wiki. Do
   NOT use for general code review (/age), single-file permission cleanup
   (/settings-clean), or app-level debugging.
 ---
@@ -233,5 +235,7 @@ of the report — cite `file:line`, don't paste.
   inline user hooks — those are not plugin-managed.
 - **Never** open an issue without deduping against open issues first.
 - **Never** fabricate git history or a wiki claim — cite the commit / page.
-- Healing edits a user-owned file: always leave the timestamped `.bak` the
-  helper writes, and report the path.
+- Healing edits a user-owned file in place: the renderers rewrite
+  `settings.json` / `config.toml` directly with no backup file. There is no
+  `.bak` to report — `git` / `chezmoi` is the undo path. Always report which
+  file changed and what was pruned.


### PR DESCRIPTION
## Why

Tracked down why the cheese-flair SessionStart hook misbehaved: it wasn't the picker (an all-Dune quote block was a ~2% unlucky draw). The real issue was a **pre-ap remnant** — the retired `agents/hooks/sync.sh` jq-merged hooks straight into `~/.claude/settings.json` before the ap migration (#217). Hook wiring then moved into the plugin tree's `plugin.json`, but `settings.json` is a chezmoi `create_` seed nothing prunes, so the old copies lingered:

- **Dead**: `bash "$HOME/.claude/hooks/session-start-cheese-flair.sh"` — path deleted when hooks moved into the plugin; exit 127 every session start.
- **Double-fired**: `moshi-hook` across 4 events — fired twice (settings.json + plugin both load).

## What

**Renderer-level self-heal (all harnesses alike).** The codex renderer already cleans its legacy `config.toml` hooks (`_clean_legacy_config_toml_hooks`). This adds the equivalent to the Claude renderer — `_clean_legacy_settings_hooks`:

- Builds a per-event signature set from the hooks it just wired into `plugin.json` (script basename for `${CLAUDE_PLUGIN_ROOT}/hooks/<base>`, or full command string for command-type hooks like moshi).
- Prunes matching `settings.json` hooks at the inner-hook level (a mixed block keeps its unmanaged hooks), drops emptied events.
- Keyed off the rendered hooks → self-extends with the registry; fails safe when nothing is managed.

`claude` + `codex` now both self-clean on every `ap install`. `opencode`/`cursor`/`copilot` receive no cross-harness registry hooks, so coverage is complete. The fix on any machine is just `dots sync`.

**`/harness-doctor` skill.** Diffs live harness config vs the `ap` render, classifies drift (stale remnant / dotfiles bug / expected local), heals via the renderers, files deduped `gh` issues for confirmed repo bugs, and writes findings back to the wiki.

**Wiki.** New `architecture/config-drift.md` documenting the drift model + heal design.

## Tests

- New `agent-profile/tests/test_claude_legacy_hook_cleanup.py` — 12 tests via the real `render()` path + helper units.
- Full `ap` suite: **447 passed**, no golden string-identity regression (cleanup no-ops on a clean render).

🤖 Generated with [Claude Code](https://claude.com/claude-code)