### PR TITLE
feat(packages): install Homebrew on Linux, replacing the apt advisory

### DIFF
--- a/.hallouminate/wiki/harnesses/opencode.md
+++ b/.hallouminate/wiki/harnesses/opencode.md
@@ -15,12 +15,16 @@ Unlike the dot-dir harnesses, opencode writes config at the *target root* (`~/.c
 | Settings / config | <https://opencode.ai/docs/config/> | `~/.config/opencode/opencode.json`. `tui.json` (theme `chocolate-donut`, `editor_open` → `ctrl+o`) and `themes/chocolate-donut.json` are always-managed by chezmoi. |
 | Skills | <https://opencode.ai/docs/skills/> | `skills/` → loaded via the native `skill` tool; opencode also reads Claude/`.agents` skill dirs. |
 
+## Local LLM provider + the `opencode-lean` launcher
+
+When the `localLLM` flag is on, `chezmoi/lib/install-local-llm.sh` jq-merges a `local-llm` provider into `opencode.json` (`Local (LiteLLM)`, `http://127.0.0.1:4000/v1`, key `sk-local`), exposing the stack's models as `local-llm/<name>`. The `opencode-lean` shell alias is the intended launch path — it sets `OPENCODE_CONFIG` to a lean overlay that disables the heavy MCP servers so a small local context window survives. Full detail (launch syntax, cold-load behavior, known rough edges #297–#300): [[operations/local-llm]] § *Using the stack from opencode*.
+
 ## Isolated settings
 
 Not available. opencode has no closed-world launch flags; `ap` isolated launches are Claude-only.
 
 ## Quirks
 
-- **No non-interactive MCP CLI**: opencode has no `mcp add` command, so the renderer edits `opencode.json` directly via Python stdlib `json` (read-modify-write, no jq). `OPENCODE_CONFIG` overrides the target path (used by tests).
+- **No non-interactive MCP CLI**: opencode has no `mcp add` command, so the renderer edits `opencode.json` directly via Python stdlib `json` (read-modify-write, no jq). `OPENCODE_CONFIG` overrides the target path (used by tests, and by `opencode-lean` for the lean overlay).
 - **`.json` not `.jsonc`**: the scaffold writes `opencode.json`. If migrating from a hand-rolled `opencode.jsonc`, merge into `opencode.json` and delete the `.jsonc` (opencode reads either; having both is confusing).
 - No native modal vim editing in the input box — the `ctrl+o` rebind pops the textbox out to `$EDITOR` (vim) as the closest workflow.

--- a/.hallouminate/wiki/operations/local-llm.md
+++ b/.hallouminate/wiki/operations/local-llm.md
@@ -47,6 +47,25 @@ Aliases from `scripts/aliases.sh`. These require a one-time manual `echo 'source
 - `llm-install-swap` (= `install-llama-swap.sh`) — pinned llama-swap release install, version-stamp idempotent.
 - `dots doctor` runs `healthcheck.sh --quiet` automatically when the stack is deployed (presence-gated on `~/local-llm/scripts/healthcheck.sh`).
 
+## Using the stack from opencode
+
+opencode reaches the stack through the `local-llm` provider (`Local (LiteLLM)`, `http://127.0.0.1:4000/v1`, key `sk-local`), jq-merged into `~/.config/opencode/opencode.json` by `chezmoi/lib/install-local-llm.sh` (see [[harnesses/opencode]]). All registered model names appear in opencode's picker as `local-llm/<name>`.
+
+**Launch shortcut — `opencode-lean`** (from `scripts/aliases.sh`):
+
+```bash
+opencode-lean --model local-llm/local-coder
+```
+
+It's a one-line wrapper — `OPENCODE_CONFIG="$HOME/local-llm/configs/lean.json" opencode "$@"`. The `lean.json` overlay `mergeDeep`s onto the global config and **only disables the heavy MCP servers** (`code-review-graph`, `hallouminate`, `tavily`), leaving `tilth` + `serena` + `context7` — so the local coder's small context window isn't blown by tool schemas before the first turn. There's no separate "lean" agent or model set; the overlay is purely the MCP trim.
+
+Operational notes (each is also an open improvement issue):
+
+- The overlay sets **no default model** — you must pass `--model local-llm/<name>` (opencode's flag is `provider/model`). Bare `opencode-lean` falls back to your global *cloud* default, silently. → #297
+- `opencode-lean` does **not** start the stack — run `llm-up` first (or `llm-ping`); otherwise opencode launches and hard-fails on the first request to a dead `:4000`. → #298
+- Pool models (`local-sonnet`/`local-coder`/`local-vision`) **cold-load on first request** (~15–20s while llama-swap swaps the backend in, held open, no 503). `local-haiku` + `local-embed` are hot and answer instantly. opencode's own request timeout vs. the cold-load window is unverified. → #299
+- `local-embed` shows in the picker but is **embeddings-only** — selecting it as a chat model errors. → #300
+
 ## Adding / tuning a model
 
 Add a `models:` entry (with `--port ${PORT}`) + group membership in `chezmoi/local-llm/configs/llama-swap.yaml` → add the route to `litellm.yaml` (api_base `:9000/v1`) → add the model name to the provider block in `chezmoi/lib/install-local-llm.sh` → add the GGUF to `download-models.sh` → `chezmoi apply` → `systemctl --user restart llama-swap litellm` → `llm-test`. Tests in `tests/local-llm.bats` pin the config shape (group semantics, ports, retirement guards) — update them with the change.

--- a/.hallouminate/wiki/operations/sync-and-chezmoi.md
+++ b/.hallouminate/wiki/operations/sync-and-chezmoi.md
@@ -14,6 +14,17 @@ How `dots sync` deploys this repo to a machine. Two mechanisms coexist: a custom
 
 The custom backup/restore/rollback subsystem has been **deleted** (chezmoi-consolidation, Stage 1). `dots rollback` no longer snapshots — it prints the git-backed undo path (`git revert` + `dots sync`). `dots backups` / `dots clean` are gone (`tests/dots.bats` asserts the retirement). The manifest/backup scaffolding in `.sync` has been removed; only `last_sync` (timestamp) remains. The file has been renamed from `.sync-with-rollback` to `.sync`.
 
+## Package installation (`packages/sync.sh`)
+
+`.sync` forks to `packages/sync.sh`, which installs everything declared in `packages/packages.yaml` (SHA-256-cached to skip when the file is unchanged).
+
+- **Homebrew is the installer on both macOS and Linux.** The old Linux path (`sync_apt`, advisory-only — it *reported* missing apt packages but never installed) is gone; Linux now runs `sync_brew` like macOS. On a fresh Linux box the install script bootstraps Homebrew to `/home/linuxbrew/.linuxbrew` and `sync_brew` evals `brew shellenv` to get it on PATH for the rest of the run; `zsh/core.zsh` does the same eval for new shells.
+- **Build deps are front-loaded on Linux.** `bootstrap_brew_deps_linux` (first thing in `sync_brew`) installs Homebrew's prerequisite toolchain (`build-essential procps curl file git`, or the dnf/yum/pacman/zypper equivalent) via the system package manager *before* the brew install, so the one sudo password prompt lands at the very start of the sync. It no-ops when `gcc`/`make`/`git`/`curl`/`file` are all present (no prompt on a warm box) and runs without `sudo` when already root (containers).
+- **Casks are macOS-only** — `brew install --cask` errors on Linux, so the cask passes (and the greedy-cask upgrade) are Darwin-guarded.
+- **Package names are always the brew formula key** (`.key`) on both platforms. There is no per-OS name override anymore (the dropped `apt:` field). `platform: mac` / `platform: linux` still gate which entries install where.
+- **Pre-brew bootstraps on Linux** (brew isn't on PATH yet when these run): yq is downloaded as the Mike Farah Go binary into `~/.local/bin` (Ubuntu's apt `yq` is the wrong kislyuk/yq), and `uv` via the astral installer.
+- Other sources (`cargo`, `npm`, `uv`, `gh-extension`) run cross-platform unconditionally. On Linux, npm comes from the brew `node` formula (which bundles it).
+
 ## Chezmoi-managed subset
 
 chezmoi renders the files that need per-machine templating (work vs. personal git email), per-OS branching, or secret injection — things plain symlinks can't do. Everything else stays on the symlink system.

--- a/packages/packages.yaml
+++ b/packages/packages.yaml
@@ -1,11 +1,10 @@
 # packages.yaml — flat package registry
 #
-# Bare string = brew (mac) / apt (linux)
+# Bare string = brew formula (mac + linux)
 # Key-value = override defaults
 #
 #   source:   brew (default) | cask | tap | cargo | npm | uv | gh-extension
 #   dev:      only when DOTFILES_DEV=true
-#   apt:      override name for linux
 #   platform: mac | linux (default: both)
 #   flags:    extra args spliced into the installer (uv source only;
 #             e.g. ["--python", "3.13", "--prerelease=allow"])
@@ -22,11 +21,11 @@ packages:
   - fzf
   - gh
   - shellcheck
-  - bats-core: { apt: bats }                  # bats test runner (tests/*.bats); brew formula is bats-core, apt pkg is bats
+  - bats-core                                 # bats test runner (tests/*.bats)
   - tree
   - htop
   - ripgrep
-  - fd: { apt: fd-find }
+  - fd
   - eza
   - bat
   - ast-grep
@@ -50,7 +49,7 @@ packages:
   - chezmoi
   - duckdb
   - watch
-  - node: { apt: nodejs }
+  - node                                      # bundles npm on mac + linux
   - bun                                       # JS/TS runtime required by jmux
   - sd
   - vhs
@@ -86,7 +85,6 @@ packages:
   - uv
   - rustup: { dev: true }
   - docker-desktop: { source: cask, dev: true, platform: mac, greedy: false } # self-updates in-app; greedy upgrade triggers repeated sudo prompts
-  - npm: { platform: linux, dev: true }       # On mac, npm comes with `brew install node`
 
   # LSP servers (for Claude Code LSP plugins)
   - bash-language-server

--- a/packages/sync.sh
+++ b/packages/sync.sh
@@ -63,26 +63,24 @@ fi
 # Entry format: bare string OR single-key map (key = name, value = overrides)
 # Map queries use: to_entries[0] | .key = name, .value.* = properties
 
-# Platform package names (brew on mac, apt on linux)
+# Brew formula names for this platform, skipping the other platform's entries.
 # Usage: get_platform_pkgs [--dev]
 get_platform_pkgs() {
     local want_dev="${1:-}"
-    local skip_platform name_expr
+    local skip_platform
     if [[ "$PLATFORM" == "Darwin" ]]; then
         skip_platform="linux"
-        name_expr=".key"
     else
         skip_platform="mac"
-        name_expr="(.value.apt // .key)"
     fi
 
     if [[ -z "$want_dev" ]]; then
         {
             yq -r ".packages[] | select(kind == \"scalar\")" "$PACKAGES_FILE" 2>/dev/null
-            yq -r ".packages[] | select(kind == \"map\") | to_entries[0] | select((.value.source // \"brew\") == \"brew\" and (.value.dev // false) == false and (.value.platform == \"$skip_platform\" | not)) | $name_expr" "$PACKAGES_FILE" 2>/dev/null
+            yq -r ".packages[] | select(kind == \"map\") | to_entries[0] | select((.value.source // \"brew\") == \"brew\" and (.value.dev // false) == false and (.value.platform == \"$skip_platform\" | not)) | .key" "$PACKAGES_FILE" 2>/dev/null
         }
     else
-        yq -r ".packages[] | select(kind == \"map\") | to_entries[0] | select((.value.source // \"brew\") == \"brew\" and .value.dev == true and (.value.platform == \"$skip_platform\" | not)) | $name_expr" "$PACKAGES_FILE" 2>/dev/null
+        yq -r ".packages[] | select(kind == \"map\") | to_entries[0] | select((.value.source // \"brew\") == \"brew\" and .value.dev == true and (.value.platform == \"$skip_platform\" | not)) | .key" "$PACKAGES_FILE" 2>/dev/null
     fi
 }
 
@@ -163,10 +161,80 @@ upgrade_casks_greedy() {
     fi
 }
 
+# Homebrew on Linux builds/bottles formulae with a system C toolchain plus a
+# few utilities; its installer assumes they're present and fails midway
+# without them. Install them up front so the sudo password prompt lands at the
+# very start of the sync instead of buried inside the brew bootstrap. No-op on
+# macOS and when the toolchain is already present (so no sudo prompt then).
+# shellcheck disable=SC2086  # $sudo_cmd is intentionally unquoted (empty = run as root)
+bootstrap_brew_deps_linux() {
+    [[ "$PLATFORM" == "Linux" ]] || return 0
+    if command -v gcc &>/dev/null && command -v make &>/dev/null \
+        && command -v git &>/dev/null && command -v curl &>/dev/null \
+        && command -v file &>/dev/null; then
+        return 0
+    fi
+
+    local sudo_cmd=""
+    if [[ "${EUID:-$(id -u)}" -ne 0 ]]; then
+        if command -v sudo &>/dev/null; then
+            sudo_cmd="sudo"
+        else
+            log_warning "Homebrew build deps are missing, but not root and sudo is unavailable."
+            log_warning "Install them manually: https://docs.brew.sh/Homebrew-on-Linux#requirements"
+            return 0
+        fi
+    fi
+
+    log_info "Installing Homebrew build dependencies (you may be prompted for your password)..."
+    local ok=true
+    if command -v apt-get &>/dev/null; then
+        $sudo_cmd apt-get update && $sudo_cmd apt-get install -y build-essential procps curl file git || ok=false
+    elif command -v dnf &>/dev/null; then
+        $sudo_cmd dnf install -y @development-tools procps-ng curl file git || ok=false
+    elif command -v yum &>/dev/null; then
+        $sudo_cmd yum groupinstall -y 'Development Tools' && $sudo_cmd yum install -y procps-ng curl file git || ok=false
+    elif command -v pacman &>/dev/null; then
+        $sudo_cmd pacman -Sy --needed --noconfirm base-devel procps-ng curl file git || ok=false
+    elif command -v zypper &>/dev/null; then
+        $sudo_cmd zypper install -y -t pattern devel_basis && $sudo_cmd zypper install -y procps curl file git || ok=false
+    else
+        log_warning "No supported package manager (apt/dnf/yum/pacman/zypper) found."
+        log_warning "Install Homebrew's prerequisites manually: https://docs.brew.sh/Homebrew-on-Linux#requirements"
+        return 0
+    fi
+
+    if ! $ok; then
+        log_error "Failed to install Homebrew build dependencies"
+        FAILED+=("brew-deps")
+    fi
+}
+
 sync_brew() {
+    # Install the OS build toolchain first so any sudo prompt is up front.
+    bootstrap_brew_deps_linux
+
     if ! command -v brew &>/dev/null; then
         log_info "Installing Homebrew..."
         /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+        # Linux installs to /home/linuxbrew/.linuxbrew (or ~/.linuxbrew) and
+        # isn't on PATH until `brew shellenv` runs; macOS lands in
+        # /opt/homebrew, already on PATH via zsh/core.zsh.
+        if [[ "$PLATFORM" == "Linux" ]]; then
+            local brew_bin
+            for brew_bin in /home/linuxbrew/.linuxbrew/bin/brew "$HOME/.linuxbrew/bin/brew"; do
+                if [[ -x "$brew_bin" ]]; then
+                    eval "$("$brew_bin" shellenv)"
+                    break
+                fi
+            done
+        fi
+    fi
+
+    if ! command -v brew &>/dev/null; then
+        log_error "Homebrew install failed — brew not on PATH"
+        FAILED+=("homebrew")
+        return 0
     fi
 
     log_info "Syncing brew packages"
@@ -196,12 +264,17 @@ sync_brew() {
     installed_formulae=$(brew list --formulae 2>/dev/null || true)
     installed_casks=$(brew list --cask 2>/dev/null || true)
 
+    # Casks are macOS-only — `brew install --cask` errors on Linux.
     brew_install_pkgs "Formulae" "$(get_platform_pkgs)" "$installed_formulae"
-    brew_install_pkgs "Casks" "$(get_source_pkgs "cask")" "$installed_casks" --cask
+    if [[ "$PLATFORM" == "Darwin" ]]; then
+        brew_install_pkgs "Casks" "$(get_source_pkgs "cask")" "$installed_casks" --cask
+    fi
 
     if [[ "${DOTFILES_DEV:-false}" == "true" ]]; then
         brew_install_pkgs "Dev formulae" "$(get_platform_pkgs "--dev")" "$installed_formulae"
-        brew_install_pkgs "Dev casks" "$(get_source_pkgs "cask" "--dev")" "$installed_casks" --cask
+        if [[ "$PLATFORM" == "Darwin" ]]; then
+            brew_install_pkgs "Dev casks" "$(get_source_pkgs "cask" "--dev")" "$installed_casks" --cask
+        fi
     fi
 
     if [[ "${UPGRADE_MODE:-false}" == "true" ]]; then
@@ -217,7 +290,7 @@ sync_brew() {
         # the greedy pass: they self-update in-app and their cask reinstall
         # prompts for sudo/admin multiple times. There's no `brew upgrade`
         # exclude flag, so enumerate the greedy-outdated set and drop them.
-        upgrade_casks_greedy
+        [[ "$PLATFORM" == "Darwin" ]] && upgrade_casks_greedy
     fi
 
     log_success "Brew sync complete"
@@ -485,55 +558,6 @@ sync_gh_extensions() {
     log_success "gh extensions sync complete"
 }
 
-########## APT
-
-apt_check_pkg() {
-    local pkg="$1"
-    # shellcheck disable=SC2178  # nameref to caller's array
-    local -n _missing="$2"
-    if [[ "$pkg" == "yq" ]]; then
-        if command -v yq &>/dev/null; then
-            echo "  + $pkg"
-        else
-            echo "  $pkg (snap — install with: sudo snap install yq)"
-        fi
-        return
-    fi
-    if dpkg -s "$pkg" &>/dev/null; then
-        echo "  + $pkg"
-    else
-        echo "  - $pkg (missing)"
-        _missing+=("$pkg")
-    fi
-}
-
-sync_apt() {
-    command -v apt-get &>/dev/null || return 0
-
-    log_info "Checking apt packages"
-    local missing=()
-
-    echo -e "\n${GREEN}Packages:${NC}"
-    while IFS= read -r pkg; do
-        [[ -z "$pkg" ]] && continue
-        apt_check_pkg "$pkg" missing
-    done <<< "$(get_platform_pkgs)"
-
-    if [[ "${DOTFILES_DEV:-false}" == "true" ]]; then
-        echo -e "\n${GREEN}Dev packages:${NC}"
-        while IFS= read -r pkg; do
-            [[ -z "$pkg" ]] && continue
-            apt_check_pkg "$pkg" missing
-        done <<< "$(get_platform_pkgs "--dev")"
-    fi
-
-    if ((${#missing[@]})); then
-        echo ""
-        log_warning "Missing packages: ${missing[*]}"
-        echo "  sudo apt-get install -y ${missing[*]}"
-    fi
-}
-
 ########## Main
 
 # Bootstrap yq if needed. The whole sync.sh is YAML-driven, so this is
@@ -599,10 +623,8 @@ if [[ "$PLATFORM" == "Linux" ]] && ! command -v uv &>/dev/null; then
     bootstrap_uv_linux || log_warning "Continuing without uv — base-profile render will be skipped"
 fi
 
-if [[ "$PLATFORM" == "Darwin" ]]; then
+if [[ "$PLATFORM" == "Darwin" || "$PLATFORM" == "Linux" ]]; then
     sync_brew
-elif [[ "$PLATFORM" == "Linux" ]]; then
-    sync_apt
 fi
 
 sync_cargo

--- a/packages/sync.sh
+++ b/packages/sync.sh
@@ -210,25 +210,38 @@ bootstrap_brew_deps_linux() {
     fi
 }
 
+# Source an already-installed linuxbrew into PATH. Linux installs to
+# /home/linuxbrew/.linuxbrew (or ~/.linuxbrew) and isn't on PATH until
+# `brew shellenv` runs; macOS lands in /opt/homebrew, already on PATH via
+# zsh/core.zsh. Best-effort: a missing brew is not a failure here (the
+# installer path handles that), so this always returns 0.
+linuxbrew_shellenv() {
+    [[ "$PLATFORM" == "Linux" ]] || return 0
+    local brew_bin
+    for brew_bin in /home/linuxbrew/.linuxbrew/bin/brew "$HOME/.linuxbrew/bin/brew"; do
+        if [[ -x "$brew_bin" ]]; then
+            eval "$("$brew_bin" shellenv)"
+            return 0
+        fi
+    done
+    return 0
+}
+
 sync_brew() {
     # Install the OS build toolchain first so any sudo prompt is up front.
     bootstrap_brew_deps_linux
 
+    # Pick up an already-installed-but-unsourced linuxbrew *before* deciding to
+    # bootstrap, so a present brew doesn't trigger a redundant installer run.
+    if ! command -v brew &>/dev/null; then
+        linuxbrew_shellenv
+    fi
+
     if ! command -v brew &>/dev/null; then
         log_info "Installing Homebrew..."
         /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-        # Linux installs to /home/linuxbrew/.linuxbrew (or ~/.linuxbrew) and
-        # isn't on PATH until `brew shellenv` runs; macOS lands in
-        # /opt/homebrew, already on PATH via zsh/core.zsh.
-        if [[ "$PLATFORM" == "Linux" ]]; then
-            local brew_bin
-            for brew_bin in /home/linuxbrew/.linuxbrew/bin/brew "$HOME/.linuxbrew/bin/brew"; do
-                if [[ -x "$brew_bin" ]]; then
-                    eval "$("$brew_bin" shellenv)"
-                    break
-                fi
-            done
-        fi
+        # Freshly installed linuxbrew still isn't on PATH — source it now.
+        linuxbrew_shellenv
     fi
 
     if ! command -v brew &>/dev/null; then

--- a/tests/packages.bats
+++ b/tests/packages.bats
@@ -23,12 +23,34 @@ setup() {
     export CARGO_LOG="$TEST_HOME/cargo.log"
     export GH_LOG="$TEST_HOME/gh.log"
     export NPM_LOG="$TEST_HOME/npm.log"
+    export SUDO_LOG="$TEST_HOME/sudo.log"
 
     write_mock_brew
     write_mock_cargo
     write_mock_gh
     write_mock_npm
+    # Mock sudo records its args and no-ops — guarantees the Linux brew-deps
+    # bootstrap can never run a real `sudo apt-get` against the test machine.
+    write_mock_sudo
     export PATH="$MOCK_BIN:$PATH"
+}
+
+write_mock_sudo() {
+    cat > "$MOCK_BIN/sudo" << 'MOCKSUDO'
+#!/bin/bash
+echo "sudo $*" >> "$SUDO_LOG"
+exit 0
+MOCKSUDO
+    chmod +x "$MOCK_BIN/sudo"
+}
+
+write_mock_uv() {
+    cat > "$MOCK_BIN/uv" << 'MOCKUV'
+#!/bin/bash
+[[ "$1 $2" == "tool list" ]] && echo ""
+exit 0
+MOCKUV
+    chmod +x "$MOCK_BIN/uv"
 }
 
 teardown() {
@@ -133,12 +155,11 @@ packages:
   - test/tap-repo: { source: tap }
   - curl
   - jq
-  - fd: { apt: fd-find }
-  - node: { apt: nodejs }
+  - fd
+  - node
   - mas: { platform: mac }
   - xclip: { platform: linux }
   - docker-desktop: { source: cask, dev: true, platform: mac, greedy: false }
-  - npm: { platform: linux, dev: true }
   - pyenv: { dev: true }
   - cargo-llvm-cov: { source: cargo }
   - gh-stack: { source: gh-extension, pkg: github/gh-stack }
@@ -201,8 +222,6 @@ run_sync() {
 # --- Integration: sync installs the right packages ---
 
 @test "sync installs bare-string formulae via brew" {
-    [[ "$(uname)" == "Darwin" ]] || skip "macOS only (sync_brew not invoked on Linux)"
-
     write_test_yaml
     run_sync
     assert_success
@@ -212,8 +231,6 @@ run_sync() {
 }
 
 @test "sync installs map formulae (fd, node) via brew" {
-    [[ "$(uname)" == "Darwin" ]] || skip "macOS only (sync_brew not invoked on Linux)"
-
     write_test_yaml
     run_sync
     assert_success
@@ -242,9 +259,92 @@ run_sync() {
     ! grep -q "brew install xclip" "$BREW_LOG"
 }
 
-@test "sync processes taps before formulae" {
-    [[ "$(uname)" == "Darwin" ]] || skip "macOS only (sync_brew not invoked on Linux)"
+@test "sync installs linux-only packages via brew on Linux" {
+    [[ "$(uname)" == "Linux" ]] || skip "Linux only"
 
+    write_test_yaml
+    run_sync
+    assert_success
+
+    grep -q "brew install xclip" "$BREW_LOG"
+}
+
+@test "sync excludes mac-only packages on Linux" {
+    [[ "$(uname)" == "Linux" ]] || skip "Linux only"
+
+    write_test_yaml
+    run_sync
+    assert_success
+
+    # Positive control: the brew path ran and installed a both-platforms formula,
+    # so the absence below is real exclusion, not an empty brew phase.
+    grep -q "brew install jq" "$BREW_LOG"
+    ! grep -q "brew install mas" "$BREW_LOG"
+}
+
+@test "sync skips casks entirely on Linux (cask is macOS-only)" {
+    [[ "$(uname)" == "Linux" ]] || skip "Linux only"
+
+    # docker-desktop is a dev cask; even with DOTFILES_DEV=true, no
+    # `brew install --cask` should run on Linux.
+    write_test_yaml
+    DOTFILES_DEV=true run_sync
+    assert_success
+
+    ! grep -q "brew install --cask" "$BREW_LOG"
+}
+
+# A PATH with the C build toolchain (gcc/make/file) absent but every tool
+# sync.sh actually needs kept via a stub of symlinks — exercises the brew-deps
+# bootstrap's "toolchain missing" branch without touching the test machine.
+path_without_buildtools() {
+    local stub="$TEST_HOME/nobuild-stub"
+    mkdir -p "$stub"
+    local -a needed=(bash sh env uname id yq jq shasum sha256sum curl git \
+        awk sed grep cut sort tr head tail cat chmod mkdir rm ln mktemp \
+        dirname basename tee wc printf find xargs sleep)
+    local tool src
+    for tool in "${needed[@]}"; do
+        src=$(command -v "$tool" 2>/dev/null || true)
+        [[ -n "$src" && ! -e "$stub/$tool" ]] && ln -sf "$src" "$stub/$tool"
+    done
+    echo "$stub"
+}
+
+@test "installs Homebrew build deps via apt up front on Linux when toolchain missing" {
+    [[ "$(uname)" == "Linux" ]] || skip "Linux only"
+
+    # apt-get + uv mocked so the apt branch is taken deterministically and the
+    # uv bootstrap doesn't shell out to curl on the scrubbed PATH.
+    printf '#!/bin/bash\nexit 0\n' > "$MOCK_BIN/apt-get"; chmod +x "$MOCK_BIN/apt-get"
+    write_mock_uv
+    write_test_yaml
+
+    PATH="$MOCK_BIN:$(path_without_buildtools)" run_sync
+    assert_success
+
+    assert_output_contains "Installing Homebrew build dependencies"
+    grep -q "sudo apt-get install -y build-essential procps curl file git" "$SUDO_LOG"
+}
+
+@test "skips Homebrew build-dep install when toolchain already present" {
+    [[ "$(uname)" == "Linux" ]] || skip "Linux only"
+
+    # Stub the full toolchain so the check passes regardless of host state.
+    local t
+    for t in gcc make file git curl; do
+        printf '#!/bin/bash\nexit 0\n' > "$MOCK_BIN/$t"; chmod +x "$MOCK_BIN/$t"
+    done
+    write_test_yaml
+
+    run_sync
+    assert_success
+
+    ! grep -q "Installing Homebrew build dependencies" <<< "$output"
+    [[ ! -f "$SUDO_LOG" ]]
+}
+
+@test "sync processes taps before formulae" {
     write_test_yaml
     run_sync
     assert_success
@@ -256,8 +356,6 @@ run_sync() {
 }
 
 @test "sync skips dev packages when DOTFILES_DEV is not set" {
-    [[ "$(uname)" == "Darwin" ]] || skip "macOS only"
-
     write_test_yaml
     unset DOTFILES_DEV
     run_sync
@@ -268,8 +366,6 @@ run_sync() {
 }
 
 @test "sync installs dev packages when DOTFILES_DEV=true" {
-    [[ "$(uname)" == "Darwin" ]] || skip "macOS only"
-
     write_test_yaml
     DOTFILES_DEV=true run_sync
     assert_success
@@ -288,8 +384,6 @@ run_sync() {
 }
 
 @test "sync skips already-installed packages" {
-    [[ "$(uname)" == "Darwin" ]] || skip "macOS only (sync_brew not invoked on Linux)"
-
     write_test_yaml
     write_mock_brew "curl"
 
@@ -301,7 +395,7 @@ run_sync() {
 }
 
 @test "sync skips already-installed tap-qualified packages by short name" {
-    [[ "$(uname)" == "Darwin" ]] || skip "macOS only (sync_brew not invoked on Linux)"
+    [[ "$(uname)" == "Darwin" ]] || skip "fixture package is platform: mac (excluded on Linux)"
 
     # brew list --formulae prints short names; the installed-check must
     # compare a tap-qualified key (rjyo/moshi/moshi-hook) by its tail or
@@ -424,8 +518,6 @@ YAML
 }
 
 @test "FORCE_PACKAGES bypasses valid cache" {
-    [[ "$(uname)" == "Darwin" ]] || skip "macOS only (sync_brew not invoked on Linux)"
-
     write_test_yaml
     shasum -a 256 "$PACKAGES_FILE" | cut -d' ' -f1 > "$CACHE_FILE"
 
@@ -437,8 +529,6 @@ YAML
 }
 
 @test "sync does NOT save cache when brew install fails" {
-    [[ "$(uname)" == "Darwin" ]] || skip "macOS only (sync_brew not invoked on Linux)"
-
     write_test_yaml
     write_mock_brew "" "" "jq"
 
@@ -450,8 +540,6 @@ YAML
 }
 
 @test "sync retries after previous failure (no cache)" {
-    [[ "$(uname)" == "Darwin" ]] || skip "macOS only (sync_brew not invoked on Linux)"
-
     write_test_yaml
     write_mock_brew "" "" "jq"
 
@@ -564,8 +652,6 @@ MOCKRUSTUP
 }
 
 @test "UPGRADE_MODE runs brew upgrade after install loop" {
-    [[ "$(uname)" == "Darwin" ]] || skip "macOS only (sync_brew not invoked on Linux)"
-
     write_test_yaml
     UPGRADE_MODE=true run bash "$SYNC_SCRIPT"
     assert_success

--- a/zsh/core.zsh
+++ b/zsh/core.zsh
@@ -15,6 +15,13 @@ if [[ $OSTYPE == darwin* ]]; then
   [[ -d "${_brew_prefix}/opt/openssl/bin" ]] && export PATH="${_brew_prefix}/opt/openssl/bin:$PATH"
   [[ -d "${_brew_prefix}/opt/rustup/bin" ]] && export PATH="${_brew_prefix}/opt/rustup/bin:$PATH"
   unset _brew_prefix
+elif [[ $OSTYPE == linux* ]]; then
+  # Homebrew on Linux installs to /home/linuxbrew/.linuxbrew (or ~/.linuxbrew);
+  # brew shellenv puts its bin/sbin on PATH and sets HOMEBREW_* vars.
+  for _brew_bin in /home/linuxbrew/.linuxbrew/bin/brew "$HOME/.linuxbrew/bin/brew"; do
+    [[ -x "$_brew_bin" ]] && eval "$("$_brew_bin" shellenv)" && break
+  done
+  unset _brew_bin
 fi
 
 # Add dotfiles bin to PATH


### PR DESCRIPTION
## What

Make `dots sync` install Homebrew on Linux. Previously Linux ran an advisory-only `sync_apt` that *reported* missing apt packages but never installed anything; macOS ran the real `sync_brew`. Now both platforms use `sync_brew`.

## Decisions (locked with the user)

- **Brew installs by default on every Linux `dots sync`** (not opt-in).
- **Brew replaces the apt advisory** — `sync_apt` / `apt_check_pkg` removed.

## Changes

- **`sync_brew` works on Linux** — bootstraps Homebrew to `/home/linuxbrew/.linuxbrew`, then `eval "$(brew shellenv)"` to put it on PATH for the rest of the run; `zsh/core.zsh` does the same for new shells. Fails loud if brew isn't on PATH after install.
- **Build deps front-loaded** — `bootstrap_brew_deps_linux` runs first in `sync_brew` and installs Homebrew's prerequisite toolchain (`build-essential procps curl file git`, or the dnf/yum/pacman/zypper equivalent) via the system package manager, so the **sudo password prompt lands at the very start of the sync** instead of buried inside the brew install. No-ops when `gcc`/`make`/`git`/`curl`/`file` are already present; runs without `sudo` when already root (containers).
- **Casks are macOS-only** — `brew install --cask` errors on Linux, so the cask passes and the greedy-cask upgrade are Darwin-guarded.
- **`get_platform_pkgs` always uses the brew formula key** — dropped the now-dead `apt:` name overrides and the Linux-only `npm` entry (brew's `node` bundles npm).
- **Wiki** — documented the installer's platform behavior in `operations/sync-and-chezmoi.md`.

## Tests

`tests/packages.bats`: un-skipped the brew tests that are now cross-platform and added Linux-side coverage — linux-only formula installs via brew, mac-only excluded, casks never run on Linux, and the front-loaded dep install (a mock `sudo` in `setup()` neutralizes real sudo across the whole suite). `shellcheck` clean. The one failing test in the suite (`sync bootstraps rust toolchain when rustup exists but cargo missing`) fails on `main` too — pre-existing, environment-specific, unrelated.

## Note on a follow-up not taken

`sesh` is still pinned `platform: mac`. It's a smart tmux session manager (`joshmedeski/sesh`) — a fuzzy picker that lets you jump between tmux sessions, zoxide directories, and configured project paths, creating/attaching sessions on the fly (the `joshmedeski/sesh` tap is already tapped on both platforms, so it *could* now install on Linux). Left the marker as-is to keep this PR scoped to enabling brew, not changing package membership — flip it in a follow-up if you want `sesh` on Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)