### PR TITLE
fix(hooks): make moshi-hook commands portable and provision the mac binary

### DIFF
--- a/agents/hooks/registry.yaml
+++ b/agents/hooks/registry.yaml
@@ -107,38 +107,37 @@ hooks:
   # session-start, prompt, turn-end, and approval events to the phone
   # so the user can babysit the agent remotely.
   #
-  # Wire format captured from `moshi-hook install` (v0.2.8 on linux). The
-  # single quotes around the absolute path are Moshi's own choice — they
-  # let the path tolerate whitespace in $HOME, preserved verbatim.
-  #
-  # Linux-only path: on macOS via brew, moshi-hook lives at
-  # /opt/homebrew/bin/moshi-hook — port this entry when adding the Mac.
+  # Bare `moshi-hook`, resolved from PATH at hook time. The binary lives at
+  # ~/.local/bin (Moshi's own installer, linux) or /opt/homebrew/bin (brew
+  # via packages.yaml, macOS). Never hardcode a machine-specific absolute
+  # path here — the original wire format captured from `moshi-hook install`
+  # on linux broke every Claude session on macOS (issue #263).
   # claude-only: codex bridge ships via ~/.codex/hooks.json (different
   # surface), out of scope here.
   moshi-session-start:
     event: SessionStart
-    command: "'/home/paul/.local/bin/moshi-hook' claude-hook"
+    command: "moshi-hook claude-hook"
     async: true
     harnesses: [claude]
     description: Moshi bridge — session-start notification to phone
 
   moshi-user-prompt-submit:
     event: UserPromptSubmit
-    command: "'/home/paul/.local/bin/moshi-hook' claude-hook"
+    command: "moshi-hook claude-hook"
     async: true
     harnesses: [claude]
     description: Moshi bridge — prompt-submit notification to phone
 
   moshi-stop:
     event: Stop
-    command: "'/home/paul/.local/bin/moshi-hook' claude-hook"
+    command: "moshi-hook claude-hook"
     async: true
     harnesses: [claude]
     description: Moshi bridge — turn-end notification to phone
 
   moshi-permission-request:
     event: PermissionRequest
-    command: "'/home/paul/.local/bin/moshi-hook' claude-hook"
+    command: "moshi-hook claude-hook"
     async: false
     timeout: 300
     harnesses: [claude]

--- a/packages/packages.yaml
+++ b/packages/packages.yaml
@@ -75,6 +75,7 @@ packages:
   - cursor: { source: cask, platform: mac }    # Cursor — AI code editor
   - cursor-cli: { source: cask, platform: mac } # Cursor CLI — command-line agent (cursor-agent)
   - obsidian: { source: cask, platform: mac }  # Obsidian — Markdown knowledge base
+  - rjyo/moshi/moshi-hook: { platform: mac }   # Moshi phone bridge (agents/hooks/registry.yaml); linux uses Moshi's own installer (~/.local/bin)
 
   # Linux-only
   - xclip: { platform: linux }

