### PR TITLE
refactor(sync): retire backup scaffolding, rename orchestrator to .sync

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -49,13 +49,13 @@ dotfiles/
 - **Package Manager**: Homebrew (packages in `.brew`)
 - **Claude Code**: Skills, agents, hooks, MCP servers
 - **Testing**: bats (shell tests via `dots test`)
-- **Sync**: `.sync-with-rollback` with backup/manifest tracking
+- **Sync**: `.sync` orchestrator (symlinks + per-directory `.sync` scripts)
 
 ## Build and Test
 
-- `dots sync` — Sync dotfiles (symlinks, Homebrew, fonts) with rollback
+- `dots sync` — Sync dotfiles (symlinks, Homebrew, fonts)
 - `dots test` — Run test suite (validates shell loading, git hooks, symlinks, Claude config sync)
-- `shellcheck bin/* .sync .sync-with-rollback` — Lint shell scripts
+- `shellcheck bin/* .sync` — Lint shell scripts
 - `mcp-sync` — Sync MCP servers from registry.yaml
 - `plugin-sync` — Sync plugins from registry.yaml
 

--- a/.hallouminate/wiki/operations/sync-and-chezmoi.md
+++ b/.hallouminate/wiki/operations/sync-and-chezmoi.md
@@ -4,7 +4,7 @@ How `dots sync` deploys this repo to a machine. Two mechanisms coexist: a custom
 
 ## The symlink + `.sync` system
 
-`.sync-with-rollback` walks the repo and symlinks dotfiles into `$HOME`, dispatching per-directory `.sync` scripts for custom setup (fonts, iterm2, chezmoi).
+`.sync` walks the repo and symlinks dotfiles into `$HOME`, dispatching per-directory `.sync` scripts for custom setup (fonts, iterm2, chezmoi).
 
 - **Skip list** — dirs never symlinked to `$HOME`. Canonical source is `SYNC_SKIP_LIST` in `.sync-lib.sh`: `.git`, `.local`, `.worktrees`, `reference`, `packages`, `brew`, `apt`, `agents`, `agent-profile`, `codex`.
 - **Hidden-directory dispatch** — visible dirs are iterated by `for file in *`; hidden dirs (leading `.`) by `sync_hidden_dirs`. Both share one rule: if `$dir/.sync` exists, run it. `chezmoi/` is a visible dir that owns its `.sync` and short-circuits before symlinking.
@@ -12,7 +12,7 @@ How `dots sync` deploys this repo to a machine. Two mechanisms coexist: a custom
 
 ### Backup/rollback subsystem — retired
 
-The custom backup/restore/rollback subsystem has been **deleted** (chezmoi-consolidation, Stage 1). `dots rollback` no longer snapshots — it prints the git-backed undo path (`git revert` + `dots sync`). `dots backups` / `dots clean` are gone (`tests/dots.bats` asserts the retirement). The symlink loop in `.sync-with-rollback` is untouched until later migration stages.
+The custom backup/restore/rollback subsystem has been **deleted** (chezmoi-consolidation, Stage 1). `dots rollback` no longer snapshots — it prints the git-backed undo path (`git revert` + `dots sync`). `dots backups` / `dots clean` are gone (`tests/dots.bats` asserts the retirement). The manifest/backup scaffolding in `.sync` has been removed; only `last_sync` (timestamp) remains. The file has been renamed from `.sync-with-rollback` to `.sync`.
 
 ## Chezmoi-managed subset
 

--- a/.sync
+++ b/.sync
@@ -1,7 +1,7 @@
 #!/bin/bash
 ############################
-# .sync-with-rollback
-# Enhanced sync script with rollback capability and state management
+# .sync
+# Dotfiles sync orchestrator
 ############################
 
 set -euo pipefail  # Fail fast on errors
@@ -13,8 +13,6 @@ olddir=~/.dotfiles.bak             # old dotfiles backup directory
 
 # State management
 DOTFILES_STATE_DIR="${HOME}/.local/state/dotfiles"
