### PR TITLE
Make the global cheez-wiki hallouminate corpus portable across machines

### DIFF
--- a/chezmoi/dot_config/hallouminate/config.toml.tmpl
+++ b/chezmoi/dot_config/hallouminate/config.toml.tmpl
@@ -4,10 +4,16 @@ paths = ["~/.cheese"]
 globs = ["**/*.md"]
 exclude = ["**/.git/**"]
 
+{{ if stat (joinPath .chezmoi.homeDir "Dev" "cheez-wiki" ".hallouminate" "wiki") -}}
 # The cheez-wiki knowledge base, exposed from the XDG baseline so every project
-# can search it. Declared as a flat [[corpus]] (NOT a [[repository]]) on purpose:
-# a baseline `[[repository]] name = "cheez-wiki"` would collide with the repo-layer
-# config at ~/Dev/cheez-wiki/.hallouminate/ — both would derive `repo:cheez-wiki:wiki`
+# can search it. Guarded by the `stat` above: hallouminate's indexer aborts the
+# entire run on a missing corpus path (see hallouminate#101), so this block is
+# emitted only on machines where the wiki tree exists — keeping the synced
+# baseline portable across computers.
+#
+# Declared as a flat [[corpus]] (NOT a [[repository]]) on purpose: a baseline
+# `[[repository]] name = "cheez-wiki"` would collide with the repo-layer config
+# at ~/Dev/cheez-wiki/.hallouminate/ — both would derive `repo:cheez-wiki:wiki`
 # and trip the duplicate-name check. A distinct corpus name sidesteps that.
 [[corpus]]
 name = "cheez-wiki"
@@ -15,6 +21,7 @@ paths = ["~/Dev/cheez-wiki/.hallouminate/wiki"]
 globs = ["**/*.md"]
 exclude = ["**/.git/**"]
 
+{{ end -}}
 # Top-level embeddings default for all repos (per-repo config can override).
 # snowflake-arctic-embed-s: 384-dim, English, retrieval-tuned. Full precision
 # (quantized=false) — corpora are small, so keep max quality.


### PR DESCRIPTION
## What

Converts the XDG-baseline hallouminate config (`dot_config/hallouminate/config.toml`) to a chezmoi template (`.tmpl`) and guards the global `cheez-wiki` `[[corpus]]` block behind a `stat` check on the wiki tree.

```go-template
{{ if stat (joinPath .chezmoi.homeDir "Dev" "cheez-wiki" ".hallouminate" "wiki") -}}
[[corpus]]
name = "cheez-wiki"
paths = ["~/Dev/cheez-wiki/.hallouminate/wiki"]
...
{{ end -}}
```

## Why

The baseline trickles down to every repo's hallouminate config, so a single global `cheez-wiki` corpus makes the shared knowledge base searchable from all configured projects. But syncing that baseline to **other machines** is unsafe unconditionally:

`hallouminate index` **aborts the entire run** on a single missing corpus path (`walk error: ... No such file or directory`) — verified empirically, and filed upstream as **paulnsorensen/hallouminate#101**. On any machine that has not cloned the `cheez-wiki` repo, an unconditional entry would break indexing for **all** corpora on that box.

The `stat` guard emits the block only where the wiki tree exists, keeping the synced baseline portable. When absent, the rendered config simply omits the corpus — graceful fallback.

## Verification

- `chezmoi cat` on this machine (repo present) → renders the block, valid TOML.
- `chezmoi execute-template` with a ghost path (repo absent) → block omitted, clean whitespace, valid TOML.
- `chezmoi apply` + `hallouminate config validate` → `ok`, 3 effective corpora unchanged.

## Context

Supersedes the unconditional entry added directly to `main` (commit ccd8700) — that made it work locally; this PR makes it safe to sync everywhere.