### PR TITLE
feat(local-llm): lean opencode MCP overlay for the 32k local-coder window

### DIFF
--- a/chezmoi/local-llm/README.md
+++ b/chezmoi/local-llm/README.md
@@ -56,7 +56,8 @@ llm-npu-on
 │   ├── llama.cpp/         # Vulkan-build llama-server (b9391)
 │   └── lemonade/          # Lemonade Server v10.6.0 (NPU)
 ├── configs/
-│   └── litellm.yaml
+│   ├── litellm.yaml
+│   └── lean.json             # opencode MCP overlay (see "Lean opencode runs" below)
 ├── logs/                  # all worker + LiteLLM logs
 ├── models/
 │   ├── Qwen3-30B-A3B-Instruct-2507-Q4_K_M.gguf
@@ -84,6 +85,23 @@ resp = client.chat.completions.create(
     messages=[{"role": "user", "content": "..."}],
 )
 ```
+
+## Lean opencode runs (fits the 32k `local-coder` window)
+
+opencode eager-loads every MCP tool schema into the prompt on every request, so
+the default MCP set crowds out the 32k window `local-coder` runs in. `configs/lean.json`
+is an `OPENCODE_CONFIG` overlay that disables the heavy non-coding servers
+(`code-review-graph`, `hallouminate`, `tavily`), keeping `tilth` + `serena` +
+`context7` for the coder.
+
+```bash
+opencode-lean --model local-coder      # OPENCODE_CONFIG=~/local-llm/configs/lean.json opencode
+```
+
+`OPENCODE_CONFIG` mergeDeeps onto the global `opencode.json` — the overlay is just the
+`enabled: false` lines, not a from-scratch config. Disabling a server is the only lever
+that stops schema injection; per-agent `tools:{x:false}` gates execution but still ships
+the schema tokens. (Todoist is already disabled globally, so the overlay omits it.)
 
 ## Fallbacks (in `litellm.yaml`)
 

--- a/chezmoi/local-llm/configs/lean.json
+++ b/chezmoi/local-llm/configs/lean.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "code-review-graph": { "enabled": false },
+    "hallouminate": { "enabled": false },
+    "tavily": { "enabled": false }
+  }
+}

--- a/chezmoi/local-llm/scripts/executable_aliases.sh
+++ b/chezmoi/local-llm/scripts/executable_aliases.sh
@@ -30,6 +30,14 @@ alias llm-health='~/local-llm/scripts/healthcheck.sh'
 # On-demand model download (never run by dots sync; idempotent).
 alias llm-download='~/local-llm/scripts/download-models.sh'
 
+# Launch opencode with the lean MCP overlay so the 32k local-coder window fits.
+# OPENCODE_CONFIG mergeDeeps onto the global config — the overlay only disables
+# the heavy non-coding servers (code-review-graph, hallouminate, tavily), leaving
+# tilth + serena + context7 for the coder. Usage: opencode-lean --model local-coder
+opencode-lean() {
+  OPENCODE_CONFIG="$HOME/local-llm/configs/lean.json" opencode "$@"
+}
+
 # Quick chat helper — usage: llm-chat local-sonnet "your prompt"
 llm-chat() {
   local model="${1:-local-sonnet}"; shift

--- a/tests/local-llm.bats
+++ b/tests/local-llm.bats
@@ -14,6 +14,8 @@ load test_helper
 
 LIB="$REAL_DOTFILES_DIR/chezmoi/lib/install-local-llm.sh"
 HEALTH="$REAL_DOTFILES_DIR/chezmoi/local-llm/scripts/executable_healthcheck.sh"
+ALIASES="$REAL_DOTFILES_DIR/chezmoi/local-llm/scripts/executable_aliases.sh"
+LEAN="$REAL_DOTFILES_DIR/chezmoi/local-llm/configs/lean.json"
 
 setup() {
     setup_test_env
@@ -169,4 +171,80 @@ teardown() {
     FAKE_ACTIVE="" run llm_quick_check
     assert_success
     assert_output_contains "not running"
+}
+
+# ─── lean opencode overlay (fits the 32k local-coder window) ──────────────────
+#
+# OPENCODE_CONFIG mergeDeeps onto the global config — it does NOT replace it — so
+# the overlay is just the `enabled: false` lines for the heavy non-coding MCP
+# servers. Disabling a server is the ONLY lever that stops schema injection;
+# per-agent `tools:{x:false}` gates execution but still ships the schema tokens.
+
+@test "lean.json is valid JSON and disables exactly the heavy MCP servers" {
+    run jq -e . "$LEAN"
+    assert_success
+
+    for server in code-review-graph hallouminate tavily; do
+        run jq -e --arg s "$server" '.mcp[$s].enabled == false' "$LEAN"
+        assert_success
+    done
+
+    # Exclusivity: exactly those three — no accidental extra disable slips in.
+    run jq -e '.mcp | keys | length == 3' "$LEAN"
+    assert_success
+}
+
+@test "lean.json leaves the coding MCP servers untouched (absent = stays enabled)" {
+    # mergeDeep semantics: only the keys the overlay names change. tilth, serena,
+    # and context7 must NOT appear, or the overlay would strip the coder's own
+    # tools out of the window it is meant to protect.
+    for server in tilth serena context7; do
+        run jq -r --arg s "$server" '.mcp | has($s)' "$LEAN"
+        assert_output_contains "false"
+    done
+}
+
+@test "every server lean.json disables is a real opencode-loaded MCP (catches registry rename drift)" {
+    # The overlay only saves tokens if its keys match opencode's actual MCP server
+    # names. A rename in agents/mcp/registry.yaml that isn't mirrored here makes the
+    # overlay a silent no-op: the 32k window blows out with no error. Tie the
+    # disabled keys to the registry source of truth so that drift fails loudly.
+    local registry="$REAL_DOTFILES_DIR/agents/mcp/registry.yaml"
+
+    # Servers the registry renders into opencode: harnesses absent (default = all
+    # harnesses) or explicitly listing opencode. `// ["opencode"]` substitutes the
+    # default only when the field is null/absent; an explicit `[]` (e.g. todoist)
+    # stays empty and is correctly excluded.
+    local opencode_servers
+    opencode_servers=$(yq -r \
+      '.mcps | to_entries | map(select((.value.harnesses // ["opencode"]) | contains(["opencode"]))) | .[].key' \
+      "$registry")
+
+    local disabled
+    disabled=$(jq -r '.mcp | keys | .[]' "$LEAN")
+    [ -n "$disabled" ]
+
+    local s
+    for s in $disabled; do
+        echo "$opencode_servers" | grep -qx "$s" || {
+            echo "lean.json disables '$s' — not an opencode-loaded MCP in registry.yaml"
+            return 1
+        }
+    done
+}
+
+@test "opencode-lean points OPENCODE_CONFIG at the deployed lean.json and forwards args" {
+    cat > "$MOCK_BIN/opencode" << 'MOCK'
+#!/bin/bash
+echo "CONFIG=$OPENCODE_CONFIG"
+echo "ARGS=$*"
+MOCK
+    chmod +x "$MOCK_BIN/opencode"
+
+    # shellcheck disable=SC1090
+    source "$ALIASES"
+    run opencode-lean --model local-coder
+    assert_success
+    assert_output_contains "CONFIG=$HOME/local-llm/configs/lean.json"
+    assert_output_contains "ARGS=--model local-coder"
 }