-BACKUP_DIR="${DOTFILES_STATE_DIR}/backups/$(date +%Y%m%d_%H%M%S)"
-MANIFEST_FILE="${DOTFILES_STATE_DIR}/current.manifest"
 
 # Source helpers from the script's own directory. Test harnesses that eval
 # this file may override the location via SYNC_SCRIPT.
@@ -29,46 +27,15 @@ unset _sync_script_path
 
 ########## Functions
 
-# Initialize state directory
-init_state() {
-    log_info "Initializing state management..."
-    mkdir -p "${DOTFILES_STATE_DIR}/backups"
-    mkdir -p "${BACKUP_DIR}"
-
-    # Save current timestamp
+# Record the current sync timestamp
+record_sync_time() {
+    mkdir -p "${DOTFILES_STATE_DIR}"
     date +%s > "${DOTFILES_STATE_DIR}/last_sync"
-}
-
-# Create manifest of current symlinks
-create_manifest() {
-    log_info "Creating manifest of current state..."
-    true > "${MANIFEST_FILE}.tmp"
-
-    # Find all symlinks pointing to our dotfiles (exclude protected directories)
-    (find "${HOME}" -maxdepth 3 -type l \
-        -not -path "${HOME}/Library/Mobile Documents*" \
-        -not -path "${HOME}/Library/Application Support/MobileSync*" \
-        -not -path "${HOME}/Music*" \
-        -not -path "${HOME}/Pictures/Photos*" \
-        2>/dev/null || true) | while read -r link; do
-        target=$(readlink "${link}" 2>/dev/null || true)
-        if [[ "${target}" == "${dir}"* ]]; then
-            echo "${link}:${target}" >> "${MANIFEST_FILE}.tmp"
-        fi
-    done
-
-    # If manifest exists, back it up
-    if [[ -f "${MANIFEST_FILE}" ]]; then
-        cp "${MANIFEST_FILE}" "${BACKUP_DIR}/manifest.backup"
-    fi
-
-    mv "${MANIFEST_FILE}.tmp" "${MANIFEST_FILE}"
-    log_success "Manifest created with $(wc -l < "${MANIFEST_FILE}") symlinks"
 }
 
 # Main sync function
 run_sync() {
-    init_state
+    record_sync_time
     parse_sync_args "$@"
 
     # Bootstrap yq (needed by packages/sync.sh to parse YAML)
@@ -93,8 +60,6 @@ run_sync() {
     install_tpm
     install_prek_hooks
 
-    create_manifest
-
     unset DOTFILES_DEV
 
     if (( ${#SYNC_FAILURES[@]} > 0 )); then
@@ -103,8 +68,7 @@ run_sync() {
         log_error "Configuration is partially applied — those areas may be stale."
         log_error "Re-run 'dots sync' after fixing the underlying cause."
         echo
-        log_info "Backup saved at: ${BACKUP_DIR}"
-        log_info "To rollback, run: $0 rollback ${BACKUP_DIR##*/}"
+        log_info "To undo, run: dots rollback"
         exit 1
     fi
 

--- a/.sync-lib.sh
+++ b/.sync-lib.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Shared sync helpers sourced by .sync-with-rollback.
+# Shared sync helpers sourced by .sync.
 # Logging, skip-list dispatch, per-entry sync, and bootstrap installers.
 #
 # Variables provided by the sourcing script: dir, olddir
@@ -33,7 +33,7 @@ log_error() {
 SYNC_SKIP_LIST=(".git" ".local" ".worktrees" "reference" "packages" "brew" "apt" "agents" "agent-profile" "codex")
 
 # Failure ledger — every .sync script that exits non-zero appends its name
-# here. .sync-with-rollback inspects this at the end of run_sync, prints a
+# here. .sync inspects this at the end of run_sync, prints a
 # summary, and exits non-zero so a partial sync doesn't masquerade as green.
 SYNC_FAILURES=()
 

--- a/bin/dots
+++ b/bin/dots
@@ -121,13 +121,7 @@ do_update() {
         echo -e "${GREEN}✅ Updated successfully!${NC}"
         echo
         echo -e "${BLUE}Running sync...${NC}"
-        # Gate fallback on existence, not exit code — otherwise a real
-        # mid-sync failure silently falls through to a different script.
-        if [[ -f "$DOTFILES_DIR/.sync-with-rollback" ]]; then
-            "$DOTFILES_DIR/.sync-with-rollback"
-        else
-            "$DOTFILES_DIR/.sync"
-        fi
+        "$DOTFILES_DIR/.sync"
     else
         echo -e "${YELLOW}⚠️  Local changes detected${NC}" >&2
         echo "Please commit or stash your changes first" >&2
@@ -141,7 +135,7 @@ do_sync() {
     echo -e "${BLUE}🔄 Syncing dotfiles...${NC}"
     cd_dotfiles
 
-    "$DOTFILES_DIR/.sync-with-rollback" "$@"
+    "$DOTFILES_DIR/.sync" "$@"
 }
 
 # Show status

--- a/chezmoi/.sync
+++ b/chezmoi/.sync
@@ -23,7 +23,7 @@
 # resolving into the dotfiles checkout (whether dangling or live) so apply
 # can claim it.
 #
-# Owning .sync here bypasses .sync-with-rollback's default symlink path —
+# Owning .sync here bypasses .sync's default symlink path —
 # chezmoi reads this dir via the absolute path written into chezmoi.toml,
 # not via a ~/.chezmoi symlink.
 
@@ -131,7 +131,7 @@ fi
 # Pre-create the ~/.claude directory symlinks that the (now-shrinking) set
 # of write-through paths from chezmoi's run_onchange templates land in. On
 # a fresh install, claude/.sync runs *after* chezmoi/.sync (alphabetical
-# iteration in .sync-with-rollback), so without these links chezmoi would
+# iteration in .sync), so without these links chezmoi would
 # create real ~/.claude/{hooks,reference}/ directories that claude/.sync
 # would then back up, orphaning anything chezmoi just wrote.
 #
@@ -161,7 +161,7 @@ prelink_claude_writethrough
 # tree that launched dots sync, not a stale sourceDir preserved in
 # ~/.config/chezmoi/chezmoi.toml. Partial-OK — we don't abort the rest of
 # dots sync if chezmoi fails, but we DO propagate the failure as our exit
-# code so .sync-lib.sh records us in SYNC_FAILURES and .sync-with-rollback
+# code so .sync-lib.sh records us in SYNC_FAILURES and .sync
 # surfaces it in the final summary. Silent partial-install regressions are
 # what trapped a missing SessionStart hook for hours.
 #

--- a/justfile
+++ b/justfile
@@ -9,7 +9,7 @@ lint: lint-shell lint-python lint-js lint-markdown
 
 # shellcheck on shell scripts
 lint-shell:
-    shellcheck -x -e SC1091 bin/* .sync-with-rollback
+    shellcheck -x -e SC1091 bin/* .sync
     shellcheck -x -e SC1091 -s bash agents/mcp/sync.sh agents/hooks/sync.sh agents/hooks/lib.sh claude/plugins/sync.sh claude/lib/sync-common.sh agents/lib/cheese-flair.sh chezmoi/lib/install-base-profile.sh chezmoi/lib/install-agents-doc.sh chezmoi/lib/install-codex.sh chezmoi/lib/install-shared-assets.sh
     shellcheck -x -e SC1091 -s bash agents/hooks/session-start-cheese-flair.sh
     shellcheck -x -e SC1091 -s bash tests/run-tests.sh tests/install-bats.sh tests/serena-smoke.sh

--- a/tests/sync-rollback.bats
+++ b/tests/sync-rollback.bats
@@ -1,13 +1,13 @@
 #!/usr/bin/env bats
 # shellcheck disable=SC2012
-# Tests for .sync-with-rollback — the main dotfiles sync orchestrator
+# Tests for .sync — the main dotfiles sync orchestrator
 #
 # Unit tests source functions via call-sync-fn helper.
 # Integration tests run the full script against a fake dotfiles directory.
 
 load test_helper
 
-SYNC_SCRIPT="$REAL_DOTFILES_DIR/.sync-with-rollback"
+SYNC_SCRIPT="$REAL_DOTFILES_DIR/.sync"
 
 setup() {
     setup_test_env
@@ -52,15 +52,12 @@ MOCK
 set -euo pipefail
 export HOME="$TEST_HOME"
 export DOTFILES_STATE_DIR="$TEST_HOME/.local/state/dotfiles"
-export BACKUP_DIR="\$DOTFILES_STATE_DIR/backups/\${BACKUP_TS:-\$(date +%Y%m%d_%H%M%S)}"
-export MANIFEST_FILE="\$DOTFILES_STATE_DIR/current.manifest"
 export SYNC_SCRIPT="$SYNC_SCRIPT"
 eval "\$(awk '/^########## Main\$/{exit} {print}' "$SYNC_SCRIPT")"
 if [[ -n "\${FAKE_DIR:-}" ]]; then
     dir="\$FAKE_DIR"
     cd "\$FAKE_DIR"
 fi
-mkdir -p "\$BACKUP_DIR"
 "\$@"
 HELPER
     chmod +x "$MOCK_BIN/call-sync-fn"
@@ -71,31 +68,15 @@ teardown() {
 }
 
 
-@test "init_state creates state directories and writes timestamp" {
-    run call-sync-fn init_state
+@test "record_sync_time writes timestamp" {
+    run call-sync-fn record_sync_time
     assert_success
-    assert_dir_exists "$TEST_HOME/.local/state/dotfiles/backups"
     assert_file_exists "$TEST_HOME/.local/state/dotfiles/last_sync"
     local ts
     ts=$(cat "$TEST_HOME/.local/state/dotfiles/last_sync")
     [[ "$ts" =~ ^[0-9]+$ ]]
 }
 
-@test "create_manifest finds dotfile symlinks and writes manifest file" {
-    export FAKE_DIR="$FAKE_DOTFILES"
-    run call-sync-fn init_state
-    assert_success
-
-    echo "test" > "$FAKE_DOTFILES/somefile"
-    ln -s "$FAKE_DOTFILES/somefile" "$TEST_HOME/.somefile"
-
-    run call-sync-fn create_manifest
-    assert_success
-    assert_file_exists "$TEST_HOME/.local/state/dotfiles/current.manifest"
-    run cat "$TEST_HOME/.local/state/dotfiles/current.manifest"
-    assert_output_contains "$TEST_HOME/.somefile:$FAKE_DOTFILES/somefile"
-    unset FAKE_DIR
-}
 
 @test "no args runs default sync" {
     cd "$FAKE_DOTFILES"


### PR DESCRIPTION
## What

Finishes the rollback-subsystem retirement an earlier consolidation started but left half-done. The wiki already described the backup/rollback subsystem as deleted, yet orphaned scaffolding was still running on every `dots sync`.

## Changes

**Remove dead scaffolding** from the sync orchestrator:

- `create_manifest()` — a per-sync `find $HOME -maxdepth 3` walk writing a `current.manifest` nothing read.
- `init_state()`'s empty timestamped backup-dir churn (`~/.local/state/dotfiles/backups/<ts>/` created every run).
- The misleading failure hint `"To rollback, run: $0 rollback …"` — there is no `rollback` subcommand, so it fell through the `case` to a re-sync. Now points at `dots rollback` (the git-backed undo).

**Keep what's load-bearing:**

- `last_sync` (consumed by `dots status`'s "Last sync:" line) via a slimmed `record_sync_time`.
- The `~/.dotfiles.bak` collision safety net in `sync_entry`.

**Rename** `.sync-with-rollback` → `.sync` (`git mv`, history preserved). The hidden name is required: `run_sync`'s `for file in *` symlink loop would otherwise symlink a visible orchestrator into `~/.sync`. It also matches how the wiki already refers to the orchestrator.

Updated every reference: `bin/dots`, `justfile`, `chezmoi/.sync`, `tests/sync-rollback.bats`, `.github/copilot-instructions.md`, and the wiki page.

## Verification

- `just lint-shell` (shellcheck) — clean
- `./tests/run-tests.sh` — 809/809 pass
- Independent review — clean across all 10 dimensions; the hidden-name self-symlink safety was verified empirically
- Zero residual `.sync-with-rollback` references outside git history

Net **−61 lines**. No behavior change beyond fixing the misleading hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
