### PR TITLE
feat(packages): add git-town and auto-trust declared brew taps

### DIFF
--- a/packages/packages.yaml
+++ b/packages/packages.yaml
@@ -43,6 +43,7 @@ packages:
   - difftastic
   - mergiraf
   - lazygit
+  - git-town
   - joshmedeski/sesh: { source: tap }            # sesh tap (joshmedeski/sesh/sesh)
   - sesh: { platform: mac }                       # session switcher; tmux binds guarded with if-shell
   - just

--- a/packages/sync.sh
+++ b/packages/sync.sh
@@ -268,8 +268,14 @@ sync_brew() {
                 if ! brew tap "$tap" </dev/null; then
                     log_error "Failed to tap $tap"
                     FAILED+=("tap:$tap")
+                    continue
                 fi
             fi
+            # Homebrew's recent tap-trust gate refuses to load formulae from
+            # untrusted third-party taps, so a fresh install from one fails. Trust
+            # each present tap idempotently. `trust` is a newer subcommand; `|| true`
+            # keeps older Homebrew (no `trust` command) from breaking sync.
+            brew trust "$tap" </dev/null >/dev/null 2>&1 || true
         done <<< "$taps"
     fi
 

--- a/tests/packages.bats
+++ b/tests/packages.bats
@@ -355,6 +355,15 @@ path_without_buildtools() {
     [[ "$tap_line" -lt "$install_line" ]]
 }
 
+@test "sync trusts declared taps to satisfy Homebrew tap-trust gate" {
+    write_test_yaml
+    run_sync
+    assert_success
+
+    # Each declared tap must be trusted so fresh formula installs aren't refused.
+    grep -q "brew trust test/tap-repo" "$BREW_LOG"
+}
+
 @test "sync skips dev packages when DOTFILES_DEV is not set" {
     write_test_yaml
     unset DOTFILES_DEV


### PR DESCRIPTION
## What

- Add `git-town` to the brew formula list — installs on **mac + linux** (bare string = `brew`, both platforms).
- Auto-trust each declared third-party tap in the `sync_brew` tap loop.

## Why

Homebrew recently turned on a **tap-trust gate** (`HOMEBREW_REQUIRE_TAP_TRUST`) that refuses to load formulae from untrusted third-party taps. A fresh install from a declared tap now fails — observed with `tinty` from `tinted-theming/tinted` during `dots sync`. The fix trusts each present tap idempotently; `|| true` keeps older Homebrew (no `trust` subcommand) from breaking sync. On a fresh machine this means `tinty` / `bun` / `skhd` / `sesh` install cleanly without manual intervention.

## Test

- New `packages.bats` test asserts `brew trust <tap>` is issued for each declared tap.
- Full `packages.bats`: 46/47 pass; the lone failure (`#35`, rust-toolchain bootstrap) is pre-existing and unrelated (confirmed failing identically on a clean tree).
- Verified live: `git-town 23.0.2` and `tinty 0.32.2` both installed; re-running `dots sync` completes clean and saves the package cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