### PR DESCRIPTION
## What

Adds a chezmoi-managed `OPENCODE_CONFIG` overlay so opencode fits the 32k `local-coder` window on the local-LLM stack.

opencode eager-loads every MCP tool schema into the prompt on every request (unlike Claude Code's lazy ToolSearch), so the default MCP set crowds out the 32k window. `configs/lean.json` disables the heavy non-coding servers — `code-review-graph`, `hallouminate`, `tavily` — keeping `tilth` + `serena` + `context7` for the coder.

## Changes

- **`chezmoi/local-llm/configs/lean.json`** (new) — overlay setting `mcp.{code-review-graph,hallouminate,tavily}.enabled: false`. Deploys to `~/local-llm/configs/lean.json` alongside `litellm.yaml`.
- **`chezmoi/local-llm/scripts/executable_aliases.sh`** — `opencode-lean()` launch function: `OPENCODE_CONFIG=~/local-llm/configs/lean.json opencode "$@"`.
- **`chezmoi/local-llm/README.md`** — "Lean opencode runs" section + file-tree entry.
- **`tests/local-llm.bats`** — 4 tests, including one that ties the disabled keys to `agents/mcp/registry.yaml` so a server rename that silently no-ops the overlay fails loudly.

## Mechanism

`OPENCODE_CONFIG` mergeDeeps onto the global `opencode.json` — the overlay is only the `enabled: false` lines, not a from-scratch config. Disabling a server is the only lever that stops schema injection; per-agent `tools:{x:false}` gates execution but still ships the schema tokens. Todoist is already disabled globally (#258), so the overlay omits it.

## Tests

`bats tests/local-llm.bats` — 16/16 pass (the registry-drift test was red/green-verified).

## Follow-up (not in this PR)

- Live apply pending: `dots sync` deploys the overlay + alias.
- Smoke test pending: `opencode-lean --model local-coder` against the running stack, and whether the minimal-tools config clears the opencode `failed to parse grammar` error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)