### PR TITLE
fix(copilot): replace serena-mux with stdio serena in mcp-config template

### DIFF
--- a/chezmoi/private_dot_copilot/mcp-config.json.tmpl
+++ b/chezmoi/private_dot_copilot/mcp-config.json.tmpl
@@ -85,11 +85,14 @@ the place to revisit.
     },
     "serena": {
       "type": "local",
-      "command": "serena-mux",
-      "args": [],
-      "env": {
-        "SERENA_MUX_HARNESS": "copilot"
-      },
+      "command": "serena",
+      "args": [
+        "start-mcp-server",
+        "--context=copilot",
+        "--project-from-cwd",
+        "--enable-web-dashboard=false",
+        "--open-web-dashboard=false"
+      ],
       "tools": [
         "*"
       ]

--- a/tests/chezmoi-wiring.bats
+++ b/tests/chezmoi-wiring.bats
@@ -715,6 +715,22 @@ YAML
     fi
 }
 
+@test "copilot template emits stdio serena, not serena-mux" {
+    local tmpl="$REAL_DOTFILES_DIR/chezmoi/private_dot_copilot/mcp-config.json.tmpl"
+    local rendered
+    rendered="$(chezmoi --source "$REAL_DOTFILES_DIR/chezmoi" execute-template < "$tmpl")"
+    # Valid JSON.
+    jq -e . <<<"$rendered" >/dev/null
+    # serena entry must use stdio command, not serena-mux.
+    [[ "$(jq -r '.mcpServers.serena.command' <<<"$rendered")" == "serena" ]]
+    # args must include start-mcp-server with copilot context.
+    jq -e '.mcpServers.serena.args | index("start-mcp-server") != null' <<<"$rendered" >/dev/null
+    jq -e '.mcpServers.serena.args | map(select(startswith("--context="))) | length == 1' <<<"$rendered" >/dev/null
+    [[ "$(jq -r '.mcpServers.serena.args[] | select(startswith("--context="))' <<<"$rendered")" == "--context=copilot" ]]
+    # No serena-mux env var.
+    [[ "$(jq -r '.mcpServers.serena.env // empty' <<<"$rendered")" == "" ]]
+}
+
 @test "copilot sensitive-file-guard source files exist" {
     assert_file_exists "$REAL_DOTFILES_DIR/chezmoi/private_dot_copilot/hooks/executable_sensitive-file-guard.sh"
     assert_file_exists "$REAL_DOTFILES_DIR/chezmoi/private_dot_copilot/hooks/sensitive-file-guard.json.tmpl"


### PR DESCRIPTION
## Summary

- `chezmoi/private_dot_copilot/mcp-config.json.tmpl` was still emitting a `serena-mux` MCP entry with `SERENA_MUX_HARNESS=copilot`, despite serena-mux being retired in 611f9e1 for spawning orphaned daemons and OOM'ing
- Replaces the retired block with the stdio form matching the canonical pattern in `agents/mcp/registry.yaml` (`command: serena`, `args: [start-mcp-server, --context=copilot, ...]`)
- Drops the `env` block with `SERENA_MUX_HARNESS` entirely

Closes #293

## Test plan

- Added bats test `"copilot template emits stdio serena, not serena-mux"` to `tests/chezmoi-wiring.bats` that renders the template and asserts:
  - `.mcpServers.serena.command == "serena"` (not `serena-mux`)
  - args include `start-mcp-server` and `--context=copilot`
  - no `env` block present

```
bats -f "copilot" tests/chezmoi-wiring.bats
# 8/8 pass
```

Validation: `chezmoi --source chezmoi execute-template < chezmoi/private_dot_copilot/mcp-config.json.tmpl | jq .` renders valid JSON with stdio serena.

🤖 Generated with [Claude Code](https://claude.com/claude-code)