### PR TITLE
fix(harness-doctor): codex prompt root-key + per-harness MCP reconcile (#262, #265)

### DIFF
--- a/agent-profile/agent_profile/cli.py
+++ b/agent-profile/agent_profile/cli.py
@@ -28,7 +28,11 @@ import yaml
 from agent_profile import discover, manifest as manifest_mod
 from agent_profile.manifest import ManifestCorrupt
 from agent_profile.parse import ParseError, parse_manifest
-from agent_profile.renderers.base import MergedConfigError, Renderer
+from agent_profile.renderers.base import (
+    MergedConfigError,
+    Renderer,
+    includes_harness,
+)
 
 ALL_HARNESSES = ["claude", "codex", "opencode", "cursor", "copilot"]
 
@@ -304,32 +308,53 @@ def _reconcile_dropped_mcps(
     out: Any,
     colors: Any,
 ) -> None:
-    """Evict MCP servers that fell out of the registry since the last install.
+    """Evict MCP servers that fell out of a harness since the last install.
 
     Renderers MERGE MCPs into persistent/user-owned files (codex config.toml,
     opencode/cursor/copilot JSON, claude user-scope ~/.claude.json), so a
-    server dropped from the registry lingers — render only writes the current
-    set. Diff the prior resolved manifest against the current one and have
-    each in-scope renderer prune the dropped servers. No prior install, or
-    nothing dropped → no-op (keeps fresh renders byte-identical)."""
+    server that stops rendering into a harness lingers — render only writes
+    the current set. A server is "dropped" from a harness either by leaving
+    the registry entirely OR by losing that harness from its membership (e.g.
+    ``harnesses: []`` scopes it out of every harness while it stays in the
+    manifest). Both must be reconciled, so the diff is computed per-harness
+    using the same membership projection render uses (:func:`includes_harness`
+    with each renderer's MCP default) rather than against the global manifest —
+    otherwise a server still present in ``manifest.mcps`` but scoped out of a
+    harness would never be pruned from it. No prior install, or nothing dropped
+    → no-op (keeps fresh renders byte-identical)."""
     if not prior_merged:
         return
-    current_names = {m.get("name") for m in manifest.mcps}
-    dropped = [
-        m
-        for m in (prior_merged.get("mcps") or [])
-        if m.get("name") not in current_names
-    ]
-    if not dropped:
+    prior_mcps = prior_merged.get("mcps") or []
+    if not prior_mcps:
         return
 
-    dropped_manifest = replace(manifest, mcps=dropped)
+    current_by_name = {m.get("name"): m for m in manifest.mcps}
+    pruned: set[str] = set()
     for h in harnesses:
         renderer = RENDERERS.get(h)
-        if renderer is not None:
-            renderer.prune_mcps(dropped_manifest, target)
+        if renderer is None:
+            continue
+        default = renderer.mcp_default
+        current_for_h = {
+            name
+            for name, m in current_by_name.items()
+            if includes_harness(m, h, default)
+        }
+        dropped_h = [
+            m
+            for m in prior_mcps
+            if includes_harness(m, h, default)
+            and m.get("name") not in current_for_h
+        ]
+        if not dropped_h:
+            continue
+        renderer.prune_mcps(replace(manifest, mcps=dropped_h), target)
+        pruned.update(str(m.get("name", "?")) for m in dropped_h)
 
-    names = ", ".join(sorted(str(m.get("name", "?")) for m in dropped))
+    if not pruned:
+        return
+
+    names = ", ".join(sorted(pruned))
     print(f"  {colors.BLUE}↺ pruned dropped MCP(s): {names}{colors.NC}", file=out)
 
 

--- a/agent-profile/agent_profile/renderers/base.py
+++ b/agent-profile/agent_profile/renderers/base.py
@@ -71,6 +71,7 @@ class Renderer(Protocol):
     """The contract every harness renderer satisfies. See module docstring."""
 
     name: str
+    mcp_default: tuple[str, ...]
 
     def render(self, manifest: Manifest, target: Path) -> list[str]:
         """Write artefacts under ``target``; return relative paths written."""

--- a/agent-profile/agent_profile/renderers/claude.py
+++ b/agent-profile/agent_profile/renderers/claude.py
@@ -81,6 +81,7 @@ class ClaudeRenderer:
     """Renderer for the Claude Code native-plugin layout. See module docstring."""
 
     name = "claude"
+    mcp_default = _MCP_DEFAULT
 
     def render(self, manifest: Manifest, target: Path) -> list[str]:
         out: list[str] = []

--- a/agent-profile/agent_profile/renderers/codex.py
+++ b/agent-profile/agent_profile/renderers/codex.py
@@ -82,6 +82,7 @@ class CodexRenderer:
     :class:`~agent_profile.renderers.base.Renderer` protocol."""
 
     name = "codex"
+    mcp_default = _CODEX_MCP_DEFAULT
 
     def render(self, manifest: Manifest, target: Path) -> list[str]:
         out_files: list[str] = []

--- a/agent-profile/agent_profile/renderers/copilot.py
+++ b/agent-profile/agent_profile/renderers/copilot.py
@@ -137,6 +137,7 @@ class CopilotRenderer:
     """Renderer for the Copilot CLI harness. See module docstring."""
 
     name = "copilot"
+    mcp_default = _COPILOT_MCP_DEFAULT
 
     def render(self, manifest: Manifest, target: Path) -> list[str]:
         out_files: list[str] = []

--- a/agent-profile/agent_profile/renderers/cursor.py
+++ b/agent-profile/agent_profile/renderers/cursor.py
@@ -71,6 +71,7 @@ class CursorRenderer:
     """Render a resolved manifest into Cursor's ``.cursor/`` layout."""
 
     name = "cursor"
+    mcp_default = _CURSOR_MCP_DEFAULT
 
     def render(self, manifest: Manifest, target: Path) -> list[str]:
         out: list[str] = []

--- a/agent-profile/agent_profile/renderers/opencode.py
+++ b/agent-profile/agent_profile/renderers/opencode.py
@@ -96,6 +96,7 @@ class OpencodeRenderer:
     surgically un-merged in :meth:`clean`."""
 
     name = "opencode"
+    mcp_default = _OPENCODE_MCP_DEFAULT
 
     def render(self, manifest: Manifest, target: Path) -> list[str]:
         """Render opencode's native subagent files (``<target>/agents/``) and

--- a/agent-profile/tests/conftest.py
+++ b/agent-profile/tests/conftest.py
@@ -87,6 +87,7 @@ class StubRenderer:
 
     def __init__(self, name: str):
         self.name = name
+        self.mcp_default = tuple(ALL_HARNESSES)
 
     def _merged_path(self, target: Path) -> Path:
         return Path(str(target).rstrip("/")) / f"{self.name}.json"

--- a/agent-profile/tests/test_mcp_reconcile.py
+++ b/agent-profile/tests/test_mcp_reconcile.py
@@ -211,3 +211,51 @@ def test_claude_prune_noop_for_plugin_scope(monkeypatch, tmp_path):
         # default mcp_scope (not "user") → plugin .mcp.json is whole-file
     )
     cl.ClaudeRenderer().prune_mcps(dropped, tmp_path)  # must be a no-op
