### PR TITLE
feat(local-llm): opencode-lean local defaults + preflight (#297 #298 #300)

### DIFF
--- a/chezmoi/lib/install-local-llm.sh
+++ b/chezmoi/lib/install-local-llm.sh
@@ -44,7 +44,6 @@ install_local_llm_opencode_provider() {
             "local-sonnet":     { name: "Local Sonnet — Qwen3-30B-A3B (iGPU)" },
             "local-haiku":      { name: "Local Haiku — Qwen3-8B (CPU)" },
             "local-coder":      { name: "Local Coder — Qwen3-Coder-30B-A3B (iGPU)" },
-            "local-embed":      { name: "Local Embed — Qwen3-Embedding-0.6B (CPU)" },
             "local-vision":     { name: "Local Vision — Qwen3-VL-8B (CPU)" },
             "local-classifier": { name: "Local Classifier — Llama-3.2-3B (NPU)" }
         }

--- a/chezmoi/local-llm/configs/lean.json
+++ b/chezmoi/local-llm/configs/lean.json
@@ -4,5 +4,6 @@
     "code-review-graph": { "enabled": false },
     "hallouminate": { "enabled": false },
     "tavily": { "enabled": false }
-  }
+  },
+  "model": "local-llm/local-coder"
 }

--- a/chezmoi/local-llm/scripts/executable_aliases.sh
+++ b/chezmoi/local-llm/scripts/executable_aliases.sh
@@ -35,7 +35,25 @@ alias llm-install-swap='~/local-llm/scripts/install-llama-swap.sh'
 # OPENCODE_CONFIG mergeDeeps onto the global config — the overlay only disables
 # the heavy non-coding servers (code-review-graph, hallouminate, tavily), leaving
 # tilth + serena + context7 for the coder. Usage: opencode-lean --model local-coder
+#
+# Pre-flights the local-LLM stack: probes :4000, starts local-llm.target if down,
+# waits up to OPENCODE_LEAN_TIMEOUT seconds (default 30), then bails with a hint.
 opencode-lean() {
+  local timeout="${OPENCODE_LEAN_TIMEOUT:-30}"
+  if ! curl -s --max-time 1 http://127.0.0.1:4000/v1/models >/dev/null 2>&1; then
+    echo 'local-LLM stack is down — starting local-llm.target...' >&2
+    systemctl --user start local-llm.target
+    local elapsed=0
+    while ! curl -s --max-time 1 http://127.0.0.1:4000/v1/models >/dev/null 2>&1; do
+      if (( elapsed >= timeout )); then
+        echo "opencode-lean: timed out waiting for local-LLM stack (:4000) after ${timeout}s" >&2
+        echo "Hint: run 'llm-up' manually or check 'llm-status'." >&2
+        return 1
+      fi
+      sleep 1
+      (( elapsed++ ))
+    done
+  fi
   OPENCODE_CONFIG="$HOME/local-llm/configs/lean.json" opencode "$@"
 }
 

