### PR TITLE
fix(ccw-init): redirect worktree-add stdout to stderr

### DIFF
--- a/bin/ccw-init
+++ b/bin/ccw-init
@@ -26,7 +26,7 @@ if [[ -d "${wt_dir}" ]]; then
     echo "Resuming worktree: ${wt_dir}" >&2
 else
     echo "Creating worktree: ${wt_dir} (branch: ${branch})" >&2
-    git -C "${repo_root}" worktree add "${wt_dir}" -b "${branch}" || exit 1
+    git -C "${repo_root}" worktree add "${wt_dir}" -b "${branch}" 1>&2 || exit 1
     created=true
 fi
 


### PR DESCRIPTION
## What

`bin/ccw-init` emits machine-readable JSON on stdout, but `git worktree add` also writes its `Preparing worktree...` progress line to stdout — polluting that JSON for consumers. Redirect the `git worktree add` stdout to stderr (`1>&2`) so only the JSON reaches stdout. The `|| exit 1` still tests git's exit status, so failure handling is unchanged.

```diff
-    git -C "${repo_root}" worktree add "${wt_dir}" -b "${branch}" || exit 1
+    git -C "${repo_root}" worktree add "${wt_dir}" -b "${branch}" 1>&2 || exit 1
```

## Why a fresh PR

This re-lands the **only** novel change from #283. The other two parts of #283 already merged to `main` independently:

- **graphite** package entry — already on `main` in a better, platform-filtered form (`platform: linux` + mac brew note).
- **`cc-env-exec`** launcher + zsh wiring + bats — already on `main`, byte-identical.

#283 was therefore ~90% superseded and conflicted on the stale graphite line; closing it and re-landing this single line is cleaner than resolving that conflict. Closes #283 as superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)