### PR TITLE
fix(setup-perms): keep committed overlay path-agnostic, route destructive rules local

### DIFF
--- a/.hallouminate/wiki/architecture/harness-permissions.md
+++ b/.hallouminate/wiki/architecture/harness-permissions.md
@@ -150,6 +150,13 @@ A `--harness` value resolving to neither claude nor codex errors loudly — it i
 
 The repo's general rule is "never commit rendered artifacts." The project overlay is the deliberate exception: the rendered `<repo>/.claude/settings.json` and `<repo>/.codex/` files are consumed by Claude / Codex *in that downstream repo*, and committing them is the point — zero-friction permissions for teammates who clone it. The *source* (`.agent-profiles/_permissions/profile.yaml`) is committed too; re-rendering is idempotent, so there is no drift class here to self-heal.
 
+### Committed overlay is path-agnostic; destructive rules go local `<certain>`
+
+The committed surface (fragment + rendered `settings.json` + `.codex/`) carries only portable, path-free rules. Destructive commands scoped to the project root (`Bash(mkdir /abs/path/*)` …) embed the clone's absolute path — committing them would bake one machine's path (and username) into every clone, where the rule silently matches nothing. `/setup-perms` therefore merges the destructive set into the gitignored `.claude/settings.local.json` instead; Claude unions allow rules across scopes, so committed-portable + local-destructive compose at runtime. Two consequences to know:
+
+- **Codex never receives destructive path rules** — it has no personal-layer analog (`ap perms --local` skips it), so Codex prompts for destructive commands. Expected, not a renderer gap.
+- **`ap perms --local` owns `settings.local.json`'s `permissions.{allow,deny}` wholesale** — a bare re-render replaces them with just the fragment's portable set, dropping the merged destructive layer (and any hand-curated entries). Re-run `/setup-perms --local` to restore. This overwrite-ownership is the documented semantics, not a bug.
+
 ## Planned fixes & remaining gaps
 
 1. **Cursor warn-and-drop → CLI render.** The renderer assumes UI-only — true for the *IDE*, but `cursor-agent` consumes declarative `permissions.allow`/`deny` from `~/.cursor/cli-config.json`. Spec: **`.cheese/specs/ap-cursor-cli-permissions.md`** — adds `_write_cli_config`, translates Claude rules → Cursor tokens (`Bash(cmd:*)`→`Shell(cmd:)`, `Edit`→`Write`, `mcp__s__t`→`Mcp(s:t)`). Harmless if only the IDE is used (the file is read solely by the CLI). Unblocked by #259's parse channel; not yet cooked.

--- a/claude/commands/setup-perms.md
+++ b/claude/commands/setup-perms.md
@@ -1,21 +1,33 @@
 ---
 name: setup-perms
-description: Scaffold canonical repo-level permissions for this project (committed .claude/settings.json + .codex/ via ap perms). Pass --local for the gitignored personal layer.
+description: Scaffold canonical repo-level permissions for this project — portable rules go to the committed fragment + ap perms render; path-scoped destructive rules go to the gitignored .claude/settings.local.json. Pass --local to keep everything personal.
 allowed-tools: Read, Write, Bash, Glob
 ---
 
 # Setup Project Permissions
 
-Scaffold or update `.agent-profiles/_permissions/profile.yaml` with sensible
-permissions for this project, then render the committed project config via
-`ap perms`.
+Scaffold or update `.agent-profiles/_permissions/profile.yaml` with portable
+permissions for this project, render the committed project config via
+`ap perms`, then merge machine-specific destructive rules into the gitignored
+`.claude/settings.local.json`.
 
-Pass `--local` to write the personal gitignored layer
-(`.claude/settings.local.json`) instead of the committed files.
+Two layers, split by portability:
+
+- **Committed (portable):** safe, path-free rules — the fragment plus the
+  `ap perms` render. Identical on every clone; absolute paths and usernames
+  never reach version control.
+- **Local (machine-specific):** destructive commands scoped to this clone's
+  absolute project root — written only to `.claude/settings.local.json`
+  (gitignored).
+
+Pass `--local` to skip the committed render and write both rule sets to the
+personal gitignored layer.
 
 ## Instructions
 
-1. **Detect project type** by checking for these indicator files in the project root:
+### 1. Detect project type
+
+Check for these indicator files in the project root:
 
 | Indicator | Project Type |
 |-----------|-------------|
@@ -28,24 +40,17 @@ Pass `--local` to write the personal gitignored layer
 
 A project can match multiple types (polyglot). If none match, use base permissions only.
 
