### PR TITLE
perf(local-llm): tune Strix Point workers + cut MCP token footprint

### DIFF
--- a/.hallouminate/wiki/architecture/index.md
+++ b/.hallouminate/wiki/architecture/index.md
@@ -5,6 +5,7 @@ How this dotfiles repo configures AI coding agents. The model is **one harness-a
 - [[agents-dir]] — the `agents/` registry system: MCP / hook / sub-agent / skill registries, the system-prompt body, and the shared cheese-flair assets. Declares *what* every agent gets.
 - [[agent-profile]] — the `ap` tool (`agent-profile/`): profiles (base / global / isolated), the five per-harness renderers, install vs launch, and the chezmoi drive path. Decides *where and in what shape*.
 - [[mcp-secret-handling]] — why MCP `${VAR}` env refs are passed through to each harness as a runtime placeholder (claude/copilot `${VAR}`, opencode `{env:VAR}`, cursor `envFile`) instead of baked as resolved secrets, and the ingest validation-vs-substitution split.
+- [[mcp-schema-loading]] — why the registry's `harnesses` field is a per-request token-budget lever, not just a compatibility flag: Claude Code lazy-loads MCP schemas (ToolSearch) but opencode / Codex / Cursor / Copilot eager-load every schema on every request. The worked example is scoping Todoist (62% of the footprint) out via `harnesses: []`.
 - [[config-drift]] — why live harness config drifts from the `ap` render (seed-once `create_` files nothing prunes), the three drift classes (stale remnant / dotfiles bug / expected local), and the `settings.json` hook self-heal behind `/harness-doctor`.
 - [[cross-harness-guards]] — the safety hooks (git-guard + the Claude-only pre-tool guards): one classifier, five harness adapters, fail-open, and why the dirty-check needs a plugin not a static deny.
 

