### PR TITLE
fix: repair three failing specs (npx isolation, PR #252 path, dots doctor set -e)

### DIFF
--- a/bin/dots
+++ b/bin/dots
@@ -261,8 +261,11 @@ do_doctor() {
     # Check chezmoi health (deps, paths, encryption backends)
     echo -e "${BLUE}Checking chezmoi...${NC}"
     if command -v chezmoi &>/dev/null; then
-        chezmoi --source "$DOTFILES_DIR/chezmoi" doctor 2>&1 | sed 's/^/  /'
-        if [[ ${PIPESTATUS[0]} -ne 0 ]]; then
+        # Capture failure with `||` — under set -e + pipefail a failing
+        # chezmoi doctor would kill the script before the status check.
+        local chezmoi_rc=0
+        chezmoi --source "$DOTFILES_DIR/chezmoi" doctor 2>&1 | sed 's/^/  /' || chezmoi_rc=$?
+        if [[ $chezmoi_rc -ne 0 ]]; then
             issues=$((issues + 1))
         fi
     else

--- a/tests/chezmoi-wiring.bats
+++ b/tests/chezmoi-wiring.bats
@@ -547,7 +547,13 @@ SH
     mkdir -p "$uv_bin"
     printf '#!/usr/bin/env bash\nexit 0\n' > "$uv_bin/uv"
     chmod +x "$uv_bin/uv"
-    PATH="$TEST_HOME/tripwire-bin:$uv_bin:/bin" run bash "$script"
+    # Minimal bin with ONLY bash — /bin can't be used here: on merged-/usr
+    # systems with apt nodejs, /bin/npx exists and defeats the missing-npx
+    # simulation (the script then runs the real installer silently).
+    local minimal_bin="$TEST_HOME/minimal-bin"
+    mkdir -p "$minimal_bin"
+    ln -s "$(command -v bash)" "$minimal_bin/bash"
+    PATH="$TEST_HOME/tripwire-bin:$uv_bin:$minimal_bin" run bash "$script"
     assert_success
     assert_output_contains "Skipping base-profile render (npx not found"
     [[ "$output" != *"TRIPWIRE"* ]]
@@ -799,12 +805,12 @@ TOML
     run chezmoi apply --force
     assert_success
 
-    # Skills now deploy through the registry-derived `base` profile rendered
-    # by `ap` (claude renderer → ~/.claude/plugins/local/base/skills/<name>).
+    # Skills deploy shared-only via `ap` (claude renderer → ~/.claude/skills/
+    # <name>; PR #252 dropped the plugin-scoped ~/.claude/plugins copy).
     # The render needs uv (+ a real `ap` env); when uv is absent the
     # run_onchange skips by design, so gate the skill assertion on uv.
     if command -v uv >/dev/null 2>&1; then
-        local skills_dir="$HOME/.claude/plugins/local/base/skills"
+        local skills_dir="$HOME/.claude/skills"
         [[ -d "$skills_dir" ]]
         # At least one dotfiles-owned (local path:) skill landed as a real dir.
         local first


### PR DESCRIPTION
## Summary

`just test` had three failures on Ubuntu 26.04 — two stale specs and one production bug in `bin/dots`.

### 1. `chezmoi-wiring.bats` — "skips cleanly when npx is missing" (test env bug)

The test restricted `PATH` to `tripwire-bin:uv-only-bin:/bin` to simulate a missing npx. On merged-`/usr` systems, apt's nodejs lands `npx` in `/bin` (`/bin/npx -> ../share/nodejs/npm/bin/npx-cli.js`), so the rendered script passed the npx preflight and silently ran the real installer through the fake uv — exit 0, empty output. Fixed by building a minimal bin containing only `bash`.

### 2. `chezmoi-wiring.bats` — "chezmoi apply triggers the base-profile render" (stale spec)

83c50a7 (#252) moved Claude skills shared-only to `~/.claude/skills/<name>` and dropped the plugin-scoped copy, but only updated ap's Python tests. The bats e2e test still asserted `~/.claude/plugins/local/base/skills`. Updated to the new path; the real-dir/not-symlink assertions are unchanged.

### 3. `bin/dots` — `dots doctor` dies mid-run (production bug)

Under `set -euo pipefail`, a failing `chezmoi doctor | sed 's/^/  /'` pipeline kills the script **before** the `PIPESTATUS` check that was meant to count it as an issue. `chezmoi doctor` exits 1 here because its hardlink check fails when `/tmp` is a different filesystem (tmpfs). Now captures the rc with `|| chezmoi_rc=$?` and continues — doctor reports the issue instead of aborting before the shell-startup profiling.

## Testing

- All three tests re-run in isolation: green
- Full suite: 788/788 pass
- `just lint-shell`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)