### PR TITLE
docs(ap): harness permission models + ground preamble in wiki

### DIFF
--- a/.hallouminate/wiki/architecture/harness-permissions.md
+++ b/.hallouminate/wiki/architecture/harness-permissions.md
@@ -79,11 +79,13 @@ This corrects the long-standing "Cursor permissions are UI-only" assumption. It 
 | **Claude** (install) | `_write_settings` (`claude.py:472-484`) writes plugin-scoped `settings.json` `permissions.allow` if non-empty; live root `settings.json` merge never touches permissions | ✅ | ✗ | `.claude/plugins/local/<profile>/settings.json` |
 | **Claude** (isolated) | `overlay.py` ephemeral `settings.json` with `permissions.allow` **and** `permissions.deny`, paired with `--setting-sources ""` + `--tools` whitelist | ✅ | ✅ | ephemeral `settings.json` |
 | **opencode** | `_translate_permission` (`opencode.py:38-47`) maps only `Bash(cmd:*)` → `cmd *`; everything else passes through verbatim into `permission.bash` | ✅ (bash only) | ✗ | `opencode.json` `permission.bash` |
-| **Codex** | **zero** permission handling — renderer writes agents/skills/hooks/mcps only | ✗ | ✗ | — |
+| **Codex** | renderer writes agents/skills/hooks/mcps only — **no per-command rule rendered**. But Codex is *not* surface-less: it has a static `config.toml` permission surface `ap` doesn't yet target (see Planned fixes #5) | ✗ † | ✗ † | — |
 | **Cursor** | declared perms **warned and dropped** (`cursor.py:117-124`, assumes "UI-only") | ✗ | ✗ | — |
 | **Copilot** | **silently skipped** (uses runtime `--deny-tool`, not config) | ✗ | ✗ | — |
 
-So a profile's `permissions_allow` only ever reaches **Claude** (full, both channels) and **opencode** (allow-only, bash-only). The other three drop it.
+† Codex's `✗` is for the **per-command rule-list** dimension only — there is no `allowed_commands`-style config key. It is *not* "no permission surface": `sandbox_mode` + `approval_policy` (posture) and MCP `enabled_tools`/`disabled_tools` are static `config.toml` keys `ap` could render and currently doesn't.
+
+So a profile's per-command `permissions_allow` rules only reach **Claude** (full, both channels) and **opencode** (allow-only, bash-only). Cursor and Copilot drop them; Codex drops the *rules* but exposes a separate static posture surface (below) that `ap` leaves on the table.
 
 ## Planned fixes & remaining gaps
 
@@ -91,7 +93,12 @@ So a profile's `permissions_allow` only ever reaches **Claude** (full, both chan
 2. **opencode loses deny + non-bash perms.** `_translate_permission` only emits `permission.bash` allow entries, yet opencode natively supports `deny` and per-tool (`edit`/`read`/`webfetch`/MCP) permissions with last-match-wins. Spec: **`.cheese/specs/ap-opencode-permission-fidelity.md`** — adds a `settings.permissions_deny` parse channel and translates the full Claude vocabulary into opencode's per-tool `permission` map.
 3. **Shared dependency:** both specs need the new `settings.permissions_deny` union-merge in `parse.py` (today deny is top-level / isolated-claude-only). Land it once.
 4. **Claude `settings.permissions_deny` not consumed (future).** Once the parse channel exists, the claude install renderer could also write `permissions.deny` (it only writes `allow` today) — explicitly out of scope of the two specs, noted here so it isn't forgotten.