--- a/.hallouminate/wiki/architecture/mcp-schema-loading.md
+++ b/.hallouminate/wiki/architecture/mcp-schema-loading.md
@@ -1,0 +1,79 @@
+# MCP schema loading: the per-harness token tax
+
+The `harnesses` field on an `agents/mcp/registry.yaml` entry is not just a
+*compatibility* lever (does this MCP make sense here) — it is a **per-request
+token-budget** lever. The reason is that harnesses differ in *when* they send
+an MCP server's tool schemas to the model.
+
+## The split: Claude defers, everyone else eager-loads
+
+Measured + sourced 2026-06 (research artifacts under
+`.cheese/research/mcp-schema-loading/` and
+`.cheese/research/opencode-mcp-eager-load/`):
+
+| Harness | MCP tool-schema loading | Consequence |
+|---|---|---|
+| **Claude Code** | **Lazy / deferred by default** since v2.1.x (2026-01-14). Only tool *names* enter context at session start; full JSON schemas fetched on demand via `ToolSearch`. `ENABLE_TOOL_SEARCH` controls it (`true`/`false`/`auto`/`auto:N`); `alwaysLoad: true` opts a server out. Disabled on Vertex / non-first-party `ANTHROPIC_BASE_URL`. | A big MCP set costs ~names-only until used (~85% schema-token cut). |
+| **opencode** | **Eager** — `SessionTools.resolve` adds every connected server's `mcp.tools()` defs to the LLM tool array every turn. `tools:{x:false}` / `permission` blocks *execution*, **not** prompt injection. No ToolSearch equivalent (sst/opencode#23045). | Full schema cost every request. |
+| **Codex CLI** | **Eager** — lazy load is an open FR (#9266, #14507), unshipped. | Full schema cost every request. |
+| **Cursor** | **Eager** + hard 40-tool cap (tools 41+ silently dropped). | Full cost + invisible tools past 40. |
+| **Copilot CLI** | **Eager** — compaction-based context mgmt, no deferral. | Full cost; large sets trigger compaction loops. |
+
+**Claude Code is the outlier, not the norm.** The intuition "MCP tools are cheap
+because they load on demand" is *Claude-specific*. On the other four harnesses,
+every configured MCP tool schema is paid for on every single request whether or
+not the model ever calls it.
+
+## Why this drives registry membership
+
+Because four of the five render targets eager-load, an MCP that is irrelevant to
+coding is dead weight measured in tens of thousands of tokens *per request* on
+those harnesses. So the `harnesses` list is a budget decision: keep an MCP out
+of harnesses that would pay for schemas they never use.
+
+Measured tool-schema footprint of the full MCP set (~61k tokens / 112 tools):
+
+| MCP | tokens | share |
+|---|---|---|
+| todoist | ~38,000 | 62% |
+| code-review-graph | ~8,300 | 14% |
+| serena | ~5,400 | 9% |
+| tilth | ~3,500 | 6% |
+| hallouminate | ~2,300 | 4% |
+| tavily | ~2,100 | 3% |
+| context7 | ~1,200 | 2% |
+
+## The Todoist decision (worked example)
+
+Todoist alone is **62%** of the footprint and is irrelevant to coding. It is
+scoped out of every harness with an explicit empty membership list:
+
+```yaml
+todoist:
+  ...
+  harnesses: []   # renders into nothing
+```
+
+`harnesses: []` (empty, **not** absent) is the mechanism: in
+`agent-profile/agent_profile/renderers/base.py`, `item_harnesses` falls back to
+the default set (`_MCP_DEFAULT`) only when `harnesses` is *missing* (`None`); an
+explicit empty list projects to zero harnesses. The entry stays in the registry
+(documented, reversible) but renders nowhere.
+
+Todoist is not lost: the **`todo` profile** (`profiles/todo/profile.yaml`)
+defines it **inline** in its own `mcps:` block, independent of the registry
+default — so the closed-world productivity session still gets it while every
+coding harness sheds the 38k tokens.
+
+## Takeaways for future edits
+
+- Adding an MCP to the default `harnesses` set taxes opencode / codex / cursor /
+  copilot on **every request**, not just when used. Budget accordingly.
+- For an MCP that is only occasionally relevant, prefer scoping it to a dedicated
+  profile (inline `mcps:`) over the default set — see Todoist / [[agents-dir]].
+- Claude Code's lazy behavior can mask the cost — a set that feels free in Claude
+  may be expensive everywhere else.
+
+See [[agents-dir]] for the registry's `harnesses` field, [[agent-profile]] for
+how renderers project it per harness, and [[../harnesses/index]] for each
+harness's native config surface.

--- a/agents/mcp/registry.yaml
+++ b/agents/mcp/registry.yaml
@@ -74,6 +74,14 @@ mcps:
       TODOIST_API_KEY: "${TODOIST_API_KEY}"
     scope: user
     optional: true   # skip non-fatally when TODOIST_API_KEY is unset
+    # Scoped out of every harness: todoist's ~45 tools ≈ 38k tokens (62% of the
+    # MCP tool footprint) are eager-loaded into every request by opencode, codex,
+    # cursor, and copilot (only claude defers via ToolSearch — see
+    # .cheese/research/mcp-schema-loading). It is irrelevant to coding; the `todo`
+    # profile defines todoist inline, so productivity sessions still get it.
+    # Empty list (not absent) renders into nothing — base.py:item_harnesses only
+    # falls back to the default set when `harnesses` is missing.
+    harnesses: []
     description: Official Todoist MCP (Doist-maintained) — invoke only when explicitly requested
 
   code-review-graph:

--- a/chezmoi/dot_config/systemd/user/worker-coder.service
+++ b/chezmoi/dot_config/systemd/user/worker-coder.service
@@ -1,21 +1,23 @@
 [Unit]
 Description=Coder-tier worker (Qwen3-Coder-30B-A3B-Instruct on iGPU — displaces Sonnet)
-# Mutual exclusion with Sonnet (same iGPU slot, same arch)
-Conflicts=worker-igpu.service
+# Mutual exclusion with the other iGPU tiers (single iGPU slot — Sonnet + Opus)
+Conflicts=worker-igpu.service worker-opus.service
 ConditionPathExists=%h/local-llm/models/Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf
 
 [Service]
 Type=simple
-ExecStartPre=/bin/mkdir -p %h/local-llm/logs
+ExecStartPre=/bin/mkdir -p %h/local-llm/logs %h/local-llm/cache/slots
 Environment="LD_LIBRARY_PATH=%h/local-llm/bin/llama.cpp"
 ExecStart=%h/local-llm/bin/llama.cpp/llama-server \
   --model %h/local-llm/models/Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf \
   --host 127.0.0.1 --port 8085 \
-  --ctx-size 65536 \
-  --parallel 4 --cont-batching \
-  --batch-size 2048 --ubatch-size 512 \
+  --ctx-size 32768 \
+  --parallel 1 --cont-batching \
+  --batch-size 4096 --ubatch-size 2048 \
   --cache-type-k q8_0 --cache-type-v q8_0 \
   --n-gpu-layers 99 \
+  --flash-attn on \
+  --slot-save-path %h/local-llm/cache/slots \
   --alias local-coder \
   --log-file %h/local-llm/logs/worker-coder.log
 Restart=on-failure

--- a/chezmoi/dot_config/systemd/user/worker-cpu.service
+++ b/chezmoi/dot_config/systemd/user/worker-cpu.service
@@ -5,18 +5,19 @@ ConditionPathExists=%h/local-llm/models/Qwen3-8B-Q4_K_M.gguf
 
 [Service]
 Type=simple
-ExecStartPre=/bin/mkdir -p %h/local-llm/logs
+ExecStartPre=/bin/mkdir -p %h/local-llm/logs %h/local-llm/cache/slots
 Environment="LD_LIBRARY_PATH=%h/local-llm/bin/llama.cpp"
 # Pin to Zen 5c efficiency cores (4-11) + their SMT siblings (16-23) — leaves Zen 5 perf cores free for foreground
 ExecStart=/usr/bin/taskset -c 4-11,16-23 %h/local-llm/bin/llama.cpp/llama-server \
   --model %h/local-llm/models/Qwen3-8B-Q4_K_M.gguf \
   --host 127.0.0.1 --port 8081 \
   --ctx-size 16384 \
-  --parallel 4 --cont-batching \
-  --batch-size 1024 --ubatch-size 256 \
+  --parallel 1 --cont-batching \
+  --batch-size 2048 --ubatch-size 512 \
   --threads 12 \
   --device none \
   --reasoning off \
+  --slot-save-path %h/local-llm/cache/slots \
   --alias local-haiku \
   --log-file %h/local-llm/logs/worker-cpu.log
 Restart=on-failure

--- a/chezmoi/dot_config/systemd/user/worker-igpu.service
+++ b/chezmoi/dot_config/systemd/user/worker-igpu.service
@@ -5,16 +5,19 @@ ConditionPathExists=%h/local-llm/models/Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf
 
 [Service]
 Type=simple
-ExecStartPre=/bin/mkdir -p %h/local-llm/logs
+ExecStartPre=/bin/mkdir -p %h/local-llm/logs %h/local-llm/cache/slots
 Environment="LD_LIBRARY_PATH=%h/local-llm/bin/llama.cpp"
 ExecStart=%h/local-llm/bin/llama.cpp/llama-server \
   --model %h/local-llm/models/Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf \
   --host 127.0.0.1 --port 8080 \
-  --ctx-size 32768 \
-  --parallel 8 --cont-batching \
-  --batch-size 2048 --ubatch-size 512 \
+  --ctx-size 98304 \
+  --rope-scaling yarn --rope-scale 3.0 --yarn-orig-ctx 32768 \
+  --parallel 1 --cont-batching \
+  --batch-size 4096 --ubatch-size 2048 \
   --cache-type-k q8_0 --cache-type-v q8_0 \
   --n-gpu-layers 99 \
+  --flash-attn on \
+  --slot-save-path %h/local-llm/cache/slots \
   --alias local-sonnet \
   --log-file %h/local-llm/logs/worker-igpu.log
 Restart=on-failure

--- a/chezmoi/dot_config/systemd/user/worker-opus.service
+++ b/chezmoi/dot_config/systemd/user/worker-opus.service
@@ -1,21 +1,24 @@
 [Unit]
 Description=Opus-tier worker (Llama 3.3 70B on iGPU — displaces Sonnet)
-# Mutual exclusion with Sonnet — systemd stops worker-igpu when this starts
-Conflicts=worker-igpu.service
+# Mutual exclusion with the other iGPU tiers (single iGPU slot — Sonnet + Coder)
+Conflicts=worker-igpu.service worker-coder.service
 ConditionPathExists=%h/local-llm/models/Llama-3.3-70B-Instruct-Q4_K_M.gguf
 
 [Service]
 Type=simple
-ExecStartPre=/bin/mkdir -p %h/local-llm/logs
+ExecStartPre=/bin/mkdir -p %h/local-llm/logs %h/local-llm/cache/slots
 Environment="LD_LIBRARY_PATH=%h/local-llm/bin/llama.cpp"
 ExecStart=%h/local-llm/bin/llama.cpp/llama-server \
   --model %h/local-llm/models/Llama-3.3-70B-Instruct-Q4_K_M.gguf \
   --host 127.0.0.1 --port 8090 \
   --ctx-size 16384 \
   --parallel 1 --cont-batching \
-  --batch-size 1024 --ubatch-size 256 \
+  --batch-size 2048 --ubatch-size 512 \
   --cache-type-k q8_0 --cache-type-v q8_0 \
   --n-gpu-layers 99 \
+  --flash-attn on \
+  --no-mmap \
+  --slot-save-path %h/local-llm/cache/slots \
   --alias local-opus \
   --log-file %h/local-llm/logs/worker-opus.log
 Restart=on-failure


### PR DESCRIPTION
Two efficiency changes for the opt-in local-LLM stack on the Minisforum AI X1 Pro 370 (Ryzen AI 9 HX 370 / Radeon 890M gfx1150 / 64GB unified LPDDR5X).

## 1. Scope Todoist out of every harness (`perf(mcp)`)

Todoist's ~45 tools (~38k tokens) are **62% of the entire MCP schema footprint** and irrelevant to coding. Research (cited below) found that **only Claude Code lazy-loads MCP schemas** (ToolSearch, default since v2.1.x); **opencode, Codex, Cursor, and Copilot all eager-load every schema into every request**. So Todoist's 38k was being paid for on 4 of 5 harnesses, every turn.

Fix: `harnesses: []` on the registry entry renders it into zero harnesses (`base.py:item_harnesses` falls back to the default set only when the field is *absent*; an explicit empty list projects to nothing). The `todo` profile declares Todoist inline, so productivity sessions keep it.

Verified via staged `ap install base` render — Todoist absent from claude `.mcp.json`, codex `config.toml`, opencode `opencode.json`, cursor `mcp.json`, and copilot; opencode's MCP footprint drops ~61k → ~23k.

New architecture wiki page `mcp-schema-loading.md` documents the eager-vs-lazy split and the per-request token tax so future registry edits weigh the cost.

## 2. Tune llama.cpp worker units for Strix Point (`perf(local-llm)`)

Retune the systemd `--user` workers:
- **sonnet (igpu):** ctx 32768 → 98304 via YaRN (`--rope-scale 3.0 --yarn-orig-ctx 32768`); `--flash-attn on`; `-b 4096 -ub 2048`
- **coder:** ctx 65536 → 32768; `--flash-attn on`; mutually `Conflicts=` with opus
- **opus:** `--flash-attn on`; `--no-mmap`; mutually `Conflicts=` with coder (one iGPU slot can't hold both)
- **haiku (cpu):** `--parallel 1`; batch bump
- **all:** `--slot-save-path` for KV reuse

flash-attn ~doubled small-prompt prefill (30 → 63 tok/s).

## Notes
- `agent-profile` suite: 456 passed.
- Live apply is a separate step (`dots sync`); these are source-only changes.
- Follow-up (not in this PR): a lean opencode config (`OPENCODE_CONFIG` + per-server `enabled: false`) to fit the 32k `local-coder` window — research confirmed per-agent `tools:` filtering only gates *execution*, not schema injection, so the trim must use `enabled: false`, not a tools allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)