### PR TITLE
feat(zsh): launch claude through cc-env-exec so fresh env-file keys reach tmux sessions

### DIFF
--- a/bin/cc-env-exec
+++ b/bin/cc-env-exec
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-# cc-env-exec — load $DOTFILES_DIR/.env (safe key=value parse: skip blanks
-# and comments, split on the first '=', no command execution — same parse as
-# zsh/core.zsh), export the pairs, then exec the given command.
+# cc-env-exec — load $DOTFILES_DIR/.env (safe key=value parse: skip blank,
+# whitespace-only, and comment lines (indented ok), skip lines without '=',
+# split on the first '=', no command execution), export the pairs, then exec
+# the given command. A stricter superset of zsh/core.zsh's shell-init parse.
 #
 # Used by _cc_base (zsh/claude.zsh) as the launcher prefix so fresh API keys
 # reach claude at process start — without the keys ever entering tmux's argv
@@ -17,8 +18,14 @@ fi
 
 env_file="${DOTFILES_DIR:-$HOME/Dev/dotfiles}/.env"
 if [[ -f "$env_file" ]]; then
-    while IFS='=' read -r key val; do
-        [[ -z "$key" || "$key" == \#* ]] && continue
+    while IFS= read -r line; do
+        [[ "$line" =~ ^[[:space:]]*$ || "$line" =~ ^[[:space:]]*# ]] && continue
+        if [[ "$line" != *=* ]]; then
+            echo "cc-env-exec: skipping .env line without '=': $line" >&2
+            continue
+        fi
+        key="${line%%=*}"
+        val="${line#*=}"
         export "$key=$val" 2>/dev/null \
             || echo "cc-env-exec: skipping invalid .env line: $key" >&2
     done < "$env_file"

--- a/bin/cc-env-exec
+++ b/bin/cc-env-exec
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# cc-env-exec — load $DOTFILES_DIR/.env (safe key=value parse: skip blanks
+# and comments, split on the first '=', no command execution — same parse as
+# zsh/core.zsh), export the pairs, then exec the given command.
+#
+# Used by _cc_base (zsh/claude.zsh) as the launcher prefix so fresh API keys
+# reach claude at process start — without the keys ever entering tmux's argv
+# (`ps` shows argv to other local users; env stays owner-readable) and
+# regardless of the tmux server's stale environment. Also works standalone
+# for headless runs: cc-env-exec claude -p '...'.
+set -euo pipefail
+
+if (( $# == 0 )); then
+    echo "Usage: cc-env-exec <command> [args...]" >&2
+    exit 2
+fi
+
+env_file="${DOTFILES_DIR:-$HOME/Dev/dotfiles}/.env"
+if [[ -f "$env_file" ]]; then
+    while IFS='=' read -r key val; do
+        [[ -z "$key" || "$key" == \#* ]] && continue
+        export "$key=$val" 2>/dev/null \
+            || echo "cc-env-exec: skipping invalid .env line: $key" >&2
+    done < "$env_file"
+fi
+
+exec "$@"

--- a/tests/cc-env.bats
+++ b/tests/cc-env.bats
@@ -1,0 +1,194 @@
+#!/usr/bin/env bats
+# shellcheck disable=SC2016  # single-quoted 'sh -c "$VAR"' is intentional:
+# the variable must expand in the exec'd shell (after cc-env-exec exports
+# it), not in the bats process — that expansion IS the assertion.
+# Tests for the .env launch-time loader: bin/cc-env-exec loads
+# $DOTFILES_DIR/.env (safe key=value parse, no command execution — matching
+# zsh/core.zsh's loader) and execs the given command; _cc_base (zsh/claude.zsh)
+# prepends it to the claude command on every launch path. Rationale: a new
+# tmux session inherits the tmux SERVER's environment — not the launching
+# client's — so a server started before a key was added would launch claude
+# without it and every ${VAR}-referencing MCP in ~/.claude.json would die.
+# The wrapper (rather than `tmux new-session -e K=V`) keeps secrets out of
+# tmux's argv, which is `ps`-visible to other local users for the lifetime
+# of the attached client.
+#
+# The wrapper is exercised directly; the _cc_base wiring is exercised
+# end-to-end in zsh with tmux/claude mocked on $PATH.
+
+load test_helper
+
+CLAUDE_ZSH="$REAL_DOTFILES_DIR/zsh/claude.zsh"
+CC_ENV_EXEC="$REAL_DOTFILES_DIR/bin/cc-env-exec"
+
+setup() {
+    FIXTURE_DIR="$(mktemp -d)"
+    MOCK_BIN="$(mktemp -d)"
+    export PATH="$MOCK_BIN:$PATH"
+    export MOCK_ARGS_FILE="$MOCK_BIN/args"
+    # _cc_base resolves the launcher under $DOTFILES_DIR — ship the real
+    # script into the fixture so e2e tests stay grounded in shipped code.
+    mkdir -p "$FIXTURE_DIR/bin"
+    cp "$CC_ENV_EXEC" "$FIXTURE_DIR/bin/cc-env-exec"
+}
+
+teardown() {
+    rm -rf "$FIXTURE_DIR" "$MOCK_BIN"
+}
+
+# Mock tmux: report no existing session, record new-session invocations.
+_mock_tmux() {
+    cat > "$MOCK_BIN/tmux" <<'EOF'
+#!/usr/bin/env bash
+[[ "$1" == "has-session" ]] && exit 1
+[[ "$1" == "new-session" ]] && printf '%s\n' "$@" > "$MOCK_ARGS_FILE"
+exit 0
+EOF
+    chmod +x "$MOCK_BIN/tmux"
+}
+
+# ── bin/cc-env-exec unit tests ──
+
+@test "cc-env-exec exists and is executable" {
+    [ -x "$CC_ENV_EXEC" ]
+}
+
+@test "cc-env-exec exports .env keys to the exec'd command" {
+    printf 'A_KEY=one\nB_KEY=two\n' > "$FIXTURE_DIR/.env"
+    export DOTFILES_DIR="$FIXTURE_DIR"
+    run "$CC_ENV_EXEC" sh -c 'printf %s:%s "$A_KEY" "$B_KEY"'
+    [ "$status" -eq 0 ]
+    [ "$output" = "one:two" ]
+}
+
+@test "cc-env-exec skips comments and blank lines" {
+    printf '# a comment\n\nKEY=val\n' > "$FIXTURE_DIR/.env"
+    export DOTFILES_DIR="$FIXTURE_DIR"
+    run "$CC_ENV_EXEC" sh -c 'printf %s "$KEY"'
+    [ "$status" -eq 0 ]
+    [ "$output" = "val" ]
+}
+
+@test "cc-env-exec keeps everything after the first = in the value" {
+    printf 'TOKEN=a=b=c\n' > "$FIXTURE_DIR/.env"
+    export DOTFILES_DIR="$FIXTURE_DIR"
+    run "$CC_ENV_EXEC" sh -c 'printf %s "$TOKEN"'
+    [ "$status" -eq 0 ]
+    [ "$output" = "a=b=c" ]
+}
+
+@test "cc-env-exec still execs the command when .env is missing" {
+    export DOTFILES_DIR="$FIXTURE_DIR"
+    run "$CC_ENV_EXEC" sh -c 'printf ok'
+    [ "$status" -eq 0 ]
+    [ "$output" = "ok" ]
+}
+
+@test "cc-env-exec never executes value content" {
+    printf 'EVIL=$(touch %s/pwned)\n' "$FIXTURE_DIR" > "$FIXTURE_DIR/.env"
+    export DOTFILES_DIR="$FIXTURE_DIR"
+    run "$CC_ENV_EXEC" sh -c 'printf %s "$EVIL"'
+    [ "$status" -eq 0 ]
+    [ "$output" = "\$(touch $FIXTURE_DIR/pwned)" ]
+    [ ! -f "$FIXTURE_DIR/pwned" ]
+}
+
+@test "cc-env-exec passes the exec'd command's exit status through" {
+    export DOTFILES_DIR="$FIXTURE_DIR"
+    run "$CC_ENV_EXEC" sh -c 'exit 7'
+    [ "$status" -eq 7 ]
+}
+
+@test "cc-env-exec without a command prints usage and exits 2" {
+    run "$CC_ENV_EXEC"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"Usage"* ]]
+}
+
+@test "cc-env-exec skips an invalid identifier line and continues" {
+    printf '1BAD=x\nGOOD=y\n' > "$FIXTURE_DIR/.env"
+    export DOTFILES_DIR="$FIXTURE_DIR"
+    run "$CC_ENV_EXEC" sh -c 'printf %s "$GOOD"'
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"y"* ]]
+    [[ "$output" == *"skipping invalid .env line"* ]]
+}
+
+@test "cc-env-exec falls back to ~/Dev/dotfiles when DOTFILES_DIR is unset" {
+    mkdir -p "$FIXTURE_DIR/Dev/dotfiles"
+    printf 'FB_KEY=fb\n' > "$FIXTURE_DIR/Dev/dotfiles/.env"
+    run env -u DOTFILES_DIR HOME="$FIXTURE_DIR" "$CC_ENV_EXEC" sh -c 'printf %s "$FB_KEY"'
+    [ "$status" -eq 0 ]
+    [ "$output" = "fb" ]
+}
+
+# ── _cc_base wiring (end-to-end in zsh, tmux/claude mocked) ──
+
+@test "cc routes the tmux command through cc-env-exec with no secret in argv" {
+    command -v zsh &>/dev/null || skip "zsh not installed"
+    printf 'FRESH_KEY=hot\n' > "$FIXTURE_DIR/.env"
+    _mock_tmux
+    run zsh -fc "export DOTFILES_DIR='$FIXTURE_DIR'; unset TMUX _CC_IN_SESSION; source '$CLAUDE_ZSH'; cc"
+    [ "$status" -eq 0 ]
+    [ -f "$MOCK_ARGS_FILE" ]
+    # The spawned command is the wrapper + claude…
+    [[ "$(tail -n 1 "$MOCK_ARGS_FILE")" == "$FIXTURE_DIR/bin/cc-env-exec claude"* ]]
+    # …and the secret never appears anywhere in tmux's argv.
+    ! grep -qF 'FRESH_KEY=hot' "$MOCK_ARGS_FILE"
+    ! grep -qx -- '-e' "$MOCK_ARGS_FILE"
+}
+
+@test "ccw-style launch routes through cc-env-exec with no secret in argv (inside-tmux path)" {
+    command -v zsh &>/dev/null || skip "zsh not installed"
+    printf 'FRESH_KEY=hot\n' > "$FIXTURE_DIR/.env"
+    _mock_tmux
+    run zsh -fc "export DOTFILES_DIR='$FIXTURE_DIR' TMUX=fake _CC_IN_SESSION=1; source '$CLAUDE_ZSH'; cc"
+    [ "$status" -eq 0 ]
+    [ -f "$MOCK_ARGS_FILE" ]
+    [[ "$(tail -n 1 "$MOCK_ARGS_FILE")" == "$FIXTURE_DIR/bin/cc-env-exec claude"* ]]
+    ! grep -qF 'FRESH_KEY=hot' "$MOCK_ARGS_FILE"
+    ! grep -qx -- '-e' "$MOCK_ARGS_FILE"
+}
+
+@test "direct claude path gets fresh .env keys via the wrapper" {
+    command -v zsh &>/dev/null || skip "zsh not installed"
+    printf 'FRESH_KEY=hot\n' > "$FIXTURE_DIR/.env"
+    cat > "$MOCK_BIN/claude" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "${FRESH_KEY:-unset}" > "$MOCK_ARGS_FILE"
+EOF
+    chmod +x "$MOCK_BIN/claude"
+    # TMUX set without _CC_IN_SESSION → the direct-exec else branch.
+    run zsh -fc "export DOTFILES_DIR='$FIXTURE_DIR' TMUX=fake; unset _CC_IN_SESSION; source '$CLAUDE_ZSH'; cc"
+    [ "$status" -eq 0 ]
+    [ "$(cat "$MOCK_ARGS_FILE")" = "hot" ]
+}
+
+@test "cc launches cleanly when .env is missing" {
+    command -v zsh &>/dev/null || skip "zsh not installed"
+    # No .env in the fixture dir at all.
+    _mock_tmux
+    run zsh -fc "export DOTFILES_DIR='$FIXTURE_DIR'; unset TMUX _CC_IN_SESSION; source '$CLAUDE_ZSH'; cc"
+    [ "$status" -eq 0 ]
+    [ -f "$MOCK_ARGS_FILE" ]
+    grep -qx 'new-session' "$MOCK_ARGS_FILE"
+    grep -qx -- '-s' "$MOCK_ARGS_FILE"
+}
+
+@test "cc falls back to plain claude when the launcher is absent" {
+    command -v zsh &>/dev/null || skip "zsh not installed"
+    rm "$FIXTURE_DIR/bin/cc-env-exec"
+    _mock_tmux
+    run zsh -fc "export DOTFILES_DIR='$FIXTURE_DIR'; unset TMUX _CC_IN_SESSION; source '$CLAUDE_ZSH'; cc"
+    [ "$status" -eq 0 ]
+    [ "$(tail -n 1 "$MOCK_ARGS_FILE")" = "claude" ]
+}
+
+@test "user args survive the wrapper prefix (ccc → --continue is final)" {
+    command -v zsh &>/dev/null || skip "zsh not installed"
+    printf 'K_ONE=v1\n' > "$FIXTURE_DIR/.env"
+    _mock_tmux
+    run zsh -fc "export DOTFILES_DIR='$FIXTURE_DIR'; unset TMUX _CC_IN_SESSION; source '$CLAUDE_ZSH'; ccc"
+    [ "$status" -eq 0 ]
+    [ "$(tail -n 1 "$MOCK_ARGS_FILE")" = "$FIXTURE_DIR/bin/cc-env-exec claude --continue" ]
+}

--- a/tests/cc-env.bats
+++ b/tests/cc-env.bats
@@ -192,3 +192,22 @@ EOF
     [ "$status" -eq 0 ]
     [ "$(tail -n 1 "$MOCK_ARGS_FILE")" = "$FIXTURE_DIR/bin/cc-env-exec claude --continue" ]
 }
+
+@test "cc-env-exec skips whitespace-only and indented-comment lines silently" {
+    printf '   \n  # indented comment\nKEY=val\n' > "$FIXTURE_DIR/.env"
+    export DOTFILES_DIR="$FIXTURE_DIR"
+    run "$CC_ENV_EXEC" sh -c 'printf %s "$KEY"'
+    [ "$status" -eq 0 ]
+    # Exact match: the value and nothing else — no spurious warnings.
+    [ "$output" = "val" ]
+}
+
+@test "cc-env-exec skips a line without = and does not clobber an inherited var" {
+    printf 'NOEQ_VAR\nKEY=val\n' > "$FIXTURE_DIR/.env"
+    export DOTFILES_DIR="$FIXTURE_DIR"
+    export NOEQ_VAR="inherited"
+    run "$CC_ENV_EXEC" sh -c 'printf %s:%s "$NOEQ_VAR" "$KEY"'
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"inherited:val"* ]]
+    [[ "$output" == *"skipping .env line without"* ]]
+}

--- a/zsh/claude.zsh
+++ b/zsh/claude.zsh
@@ -18,13 +18,19 @@ export ENABLE_CLAUDEAI_MCP_SERVERS=false
 # CLAUDE.md auto-discovery, hooks, plugins, auto-memory all stay active —
 # only Anthropic's system prompt is swapped out. Symbol-level reads/edits
 # now route through Serena (MCP) instead of dynamically gated LSP plugins.
-# _cc_base — common launcher: prepends preamble flag, then wraps in tmux
-# unless already inside tmux ($TMUX set) or tmux is not installed.
+# _cc_base — common launcher: prepends preamble flag, routes through
+# bin/cc-env-exec (when present) so the spawned claude loads fresh .env keys
+# at process start — keys never enter tmux's argv (`ps`-visible), and a
+# stale tmux server env can't strip them (a new session inherits the
+# SERVER's environment, not this client's). Then wraps in tmux unless
+# already inside tmux ($TMUX set) or tmux is not installed.
 # ccw sets _CC_IN_SESSION=1 to trigger the inside-tmux switch-client path.
 _cc_base() {
     local -a flags=()
     [[ -f "$AGENTS_DOTFILES/preamble.md" ]] && flags+=(--system-prompt-file "$AGENTS_DOTFILES/preamble.md")
     local -a cmd=(claude "${flags[@]}" "$@")
+    local launcher="${DOTFILES_DIR:-$HOME/Dev/dotfiles}/bin/cc-env-exec"
+    [[ -x "$launcher" ]] && cmd=("$launcher" "${cmd[@]}")
     # Outside tmux: create-or-attach session (-A attaches if it exists, command ignored on attach).
     if [[ -z "$TMUX" ]] && command -v tmux &>/dev/null; then
         local session="${${PWD:t}//[.:]/-}"
@@ -37,7 +43,7 @@ _cc_base() {
             || tmux new-session -d -s "$session" "${(j: :)${(@q)cmd}}"
         tmux switch-client -t "$session"
     else
-        claude "${flags[@]}" "$@"
+        "${cmd[@]}"
     fi
 }
 


### PR DESCRIPTION
## Why

A new tmux session inherits the **tmux server's** environment, not the launching client's. A server started before a key was added to `.env` spawns claude without it — and an unset `${VAR}` reference makes Claude fail to parse `~/.claude.json`, killing every MCP. Verified empirically on tmux 3.6 (a client-side var does not reach `tmux new-session` without intervention).

## What

- **`bin/cc-env-exec`** — safe `.env` loader (skip blanks/comments, split on first `=`, no command execution — same parse as `zsh/core.zsh`) that exports the pairs and `exec`s the given command. Also usable standalone for headless runs: `cc-env-exec claude -p '...'`.
- **`zsh/claude.zsh`** — `_cc_base` prepends the wrapper to the claude command on all three launch paths (outside-tmux `new-session -A`, ccw inside-tmux `new-session -d`, direct exec). Degrades to plain `claude` when the wrapper is absent.
- **`tests/cc-env.bats`** — 16 tests: 10 wrapper unit tests (no-command-execution, exit-status passthrough, invalid-identifier skip-and-warn, `~/Dev/dotfiles` fallback) + 6 zsh end-to-end tests with mocked tmux/claude asserting the wrapper is wired on every path and **no secret appears in tmux argv**.

## Design note

`tmux new-session -e K=V` (tmux ≥ 3.2) was considered and rejected: it puts every secret in the tmux client's `ps`-visible argv for the lifetime of the attached session. The wrapper keeps secrets in env/disk only, and reads `.env` at actual process start — fresher than any client-side export.

Known limit (pre-existing): `-A` attaching to a live session keeps that session's old env; only new sessions pick up new keys.

## Test plan

- [x] `bats tests/cc-env.bats` — 16/16
- [x] Full suite `tests/run-tests.sh` — 804/804 (one non-reproducible `chezmoi-wiring.bats:159` flake on a single run; passes in isolation ×2 and on full re-run; that test touches nothing in this diff)
- [x] `shellcheck bin/cc-env-exec`, `zsh -n zsh/claude.zsh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