-5. **Codex/Copilot have no static config permission surface by design** — Codex gates via sandbox+approval (+`.rules` DSL), Copilot via runtime `--deny-tool`. Their "skip" is intentional. (Codex MCP `enabled_tools`/`disabled_tools` *is* renderable but `ap` doesn't emit it — a possible future.)
+5. **Permissions are two orthogonal dimensions, not one — and Codex covers the second.** Earlier framing ("Codex/Copilot have no static config permission surface by design") was wrong: it conflated *per-command rule-lists* with *permission surface in general*. Split them:
+   - **Per-command rule-list** (`Bash(git:*)`, `Read(...)`, `mcp__s__t`). Renderable to Claude / opencode / Cursor-CLI. **Codex has no config key for this** (verified: no `allowed_commands`/`trusted_commands`/`permissions.allow` in `config.toml` — `developers.openai.com/codex/agent-approvals-security` and `config-reference`, `codex-config-reference.md:49`; per-command allow/deny is the TUI-written `.rules` execpolicy DSL at `~/.codex/rules/default.rules`, not declarative profile config). **Copilot has none either** (runtime `--allow-tool`/`--deny-tool` only; "No trustedTools in config.json yet" — feature request, `copilot-cli-permissions-raw.md:105`).
+   - **Posture / mode** (read-only vs write, how aggressively to gate). **Codex renders cleanly here:** `sandbox_mode` (`read-only`|`workspace-write`|`danger-full-access`) + `approval_policy` (`untrusted`|`on-request`|`never`|`{ granular = { sandbox_approval, rules, mcp_elicitations, request_permissions, skill_approval } }`) — both static `config.toml` keys (`codex-config-reference.md:10-29`). An isolated read-only profile (e.g. `review`) maps directly to `sandbox_mode = read-only` + `approval_policy = untrusted`. `ap` doesn't render this today; it should.
+   - **MCP tool scoping** is statically renderable for *both* Codex (`enabled_tools`/`disabled_tools`, `config-reference`) and Copilot (`mcp-config.json` `tools: [...]` exposure list, `copilot-cli-permissions-raw.md:57-72`). `ap` emits neither.
+
+   Net: a "generic permission setting scoped for all harnesses" is achievable only when split by dimension — per-command rules reach Claude/opencode/Cursor; posture reaches Codex (+Claude `defaultMode`/`permission-mode`, opencode default action); MCP scoping reaches all five. No single channel reaches all five with the full vocabulary.
 
 ## Provenance
 

--- a/.hallouminate/wiki/architecture/harness-permissions.md
+++ b/.hallouminate/wiki/architecture/harness-permissions.md
@@ -1,107 +1,136 @@
 # Harness Permission Models & How `ap` Maps Onto Them
 
-The five harnesses each have a *different* permission/tool-access model — different config surface, different allow/deny/ask vocabulary, different precedence. `ap` declares permissions once (in a profile) and renders them per harness, but the mapping is **lossy and uneven**: only Claude gets a full allow+deny surface, opencode gets allow-only-bash-only, and two harnesses get nothing. This page is the cross-harness reference behind those renderer decisions, plus the planned fixes.
+The five harnesses — Claude Code, opencode, Cursor, Codex, Copilot — each have a *different* permission/tool-access model: different config surface, different allow/deny/ask vocabulary, different precedence. The trap is to picture "permissions" as one knob. It isn't. Permission control splits into **three orthogonal levers**, and each harness exposes a *different subset* of them through a *different surface*:
 
-For the renderer mechanics see [[agent-profile]]; for each harness's wider config surface see [[../harnesses/index]].
+1. **Per-command / per-tool rules** — "allow `git status`, deny `rm`, allow this one MCP tool." Fine-grained allow/deny lists keyed on a command or tool name. This is what people usually mean by "the allowlist."
+2. **Posture / mode** — the coarse stance: read-only vs. write, sandbox confinement, how aggressively the agent pauses to ask.
+3. **MCP-tool scoping** — which tools a given MCP server even *exposes* to the model, upstream of any allow/deny rule.
 
-## TL;DR — `ap` has no default permissions
+`ap` declares permissions once (in a profile) and renders them per harness. The mapping is **lossy and uneven**: no single lever reaches all five harnesses with full vocabulary, and `ap` today renders only a slice of what the harnesses natively accept. This page is the per-lever reference behind the renderer decisions, plus the planned fixes.
 
-There is **no hardcoded default permission set** anywhere in `ap` (verified: zero `DEFAULT_ALLOW`/`DEFAULT_DENY` constants across the package). Permissions are *purely profile-declared*. If a `profile.yaml` declares nothing, nothing is written, and the harness falls back to whatever the user's own live config already grants. The "default perms" for every non-isolated profile is therefore **the user's existing harness config** — `ap` only layers additively on top. The single exception is an **isolated** Claude launch, which cuts off inheritance (`--setting-sources ""`) so its surface is exactly its declared `tools` + `permissions_deny`.
+For renderer mechanics see [[agent-profile]]; for each harness's wider config surface see [[../harnesses/index]].
 
-## Two permission channels in `profile.yaml`
+## TL;DR
+
+- **`ap` ships no default permissions.** No hardcoded default set anywhere in the package (verified: zero `DEFAULT_ALLOW`/`DEFAULT_DENY` constants). Permissions are *purely profile-declared*; if a `profile.yaml` declares nothing, nothing is written and the harness falls back to the user's own live config. `ap` only layers additively. The one exception is an **isolated** Claude launch, which cuts inheritance (`--setting-sources ""`) so its surface is exactly its declared `tools` + deny.
+- **Three levers, not one.** Per-command rules reach Claude / opencode / Cursor-CLI (Codex and Copilot have no *config* surface for them). Posture reaches Codex, Claude, opencode, and Cursor. MCP-tool scoping is statically renderable to **all five**. No single channel reaches all five with the full vocabulary — a canonical permission set has to be lowered per-lever, per-harness.
+- **Where `ap` is lossy today:** opencode full allow+deny render landed in #259 (in review); Cursor-CLI rendering, Codex posture + MCP scoping, and Copilot MCP exposure are still on the table (see [Planned fixes](#planned-fixes--remaining-gaps)).
+
+## How `ap` declares permissions
+
+Two channels in `profile.yaml`, both defaulting to empty:
 
 | Channel | Profile key | Merges from `include:`? | Used by |
 |---|---|---|---|
-| Install (non-isolated) | `settings.permissions_allow` | yes — union + sorted (`parse.py`) | claude install, opencode |
+| Install (non-isolated) | `settings.permissions_allow` / `settings.permissions_deny` | yes — union + sorted (`parse.py`) | claude install, opencode |
 | Launch overlay (isolated) | top-level `permissions_allow` / `permissions_deny` | **no** — outermost profile only | isolated claude launch only |
 
-Both default to empty list. The isolated fields are launch-overlay fields (the ccp parity); the `settings.permissions_allow` nested field is the only one that feeds non-isolated installs. **There is no `settings.permissions_deny` channel today** — that gap blocks rendering deny rules to opencode/cursor (the planned-fix specs add it).
+The isolated top-level fields are the launch-overlay (ccp parity); the nested `settings.*` fields feed non-isolated installs. The `settings.permissions_deny` union-merge in `parse.py` shipped with #259 — before that, deny existed only as the top-level isolated-Claude field, which is why deny rules couldn't reach opencode or Cursor. A separate, non-`ap` channel seeds the Claude baseline: `chezmoi/dot_claude/create_settings.json` (one-time user-owned seed) — any canonical permission model has to decide how it relates to that seed.
 
-## Native model per harness
+---
 
-### Claude Code — full allow / deny / ask, the richest surface
+## Lever 1 — Per-command / per-tool rules
+
+Fine-grained allow/deny keyed on a command (`Bash(git:*)`), a file path (`Read(...)`), or an MCP tool (`mcp__server__tool`). This is the lever with the widest *vocabulary* divergence and the one Codex/Copilot can't express in config at all.
+
+### Claude Code — full allow / deny / ask, the richest surface `<certain>`
 
 The only harness with a first-class deny path in config.
 
-- **Surface:** `settings.json` → `permissions: { allow: [], deny: [], ask: [] }`. CLI: `--allowedTools` / `--disallowedTools` (permission-rule syntax, skip-the-prompt), `--tools` (availability — restricts the model's context), `--setting-sources`, `--permission-mode`, `--append-system-prompt[-file]`.
-- **Model:** evaluated **deny → ask → allow**, first matching rule wins. Rules **merge across all scopes** (managed > CLI > local > project > user) — a deny at *any* level cannot be cancelled by an allow at another. Bare `Bash` (≡ `Bash(*)`) removes the tool from context; scoped `Bash(rm *)` leaves it visible but blocks matches.
-- **Rule syntax:** `Bash(cmd:*)` (`:*` = trailing wildcard; space before `*` enforces a word boundary; compound commands split on `&&`/`||`/`;`/`|`/newline and matched per-subcommand; wrappers like `timeout`/`nice`/`xargs` stripped first). Path tools anchor: `//abs`, `~/home`, `/project-root`, `./cwd`; `*` = one dir depth, `**` = recursive. `WebFetch(domain:example.com)`, `mcp__server__tool` / `mcp__server__*`, `Agent(Explore)`.
-- **Modes (`defaultMode` / `--permission-mode`):** `default`, `acceptEdits`, `plan`, `auto`, `dontAsk`, `bypassPermissions`. `--setting-sources ""` (or `settingSources: []`) disables the three filesystem sources; **managed policy still loads**. `permissions.additionalDirectories` grants file access only (no `.claude/` config load); `--add-dir` additionally loads skills/plugins.
+- **Surface:** `settings.json` → `permissions: { allow: [], deny: [], ask: [] }`. CLI: `--allowedTools` / `--disallowedTools` (skip-the-prompt), `--tools` (availability — restricts the model's context).
+- **Precedence:** evaluated **deny → ask → allow**, first matching rule wins. Rules **merge across all scopes** (managed > CLI > local > project > user) — a deny at *any* level cannot be cancelled by an allow at another.
+- **Rule syntax:** `Bash(cmd:*)` (`:*` = trailing wildcard; space before `*` enforces a word boundary; compound commands split on `&&`/`||`/`;`/`|`/newline, matched per-subcommand; wrappers like `timeout`/`nice`/`xargs` stripped first). Bare `Bash` (≡ `Bash(*)`) removes the tool from context; scoped `Bash(rm *)` leaves it visible but blocks matches. Path tools anchor: `//abs`, `~/home`, `/project-root`, `./cwd`; `*` = one dir depth, `**` = recursive. Also `WebFetch(domain:example.com)`, `Agent(Explore)`.
 - **Docs:** [settings](https://code.claude.com/docs/en/settings) · [permissions](https://code.claude.com/docs/en/permissions) · [cli-reference](https://docs.anthropic.com/en/docs/claude-code/cli-reference)
 
-### Codex CLI — sandbox + approval, **no per-command allow/deny in `config.toml`**
+### opencode — full allow / ask / deny, last-match-wins `<certain>`
 
-The key surprise: there is **no `allowed_commands` / `trusted_commands` array** in `config.toml`. Per-command allow/deny lives in a *separate* file with a DSL.
-
-- **Primary model = two layers:** `sandbox_mode` (`read-only` | `workspace-write` | `danger-full-access`) — what the process *can* do; and `approval_policy` (`untrusted` | `on-request` | `never`; `on-failure` deprecated) — when Codex *pauses to ask*.
-- **Per-command allow/deny = execpolicy `.rules` DSL**, not config.toml. Lives at `~/.codex/rules/default.rules`; Starlark-like `prefix_rule()` / `exact_rule()` with `decision = allow | prompt | forbidden`. The TUI "always allow" writes here automatically. `--ignore-rules` skips it for a run.
-- **MCP per-tool filtering exists** (unlike codex's shell side): `[mcp_servers.<name>]` → `enabled_tools` (allowlist) / `disabled_tools` (denylist), plus `tools.<tool>.approval_mode` (`auto`|`prompt`|`approve`) and `default_tools_approval_mode`.
-- **CLI:** `--sandbox`, `--ask-for-approval`/`-a`, `--full-auto` (deprecated alias), `--dangerously-bypass-approvals-and-sandbox`/`--yolo`, `-c key=value`. File: `~/.codex/config.toml`.
-- **Docs:** [config-reference](https://developers.openai.com/codex/config-reference) · [exec-policy](https://developers.openai.com/codex/exec-policy) · [cli/reference](https://developers.openai.com/codex/cli/reference)
-
-### opencode — `permission` object, allow / ask / **deny** supported
-
-- **Surface:** `permission` object in `~/.config/opencode/opencode.json` (`OPENCODE_CONFIG` overrides path; `OPENCODE_PERMISSION` env accepts inline JSON).
-- **Model:** every key is a tool name or wildcard; value is a string shorthand `"allow"` | `"ask"` | `"deny"`, OR (for 8 tools — `read`, `edit`, `glob`, `grep`, `bash`, `task`, `external_directory`, `skill`) a **pattern → action map**. The remaining keys (`lsp`, `webfetch`, `websearch`, `question`, `todowrite`) accept shorthand only. **Default when unset = `allow`** (all tools run without approval).
-- **Precedence: last matching rule wins** — so put the catch-all `"*"` *first*, specifics after. `bash` matches the **parsed** command (`git status --porcelain`), not raw input. `~`/`$HOME` expand in patterns.
-- **Key gotchas:** `edit` covers `write`/`apply_patch` (no separate `write` key); `read` is its own key; MCP tools match as `<server>_<tool>` (`mymcp_*: deny`). Per-agent overrides via `agent.<name>.permission` or agent markdown frontmatter.
+- **Surface:** the `permission` object in `~/.config/opencode/opencode.json` (`OPENCODE_CONFIG` overrides path; `OPENCODE_PERMISSION` env accepts inline JSON).
+- **Model:** every key is a tool name or wildcard; value is shorthand `"allow"` | `"ask"` | `"deny"`, OR — for 8 tools (`read`, `edit`, `glob`, `grep`, `bash`, `task`, `external_directory`, `skill`) — a **pattern → action map**. The other keys (`lsp`, `webfetch`, `websearch`, `question`, `todowrite`) take shorthand only. **Default when unset = `allow`.**
+- **Precedence: last matching rule wins** — put the catch-all `"*"` *first*, specifics after. `bash` matches the **parsed** command (`git status --porcelain`), not raw input; `~`/`$HOME` expand in patterns.
+- **Gotchas:** `edit` covers `write`/`apply_patch` (no separate `write` key); `read` is its own key; MCP tools match as `<server>_<tool>` (`mymcp_*: deny`). Per-agent overrides via `agent.<name>.permission` or agent-markdown frontmatter.
 - **Docs:** [permissions](https://opencode.ai/docs/permissions) · [tools](https://opencode.ai/docs/tools)
 
-### Cursor — **split**: IDE allowlist is UI-only, but the CLI is fully declarative
+### Cursor CLI — declarative tokens, deny-wins `<certain>`
 
-This corrects the long-standing "Cursor permissions are UI-only" assumption. It is only half true — the IDE is UI-only, the `cursor-agent` CLI is a declarative JSON file with a Claude-like token grammar.
+The IDE is UI-only (Run Mode + command/MCP allowlist live in Settings → Agents → Run Mode + Protection; no config file, denylist UI removed post-0.47). But the `cursor-agent` **CLI** is fully declarative — this corrects the long-standing "Cursor permissions are UI-only" assumption, which is only half true.
 
-- **IDE (Cursor editor):** UI-only. Run Mode + command/MCP allowlist live in Settings → Agents → Run Mode + Protection. No config file for the IDE allowlist (the denylist UI was removed post-0.47).
-- **CLI (`cursor-agent`) config files:**
-  - **Global** `~/.cursor/cli-config.json` — holds *all* settings: `version` (int, current `1`), `editor.vimMode` (bool), `permissions.allow` (string[]), `permissions.deny` (string[]).
-  - **Project** `<project>/.cursor/cli.json` — holds **only** `permissions`, and **takes precedence over global** for that key.
-- **Token grammar (5 types):**
-  - `Shell(base)` — matches the first command token; `Shell(curl:)` (colon) = curl with *any* args; `Shell(git)` allows **all** git subcommands (no subcommand-level filtering).
-  - `Read(glob)` / `Write(glob)` — glob path; relative = workspace-scoped, absolute = anywhere. In `-p`/`--print` headless mode, `Write` also needs `--force` to actually write.
-  - `WebFetch(domain)` — `*.example.com` (subdomains), `example.com` (exact), `*` (all).
-  - `Mcp(server:tool)` — `Mcp(datadog:)` = all tools of a server; `Mcp(:search)` = any server's `search`; `Mcp(:)` = all MCP tools.
+- **Files:** global `~/.cursor/cli-config.json` holds *all* settings (`version`, `editor.vimMode`, `permissions.allow` string[], `permissions.deny` string[]); project `<project>/.cursor/cli.json` holds **only** `permissions` and **takes precedence over global** for that key.
+- **Token grammar (5 types):** `Shell(base)` matches the first command token — `Shell(curl:)` (colon) = curl with *any* args; `Shell(git)` allows **all** git subcommands (no subcommand-level filtering). `Read(glob)` / `Write(glob)` glob a path (relative = workspace-scoped, absolute = anywhere; in `-p`/`--print` headless mode `Write` also needs `--force`). `WebFetch(domain)` — `*.example.com` / `example.com` / `*`. `Mcp(server:tool)` — `Mcp(datadog:)` = all tools of a server, `Mcp(:search)` = any server's `search`, `Mcp(:)` = all MCP tools.
 - **Precedence: deny wins** over allow (not first-match).
-- **`sandbox.json`** is a **separate file** (`~/.cursor/sandbox.json` or `<workspace>/.cursor/sandbox.json`) — sandbox network + filesystem policy (`type`, `additionalReadwritePaths`, `additionalReadonlyPaths`, `disableTmpWrite`, `networkPolicy.default: allow|deny`). Not part of `cli-config.json`. `.cursor/` is always sandbox-protected.
-- **Headless flags:** `-p`/`--print` (non-interactive), `--force`/`-f` (allow all unless denied — deny list still enforced), `--approve-mcps` (+ `--force` for reliable headless MCP). No `--allow`/`--deny` runtime flags — permissions are config-file only.
-- **Docs:** [cli permissions](https://cursor.com/docs/cli/reference/permissions) · [cli configuration](https://cursor.com/docs/cli/reference/configuration) · [sandbox.json](https://cursor.com/docs/reference/sandbox) · [terminal/run-mode](https://cursor.com/docs/agent/tools/terminal) · [mcp](https://cursor.com/docs/mcp)
+- **Headless flags:** `-p`/`--print`, `--force`/`-f` (allow all unless denied — deny list still enforced), `--approve-mcps`. **No `--allow`/`--deny` runtime flags** — permissions are config-file only.
+- **Docs:** [cli permissions](https://cursor.com/docs/cli/reference/permissions) · [cli configuration](https://cursor.com/docs/cli/reference/configuration) · [terminal/run-mode](https://cursor.com/docs/agent/tools/terminal) · [mcp](https://cursor.com/docs/mcp)
 
-### Copilot CLI — layered: MCP `tools` exposure vs runtime approval flags
+### Codex — **no per-command rule-list in config** `<certain>`
 
-- **Two layers:** (1) per-MCP-server `tools` field in `~/.copilot/mcp-config.json` controls which tools are *exposed* (`["*"]` = all; a named list restricts); (2) `--allow-tool` / `--deny-tool` runtime flags control whether the agent must *prompt* before using an exposed tool.
-- **Flag syntax:** `Kind(argument)`; kinds are `memory`, `read`, `shell`, `url`, `write`, and `SERVER-NAME`. `shell(git:)` (colon = prefix, all subcommands), MCP as `MyMCP(create_issue)`. Comma-separate multiple in one flag. **`--deny-tool` always beats allow, even under `--allow-all`.** `--available-tools` removes tools from the set entirely (stronger than deny). `--allow-all-tools` (env `COPILOT_ALLOW_ALL`), `--allow-all`/`--yolo`.
-- **Persistent approvals:** `~/.copilot/permissions-config.json` (auto-managed per project — *not* for hand-editing). `~/.copilot/config.json` holds `trustedFolders` (path trust, not tool perms); `~/.copilot/settings.json` holds `allowedUrls`/`deniedUrls`/`disabledMcpServers`/`enabledMcpServers`. `preToolUse` hook can return `permissionDecision: allow|deny`.
-- **Docs:** [cli-command-reference](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-command-reference) · [allowing-tools](https://docs.github.com/en/copilot/how-tos/copilot-cli/use-copilot-cli/allowing-tools) · [add-mcp-servers](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-mcp-servers) · [config-dir-reference](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-config-dir-reference)
+The key surprise: there is **no `allowed_commands` / `trusted_commands` / `permissions.allow` array** in `config.toml` (verified three ways — `codex-config-reference.md:49`, the exec-policy page, and agent-approvals-security). Per-command allow/deny lives in a *separate* file with a DSL: the **execpolicy `.rules`** at `~/.codex/rules/default.rules` (Starlark-like `prefix_rule()` / `exact_rule()` with `decision = allow | prompt | forbidden`). The TUI "always allow" writes here automatically; `--ignore-rules` skips it for a run. This is not declarative profile config, so `ap` cannot lower a per-command rule onto Codex. (Codex *does* expose the other two levers — see below.)
 
-## How `ap` renders a declared permission per harness (today)
+### Copilot CLI — runtime flags only, no config `<certain>`
 
-| Harness | Renderer behavior | Allow | Deny | File written |
-|---|---|:---:|:---:|---|
-| **Claude** (install) | `_write_settings` (`claude.py:472-484`) writes plugin-scoped `settings.json` `permissions.allow` if non-empty; live root `settings.json` merge never touches permissions | ✅ | ✗ | `.claude/plugins/local/<profile>/settings.json` |
-| **Claude** (isolated) | `overlay.py` ephemeral `settings.json` with `permissions.allow` **and** `permissions.deny`, paired with `--setting-sources ""` + `--tools` whitelist | ✅ | ✅ | ephemeral `settings.json` |
-| **opencode** | `_translate_permission` (`opencode.py:38-47`) maps only `Bash(cmd:*)` → `cmd *`; everything else passes through verbatim into `permission.bash` | ✅ (bash only) | ✗ | `opencode.json` `permission.bash` |
-| **Codex** | renderer writes agents/skills/hooks/mcps only — **no per-command rule rendered**. But Codex is *not* surface-less: it has a static `config.toml` permission surface `ap` doesn't yet target (see Planned fixes #5) | ✗ † | ✗ † | — |
-| **Cursor** | declared perms **warned and dropped** (`cursor.py:117-124`, assumes "UI-only") | ✗ | ✗ | — |
-| **Copilot** | **silently skipped** (uses runtime `--deny-tool`, not config) | ✗ | ✗ | — |
+Per-tool allow/deny is **runtime `--allow-tool` / `--deny-tool` only** — there is no `trustedTools`-style config key (feature request open, `copilot-cli-permissions-raw.md:105`). Flag syntax: `Kind(argument)` where kinds are `memory`, `read`, `shell`, `url`, `write`, and `SERVER-NAME` — e.g. `shell(git:)` (colon = prefix, all subcommands), `MyMCP(create_issue)`; comma-separate multiple per flag. **`--deny-tool` always beats allow, even under `--allow-all`.** `--available-tools` removes tools from the set entirely (stronger than deny). Because it's flags-only, `ap` (which writes config, not launch flags) cannot lower a per-command rule onto Copilot either.
 
-† Codex's `✗` is for the **per-command rule-list** dimension only — there is no `allowed_commands`-style config key. It is *not* "no permission surface": `sandbox_mode` + `approval_policy` (posture) and MCP `enabled_tools`/`disabled_tools` are static `config.toml` keys `ap` could render and currently doesn't.
+**Lever-1 reach:** Claude (full, both channels) · opencode (full, last-match) · Cursor-CLI (tokens, deny-wins). Codex and Copilot have **no config surface** for this lever — only a TUI-written DSL (Codex) or runtime flags (Copilot).
 
-So a profile's per-command `permissions_allow` rules only reach **Claude** (full, both channels) and **opencode** (allow-only, bash-only). Cursor and Copilot drop them; Codex drops the *rules* but exposes a separate static posture surface (below) that `ap` leaves on the table.
+---
+
+## Lever 2 — Posture / mode
+
+The coarse stance: read-only vs. write, sandbox confinement, gate aggressiveness. This is the lever **Codex renders most cleanly**, and the one that maps an isolated `review`-style profile to a genuinely read-only run.
+
+- **Claude** `<certain>` — `defaultMode` / `--permission-mode`: `default`, `acceptEdits`, `plan`, `auto`, `dontAsk`, `bypassPermissions`. `--setting-sources ""` (or `settingSources: []`) disables the three filesystem sources (managed policy still loads). `permissions.additionalDirectories` grants file access only; `--add-dir` also loads skills/plugins.
+- **Codex** `<certain>` — two static `config.toml` keys: `sandbox_mode` (`read-only` | `workspace-write` | `danger-full-access` — what the process *can* do) and `approval_policy` (`untrusted` | `on-request` | `never`; `on-failure` deprecated — when Codex *pauses to ask*), including the granular form `approval_policy = { granular = { sandbox_approval, rules, mcp_elicitations, request_permissions, skill_approval } }` (`codex-config-reference.md:10-29`). An isolated read-only profile maps directly to `sandbox_mode = read-only` + `approval_policy = untrusted`. CLI: `--sandbox`, `--ask-for-approval`/`-a`, `--dangerously-bypass-approvals-and-sandbox`/`--yolo`.
+- **opencode** `<certain>` — the per-tool `"allow"|"ask"|"deny"` default action *is* its posture knob; setting `"*": "ask"` first yields an ask-everything stance, `"deny"` a read-only-ish one.
+- **Cursor** `<certain>` — Run Mode (IDE UI) plus a **separate** `sandbox.json` (`~/.cursor/sandbox.json` or `<workspace>/.cursor/sandbox.json`): `type`, `additionalReadwritePaths`, `additionalReadonlyPaths`, `disableTmpWrite`, `networkPolicy.default: allow|deny`. Not part of `cli-config.json`; `.cursor/` is always sandbox-protected. ([sandbox.json](https://cursor.com/docs/reference/sandbox))
+- **Copilot** `<certain>` — `--allow-all-tools` (env `COPILOT_ALLOW_ALL`), `--allow-all`/`--yolo`; `~/.copilot/config.json` `trustedFolders` (path trust, not tool perms); a `preToolUse` hook can return `permissionDecision: allow|deny`.
+- **Docs:** Codex [config-reference](https://developers.openai.com/codex/config-reference) · [exec-policy](https://developers.openai.com/codex/exec-policy) · [cli/reference](https://developers.openai.com/codex/cli/reference)
+
+**Lever-2 reach:** Codex (richest, static), Claude (`defaultMode`/`--permission-mode`), opencode (default action), Cursor (Run Mode + `sandbox.json`), Copilot (flags + `trustedFolders`).
+
+---
+
+## Lever 3 — MCP-tool scoping
+
+Which tools a server *exposes* to the model — upstream of allow/deny. This is the **only lever statically renderable to all five harnesses**, which makes it the natural backbone of a cross-harness canonical model.
+
+- **Claude** `<certain>` — `mcp__server__tool` / `mcp__server__*` rules in the same `permissions.allow`/`deny` surface as Lever 1.
+- **opencode** `<certain>` — MCP tools match as `<server>_<tool>` in the `permission` map (`mymcp_*: deny`).
+- **Cursor** `<certain>` — `Mcp(server:tool)` tokens in `permissions.allow`/`deny` (`Mcp(datadog:)`, `Mcp(:search)`, `Mcp(:)`).
+- **Codex** `<certain>` — `[mcp_servers.<name>]` → `enabled_tools` (allowlist) / `disabled_tools` (denylist), plus `tools.<tool>.approval_mode` (`auto`|`prompt`|`approve`) and `default_tools_approval_mode` (`config-reference`).
+- **Copilot** `<certain>` — per-MCP-server `tools` field in `~/.copilot/mcp-config.json` controls exposure (`["*"]` = all; a named list restricts) (`copilot-cli-permissions-raw.md:57-72`). Plus `~/.copilot/settings.json` `disabledMcpServers`/`enabledMcpServers`.
+
+**Lever-3 reach:** all five — but `ap` renders MCP scoping for **none of them** as a dedicated channel today (Claude/opencode/Cursor would get it for free once their Lever-1 renderers carry MCP rules; Codex `enabled/disabled_tools` and Copilot `tools:[]` are net-new renderer work).
+
+---
+
+## What `ap` renders today
+
+Native capability (above) is not the same as what `ap` lowers. Current render state per lever:
+
+| Harness | Lever 1 (per-command rules) | Lever 2 (posture) | Lever 3 (MCP scoping) | File written |
+|---|:---:|:---:|:---:|---|
+| **Claude** (install) | ✅ allow only † | ✗ | via Lever 1 | `.claude/plugins/local/<profile>/settings.json` |
+| **Claude** (isolated) | ✅ allow **+** deny | ✅ `--setting-sources ""` + `--tools` | via Lever 1 | ephemeral `settings.json` |
+| **opencode** | ✅ allow **+** deny (#259) ‡ | partial (default action) | via Lever 1 | `opencode.json` `permission` |
+| **Cursor** | ✗ warned + dropped | ✗ | ✗ | — |
+| **Codex** | ✗ (no config surface) | ✗ not rendered | ✗ not rendered | — |
+| **Copilot** | ✗ (flags-only) | ✗ | ✗ not rendered | — |
+
+† Claude install writes plugin-scoped `permissions.allow` if non-empty (`claude.py:472-484`); the live root `settings.json` merge never touches permissions. Deny is written only on the isolated launch path (`overlay.py`).
+‡ Pre-#259 the opencode renderer (`_translate_permission`, `opencode.py`) emitted bash-allow-only — it mapped `Bash(cmd:*)` → `cmd *` and passed everything else through into `permission.bash`. #259 adds the `settings.permissions_deny` parse channel and translates the full Claude vocabulary into opencode's per-tool `permission` map (last-match-wins, deny emitted last for deny-wins parity).
+
+Net: a profile's per-command rules reach **Claude** (full) and **opencode** (full, post-#259). Cursor drops them (renderer assumes UI-only, `cursor.py:117-124`); Codex has no per-command config surface to render to; Copilot is flags-only. Posture and MCP-scoping are largely unrendered everywhere.
 
 ## Planned fixes & remaining gaps
 
-1. **Cursor warn-and-drop → CLI render.** The renderer assumes UI-only — true for the *IDE*, but `cursor-agent` consumes declarative `permissions.allow`/`permissions.deny` from `~/.cursor/cli-config.json` with a token grammar near-identical to Claude's. Spec: **`.cheese/specs/ap-cursor-cli-permissions.md`** — adds `_write_cli_config`, translates Claude rules → Cursor tokens (`Bash(cmd:*)`→`Shell(cmd:)`, `Edit`→`Write`, `mcp__s__t`→`Mcp(s:t)`), merges like `.cursor/mcp.json`. Harmless if only the IDE is used (the file is read solely by the CLI), so safe to ship now.
-2. **opencode loses deny + non-bash perms.** `_translate_permission` only emits `permission.bash` allow entries, yet opencode natively supports `deny` and per-tool (`edit`/`read`/`webfetch`/MCP) permissions with last-match-wins. Spec: **`.cheese/specs/ap-opencode-permission-fidelity.md`** — adds a `settings.permissions_deny` parse channel and translates the full Claude vocabulary into opencode's per-tool `permission` map.
-3. **Shared dependency:** both specs need the new `settings.permissions_deny` union-merge in `parse.py` (today deny is top-level / isolated-claude-only). Land it once.
-4. **Claude `settings.permissions_deny` not consumed (future).** Once the parse channel exists, the claude install renderer could also write `permissions.deny` (it only writes `allow` today) — explicitly out of scope of the two specs, noted here so it isn't forgotten.
-5. **Permissions are two orthogonal dimensions, not one — and Codex covers the second.** Earlier framing ("Codex/Copilot have no static config permission surface by design") was wrong: it conflated *per-command rule-lists* with *permission surface in general*. Split them:
-   - **Per-command rule-list** (`Bash(git:*)`, `Read(...)`, `mcp__s__t`). Renderable to Claude / opencode / Cursor-CLI. **Codex has no config key for this** (verified: no `allowed_commands`/`trusted_commands`/`permissions.allow` in `config.toml` — `developers.openai.com/codex/agent-approvals-security` and `config-reference`, `codex-config-reference.md:49`; per-command allow/deny is the TUI-written `.rules` execpolicy DSL at `~/.codex/rules/default.rules`, not declarative profile config). **Copilot has none either** (runtime `--allow-tool`/`--deny-tool` only; "No trustedTools in config.json yet" — feature request, `copilot-cli-permissions-raw.md:105`).
-   - **Posture / mode** (read-only vs write, how aggressively to gate). **Codex renders cleanly here:** `sandbox_mode` (`read-only`|`workspace-write`|`danger-full-access`) + `approval_policy` (`untrusted`|`on-request`|`never`|`{ granular = { sandbox_approval, rules, mcp_elicitations, request_permissions, skill_approval } }`) — both static `config.toml` keys (`codex-config-reference.md:10-29`). An isolated read-only profile (e.g. `review`) maps directly to `sandbox_mode = read-only` + `approval_policy = untrusted`. `ap` doesn't render this today; it should.
-   - **MCP tool scoping** is statically renderable for *both* Codex (`enabled_tools`/`disabled_tools`, `config-reference`) and Copilot (`mcp-config.json` `tools: [...]` exposure list, `copilot-cli-permissions-raw.md:57-72`). `ap` emits neither.
+1. **Cursor warn-and-drop → CLI render.** The renderer assumes UI-only — true for the *IDE*, but `cursor-agent` consumes declarative `permissions.allow`/`deny` from `~/.cursor/cli-config.json`. Spec: **`.cheese/specs/ap-cursor-cli-permissions.md`** — adds `_write_cli_config`, translates Claude rules → Cursor tokens (`Bash(cmd:*)`→`Shell(cmd:)`, `Edit`→`Write`, `mcp__s__t`→`Mcp(s:t)`). Harmless if only the IDE is used (the file is read solely by the CLI). Unblocked by #259's parse channel; not yet cooked.
+2. **opencode full-fidelity render — shipped in #259** (in review). Adds the `settings.permissions_deny` union-merge in `parse.py` and the full per-tool translation. This is the shared dependency the other render specs lean on.
+3. **Claude `settings.permissions_deny` not consumed (future).** With the parse channel live, the claude *install* renderer could also write `permissions.deny` (it only writes `allow` today). Out of scope of the two render specs; noted so it isn't forgotten.
+4. **Codex posture renderer (net-new, Lever 2).** `sandbox_mode` + `approval_policy` (incl. the `granular` form) are static `config.toml` keys `ap` doesn't target. An isolated read-only profile should lower to `sandbox_mode = read-only` + `approval_policy = untrusted`.
+5. **MCP-scoping renderers for Codex + Copilot (net-new, Lever 3).** Codex `enabled_tools`/`disabled_tools` and Copilot `mcp-config.json` `tools:[]` are the only way those two harnesses accept any static tool restriction. `ap` emits neither.
 
-   Net: a "generic permission setting scoped for all harnesses" is achievable only when split by dimension — per-command rules reach Claude/opencode/Cursor; posture reaches Codex (+Claude `defaultMode`/`permission-mode`, opencode default action); MCP scoping reaches all five. No single channel reaches all five with the full vocabulary.
+The through-line for a canonical permission model: **no single channel reaches all five harnesses with full vocabulary.** It has to be declared once and *lowered per-lever*: per-command rules → Claude / opencode / Cursor-CLI; posture → Codex / Claude / opencode / Cursor; MCP scoping → all five. That per-lever lowering, plus reconciliation with the `create_settings.json` Claude seed, is the work the canonical allow/disallow-list spec has to design.
 
 ## Provenance
 
-Native-model facts extracted via `/briesearch` (2026-06-02) from each vendor's official docs (URLs cited inline); the deep Cursor CLI grammar in `.cheese/research/harness-perms/cursor-cli-permissions.md`, other raw bodies under `.cheese/research/harness-perms/raw/`. `ap` mapping + the two specs grounded by reading `agent_profile/renderers/*.py` + `overlay.py` + `parse.py` (file:line in the specs).
+Native-model facts extracted via `/briesearch` (2026-06-02) from each vendor's official docs (URLs cited inline); the deep Cursor CLI grammar in `.cheese/research/harness-perms/cursor-cli-permissions.md`, other raw bodies under `.cheese/research/harness-perms/raw/`. `ap` mapping + the render specs grounded by reading `agent_profile/renderers/*.py` + `overlay.py` + `parse.py` (file:line in the specs). Codex correction (`478705f`, this PR) replaced the false "Codex has no static config permission surface" framing with the per-lever split above.
 
 See also [[agent-profile]] · [[config-drift]] · [[../harnesses/claude]] · [[../harnesses/cursor]] · [[../harnesses/opencode]]

--- a/.hallouminate/wiki/architecture/harness-permissions.md
+++ b/.hallouminate/wiki/architecture/harness-permissions.md
@@ -1,0 +1,100 @@
+# Harness Permission Models & How `ap` Maps Onto Them
+
+The five harnesses each have a *different* permission/tool-access model — different config surface, different allow/deny/ask vocabulary, different precedence. `ap` declares permissions once (in a profile) and renders them per harness, but the mapping is **lossy and uneven**: only Claude gets a full allow+deny surface, opencode gets allow-only-bash-only, and two harnesses get nothing. This page is the cross-harness reference behind those renderer decisions, plus the planned fixes.
+
+For the renderer mechanics see [[agent-profile]]; for each harness's wider config surface see [[../harnesses/index]].
+
+## TL;DR — `ap` has no default permissions
+
+There is **no hardcoded default permission set** anywhere in `ap` (verified: zero `DEFAULT_ALLOW`/`DEFAULT_DENY` constants across the package). Permissions are *purely profile-declared*. If a `profile.yaml` declares nothing, nothing is written, and the harness falls back to whatever the user's own live config already grants. The "default perms" for every non-isolated profile is therefore **the user's existing harness config** — `ap` only layers additively on top. The single exception is an **isolated** Claude launch, which cuts off inheritance (`--setting-sources ""`) so its surface is exactly its declared `tools` + `permissions_deny`.
+
+## Two permission channels in `profile.yaml`
+
+| Channel | Profile key | Merges from `include:`? | Used by |
+|---|---|---|---|
+| Install (non-isolated) | `settings.permissions_allow` | yes — union + sorted (`parse.py`) | claude install, opencode |
+| Launch overlay (isolated) | top-level `permissions_allow` / `permissions_deny` | **no** — outermost profile only | isolated claude launch only |
+
+Both default to empty list. The isolated fields are launch-overlay fields (the ccp parity); the `settings.permissions_allow` nested field is the only one that feeds non-isolated installs. **There is no `settings.permissions_deny` channel today** — that gap blocks rendering deny rules to opencode/cursor (the planned-fix specs add it).
+
+## Native model per harness
+
+### Claude Code — full allow / deny / ask, the richest surface
+
+The only harness with a first-class deny path in config.
+
+- **Surface:** `settings.json` → `permissions: { allow: [], deny: [], ask: [] }`. CLI: `--allowedTools` / `--disallowedTools` (permission-rule syntax, skip-the-prompt), `--tools` (availability — restricts the model's context), `--setting-sources`, `--permission-mode`, `--append-system-prompt[-file]`.
+- **Model:** evaluated **deny → ask → allow**, first matching rule wins. Rules **merge across all scopes** (managed > CLI > local > project > user) — a deny at *any* level cannot be cancelled by an allow at another. Bare `Bash` (≡ `Bash(*)`) removes the tool from context; scoped `Bash(rm *)` leaves it visible but blocks matches.
+- **Rule syntax:** `Bash(cmd:*)` (`:*` = trailing wildcard; space before `*` enforces a word boundary; compound commands split on `&&`/`||`/`;`/`|`/newline and matched per-subcommand; wrappers like `timeout`/`nice`/`xargs` stripped first). Path tools anchor: `//abs`, `~/home`, `/project-root`, `./cwd`; `*` = one dir depth, `**` = recursive. `WebFetch(domain:example.com)`, `mcp__server__tool` / `mcp__server__*`, `Agent(Explore)`.
+- **Modes (`defaultMode` / `--permission-mode`):** `default`, `acceptEdits`, `plan`, `auto`, `dontAsk`, `bypassPermissions`. `--setting-sources ""` (or `settingSources: []`) disables the three filesystem sources; **managed policy still loads**. `permissions.additionalDirectories` grants file access only (no `.claude/` config load); `--add-dir` additionally loads skills/plugins.
+- **Docs:** [settings](https://code.claude.com/docs/en/settings) · [permissions](https://code.claude.com/docs/en/permissions) · [cli-reference](https://docs.anthropic.com/en/docs/claude-code/cli-reference)
+
+### Codex CLI — sandbox + approval, **no per-command allow/deny in `config.toml`**
+
+The key surprise: there is **no `allowed_commands` / `trusted_commands` array** in `config.toml`. Per-command allow/deny lives in a *separate* file with a DSL.
+
+- **Primary model = two layers:** `sandbox_mode` (`read-only` | `workspace-write` | `danger-full-access`) — what the process *can* do; and `approval_policy` (`untrusted` | `on-request` | `never`; `on-failure` deprecated) — when Codex *pauses to ask*.
+- **Per-command allow/deny = execpolicy `.rules` DSL**, not config.toml. Lives at `~/.codex/rules/default.rules`; Starlark-like `prefix_rule()` / `exact_rule()` with `decision = allow | prompt | forbidden`. The TUI "always allow" writes here automatically. `--ignore-rules` skips it for a run.
+- **MCP per-tool filtering exists** (unlike codex's shell side): `[mcp_servers.<name>]` → `enabled_tools` (allowlist) / `disabled_tools` (denylist), plus `tools.<tool>.approval_mode` (`auto`|`prompt`|`approve`) and `default_tools_approval_mode`.
+- **CLI:** `--sandbox`, `--ask-for-approval`/`-a`, `--full-auto` (deprecated alias), `--dangerously-bypass-approvals-and-sandbox`/`--yolo`, `-c key=value`. File: `~/.codex/config.toml`.
+- **Docs:** [config-reference](https://developers.openai.com/codex/config-reference) · [exec-policy](https://developers.openai.com/codex/exec-policy) · [cli/reference](https://developers.openai.com/codex/cli/reference)
+
+### opencode — `permission` object, allow / ask / **deny** supported
+
+- **Surface:** `permission` object in `~/.config/opencode/opencode.json` (`OPENCODE_CONFIG` overrides path; `OPENCODE_PERMISSION` env accepts inline JSON).
+- **Model:** every key is a tool name or wildcard; value is a string shorthand `"allow"` | `"ask"` | `"deny"`, OR (for 8 tools — `read`, `edit`, `glob`, `grep`, `bash`, `task`, `external_directory`, `skill`) a **pattern → action map**. The remaining keys (`lsp`, `webfetch`, `websearch`, `question`, `todowrite`) accept shorthand only. **Default when unset = `allow`** (all tools run without approval).
+- **Precedence: last matching rule wins** — so put the catch-all `"*"` *first*, specifics after. `bash` matches the **parsed** command (`git status --porcelain`), not raw input. `~`/`$HOME` expand in patterns.
+- **Key gotchas:** `edit` covers `write`/`apply_patch` (no separate `write` key); `read` is its own key; MCP tools match as `<server>_<tool>` (`mymcp_*: deny`). Per-agent overrides via `agent.<name>.permission` or agent markdown frontmatter.
+- **Docs:** [permissions](https://opencode.ai/docs/permissions) · [tools](https://opencode.ai/docs/tools)
+
+### Cursor — **split**: IDE allowlist is UI-only, but the CLI is fully declarative
+
+This corrects the long-standing "Cursor permissions are UI-only" assumption. It is only half true — the IDE is UI-only, the `cursor-agent` CLI is a declarative JSON file with a Claude-like token grammar.
+
+- **IDE (Cursor editor):** UI-only. Run Mode + command/MCP allowlist live in Settings → Agents → Run Mode + Protection. No config file for the IDE allowlist (the denylist UI was removed post-0.47).
+- **CLI (`cursor-agent`) config files:**
+  - **Global** `~/.cursor/cli-config.json` — holds *all* settings: `version` (int, current `1`), `editor.vimMode` (bool), `permissions.allow` (string[]), `permissions.deny` (string[]).
+  - **Project** `<project>/.cursor/cli.json` — holds **only** `permissions`, and **takes precedence over global** for that key.
+- **Token grammar (5 types):**
+  - `Shell(base)` — matches the first command token; `Shell(curl:)` (colon) = curl with *any* args; `Shell(git)` allows **all** git subcommands (no subcommand-level filtering).
+  - `Read(glob)` / `Write(glob)` — glob path; relative = workspace-scoped, absolute = anywhere. In `-p`/`--print` headless mode, `Write` also needs `--force` to actually write.
+  - `WebFetch(domain)` — `*.example.com` (subdomains), `example.com` (exact), `*` (all).
+  - `Mcp(server:tool)` — `Mcp(datadog:)` = all tools of a server; `Mcp(:search)` = any server's `search`; `Mcp(:)` = all MCP tools.
+- **Precedence: deny wins** over allow (not first-match).
+- **`sandbox.json`** is a **separate file** (`~/.cursor/sandbox.json` or `<workspace>/.cursor/sandbox.json`) — sandbox network + filesystem policy (`type`, `additionalReadwritePaths`, `additionalReadonlyPaths`, `disableTmpWrite`, `networkPolicy.default: allow|deny`). Not part of `cli-config.json`. `.cursor/` is always sandbox-protected.
+- **Headless flags:** `-p`/`--print` (non-interactive), `--force`/`-f` (allow all unless denied — deny list still enforced), `--approve-mcps` (+ `--force` for reliable headless MCP). No `--allow`/`--deny` runtime flags — permissions are config-file only.
+- **Docs:** [cli permissions](https://cursor.com/docs/cli/reference/permissions) · [cli configuration](https://cursor.com/docs/cli/reference/configuration) · [sandbox.json](https://cursor.com/docs/reference/sandbox) · [terminal/run-mode](https://cursor.com/docs/agent/tools/terminal) · [mcp](https://cursor.com/docs/mcp)
+
+### Copilot CLI — layered: MCP `tools` exposure vs runtime approval flags
+
+- **Two layers:** (1) per-MCP-server `tools` field in `~/.copilot/mcp-config.json` controls which tools are *exposed* (`["*"]` = all; a named list restricts); (2) `--allow-tool` / `--deny-tool` runtime flags control whether the agent must *prompt* before using an exposed tool.
+- **Flag syntax:** `Kind(argument)`; kinds are `memory`, `read`, `shell`, `url`, `write`, and `SERVER-NAME`. `shell(git:)` (colon = prefix, all subcommands), MCP as `MyMCP(create_issue)`. Comma-separate multiple in one flag. **`--deny-tool` always beats allow, even under `--allow-all`.** `--available-tools` removes tools from the set entirely (stronger than deny). `--allow-all-tools` (env `COPILOT_ALLOW_ALL`), `--allow-all`/`--yolo`.
+- **Persistent approvals:** `~/.copilot/permissions-config.json` (auto-managed per project — *not* for hand-editing). `~/.copilot/config.json` holds `trustedFolders` (path trust, not tool perms); `~/.copilot/settings.json` holds `allowedUrls`/`deniedUrls`/`disabledMcpServers`/`enabledMcpServers`. `preToolUse` hook can return `permissionDecision: allow|deny`.
+- **Docs:** [cli-command-reference](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-command-reference) · [allowing-tools](https://docs.github.com/en/copilot/how-tos/copilot-cli/use-copilot-cli/allowing-tools) · [add-mcp-servers](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-mcp-servers) · [config-dir-reference](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-config-dir-reference)
+
+## How `ap` renders a declared permission per harness (today)
+
+| Harness | Renderer behavior | Allow | Deny | File written |
+|---|---|:---:|:---:|---|
+| **Claude** (install) | `_write_settings` (`claude.py:472-484`) writes plugin-scoped `settings.json` `permissions.allow` if non-empty; live root `settings.json` merge never touches permissions | ✅ | ✗ | `.claude/plugins/local/<profile>/settings.json` |
+| **Claude** (isolated) | `overlay.py` ephemeral `settings.json` with `permissions.allow` **and** `permissions.deny`, paired with `--setting-sources ""` + `--tools` whitelist | ✅ | ✅ | ephemeral `settings.json` |
+| **opencode** | `_translate_permission` (`opencode.py:38-47`) maps only `Bash(cmd:*)` → `cmd *`; everything else passes through verbatim into `permission.bash` | ✅ (bash only) | ✗ | `opencode.json` `permission.bash` |
+| **Codex** | **zero** permission handling — renderer writes agents/skills/hooks/mcps only | ✗ | ✗ | — |
+| **Cursor** | declared perms **warned and dropped** (`cursor.py:117-124`, assumes "UI-only") | ✗ | ✗ | — |
+| **Copilot** | **silently skipped** (uses runtime `--deny-tool`, not config) | ✗ | ✗ | — |
+
+So a profile's `permissions_allow` only ever reaches **Claude** (full, both channels) and **opencode** (allow-only, bash-only). The other three drop it.
+
+## Planned fixes & remaining gaps
+
+1. **Cursor warn-and-drop → CLI render.** The renderer assumes UI-only — true for the *IDE*, but `cursor-agent` consumes declarative `permissions.allow`/`permissions.deny` from `~/.cursor/cli-config.json` with a token grammar near-identical to Claude's. Spec: **`.cheese/specs/ap-cursor-cli-permissions.md`** — adds `_write_cli_config`, translates Claude rules → Cursor tokens (`Bash(cmd:*)`→`Shell(cmd:)`, `Edit`→`Write`, `mcp__s__t`→`Mcp(s:t)`), merges like `.cursor/mcp.json`. Harmless if only the IDE is used (the file is read solely by the CLI), so safe to ship now.
+2. **opencode loses deny + non-bash perms.** `_translate_permission` only emits `permission.bash` allow entries, yet opencode natively supports `deny` and per-tool (`edit`/`read`/`webfetch`/MCP) permissions with last-match-wins. Spec: **`.cheese/specs/ap-opencode-permission-fidelity.md`** — adds a `settings.permissions_deny` parse channel and translates the full Claude vocabulary into opencode's per-tool `permission` map.
+3. **Shared dependency:** both specs need the new `settings.permissions_deny` union-merge in `parse.py` (today deny is top-level / isolated-claude-only). Land it once.
+4. **Claude `settings.permissions_deny` not consumed (future).** Once the parse channel exists, the claude install renderer could also write `permissions.deny` (it only writes `allow` today) — explicitly out of scope of the two specs, noted here so it isn't forgotten.
+5. **Codex/Copilot have no static config permission surface by design** — Codex gates via sandbox+approval (+`.rules` DSL), Copilot via runtime `--deny-tool`. Their "skip" is intentional. (Codex MCP `enabled_tools`/`disabled_tools` *is* renderable but `ap` doesn't emit it — a possible future.)
+
+## Provenance
+
+Native-model facts extracted via `/briesearch` (2026-06-02) from each vendor's official docs (URLs cited inline); the deep Cursor CLI grammar in `.cheese/research/harness-perms/cursor-cli-permissions.md`, other raw bodies under `.cheese/research/harness-perms/raw/`. `ap` mapping + the two specs grounded by reading `agent_profile/renderers/*.py` + `overlay.py` + `parse.py` (file:line in the specs).
+
+See also [[agent-profile]] · [[config-drift]] · [[../harnesses/claude]] · [[../harnesses/cursor]] · [[../harnesses/opencode]]

--- a/.hallouminate/wiki/architecture/index.md
+++ b/.hallouminate/wiki/architecture/index.md
@@ -4,7 +4,9 @@ How this dotfiles repo configures AI coding agents. The model is **one harness-a
 
 - [[agents-dir]] — the `agents/` registry system: MCP / hook / sub-agent / skill registries, the system-prompt body, and the shared cheese-flair assets. Declares *what* every agent gets.
 - [[agent-profile]] — the `ap` tool (`agent-profile/`): profiles (base / global / isolated), the five per-harness renderers, install vs launch, and the chezmoi drive path. Decides *where and in what shape*.
+- [[harness-permissions]] — each harness's native permission/tool-access model (Claude allow/deny/ask, Codex sandbox+approval+`.rules`, opencode `permission` object, Cursor IDE-UI-vs-CLI split, Copilot `tools` + `--deny-tool`), how `ap` maps profile-declared permissions onto each (only Claude gets full allow+deny; Codex/Cursor/Copilot drop it), and the two known gaps.
 - [[mcp-secret-handling]] — why MCP `${VAR}` env refs are passed through to each harness as a runtime placeholder (claude/copilot `${VAR}`, opencode `{env:VAR}`, cursor `envFile`) instead of baked as resolved secrets, and the ingest validation-vs-substitution split.
+- [[mcp-schema-loading]] — why the registry's `harnesses` field is a per-request token-budget lever, not just a compatibility flag: Claude Code lazy-loads MCP schemas (ToolSearch) but opencode / Codex / Cursor / Copilot eager-load every schema on every request. The worked example is scoping Todoist (62% of the footprint) out via `harnesses: []`.
 - [[config-drift]] — why live harness config drifts from the `ap` render (seed-once `create_` files nothing prunes), the three drift classes (stale remnant / dotfiles bug / expected local), and the `settings.json` hook self-heal behind `/harness-doctor`.
 - [[cross-harness-guards]] — the safety hooks (git-guard + the Claude-only pre-tool guards): one classifier, five harness adapters, fail-open, and why the dirty-check needs a plugin not a static deny.
 

--- a/.hallouminate/wiki/harnesses/cursor.md
+++ b/.hallouminate/wiki/harnesses/cursor.md
@@ -1,6 +1,6 @@
 # Cursor
 
-The Cursor AI code editor (cursor.com). Unlike the other four, Cursor is an **IDE plugin surface, not a CLI harness** — but it's a full `ap` render target (`renderers/cursor.py`) plus a chezmoi-deployed plugin tree, so it carries the same six capabilities. Docs root: [cursor.com/docs](https://cursor.com/docs).
+The Cursor AI code editor (cursor.com). Unlike the other four, Cursor is an **IDE plugin surface, not a CLI harness** — but it's a full `ap` render target (`renderers/cursor.py`) plus a chezmoi-deployed plugin tree, so it carries the same six capabilities. Docs root: [cursor.com/docs](https://cursor.com/docs). (It *does* also ship a `cursor-agent` CLI with its own declarative config — see the permissions note below — but the repo currently drives only the IDE plugin surface.)
 
 Two deploy paths feed Cursor:
 
@@ -15,19 +15,20 @@ Two deploy paths feed Cursor:
 | Sub-agents | [subagents](https://cursor.com/docs/context/subagents) | Cursor 2.x agents live in `.cursor/agents/` + `~/.cursor/agents/` (markdown + YAML: `name`, `description`, `model: inherit`, `readonly`, `is_background`). This repo currently deploys the legacy **custom-modes** surface (`modes/<name>.json` → merged into `~/.cursor/modes.json` under `.modes.<name>`). |
 | MCP | [mcp](https://cursor.com/docs/context/mcp) | `agents/mcp/registry.yaml` → `ap` cursor renderer writes `~/.cursor/mcp.json` via stdlib `json` (`mcpServers`). stdio / SSE / Streamable-HTTP transport; project `.cursor/mcp.json` vs global `~/.cursor/mcp.json` scope; `env` / `envFile` / `${env:NAME}` interpolation. |
 | Rules (system prompt) | [rules](https://cursor.com/docs/context/rules) | `cursor/plugins/local/<plugin>/rules/*.mdc` → `~/.cursor/rules/*.mdc`. Four rule types (Always / Apply Intelligently / Apply to Specific Files via glob / Apply Manually), `alwaysApply` / `description` / `globs` frontmatter, `AGENTS.md` support (incl. nested), precedence Team → Project → User. |
-| Settings / config | [plugin manifest](https://cursor.com/docs/plugins/building) · [permissions](https://cursor.com/docs/reference/permissions) | `.cursor-plugin/plugin.json` manifest (required `name`; optional `version`/`author`/`description` + component paths) drives folder-based auto-discovery. `permissions.json` holds auto-run allowlists. |
+| Settings / config | [cli permissions](https://cursor.com/docs/cli/reference/permissions) · [cli configuration](https://cursor.com/docs/cli/reference/configuration) | **Permissions are split** — see [[../architecture/harness-permissions]]. The **IDE** allowlist (Run Mode + command/MCP approval) is UI-only (Settings → Agents). The **`cursor-agent` CLI** is declarative: `~/.cursor/cli-config.json` (global: `version`, `editor.vimMode`, `permissions.allow`/`deny`) and project `<project>/.cursor/cli.json` (only `permissions`, precedence over global). Tokens: `Shell()`/`Read()`/`Write()`/`WebFetch()`/`Mcp()`; **deny wins**. `~/.cursor/sandbox.json` is a separate sandbox network/fs policy. `ap` does **not** render any of these today (warn-and-drop) — planned via `.cheese/specs/ap-cursor-cli-permissions.md`. |
 | Skills / commands | [skills](https://cursor.com/docs/skills) · [slash commands](https://cursor.com/docs/cli/reference/slash-commands) | `cursor/plugins/local/<plugin>/skills/<name>/SKILL.md` → `~/.cursor/skills/<name>/` (frontmatter `name` + `description`, optional `paths`). `commands/*.md` → `~/.cursor/commands/*.md` — **Cursor commands carry NO frontmatter**, unlike Claude. |
 
 ## Isolated settings
 
-Not available. Cursor is an IDE, not a launchable CLI — there are no closed-world launch flags; `ap` isolated launches are Claude-only.
+Not available. Cursor's IDE is not a launchable closed-world CLI — `ap` isolated launches are Claude-only. (The separate `cursor-agent` CLI has headless flags — `-p`/`--print`, `--force`, `--approve-mcps` — but `ap` doesn't drive it.)
 
 ## Quirks
 
 - **Canonical host is `cursor.com/docs`** — `docs.cursor.com/*` URLs redirect there. Cite the `cursor.com/docs` form.
+- **Permissions are not UI-only** — a long-standing assumption corrected: only the *IDE* allowlist is UI-only; the `cursor-agent` CLI reads a declarative `cli-config.json`. See [[../architecture/harness-permissions]] § Cursor.
 - **"Custom modes" is dead.** `cursor.com/docs/chat/custom-modes` 404s; the schema reference is now [Subagents](https://cursor.com/docs/context/subagents). The repo's `modes/<name>.json` deploy targets the legacy `~/.cursor/modes.json` surface — migrate to `.cursor/agents/` when convenient. `cursor.com/docs/agent/modes` documents only the built-in Plan Mode, not custom agents.
 - **Commands have no frontmatter** — a Cursor `commands/*.md` is plain markdown; a Claude command's YAML frontmatter must be stripped when porting.
 - **Skills + agents read cross-harness dirs.** Cursor discovers skills/agents from `.claude/` and `.codex/` trees too (with its own `.cursor/` taking precedence), so some shared dirs are picked up without a Cursor-specific copy.
 - Every Cursor doc page has a raw-markdown twin at `<url>.md` (e.g. `cursor.com/docs/hooks.md`) for unstyled source.
 
-See also [[index]] for the capability matrix and `AGENTS.md` § Cursor Plugins for the full deploy-target table. Wiring details: [[../architecture/agent-profile]].
+See also [[index]] for the capability matrix, [[../architecture/harness-permissions]] for the permission model, and `AGENTS.md` § Cursor Plugins for the full deploy-target table. Wiring details: [[../architecture/agent-profile]].

--- a/agents/preamble.md
+++ b/agents/preamble.md
@@ -4,6 +4,16 @@ Reinforces `~/.claude/CLAUDE.md`'s Code-Intelligence Routing section. That secti
 
 The `cheez-search` / `cheez-read` / `cheez-write` skills route through tilth — use them instead of host `Read` / `Edit` / `Write` / `Grep` whenever they're available.
 
+## Ground in the repo wiki (hallouminate) first
+
+If the hallouminate MCP is connected, **ground before you act and maintain before you stop** — the per-repo wiki holds the cross-session *why* (architecture rationale, gotchas, design decisions) that code and `git` can't tell you.
+
+- **At session start / before non-trivial work** — especially anything touching architecture, config, or unfamiliar subsystems — query the wiki first: `ground` (semantic search) or `list_tree` / `read_markdown`. Run `list_corpora` if unsure which wiki applies. This is a read; it costs little and routinely saves a re-derivation. Skip only for trivial one-step edits or when no `repo:<name>:wiki` corpus exists.
+- **Before each tool call, the self-check extends:** "Is the *why* behind this already written down?" If it's a design/rationale question, `ground` it before reading code blind.
+- **At session end** — when the session established a non-obvious fact, decision, or gotcha a future agent would otherwise re-learn, write it back via `add_markdown` (one topic per file, capture the *why* not the *what*, link related pages). Don't duplicate what the code or `AGENTS.md` already states.
+
+The wiki is the fast path to design rationale; `AGENTS.md` / `CLAUDE.md` is the command/structure reference. Use both.
+
 ## Serena mapping (symbol-level)
 
 | Task | Tool |


### PR DESCRIPTION
## What

Documents how each harness models tool/command permissions and how `ap` maps profile-declared permissions onto each — and makes the preamble ground in the repo wiki by default.

### Wiki
- **New** `architecture/harness-permissions.md` — cross-harness reference: per-harness native model (config surface, allow/deny/ask vocabulary, rule syntax, precedence) for Claude, Codex, opencode, Cursor, Copilot, plus the `ap` render mapping. Key facts:
  - `ap` has **no default permission set** — permissions are purely profile-declared; the effective default is the user's own live harness config.
  - Only **Claude** gets a full allow+deny surface; **opencode** gets allow-only/bash-only; **Codex/Cursor/Copilot** currently drop declared perms.
  - Linked from the architecture index.
- **Correct** `harnesses/cursor.md` — the long-standing "Cursor permissions are UI-only" claim was only half true. The IDE allowlist is UI-only, but the `cursor-agent` **CLI** is declarative (`~/.cursor/cli-config.json` `permissions.allow`/`deny`, with `Shell()/Read()/Write()/WebFetch()/Mcp()` tokens, deny-wins). Cell corrected and cross-linked.

### Preamble
- `agents/preamble.md` now opens with a standing rule to **ground in the hallouminate repo wiki** at session start / before non-trivial work, extends the pre-call self-check with "is the *why* already written down?", and to **maintain the wiki** at session end. Gated on the MCP being connected and a `repo:<name>:wiki` corpus existing.

## Follow-up (next session)
Two renderer gaps are documented with tabled specs under `.cheese/specs/` (local working tree, gitignored):
- `ap-opencode-permission-fidelity.md` — translate the full Claude rule vocabulary into opencode's per-tool `permission` map + add a `settings.permissions_deny` channel.
- `ap-cursor-cli-permissions.md` — render profile perms to `cursor-agent`'s `cli-config.json` instead of warn-and-drop.

Both depend on a shared `settings.permissions_deny` parse change. Implementation is the next session's work.

## Notes
- Docs-only + preamble; no renderer behavior changes in this PR.
- The preamble change reaches live harnesses on `dots sync` (renders via `install-prompts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)