+
+
+# ─── regression: an MCP scoped out of a harness must be pruned (#265) ─────────
+
+
+def _yaml_scoped(name: str, specs: dict[str, list[str]]) -> str:
+    """Profile YAML with an explicit per-MCP ``harnesses`` list."""
+    lines = [f"name: {name}", "description: reconcile probe", "mcps:"]
+    for n, harnesses in specs.items():
+        lines += [
+            f"  - name: {n}",
+            "    command: /bin/true",
+            "    args: [--flag]",
+            f"    harnesses: {json.dumps(harnesses)}",
+        ]
+    return "\n".join(lines) + "\n"
+
+
+def test_mcp_scoped_to_no_harnesses_is_pruned(env, capsys, prod_renderers):
+    # srv1 + srv2 both render into the merge-target harnesses.
+    write_profile(env.profiles, "p", _yaml("p", ["srv1", "srv2"]))
+    assert _install(env, "p") == 0
+    capsys.readouterr()
+    t = env.target
+    cur = json.loads((t / ".cursor/mcp.json").read_text())["mcpServers"]
+    assert "srv2" in cur  # precondition: srv2 was rendered into cursor
+
+    # Re-install with srv2 scoped OUT of every harness (harnesses: []). It stays
+    # in manifest.mcps but should no longer render anywhere — the reconcile must
+    # evict the stale entry a prior render merged into cursor/copilot. The bug:
+    # current_names was global, so srv2 (still in manifest.mcps) never dropped.
+    write_profile(
+        env.profiles,
+        "p",
+        _yaml_scoped(
+            "p",
+            {"srv1": ["codex", "opencode", "cursor", "copilot"], "srv2": []},
+        ),
+    )
+    assert _install(env, "p") == 0
+    capsys.readouterr()
+
+    cur = json.loads((t / ".cursor/mcp.json").read_text())["mcpServers"]
+    assert "srv2" not in cur, "srv2 scoped to harnesses:[] must be pruned from cursor"
+    assert "srv1" in cur, "survivor srv1 must stay"
+
+    cop = json.loads((t / ".copilot/mcp-config.json").read_text())["mcpServers"]
+    assert "srv2" not in cop, "srv2 scoped to harnesses:[] must be pruned from copilot"

