### PR TITLE
fix(hooks): allow cheese durable-corpus writes in worktrees

### DIFF
--- a/claude/hooks/worktree-guard.js
+++ b/claude/hooks/worktree-guard.js
@@ -6,7 +6,8 @@
 // Enforced by default in a worktree (opt-out):
 //   CLAUDE_WORKTREE_GUARD=0|false|off|no   → disable entirely
 // Allowed-path escape hatch (writable even outside the worktree):
-//   built-in: worktree root, $TMPDIR, /tmp, ~/.claude/, any .cheese/ dir
+//   built-in: worktree root, $TMPDIR, /tmp, ~/.claude/, any .cheese/ dir,
+//             ${XDG_DATA_HOME:-~/.local/share}/cheese/ (durable corpus)
 //   extra:    CLAUDE_WORKTREE_GUARD_ALLOW=/abs/prefix,/another  (comma-separated)
 
 const { execSync } = require('child_process');
@@ -43,6 +44,10 @@ function allowedPrefixes(worktreeRoot) {
   const prefixes = [worktreeRoot];
   const home = process.env.HOME || '';
   if (home) prefixes.push(path.join(home, '.claude'));
+  // Cheese durable corpus (specs, rfds, reports, research) — the /mold and
+  // /cheese artifact resolvers write here (see issue #270).
+  const dataHome = process.env.XDG_DATA_HOME || (home && path.join(home, '.local', 'share'));
+  if (dataHome) prefixes.push(path.join(dataHome, 'cheese'));
   const tmp = process.env.TMPDIR;
   if (tmp) prefixes.push(tmp.replace(/\/$/, ''));
   const extra = (process.env.CLAUDE_WORKTREE_GUARD_ALLOW || '')
@@ -96,6 +101,7 @@ In a worktree, writes are scoped to:
 - $TMPDIR, /tmp (scratch)
 - ~/.claude/ (memories, specs)
 - any .cheese/ dir (specs, rfds, reports)
+- \${XDG_DATA_HOME:-~/.local/share}/cheese/ (durable corpus)
 - CLAUDE_WORKTREE_GUARD_ALLOW prefixes
 
 Disable this guard: export CLAUDE_WORKTREE_GUARD=0

--- a/tests/hooks-blockers.bats
+++ b/tests/hooks-blockers.bats
@@ -675,6 +675,112 @@ teardown() {
     [[ "$output" == "allowed" ]]
 }
 
+@test "worktree-guard: write to cheese durable corpus under HOME is allowed" {
+    mkdir -p "$TEST_HOME/main"
+    (
+        cd "$TEST_HOME/main"
+        GIT_TEMPLATE_DIR="" git init -q 2>/dev/null
+        git config user.email "t@e"
+        git config user.name "t"
+        echo "x" > f.txt && git add f.txt && git commit -qm "x" 2>/dev/null
+    ) 2>/dev/null
+    cd "$TEST_HOME/main"
+    git worktree add ../wt -b wtbranch 2>/dev/null || skip "git worktree unavailable"
+    # Non-/tmp HOME: a /tmp-rooted home would be allowed via the scratch rule,
+    # masking the corpus logic. Path need not exist — the matcher classifies it.
+    local corpus_path="/wt-guard-home/.local/share/cheese/proj/specs/slug.md"
+    HOME="/wt-guard-home" XDG_DATA_HOME="" run_hook_event "$HOOKS_DIR/worktree-guard.js" Write "{\"file_path\":\"$corpus_path\",\"new_string\":\"x\"}" "$TEST_HOME/wt"
+    [ "$status" -eq 0 ]
+    if [[ "$output" == *"couldn't create cache file"* ]]; then
+        skip "git xcrun permissions (sandbox issue)"
+    fi
+    [[ "$output" == "allowed" ]]
+}
+
+@test "worktree-guard: write to cheese durable corpus under XDG_DATA_HOME is allowed" {
+    mkdir -p "$TEST_HOME/main"
+    (
+        cd "$TEST_HOME/main"
+        GIT_TEMPLATE_DIR="" git init -q 2>/dev/null
+        git config user.email "t@e"
+        git config user.name "t"
+        echo "x" > f.txt && git add f.txt && git commit -qm "x" 2>/dev/null
+    ) 2>/dev/null
+    cd "$TEST_HOME/main"
+    git worktree add ../wt -b wtbranch 2>/dev/null || skip "git worktree unavailable"
+    # XDG_DATA_HOME overrides ~/.local/share as the corpus root.
+    local corpus_path="/wt-guard-xdg/cheese/proj/rfds/slug.md"
+    HOME="/wt-guard-home" XDG_DATA_HOME="/wt-guard-xdg" run_hook_event "$HOOKS_DIR/worktree-guard.js" Write "{\"file_path\":\"$corpus_path\",\"new_string\":\"x\"}" "$TEST_HOME/wt"
+    [ "$status" -eq 0 ]
+    if [[ "$output" == *"couldn't create cache file"* ]]; then
+        skip "git xcrun permissions (sandbox issue)"
+    fi
+    [[ "$output" == "allowed" ]]
+}
+
+@test "worktree-guard: non-cheese sibling under data home is still blocked" {
+    mkdir -p "$TEST_HOME/main"
+    (
+        cd "$TEST_HOME/main"
+        GIT_TEMPLATE_DIR="" git init -q 2>/dev/null
+        git config user.email "t@e"
+        git config user.name "t"
+        echo "x" > f.txt && git add f.txt && git commit -qm "x" 2>/dev/null
+    ) 2>/dev/null
+    cd "$TEST_HOME/main"
+    git worktree add ../wt -b wtbranch 2>/dev/null || skip "git worktree unavailable"
+    # The carve-out is cheese-only — a sibling app dir must stay blocked.
+    local sibling_path="/wt-guard-home/.local/share/other-app/file.txt"
+    HOME="/wt-guard-home" XDG_DATA_HOME="" run_hook_event "$HOOKS_DIR/worktree-guard.js" Write "{\"file_path\":\"$sibling_path\",\"new_string\":\"x\"}" "$TEST_HOME/wt"
+    [ "$status" -eq 0 ]
+    if [[ "$output" == *"couldn't create cache file"* ]]; then
+        skip "git xcrun permissions (sandbox issue)"
+    fi
+    [[ "$output" == blocked:* ]]
+}
+
+@test "worktree-guard: cheese prefix-sneak sibling (cheesecake) is blocked" {
+    mkdir -p "$TEST_HOME/main"
+    (
+        cd "$TEST_HOME/main"
+        GIT_TEMPLATE_DIR="" git init -q 2>/dev/null
+        git config user.email "t@e"
+        git config user.name "t"
+        echo "x" > f.txt && git add f.txt && git commit -qm "x" 2>/dev/null
+    ) 2>/dev/null
+    cd "$TEST_HOME/main"
+    git worktree add ../wt -b wtbranch 2>/dev/null || skip "git worktree unavailable"
+    # startsWith must match the prefix as a path segment, not a string prefix.
+    local sneak_path="/wt-guard-home/.local/share/cheesecake/x.txt"
+    HOME="/wt-guard-home" XDG_DATA_HOME="" run_hook_event "$HOOKS_DIR/worktree-guard.js" Write "{\"file_path\":\"$sneak_path\",\"new_string\":\"x\"}" "$TEST_HOME/wt"
+    [ "$status" -eq 0 ]
+    if [[ "$output" == *"couldn't create cache file"* ]]; then
+        skip "git xcrun permissions (sandbox issue)"
+    fi
+    [[ "$output" == blocked:* ]]
+}
+
+@test "worktree-guard: traversal out of cheese corpus (..) is blocked" {
+    mkdir -p "$TEST_HOME/main"
+    (
+        cd "$TEST_HOME/main"
+        GIT_TEMPLATE_DIR="" git init -q 2>/dev/null
+        git config user.email "t@e"
+        git config user.name "t"
+        echo "x" > f.txt && git add f.txt && git commit -qm "x" 2>/dev/null
+    ) 2>/dev/null
+    cd "$TEST_HOME/main"
+    git worktree add ../wt -b wtbranch 2>/dev/null || skip "git worktree unavailable"
+    # path.resolve must normalize .. before the prefix check.
+    local escape_path="/wt-guard-home/.local/share/cheese/../other-app/x.txt"
+    HOME="/wt-guard-home" XDG_DATA_HOME="" run_hook_event "$HOOKS_DIR/worktree-guard.js" Write "{\"file_path\":\"$escape_path\",\"new_string\":\"x\"}" "$TEST_HOME/wt"
+    [ "$status" -eq 0 ]
+    if [[ "$output" == *"couldn't create cache file"* ]]; then
+        skip "git xcrun permissions (sandbox issue)"
+    fi
+    [[ "$output" == blocked:* ]]
+}
+
 # ── auto-format.js ───────────────────────────────────────────────────
 
 @test "auto-format: exits 0 on non-file-editing tool (Bash)" {


### PR DESCRIPTION
## Summary

`worktree-guard.js` blocked writes to the cheese durable-corpus root (`${XDG_DATA_HOME:-~/.local/share}/cheese/`) — the exact path the `/mold` / `/cheese` spec resolver emits — so every durable spec write inside a Conductor worktree failed and silently fell back to repo-local `.cheese/specs/`, diverging artifact locations and hiding specs from `/cheese --continue`.

Closes #270. Refs #269 (the MCP tool-surface audit this bug was blocking).

## Fix

Issue #270 **option 1**: teach the guard the resolver's real output path.

- `allowedPrefixes()` now includes `${XDG_DATA_HOME:-$HOME/.local/share}/cheese` (XDG-aware; fails closed when `HOME` is unset or `XDG_DATA_HOME` is relative).
- Header comment and block-message text updated to advertise the corpus path, per the issue's notes.

Option 2 (per-subtree narrowing) was rejected: the artifact subtree list would drift just like the allowlist did — this bug *is* allowlist/resolver drift. Option 3 (resolver-side) lives in a different repo and loses durability.

## Tests

5 new `tests/hooks-blockers.bats` cases (repo convention for guard behavior), the first two watched red before the fix:

- corpus write under `HOME` allowed
- corpus write under `XDG_DATA_HOME` allowed
- non-cheese sibling under the data home still blocked
- `cheesecake` prefix-sneak sibling still blocked
- `cheese/../other-app` traversal escape still blocked

All use a non-`/tmp` fake home so the always-allowed scratch rule can't mask the corpus logic.

`bats tests/hooks-blockers.bats`: 84/84 green (re-verified on this rebased head). Full suite: 4 pre-existing failures (chezmoi-wiring/dots), reproduced identically with this change stashed.

## Follow-up (not in this PR)

The guard allowlist (this repo) and the resolver path scheme (`~/.claude/skills/`) have no shared contract — they drifted once and can again. A single source of truth for artifact roots is worth considering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)