--- a/packages/sync.sh
+++ b/packages/sync.sh
@@ -115,7 +115,10 @@ brew_install_pkgs() {
     echo -e "\n${GREEN}${label}:${NC}"
     while IFS= read -r pkg; do
         [[ -z "$pkg" ]] && continue
-        if echo "$installed" | grep -qx "$pkg"; then
+        # Tap-qualified keys (user/tap/formula) install under their short
+        # name — `brew list` prints `moshi-hook`, not `rjyo/moshi/moshi-hook` —
+        # so compare by the path tail.
+        if echo "$installed" | grep -qx "${pkg##*/}"; then
             echo "  + $pkg"
         else
             echo "  Installing $pkg..."

--- a/tests/agents-hooks-sync.bats
+++ b/tests/agents-hooks-sync.bats
@@ -83,6 +83,46 @@ teardown() {
     [[ "$(jq -r 'has("sensitive-file-guard")' <<<"$x")" == "true" ]]
 }
 
+@test "registry command entries carry no machine-specific absolute paths" {
+    # Issue #263: the moshi hooks hardcoded '/home/paul/.local/bin/moshi-hook',
+    # so all four fired against a nonexistent path every session on macOS.
+    # command: entries must be PATH-resolved (bare) or platform-neutral —
+    # never /home/* or /Users/*.
+    local cmds
+    cmds=$(yq -r '.hooks[] | select(has("command")) | .command' "$REGISTRY_FILE")
+    run grep -E '(/home/|/Users/)' <<<"$cmds"
+    if [[ "$status" -eq 0 ]]; then
+        echo "machine-specific paths in registry commands:" >&2
+        echo "$output" >&2
+        return 1
+    fi
+}
+
+@test "moshi registry entries are portable, claude-only, and complete" {
+    local entry name
+    for name in moshi-session-start moshi-user-prompt-submit moshi-stop moshi-permission-request; do
+        entry=$(yq -o=json ".hooks.\"$name\"" "$REGISTRY_FILE")
+        [[ "$(jq -r '.command' <<<"$entry")" == "moshi-hook claude-hook" ]]
+        [[ "$(jq -r '.harnesses | length' <<<"$entry")" == "1" ]]
+        [[ "$(jq -r '.harnesses[0]' <<<"$entry")" == "claude" ]]
+    done
+    # Synchronous approval hook keeps its 5-minute phone-reach window.
+    entry=$(yq -o=json '.hooks."moshi-permission-request"' "$REGISTRY_FILE")
+    [[ "$(jq -r '.async' <<<"$entry")" == "false" ]]
+    [[ "$(jq -r '.timeout' <<<"$entry")" == "300" ]]
+}
+
+@test "macOS gets the moshi-hook binary via packages.yaml" {
+    # Issue #263, second half: a portable command still fails if the binary
+    # is never provisioned. The registry's moshi hooks rely on the brew
+    # package on the Mac (linux uses Moshi's own installer to ~/.local/bin).
+    local entry
+    entry=$(yq -o=json '.packages[] | select(kind == "map") | to_entries[0] | select(.key == "rjyo/moshi/moshi-hook")' \
+        "$REAL_DOTFILES_DIR/packages/packages.yaml")
+    [[ -n "$entry" ]]
+    [[ "$(jq -r '.value.platform' <<<"$entry")" == "mac" ]]
+}
+
 @test "sensitive-file-guard renders a runnable bash command under both harnesses" {
     local sc sx
     sc=$(hook_desired_signature sensitive-file-guard claude)

--- a/tests/packages.bats
+++ b/tests/packages.bats
@@ -283,6 +283,27 @@ run_sync() {
     grep -q "brew install jq" "$BREW_LOG"
 }
 
+@test "sync skips already-installed tap-qualified packages by short name" {
+    [[ "$(uname)" == "Darwin" ]] || skip "macOS only (sync_brew not invoked on Linux)"
+
+    # brew list --formulae prints short names; the installed-check must
+    # compare a tap-qualified key (rjyo/moshi/moshi-hook) by its tail or
+    # it reinstalls on every sync.
+    cat > "$PACKAGES_FILE" << 'YAML'
+packages:
+  - rjyo/moshi/moshi-hook: { platform: mac }
+YAML
+    write_mock_brew "moshi-hook"
+
+    run_sync
+    assert_success
+
+    # Positive control: the entry was considered and skipped as installed,
+    # not silently dropped by platform/source filtering.
+    assert_output_contains "+ rjyo/moshi/moshi-hook"
+    ! grep -q "brew install rjyo/moshi/moshi-hook" "$BREW_LOG"
+}
+
 @test "sync installs cargo packages" {
     write_test_yaml
     run_sync


### PR DESCRIPTION
## Summary

The four moshi hooks in `agents/hooks/registry.yaml` hardcoded the Linux path `'/home/paul/.local/bin/moshi-hook'`, so every Claude session on macOS fired SessionStart / UserPromptSubmit / Stop / PermissionRequest against a nonexistent binary. The renderer copies `command:` entries verbatim by design, and moshi-hook was never declared in `packages.yaml`, so the Mac had no binary to point at either.

Fixes #263

## Changes

- **registry** — all four moshi `command:` entries become bare PATH-resolved `moshi-hook claude-hook`; comment block now states the no-machine-specific-paths invariant
- **packages** — `rjyo/moshi/moshi-hook: { platform: mac }`. The real tap is `rjyo/homebrew-moshi` (verified: formula installs `moshi-hook` on macOS arm + intel); the issue's suggested `rjyo/tap` does not exist. Linux keeps Moshi's own installer (`~/.local/bin`)
- **sync.sh** — `brew_install_pkgs` installed-check compares tap-qualified keys by their short name (`${pkg##*/}`), since `brew list --formulae` prints short names; stops `rjyo/moshi/moshi-hook`, `taf2/tap/mdvi`, `anomalyco/tap/opencode`, and `charmbracelet/tap/crush` from re-running `brew install` every sync
- **tests** — four new bats cases: registry portability invariant (no `/home/*` / `/Users/*` in `command:` entries, watched fail before the fix), moshi registry shape (claude-only, `async: false` + `timeout: 300` on PermissionRequest), registry↔packages provisioning seam, and a mocked-brew qualified-skip case (macOS-only, consistent with the suite)

## Validation

- `bats tests/agents-hooks-sync.bats` — 74/74
- `bats tests/packages.bats` — 35/35 (qualified-skip case skips on Linux; executes on the Mac's `dots test`)
- `agent-profile` pytest — 577 passed
- `shellcheck packages/sync.sh` — clean

Caveat: on-Mac end-to-end (brew install + live hooks) lands on that machine's next `dots sync`; unverifiable from this Linux box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)