--- a/chezmoi/lib/install-prompts.sh
+++ b/chezmoi/lib/install-prompts.sh
@@ -75,11 +75,23 @@ install_prompts_wire_codex() {
     local current
     current="$(yq -p=toml '.model_instructions_file // ""' "$codex_config" 2>/dev/null || true)"
     if [[ "$current" != "$codex_prompt" ]]; then
-        # Pass the path via env so a quote/backslash in $codex_prompt can't
-        # escape into the yq filter and corrupt the file.
-        CODEX_PROMPT_PATH="$codex_prompt" \
-            yq -p=toml -o=toml -i '.model_instructions_file = strenv(CODEX_PROMPT_PATH)' \
-            "$codex_config"
+        # yq -i appends a new root key at the END of the document, so it lands
+        # inside whatever [table] sits at the bottom of config.toml (codex
+        # auto-adds [tui.*] there). A root key after a table header belongs to
+        # that table, so Codex can't read it as model_instructions_file, the
+        # guard above re-reads "" every run, and duplicates accumulate (#262).
+        # Instead: drop any existing model_instructions_file line(s) — including
+        # a misplaced or duplicated one — and prepend the key at the very top,
+        # before any [section] header, where Codex reads it as a root key.
+        local escaped tmp
+        escaped="${codex_prompt//\\/\\\\}"   # backslash -> \\  for the TOML string
+        escaped="${escaped//\"/\\\"}"         # "        -> \"
+        tmp="$(mktemp)"
+        {
+            printf 'model_instructions_file = "%s"\n' "$escaped"
+            grep -v '^[[:space:]]*model_instructions_file[[:space:]]*=' "$codex_config" || true
+        } >"$tmp"
+        mv "$tmp" "$codex_config"
         echo "  Set model_instructions_file in $codex_config"
     fi
 }

--- a/tests/install-prompts.bats
+++ b/tests/install-prompts.bats
@@ -147,3 +147,44 @@ TOML
     assert_file_exists "$OPENCODE_HOME/agents/build.md"
     grep -q "model_instructions_file" "$CODEX_HOME/config.toml"
 }