-1. **Determine the project root** using the current working directory. This path is
-   used to scope destructive commands. Refer to it as `$PWD` below.
+### 2. Build the two rule sets
 
-   **IMPORTANT:** Replace `$PWD` with the actual absolute path in the output
-   (e.g. `/Users/paulsorensen/Dev/myproject`). Do NOT leave `$PWD` as a literal string.
-
-2. **Build the allow/deny lists** by combining layers. Start with the base layer,
-   then add each detected type's layer.
-
-Commands are split into two categories:
-
-- **Safe (read-only / non-destructive):** unscoped, can run anywhere
-- **Destructive (writes / moves / deletes):** scoped to `$PWD/*` so they only work inside the project
+**Committed, portable set** — safe (read-only / non-destructive) commands,
+unscoped. Combine the base layer with each detected type's layer. This set is
+committed (fragment + rendered `settings.json` + `.codex/`), so it MUST stay
+path-free: never include an absolute path, a `$PWD` substitution, or anything
+machine-specific.
 
 **Base (always included):**
 
 ```
-# Safe — unscoped
 Bash(git:*)
 Bash(ls:*)
 Bash(cat:*)
@@ -64,15 +69,6 @@ Bash([:*)
 Bash(true)
 Bash(false)
 Bash(gh:*)
-
-# Destructive — scoped to project
-Bash(mkdir $PWD/*)
-Bash(mv $PWD/*)
-Bash(cp $PWD/*)
-Bash(chmod $PWD/*)
-Bash(sed $PWD/*)
-Bash(awk $PWD/*)
-Bash(xargs $PWD/*)
 
 # MCP & web
 WebSearch
@@ -149,20 +145,39 @@ Bash(gem:*)
 Bash(rake:*)
 ```
 
-1. **Write `.agent-profiles/_permissions/profile.yaml`** with the computed
-   allow/deny set using the canonical grammar. Create the directory if it does not
-   exist. Overwrite the entire `permissions` block on re-run — do NOT merge with
-   old accumulated permissions. Example:
+**Local destructive set** — write/move/delete commands scoped to the project
+root so they only run inside this clone. These embed the absolute path, so
+they are machine-specific by construction and go ONLY to the gitignored
+`.claude/settings.local.json` — never the fragment, never the committed
+`settings.json`:
+
+```
+Bash(mkdir <abs-project-root>/*)
+Bash(mv <abs-project-root>/*)
+Bash(cp <abs-project-root>/*)
+Bash(chmod <abs-project-root>/*)
+Bash(sed <abs-project-root>/*)
+Bash(awk <abs-project-root>/*)
+Bash(xargs <abs-project-root>/*)
+```
+
+Replace `<abs-project-root>` with the real absolute path of the current
+working directory (e.g. `/Users/you/Dev/myproject`). The substitution is safe
+here precisely because the target file is gitignored.
+
+### 3. Write the committed fragment
+
+Write `.agent-profiles/_permissions/profile.yaml` with ONLY the portable set,
+using the canonical grammar. Create the directory if it does not exist.
+Overwrite the entire `permissions` block on re-run — do NOT merge with old
+accumulated permissions. Sort the allow list alphabetically. Example:
 
 ```yaml
 name: _permissions
 settings:
   permissions_allow:
     - Bash([:*)
-    - Bash(awk $PWD/*)
     - Bash(cat:*)
-    - Bash(chmod $PWD/*)
-    - Bash(cp $PWD/*)
     - Bash(diff:*)
     - Bash(echo:*)
     - Bash(false)
@@ -172,9 +187,6 @@ settings:
     - Bash(grep:*)
     - Bash(head:*)
     - Bash(ls:*)
-    - Bash(mkdir $PWD/*)
-    - Bash(mv $PWD/*)
-    - Bash(sed $PWD/*)
     - Bash(sort:*)
     - Bash(tail:*)
     - Bash(test:*)
@@ -182,30 +194,42 @@ settings:
     - Bash(true)
     - Bash(wc:*)
     - Bash(which:*)
-    - Bash(xargs $PWD/*)
     - WebSearch
   permissions_deny: []
 ```
 
-   Replace `$PWD` with the actual absolute path. Sort the allow list alphabetically.
+No absolute paths, no `$PWD` — if a rule needs the project path, it belongs in
+the local destructive set (step 5), not here.
 
-1. **Run `ap perms`** to render the canonical project config:
+### 4. Render with ap perms
 
-   - Default (committed files): `ap perms --target $PWD`
-   - With `--local` passthrough (personal, gitignored): `ap perms --local --target $PWD`
+- Default (committed files): `ap perms --target "$(pwd)"`
+- Under `--local` (personal, gitignored): `ap perms --local --target "$(pwd)"`
 
