### PR TITLE
fix(ccw-sweep): make --auto non-interactive; read branch from worktree HEAD

### DIFF
--- a/bin/ccw-sweep
+++ b/bin/ccw-sweep
@@ -4,7 +4,7 @@
 # Usage:
 #   ccw-sweep              Interactive sweep with safety checks
 #   ccw-sweep --dry-run    Preview what would be cleaned (no changes)
-#   ccw-sweep --auto       Auto-remove safe worktrees (merged + clean), prompt for others
+#   ccw-sweep --auto       Auto-remove safe worktrees (merged + clean), skip others
 #   ccw-sweep --path DIR   Scan a specific directory instead of ~/Dev
 
 set -euo pipefail
@@ -36,7 +36,7 @@ while [[ $# -gt 0 ]]; do
             echo ""
             echo "Options:"
             echo "  --dry-run   Preview what would be cleaned (no changes)"
-            echo "  --auto      Auto-remove safe worktrees, prompt for others"
+            echo "  --auto      Auto-remove safe worktrees, skip WARN/DIRTY ones"
             echo "  --path DIR  Scan DIR instead of ~/Dev"
             exit 0 ;;
         *) echo "Unknown option: $1" >&2; exit 1 ;;
@@ -91,7 +91,11 @@ check_worktree() {
     local default_branch="$3"
     local slug
     slug="$(basename "$wt_path")"
-    local branch="claude/${slug}"
+    # The worktree's actual branch, read from its HEAD. Never derive it from
+    # the directory name — guessing "claude/<slug>" flagged real branches as
+    # "branch not found" whenever the dir name didn't match the branch name.
+    local branch
+    branch="$(git -C "$wt_path" symbolic-ref --short --quiet HEAD 2>/dev/null || true)"
     local default_remote="origin/${default_branch}"
 
     local status="SAFE"
@@ -127,11 +131,11 @@ check_worktree() {
         reasons+=("${count} untracked file(s)")
     fi
 
-    # Check if branch ref exists
+    # Empty branch = detached HEAD (symbolic-ref resolves nothing)
     local branch_exists=true
-    if ! git -C "$repo_root" rev-parse --verify "$branch" &>/dev/null; then
+    if [[ -z "$branch" ]]; then
         branch_exists=false
-        reasons+=("branch not found")
+        reasons+=("detached HEAD")
     fi
 
     # Determine merge status — always check the worktree's actual content
@@ -264,11 +268,15 @@ check_worktree() {
             [[ "$answer" =~ ^[Yy] ]] && should_remove=true
         fi
     elif [[ "$status" == "WARN" ]]; then
-        read -rp "         Remove anyway? [y/N] " answer </dev/tty
-        [[ "$answer" =~ ^[Yy] ]] && should_remove=true
+        if ! $AUTO_CLEAN; then
+            read -rp "         Remove anyway? [y/N] " answer </dev/tty
+            [[ "$answer" =~ ^[Yy] ]] && should_remove=true
+        fi
     else
-        read -rp "         Has uncommitted work. Remove? [y/N] " answer </dev/tty
-        [[ "$answer" =~ ^[Yy] ]] && should_remove=true
+        if ! $AUTO_CLEAN; then
+            read -rp "         Has uncommitted work. Remove? [y/N] " answer </dev/tty
+            [[ "$answer" =~ ^[Yy] ]] && should_remove=true
+        fi
     fi
 
     if $should_remove; then

--- a/tests/ccw-sweep.bats
+++ b/tests/ccw-sweep.bats
@@ -353,3 +353,66 @@ teardown() {
   assert_not_contains "[SAFE]"
   assert_not_contains "[WARN]"
 }
+
+# ── Regression: --auto must never prompt ──────────────────────────────
+# --auto used to fall through to `read … </dev/tty` for WARN/DIRTY
+# worktrees, crashing in non-interactive sessions (no TTY → unbound
+# variable under set -u) before any later SAFE worktree was reached.
+# --auto now skips non-SAFE worktrees outright.
+
+@test "auto skips WARN worktrees without prompting" {
+  create_repo "$SCAN/repo"
+  add_diverged_worktree "$SCAN/repo" "diverged"
+  add_safe_worktree "$SCAN/repo" "clean"
+
+  run ccw-sweep --auto --path "$SCAN"
+  assert_success
+  assert_contains "Removed: 1"
+  assert_contains "Skipped: 1"
+  [[ -d "$SCAN/repo/.worktrees/diverged" ]] || {
+    echo "WARN worktree was removed under --auto"
+    return 1
+  }
+}
+
+@test "auto skips DIRTY worktrees without prompting" {
+  create_repo "$SCAN/repo"
+  add_safe_worktree "$SCAN/repo" "dirty"
+  echo "wip" >> "$SCAN/repo/.worktrees/dirty/README.md"
+
+  run ccw-sweep --auto --path "$SCAN"
+  assert_success
+  assert_contains "Skipped: 1"
+  [[ -d "$SCAN/repo/.worktrees/dirty" ]] || {
+    echo "DIRTY worktree was removed under --auto"
+    return 1
+  }
+}
+
+# ── Regression: branch read from worktree HEAD, not dir name ──────────
+# The branch used to be guessed as claude/<dir-name>, so a worktree on a
+# differently-named branch was flagged "branch not found" and its
+# branch-based checks (merged-list, PR lookup) ran against a nonexistent ref.
+
+@test "reads worktree branch from HEAD when dir name differs" {
+  create_repo "$SCAN/repo"
+  mkdir -p "$SCAN/repo/.worktrees"
+  git -C "$SCAN/repo" worktree add "$SCAN/repo/.worktrees/short-name" \
+    -b "feat/completely-different" --quiet 2>/dev/null
+
+  run ccw-sweep --dry-run --path "$SCAN"
+  assert_success
+  assert_not_contains "branch not found"
+  assert_contains "[SAFE]"
+}
+
+@test "flags detached-HEAD worktree as such" {
+  create_repo "$SCAN/repo"
+  mkdir -p "$SCAN/repo/.worktrees"
+  git -C "$SCAN/repo" worktree add --detach "$SCAN/repo/.worktrees/loose" --quiet 2>/dev/null
+
+  run ccw-sweep --dry-run --path "$SCAN"
+  assert_success
+  assert_contains "detached HEAD"
+  assert_not_contains "branch not found"
+}


### PR DESCRIPTION
## Summary

Two `ccw-sweep` bugs found during a real sweep:

1. **`--auto` prompted on WARN/DIRTY worktrees** via `read … </dev/tty`, crashing in non-interactive sessions (no TTY → `unbound variable` under `set -u`) before any later SAFE worktree was processed. `--auto` now skips non-SAFE worktrees, matching its documented "auto-remove safe ones" contract. Usage/help text updated to say "skip" instead of "prompt".

2. **Branch guessed from directory name** (`claude/<slug>`) instead of read from the worktree's HEAD — any worktree on a differently-named branch (e.g. `.worktrees/ap-opencode-perms` on `feat/ap-opencode-permission-fidelity`) was falsely flagged "branch not found", and the merged-branch + `gh pr list --head` checks ran against a nonexistent ref, degrading merge detection to the rev-list fallback. Now reads `git symbolic-ref --short HEAD` from the worktree; empty (detached HEAD) is reported as such.

## Verification

- 4 regression tests added to `tests/ccw-sweep.bats`; watched red against the pre-fix script (`branch not found` on a real branch; detached-HEAD mislabel), 22/22 green after.
- `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)