+
+# ── regression: model_instructions_file must stay a root-level key (#262) ─────
+
+@test "install-prompts.sh keeps model_instructions_file at root when config.toml ends with a [section]" {
+    mkdir -p "$CODEX_HOME"
+    cat > "$CODEX_HOME/config.toml" <<'TOML'
+approval_policy = "on-request"
+
+[tui.model_availability_nux]
+seen = true
+TOML
+    INSTALL_PROMPTS_HAVE_CODEX=1 INSTALL_PROMPTS_HAVE_OPENCODE=0 INSTALL_PROMPTS_HAVE_YQ=1 \
+        run bash "$LIB" "$PREAMBLE_SRC"
+    assert_success
+    # Codex reads model_instructions_file as a ROOT key. The old yq -i append
+    # dropped it inside the trailing [tui.*] table, so the root read returned "".
+    local root_path nested_path seen_val
+    root_path="$(yq -p=toml '.model_instructions_file // ""' "$CODEX_HOME/config.toml")"
+    nested_path="$(yq -p=toml '.tui.model_availability_nux.model_instructions_file // ""' "$CODEX_HOME/config.toml")"
+    seen_val="$(yq -p=toml '.tui.model_availability_nux.seen' "$CODEX_HOME/config.toml")"
+    # Single compound assertion so ANY mismatch fails the test (bats checks only
+    # the final command's status): root key set, not nested in [tui.*], table kept.
+    [[ "$root_path" == "$CODEX_HOME/preamble.md" ]] \
+        && [[ "$nested_path" == "" ]] \
+        && [[ "$seen_val" == "true" ]]
+}
+
+@test "install-prompts.sh does not accumulate duplicate model_instructions_file across runs with a trailing [section]" {
+    mkdir -p "$CODEX_HOME"
+    cat > "$CODEX_HOME/config.toml" <<'TOML'
+approval_policy = "on-request"
+
+[tui.model_availability_nux]
+seen = true
+TOML
+    for _ in 1 2 3; do
+        INSTALL_PROMPTS_HAVE_CODEX=1 INSTALL_PROMPTS_HAVE_OPENCODE=0 INSTALL_PROMPTS_HAVE_YQ=1 \
+            bash "$LIB" "$PREAMBLE_SRC"
+    done
+    [[ "$(grep -c 'model_instructions_file' "$CODEX_HOME/config.toml")" -eq 1 ]]
+}


### PR DESCRIPTION
Two `/harness-doctor`-filed bugs, each with a regression test written first (red) then a minimal fix (green).

## #262 — codex `model_instructions_file` written inside `[tui.*]`
`chezmoi/lib/install-prompts.sh` set the key with `yq -p=toml -o=toml -i '.model_instructions_file = ...'`. yq appends a new root key at the **end** of the document, so it landed inside the trailing `[tui.model_availability_nux]` table codex auto-adds. A root key after a table header belongs to that table → Codex never read it as `model_instructions_file`, the idempotence guard re-read `""` every run, and duplicate keys accumulated.

**Fix:** strip any existing `model_instructions_file` line(s) and prepend the key at the very top, before any `[section]` header. Also self-heals a config already corrupted by the old append (collapses duplicates to one correct root key).

## #265 — `_reconcile_dropped_mcps` missed MCPs scoped out of a harness
`current_names` was built from the full `manifest.mcps`, so an MCP still present in the manifest but scoped out of a harness (`harnesses: []`, or a harness-exclusive list) never appeared in `dropped` — its stale entry lingered in `~/.cursor/mcp.json` / copilot's merged config indefinitely.

**Fix:** compute the dropped set **per-harness** via `includes_harness` + each renderer's MCP default (now exposed as `Renderer.mcp_default`). A server is pruned from a harness when it leaves the registry **or** loses that harness from its membership. (copilot's default excludes copilot itself, so a single global default would have been wrong — hence per-renderer defaults.)

## Not included — #263 (moshi-hook macOS path)
#263 isn't a debuggable bug — it needs a **decision**: install `moshi-hook` via brew and point the registry at the macOS path, or disable the moshi hooks on this Mac. Left out of this PR pending that call.

## Test plan
- `bats tests/install-prompts.bats` → 14/14 green (2 new #262 regression tests; the placement test uses a single compound assertion so a mid-body failure can't be masked by bats' last-command-only status)
- `uv run pytest` in `agent-profile/` → reconcile + all five renderer + stub-CLI suites green (1 new #265 test asserting prune from cursor **and** copilot)
- Verified the #262 fix heals an already-duplicated config down to one correct root key

> **Pre-existing, unrelated:** 7 failures in `test_canonical_permissions.py` / `test_global_profile.py` assert `chezmoi/dot_claude/create_settings.json` carries no permission lists, but it does. Confirmed they fail identically on `origin/main` (stashed these changes and re-ran) — not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)