-   This writes:
-   - **Claude** → `$PWD/.claude/settings.json` (or `settings.local.json` under `--local`)
-   - **Codex** → `$PWD/.codex/rules/ap-canonical.rules` + `$PWD/.codex/config.toml`
-     tool scopes (skipped under `--local`)
+This writes:
 
-2. **Print a summary** like:
+- **Claude** → `.claude/settings.json` (or `settings.local.json` under `--local`)
+- **Codex** → `.codex/rules/ap-canonical.rules` + `.codex/config.toml`
+  tool scopes (skipped under `--local`)
+
+### 5. Merge the local destructive set into settings.local.json
+
+Read `.claude/settings.local.json` if it exists (create it otherwise) and
+union the destructive rules into `permissions.allow`: keep every existing
+entry, dedupe, sort alphabetically, and preserve all sibling keys. Never
+remove entries you did not add.
+
+Ordering under `--local`: run `ap perms --local` (step 4) FIRST, then this
+merge — `ap perms` owns `permissions.{allow,deny}` wholesale and would drop
+rules merged before it ran.
+
+### 6. Print a summary
 
 ```
 Detected: dotfiles, python
-Permissions: 45 rules (base: 27, dotfiles: 16, python: 6)
-Wrote: .agent-profiles/_permissions/profile.yaml
-Rendered: .claude/settings.json, .codex/rules/ap-canonical.rules
+Committed (portable): 38 rules → .agent-profiles/_permissions/profile.yaml,
+  .claude/settings.json, .codex/rules/ap-canonical.rules
+Local (destructive): 7 rules → .claude/settings.local.json
 ```
 
 ## Codex trust note
@@ -216,8 +240,20 @@ the Codex TUI or CLI. This is expected behavior — not a bug in the overlay.
 
 ## Important
 
-- Overwrite the entire `permissions` block in `profile.yaml` on re-run — do NOT merge with old accumulated permissions
-- Sort the allow list alphabetically for readability
-- The `deny` array should always be empty unless explicitly requested (hooks handle blocking)
-- Under `--local`, the committed `settings.json` is NOT written; only `settings.local.json`
-- The `profile.yaml` fragment is committed to the repo; `settings.local.json` is gitignored
+- The committed fragment and `settings.json` must never contain absolute
+  paths or `$PWD` substitutions — portability across clones and machines is
+  the contract. Path-scoped rules live only in `settings.local.json`.
+- Codex gets no destructive path rules: it has no personal-layer analog
+  (`ap perms --local` skips it), so Codex prompts for destructive commands.
+  Expected, not a gap to fix here.
+- Overwrite the entire `permissions` block in `profile.yaml` on re-run — do
+  NOT merge with old accumulated permissions. For `settings.local.json` the
+  opposite holds: merge additively, never drop entries you did not write.
+- A bare `ap perms --local` re-render overwrites `permissions.{allow,deny}`
+  in `settings.local.json` with just the portable set, dropping the merged
+  destructive rules — re-run `/setup-perms --local` to restore them.
+- Sort allow lists alphabetically for readability.
+- The `deny` array should always be empty unless explicitly requested (hooks
+  handle blocking).
+- The `profile.yaml` fragment is committed to the repo; `settings.local.json`
+  is gitignored.


### PR DESCRIPTION
Follow-up to #272 (landed after its squash-merge — cherry-picked from the now-dead `claude/dots` branch).

Resolves the high-severity portability finding from #272's review pass: the `/setup-perms` skill instructed substituting the literal absolute project path (including the username) into **committed** permission rules — baking one machine's path into the fragment, `settings.json`, and `.codex` rules, where it leaks into VCS and silently matches nothing on any other clone.

**Change — split the rule set by portability:**

- **Committed** (fragment + `ap perms` render): portable, path-free rules only; absolute paths / `$PWD` substitution now explicitly forbidden there.
- **Local** (`.claude/settings.local.json`, gitignored): the path-scoped destructive set (`mkdir/mv/cp/chmod/sed/awk/xargs`), merged additively after the render. Claude unions allow rules across scopes, so the layers compose at runtime.

Also documents the two consequences (in the skill + wiki):

1. Codex receives no destructive path rules (no personal-layer analog; `ap perms --local` skips it) — it prompts for those.
2. A bare `ap perms --local` re-render owns `permissions.{allow,deny}` wholesale and drops the merged local layer — re-run `/setup-perms --local` to restore. This closes the open design-intent question from the #272 review as documented ownership semantics.

Instructions restructured under `###` step headings (also removes the MD029 ordered-list fragmentation from the earlier lint autofix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)