--- a/tests/local-llm.bats
+++ b/tests/local-llm.bats
@@ -79,7 +79,7 @@ teardown() {
 
 # ─── provider lib ───────────────────────────────────────────────────────────
 
-@test "provider lib adds local-llm with 6 models (embed in, opus out) and preserves existing .mcp" {
+@test "provider lib adds local-llm with 5 models (embed out, opus out) and preserves existing .mcp" {
     local cfg="$TEST_HOME/opencode.json"
     echo '{"$schema":"x","formatter":true,"mcp":{"tilth":{"type":"local"}}}' > "$cfg"
 
@@ -87,10 +87,11 @@ teardown() {
     assert_success
 
     run jq -r '.provider["local-llm"].models | keys | length' "$cfg"
-    assert_output_contains "6"
+    assert_output_contains "5"
 
-    # #289: opus dropped (cloud-routes), embed added.
-    run jq -e '.provider["local-llm"].models | has("local-embed")' "$cfg"
+    # #300: local-embed removed from chat-model picker (embed-only, not chat-capable).
+    # #289: local-opus dropped (cloud-routes).
+    run jq -e '.provider["local-llm"].models | has("local-embed") | not' "$cfg"
     assert_success
     run jq -e '.provider["local-llm"].models | has("local-opus") | not' "$cfg"
     assert_success
@@ -558,4 +559,110 @@ MOCK
     assert_success
     assert_output_contains "CONFIG=$HOME/local-llm/configs/lean.json"
     assert_output_contains "ARGS=--model local-coder"
+}
+
+@test "lean.json sets model to local-llm/local-coder by default" {
+    run jq -r '.model' "$LEAN"
+    assert_success
+    assert_output_contains "local-llm/local-coder"
+}
+
+@test "lean.json top-level keys: mcp + model only" {
+    # mergeDeep overlay must stay minimal: only the two intentional keys.
+    run jq -e 'keys == ["$schema","mcp","model"]' "$LEAN"
+    assert_success
+}
+
+@test "opencode-lean pre-flights the stack: stack-up skips llm-up" {
+    # Stack already up: opencode-lean must NOT call llm-up.
+    cat > "$MOCK_BIN/opencode" << 'MOCK'
+#!/bin/bash
+echo "ARGS=$*"
+MOCK
+    chmod +x "$MOCK_BIN/opencode"
+
+    local llm_up_log="$TEST_HOME/llm-up-called"
+    cat > "$MOCK_BIN/systemctl" << 'MOCK'
+#!/bin/bash
+echo "$*" >> "${LLM_UP_LOG:?}"
+MOCK
+    chmod +x "$MOCK_BIN/systemctl"
+
+    # shellcheck disable=SC1090
+    FAKE_PORT=up LLM_UP_LOG="$llm_up_log" source "$ALIASES"
+    run opencode-lean
+    assert_success
+    [[ ! -f "$llm_up_log" ]] || ! grep -q 'start local-llm.target' "$llm_up_log"
+}
+
+@test "opencode-lean pre-flights the stack: stack-down triggers llm-up then proceeds" {
+    cat > "$MOCK_BIN/opencode" << 'MOCK'
+#!/bin/bash
+echo "opencode-called"
+MOCK
+    chmod +x "$MOCK_BIN/opencode"
+
+    local llm_up_log="$TEST_HOME/llm-up.log"
+    # systemctl mock: log calls, succeeds
+    cat > "$MOCK_BIN/systemctl" << 'MOCK'
+#!/bin/bash
+echo "$*" >> "${LLM_UP_LOG:?}"
+exit 0
+MOCK
+    chmod +x "$MOCK_BIN/systemctl"
+
+    # curl mock: port starts down, comes up after first probe
+    cat > "$MOCK_BIN/curl" << 'MOCK'
+#!/bin/bash
+count_file="${CURL_COUNT_FILE:?}"
+count=$(cat "$count_file" 2>/dev/null || echo 0)
+count=$((count + 1))
+echo "$count" > "$count_file"
+if [[ "$*" == */v1/models* ]]; then
+    # first probe: down; subsequent: up (simulates llm-up bringing it online)
+    [[ $count -le 1 ]] && exit 7
+    exit 0
+fi
+exit 0
+MOCK
+    chmod +x "$MOCK_BIN/curl"
+
+    # shellcheck disable=SC1090
+    source "$ALIASES"
+    export LLM_UP_LOG="$llm_up_log"
+    export CURL_COUNT_FILE="$TEST_HOME/curl-count"
+    run opencode-lean
+    assert_success
+    assert_output_contains "opencode-called"
+    # llm-up must have been called
+    grep -q 'start local-llm.target' "$llm_up_log"
+}
+
+@test "opencode-lean pre-flights the stack: wedged stack times out instead of hanging" {
+    cat > "$MOCK_BIN/opencode" << 'MOCK'
+#!/bin/bash
+exit 0
+MOCK
+    chmod +x "$MOCK_BIN/opencode"
+
+    cat > "$MOCK_BIN/systemctl" << 'MOCK'
+#!/bin/bash
+exit 0
+MOCK
+    chmod +x "$MOCK_BIN/systemctl"
+
+    # curl always returns down -- stack never comes up
+    cat > "$MOCK_BIN/curl" << 'MOCK'
+#!/bin/bash
+[[ "$*" == */v1/models* ]] && exit 7
+exit 0
+MOCK
+    chmod +x "$MOCK_BIN/curl"
+
+    # shellcheck disable=SC1090
+    # Override timeout to 2s so the test completes quickly
+    run bash -c 'source "'"$ALIASES"'"; OPENCODE_LEAN_TIMEOUT=2 opencode-lean 2>&1'
+    # Must fail (timeout/bail) rather than block forever
+    assert_failure
+    assert_output_contains "timed out"
 }


### PR DESCRIPTION
## Summary

- **#297** Add `"model": "local-llm/local-coder"` to `lean.json` so `opencode-lean` defaults to the local coder model instead of silently burning cloud tokens on the user's global default.
- **#298** Expand `opencode-lean()` from a bare one-liner into a pre-flight function: probes `:4000`, auto-starts `local-llm.target` if down, waits up to `OPENCODE_LEAN_TIMEOUT` seconds (default 30, overridable for tests), and exits non-zero with a clear hint on a wedged stack.
- **#300** Remove `local-embed` from the `install-local-llm.sh` provider models map — it only answers `/v1/embeddings` and errors when selected as a chat model in opencode's picker. `local-classifier` (NPU with haiku fallback) remains.

Closes #297
Closes #298
Closes #300

## Test plan

- [ ] `bats tests/local-llm.bats` — 46 tests, all pass (5 new: lean model key, lean key-set, preflight-up, preflight-down, preflight-timeout)
- [ ] All pre-existing 41 tests continue to pass
- [ ] Preflight timeout test uses `OPENCODE_LEAN_TIMEOUT=2` to avoid hanging CI

```
bats tests/local-llm.bats
1..46
ok 1 ... ok 46
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)