### PR TITLE
fix(ap): staged install no longer leaks external skills into user scope

### DIFF
--- a/agent-profile/agent_profile/cli.py
+++ b/agent-profile/agent_profile/cli.py
@@ -288,7 +288,7 @@ def cmd_install(
         written = renderer.render(manifest, target)
         all_new_files.extend(written)
 
-    _fetch_external_skills(manifest, harnesses, colors, out)
+    _fetch_external_skills(manifest, harnesses, colors, out, live=target_opt is None)
 
     new_files = sorted(set(all_new_files))
 
@@ -431,11 +431,20 @@ def _fetch_external_skills(
     harnesses: list[str],
     colors: _Colors,
     out: Any,
+    *,
+    live: bool = True,
 ) -> None:
     """Fetch every ``source:`` skill into the in-scope harnesses via
     ``npx skills add`` (spec curd 4) — one shallow clone per source repo,
     installed to all harnesses at once. ``path:`` skills are copied by the
-    renderers, so they are excluded here."""
+    renderers, so they are excluded here.
+
+    ``live=False`` (staged installs: ``--target`` was given explicitly) skips
+    the fetch entirely. ``npx skills add`` always installs at global scope
+    (``-g``) regardless of the target directory, so running it during a staged
+    render would mutate the user's real skill dirs even though the caller
+    requested a throwaway target. Staged callers should run ``ap install``
+    without ``--target`` when they are ready to populate the live dirs."""
     from agent_profile.fetch import (
         SkillFetchError,
         external_skills,
@@ -444,6 +453,14 @@ def _fetch_external_skills(
 
     ext = external_skills(manifest.skills)
     if not ext:
+        return
+
+    if not live:
+        print(
+            f"  {colors.BLUE}↳{colors.NC} external skills skipped "
+            f"(staged install — run without --target to fetch into live dirs)",
+            file=out,
+        )
         return
 
     # Group items by source repo. A bare `source:` (no name) means "all skills"

--- a/agent-profile/agent_profile/fetch.py
+++ b/agent-profile/agent_profile/fetch.py
@@ -41,6 +41,7 @@ A ``runner`` callable is injected so the fetch is unit-testable without spawning
 from __future__ import annotations
 
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any, Callable
 
@@ -95,10 +96,10 @@ def _default_runner(argv: list[str]) -> int:
 
     Also scans combined stdout+stderr for per-skill failure lines. The
     ``skills`` CLI exits 0 even when individual skill installs fail (e.g.
-    EPERM on a globally-scoped write). Any line containing "error" or "failed"
-    (case-insensitive) in the captured output is treated as a failure and
-    causes a non-zero return, so the caller's existing non-zero-exit guard
-    catches it.
+    EPERM on a globally-scoped write). A line is treated as a failure when it
+    starts with "error"/"failed" or contains "error:" / "failed to" / "✖"
+    (case-insensitive) — precise enough to skip benign substrings like
+    "0 errors" or a slug that happens to contain "failed".
 
     Note: the exact output format of ``npx skills add`` is not publicly
     documented. This is the smallest reliable check — if the heuristic
@@ -109,12 +110,23 @@ def _default_runner(argv: list[str]) -> int:
         return result.returncode
     combined = result.stdout + result.stderr
     for line in combined.splitlines():
-        lower = line.lower()
-        if "error" in lower or "failed" in lower:
+        lower = line.lstrip().lower()
+        if (
+            lower.startswith("error")
+            or lower.startswith("failed")
+            or "error:" in lower
+            or "failed to" in lower
+            or "✖" in line
+        ):
             # Print the suspicious line so the caller can surface it.
-            import sys
             print(line, file=sys.stderr)
             return 1
+    # Clean scan: replay captured output so a successful live install isn't
+    # silent (capture_output swallows what the CLI would otherwise print).
+    if result.stdout:
+        print(result.stdout, end="")
+    if result.stderr:
+        print(result.stderr, end="", file=sys.stderr)
     return 0
 
 

--- a/agent-profile/agent_profile/fetch.py
+++ b/agent-profile/agent_profile/fetch.py
@@ -91,7 +91,31 @@ def skill_agent_for(harness: str) -> str:
 
 
 def _default_runner(argv: list[str]) -> int:
-    return subprocess.run(argv, check=False).returncode
+    """Run ``argv`` and return its exit code.
+
+    Also scans combined stdout+stderr for per-skill failure lines. The
+    ``skills`` CLI exits 0 even when individual skill installs fail (e.g.
+    EPERM on a globally-scoped write). Any line containing "error" or "failed"
+    (case-insensitive) in the captured output is treated as a failure and
+    causes a non-zero return, so the caller's existing non-zero-exit guard
+    catches it.
+
+    Note: the exact output format of ``npx skills add`` is not publicly
+    documented. This is the smallest reliable check — if the heuristic
+    produces false positives for a future CLI version, the runner can be
+    replaced via the ``runner`` parameter of ``fetch_external_source``."""
+    result = subprocess.run(argv, check=False, capture_output=True, text=True)
+    if result.returncode != 0:
+        return result.returncode
+    combined = result.stdout + result.stderr
+    for line in combined.splitlines():
+        lower = line.lower()
+        if "error" in lower or "failed" in lower:
+            # Print the suspicious line so the caller can surface it.
+            import sys
+            print(line, file=sys.stderr)
+            return 1
+    return 0
 
 
 def fetch_external_source(

--- a/agent-profile/tests/test_fetch.py
+++ b/agent-profile/tests/test_fetch.py
@@ -11,11 +11,15 @@ The runner is injected so tests assert the exact argv without spawning npx.
 
 from __future__ import annotations
 
+import subprocess
+import types
+
 import pytest
 
 from agent_profile.fetch import (
     SKILL_AGENT,
     SkillFetchError,
+    _default_runner,
     external_skills,
     fetch_external_source,
     skill_agent_for,
@@ -148,3 +152,63 @@ def test_external_skills_filters_source_items_only():
         tuple(sorted({"name": "mold", "source": "o/r"}.items())),
         tuple(sorted({"source": "o/r2"}.items())),
     }
+
+
+# ─── _default_runner output scanning (exit-0 false-success detection) ─
+
+
+def _make_completed(returncode: int, stdout: str = "", stderr: str = "") -> subprocess.CompletedProcess:  # type: ignore[type-arg]
+    """Build a mock CompletedProcess without running anything."""
+    cp: subprocess.CompletedProcess = types.SimpleNamespace(  # type: ignore[assignment]
+        returncode=returncode, stdout=stdout, stderr=stderr
+    )
+    return cp  # type: ignore[return-value]
+
+
+def test_default_runner_returns_zero_on_clean_output(monkeypatch):
+    monkeypatch.setattr(
+        subprocess, "run",
+        lambda *a, **kw: _make_completed(0, stdout="✓ Installed mold\n✓ done\n"),
+    )
+    assert _default_runner(["npx", "skills", "add", "o/r"]) == 0
+
+
+def test_default_runner_propagates_nonzero_exit(monkeypatch):
+    monkeypatch.setattr(
+        subprocess, "run",
+        lambda *a, **kw: _make_completed(2, stdout="", stderr="fatal error\n"),
+    )
+    assert _default_runner(["npx", "skills", "add", "o/r"]) == 2
+
+
+def test_default_runner_returns_one_when_output_contains_error_at_exit_zero(monkeypatch):
+    # The skills CLI exits 0 even on per-skill EPERM failures; the output scan
+    # catches this and returns non-zero so the caller's error guard fires.
+    monkeypatch.setattr(
+        subprocess, "run",
+        lambda *a, **kw: _make_completed(
+            0, stdout="", stderr="Error: EPERM writing to ~/.claude/skills\n"
+        ),
+    )
+    assert _default_runner(["npx", "skills", "add", "o/r"]) == 1
+
+
+def test_default_runner_returns_one_when_output_contains_failed_at_exit_zero(monkeypatch):
+    monkeypatch.setattr(
+        subprocess, "run",
+        lambda *a, **kw: _make_completed(
+            0, stdout="Skill 'mold' failed to install\n", stderr=""
+        ),
+    )
+    assert _default_runner(["npx", "skills", "add", "o/r"]) == 1
+
+
+def test_default_runner_clean_output_with_no_failure_words(monkeypatch):
+    # "succeeded", "done", progress dots — none of these should trip the scan.
+    monkeypatch.setattr(
+        subprocess, "run",
+        lambda *a, **kw: _make_completed(
+            0, stdout="Cloning... done\nInstalling mold... ✓\n", stderr=""
+        ),
+    )
+    assert _default_runner(["npx", "skills", "add", "o/r"]) == 0

--- a/agent-profile/tests/test_staged_install_skill_fetch.py
+++ b/agent-profile/tests/test_staged_install_skill_fetch.py
@@ -1,0 +1,86 @@
+"""test_staged_install_skill_fetch.py — staged installs must not invoke global skill fetch.
+
+A staged install (explicit --target <dir>) renders artifacts into the tmp target
+but must never run `npx skills add -g` which installs globally into ~/.claude/skills etc.
+A live install (no --target, target resolved from profile default or cwd) keeps the
+existing fetch behavior.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent_profile import cli
+from tests.conftest import write_profile
+
+
+# ─── staged install skips the global skill fetch ──────────────────────────────
+
+
+def test_staged_install_does_not_invoke_skill_fetch(
+    env, stub_renderers, monkeypatch, capsys
+):
+    """Explicit --target makes the install staged; fetch must be suppressed."""
+    write_profile(
+        env.profiles,
+        "extprof",
+        "name: extprof\n"
+        "skills:\n"
+        "  - name: mold\n    source: paulnsorensen/easy-cheese\n",
+    )
+    calls = []
+    monkeypatch.setattr(cli, "_skill_fetch_runner", lambda argv: calls.append(argv) or 0)
+
+    assert cli.main(["install", "extprof", "--harness", "claude", "--target", str(env.target)]) == 0
+    # No npx skills add should have been invoked
+    assert calls == []
+
+
+def test_staged_install_prints_skip_message(env, stub_renderers, monkeypatch, capsys):
+    """Staged install prints a one-line message explaining why fetch is skipped."""
+    write_profile(
+        env.profiles,
+        "extprof",
+        "name: extprof\n"
+        "skills:\n"
+        "  - name: mold\n    source: paulnsorensen/easy-cheese\n",
+    )
+    monkeypatch.setattr(cli, "_skill_fetch_runner", lambda argv: 0)
+
+    assert cli.main(["install", "extprof", "--harness", "claude", "--target", str(env.target)]) == 0
+    out = capsys.readouterr().out
+    # A message about skipping external skills for staged/non-live target
+    assert "external skills" in out.lower() or "staged" in out.lower() or "skipped" in out.lower()
+
+
+# ─── live install still runs the global skill fetch ───────────────────────────
+
+
+def test_live_install_invokes_skill_fetch(env, stub_renderers, monkeypatch):
+    """No explicit --target means a live install; fetch must still run."""
+    write_profile(
+        env.profiles,
+        "extprof",
+        "name: extprof\n"
+        "target_default: " + str(env.target) + "\n"
+        "skills:\n"
+        "  - name: mold\n    source: paulnsorensen/easy-cheese\n",
+    )
+    calls = []
+    monkeypatch.setattr(cli, "_skill_fetch_runner", lambda argv: calls.append(argv) or 0)
+
+    # No --target flag: target comes from profile's target_default
+    assert cli.main(["install", "extprof", "--harness", "claude"]) == 0
+    fetches = [c for c in calls if "npx" in c and "add" in c]
+    assert len(fetches) == 1
+
+
+def test_staged_no_source_skills_still_exits_zero(env, stub_renderers, monkeypatch):
+    """Staged install with no source: skills exits zero and emits no fetch call."""
+    write_profile(env.profiles, "noext", "name: noext\n")
+    calls = []
+    monkeypatch.setattr(cli, "_skill_fetch_runner", lambda argv: calls.append(argv) or 0)
+    assert cli.main(["install", "noext", "--harness", "claude", "--target", str(env.target)]) == 0
+    assert calls == []

--- a/agent-profile/tests/test_staged_install_skill_fetch.py
+++ b/agent-profile/tests/test_staged_install_skill_fetch.py
@@ -8,10 +8,6 @@ existing fetch behavior.
 
 from __future__ import annotations
 
-from pathlib import Path
-
-import pytest
-
 from agent_profile import cli
 from tests.conftest import write_profile
 
@@ -52,7 +48,7 @@ def test_staged_install_prints_skip_message(env, stub_renderers, monkeypatch, ca
     assert cli.main(["install", "extprof", "--harness", "claude", "--target", str(env.target)]) == 0
     out = capsys.readouterr().out
     # A message about skipping external skills for staged/non-live target
-    assert "external skills" in out.lower() or "staged" in out.lower() or "skipped" in out.lower()
+    assert "external skills skipped" in out
 
 
 # ─── live install still runs the global skill fetch ───────────────────────────


### PR DESCRIPTION
## Summary

- `ap install --target <dir>` (staged render) now skips `npx skills add -g` entirely and prints a one-line skip message. Previously it ran the global fetch even though the caller asked for a throwaway target, mutating `~/.claude/skills` etc. — and in sandboxed environments the EPERM threw but the install still printed "✓ Installed".
- Live installs (no `--target`, target from profile default or cwd) keep the existing fetch behavior unchanged.
- Hardened `_default_runner` to scan combined stdout+stderr for per-skill failure lines (case-insensitive "error"/"failed") even when `npx skills add` exits 0, so silent partial failures raise `SkillFetchError` rather than printing "✓ Installed".

## Root cause

`_fetch_external_skills` in `cli.py` had no awareness of whether the install was staged or live; it always called `fetch_external_source` which hardcodes `-g --copy -y`. The `target` resolved at `cli.py:261` was never forwarded to the fetch call at `cli.py:291`.

## Fix

Threads a `live: bool` keyword arg through `_fetch_external_skills`. `cmd_install` passes `live=(target_opt is None)` — `True` for live installs, `False` when `--target` was given explicitly.

## Test plan

- `test_staged_install_skill_fetch.py` — 4 new tests: staged install suppresses fetch, prints skip message, live install still fetches, staged with no source: skills exits 0.
- `test_fetch.py` — 5 new tests for `_default_runner` output scanning: clean output returns 0, non-zero exit propagates, "error" in stderr at exit 0 returns 1, "failed" in stdout at exit 0 returns 1, clean progress text passes through.

```
uv run pytest agent-profile/tests/ -q
# 586 passed in 0.74s
```

Closes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)