### PR TITLE
feat(ap): isolated profiles for codex and opencode (#221, #222)

### DIFF
--- a/.hallouminate/wiki/architecture/agent-profile.md
+++ b/.hallouminate/wiki/architecture/agent-profile.md
@@ -62,18 +62,31 @@ Renders a profile into a target directory and records a manifest for surgical un
 
 For a **non-isolated** profile: `install` for the single named harness, then `os.execvp` the bare harness CLI with passthrough args.
 
-For an **isolated** profile (`overlay.py:build_isolated_flags`): build the ccp-parity closed-world flags, inject the profile's `env`, and `execvp claude` — no install, no manifest. The flags reproduce the retired `ccp` zsh launcher:
+For an **isolated** profile (`overlay.py:build_isolated_launch`): build the closed-world `(flags, env)`, inject the profile's `env`, and `execvp <harness>` — no install, no manifest. Isolation is dispatched per harness via `_ISOLATION_BUILDERS` (`{claude, codex, opencode}`); each harness reaches the same closed world by a *different mechanism* behind the one `(flags, env)` contract. cursor/copilot/crush have no runtime-isolation lever, so an isolated launch against them fails loud (`IsolationError` → `CliError`).
 
-```
---strict-mcp-config --mcp-config <ephemeral .mcp.json>   # only the profile's MCPs
---setting-sources ""                                      # strip inherited settings
---tools <csv>                                             # hard tool whitelist (if declared)
---append-system-prompt-file <profile>/CLAUDE.md           # if system_prompt declared
---settings <ephemeral settings.json>                      # permissions + enabledPlugins
-<extra_args...>                                           # ${VAR}-expanded, verbatim
-```
+### Per-harness closed-world matrix
 
-Isolation is **claude-only** — launching an isolated profile against any other harness fails loud, since the flags are Claude's. The closed `--setting-sources ""` means there's no inherited user allowlist, so a profile's tool surface is exactly its `tools` whitelist + `permissions` — the MCP's own tools must be in `tools` (or rely on the closed `--mcp-config`). `_server_record` supports both stdio (`command`/`args`/`env`) and HTTP (`type: http` + `url`, e.g. `notion`) MCP shapes.
+| Capability | claude (`_build_isolated_claude`) | codex (`_build_isolated_codex`) | opencode (`_build_isolated_opencode`) |
+|---|---|---|---|
+| Closed MCP world | `--strict-mcp-config --mcp-config <ephemeral .mcp.json>` | `-c mcp_servers.<n>.command/args/env` per server (no whole-file flag exists) | `OPENCODE_CONFIG_CONTENT.mcp` = profile servers + inherited servers `enabled:false` |
+| Ignore inherited config | `--setting-sources ""` | `--ignore-user-config` (drops the **user** `config.toml` layer only) | inline highest-layer override (suppresses the global-config seed write) + per-server disable |
+| Ephemeral session | (n/a) | `--ephemeral` | (no env equivalent — documented gap) |
+| System prompt | `--append-system-prompt-file <profile>/<sp>` | `-c instructions=<file content>` (codex's `instructions` key takes content, **not** a path; raw-literal fallback handles arbitrary markdown) | `OPENCODE_CONFIG_CONTENT.instructions:[<sp abs path>]` (additive) |
+| Tool/permission restriction | `--tools <csv>` + `--settings` (`permissions`+`enabledPlugins`) | **dropped** — codex has no per-launch built-in-tool whitelist (caveat + follow-up ticket) | `OPENCODE_PERMISSION` from `permissions_deny` (`Edit`/`Write`→`edit:deny`, `Read`/`Grep`/`Glob`/`Bash`→key, `mcp__*` verbatim) |
+| Per-profile env | injected | injected | injected alongside the two `OPENCODE_*` vars |
+
+The `(flags, env)` contract is uniform: claude/codex carry isolation in `flags`, opencode carries it in `env` (`flags == []`); `_launch_isolated` injects `env` into `os.environ` then execs `harness + flags + exec_args` identically for all three. `${VAR}` MCP-env refs resolve from `.env` at launch on every path, failing loud on an unset reference (D4).
+
+**Field handling (D3):** `extra_args` (raw claude flags) and `enabled_plugins` (claude marketplace) are claude-only — on codex/opencode they print `field <x> ignored for harness <y>` and proceed (never fail, never silently drop). codex additionally ignores-with-warning `tools` / `permissions_deny`.
+
+**Caveats:**
+
+- **codex tool restriction dropped** — an isolated codex profile gets MCP-world + no-user-config + ephemeral but **not** built-in tool-set restriction. Tracked in `feat(ap): revisit codex tool restriction for isolated profiles`.
+- **codex `/etc/codex/config.toml`** still loads under `--ignore-user-config` (it drops only the user layer); a system config can inject servers/approvals. Out of scope.
+- **opencode can't suppress project `AGENTS.md`/`CLAUDE.md` auto-load** — the system prompt is *appended* via `instructions`; not a fully-closed instruction world.
+- **opencode `mcp__*` deny keys** are syntactically accepted as `OPENCODE_PERMISSION` freeform keys but enforcement is unconfirmed — best-effort.
+
+`_server_record` (claude) and `_mcp_server_record` (opencode, reused from the renderer) support both stdio (`command`/`args`/`env`) and HTTP (`type: http` + `url`, e.g. `notion`) MCP shapes.
 
 ### Target resolution (`cli._resolve_target`)
 

--- a/.hallouminate/wiki/architecture/agent-profile.md
+++ b/.hallouminate/wiki/architecture/agent-profile.md
@@ -68,21 +68,23 @@ For an **isolated** profile (`overlay.py:build_isolated_launch`): build the clos
 
 | Capability | claude (`_build_isolated_claude`) | codex (`_build_isolated_codex`) | opencode (`_build_isolated_opencode`) |
 |---|---|---|---|
-| Closed MCP world | `--strict-mcp-config --mcp-config <ephemeral .mcp.json>` | `-c mcp_servers.<n>.command/args/env` per server (no whole-file flag exists) | `OPENCODE_CONFIG_CONTENT.mcp` = profile servers + inherited servers `enabled:false` |
-| Ignore inherited config | `--setting-sources ""` | `--ignore-user-config` (drops the **user** `config.toml` layer only) | inline highest-layer override (suppresses the global-config seed write) + per-server disable |
-| Ephemeral session | (n/a) | `--ephemeral` | (no env equivalent — documented gap) |
-| System prompt | `--append-system-prompt-file <profile>/<sp>` | `-c instructions=<file content>` (codex's `instructions` key takes content, **not** a path; raw-literal fallback handles arbitrary markdown) | `OPENCODE_CONFIG_CONTENT.instructions:[<sp abs path>]` (additive) |
-| Tool/permission restriction | `--tools <csv>` + `--settings` (`permissions`+`enabledPlugins`) | **dropped** — codex has no per-launch built-in-tool whitelist (caveat + follow-up ticket) | `OPENCODE_PERMISSION` from `permissions_deny` (`Edit`/`Write`→`edit:deny`, `Read`/`Grep`/`Glob`/`Bash`→key, `mcp__*` verbatim) |
-| Per-profile env | injected | injected | injected alongside the two `OPENCODE_*` vars |
+| Closed MCP world | `--strict-mcp-config --mcp-config <ephemeral .mcp.json>` | `[mcp_servers.<n>]` tables in a generated `<CODEX_HOME>/config.toml` (no whole-file `--mcp-config` flag exists; HTTP MCPs carry `url`/`type`/`http_headers`) | `OPENCODE_CONFIG_CONTENT.mcp` = profile servers + inherited servers `enabled:false` |
+| Ignore inherited config | `--setting-sources ""` | redirected `CODEX_HOME` → a fresh dir whose `config.toml` is the only user-layer config (codex 0.135.0 has **no** top-level `--ignore-user-config`; it's a `codex exec`-only flag) | inline highest-layer override (suppresses the global-config seed write) + per-server disable |
+| Auth preservation | (n/a — uses real `~/.claude`) | symlink `<CODEX_HOME>/auth.json` → `~/.codex/auth.json` (`File` auth-storage mode only) | (n/a) |
+| Ephemeral session | (n/a) | (no interactive flag; the per-launch `CODEX_HOME` tmp dir is the ephemeral store — `--ephemeral` is `codex exec`-only) | (no env equivalent — documented gap) |
+| System prompt | `--append-system-prompt-file <profile>/<sp>` | `model_instructions_file = <sp abs path>` in the generated `config.toml` (codex's `instructions` key is reserved/noop — `model_instructions_file` is the documented lever) | `OPENCODE_CONFIG_CONTENT.instructions:[<sp abs path>]` (additive) |
+| Tool/permission restriction | `--tools <csv>` + `--settings` (`permissions`+`enabledPlugins`) | **dropped** — codex has no per-launch built-in-tool whitelist (caveat + follow-up ticket) | `OPENCODE_PERMISSION` from `permissions_deny` (`Edit`/`Write`→`edit:deny`, `Read`/`Grep`/`Glob`/`Bash`→key, `mcp__*` verbatim) + `OPENCODE_DISABLE_PROJECT_CONFIG=true` |
+| Per-profile env | injected | injected (alongside `CODEX_HOME`) | injected alongside the two `OPENCODE_*` vars |
 
-The `(flags, env)` contract is uniform: claude/codex carry isolation in `flags`, opencode carries it in `env` (`flags == []`); `_launch_isolated` injects `env` into `os.environ` then execs `harness + flags + exec_args` identically for all three. `${VAR}` MCP-env refs resolve from `.env` at launch on every path, failing loud on an unset reference (D4).
+The `(flags, env)` contract is uniform: claude carries isolation in `flags`, codex and opencode carry it in `env` (`flags == []` for both — codex's `CODEX_HOME`, opencode's `OPENCODE_*`); `_launch_isolated` injects `env` into `os.environ` then execs `harness + flags + exec_args` identically for all three. `${VAR}` MCP-env resolution differs by harness: **claude and codex bake-resolve** from `.env` at launch and **fail loud** on an unset reference (D4); **opencode does not** — it rewrites `${VAR}` to opencode's `{env:VAR}` placeholder and defers expansion to opencode's runtime (which reads the shell-exported `.env`), so a missing var surfaces only when opencode expands it, not as a launch-time error.
 
 **Field handling (D3):** `extra_args` (raw claude flags) and `enabled_plugins` (claude marketplace) are claude-only — on codex/opencode they print `field <x> ignored for harness <y>` and proceed (never fail, never silently drop). codex additionally ignores-with-warning `tools` / `permissions_deny`.
 
 **Caveats:**
 
-- **codex tool restriction dropped** — an isolated codex profile gets MCP-world + no-user-config + ephemeral but **not** built-in tool-set restriction. Tracked in `feat(ap): revisit codex tool restriction for isolated profiles`.
-- **codex `/etc/codex/config.toml`** still loads under `--ignore-user-config` (it drops only the user layer); a system config can inject servers/approvals. Out of scope.
+- **codex tool restriction dropped** — an isolated codex profile gets the closed MCP world + a redirected `CODEX_HOME` but **not** built-in tool-set restriction. Tracked in `feat(ap): revisit codex tool restriction for isolated profiles`.
+- **codex auth.json symlink is File-mode only** — login is preserved by symlinking `<CODEX_HOME>/auth.json` → `~/.codex/auth.json`, which works for `File` auth-storage mode (`codex doctor` → `auth storage mode: File`). Keyring users must set `CODEX_ACCESS_TOKEN` instead — known limitation.
+- **codex `/etc/codex/config.toml`** (system config) still loads regardless of `CODEX_HOME` (separate load path); a system config can inject servers/approvals. Out of scope. A project `.codex/config.toml` is loaded but inert — the fresh `config.toml` trusts no projects.
 - **opencode can't suppress project `AGENTS.md`/`CLAUDE.md` auto-load** — the system prompt is *appended* via `instructions`; not a fully-closed instruction world.
 - **opencode `mcp__*` deny keys** are syntactically accepted as `OPENCODE_PERMISSION` freeform keys but enforcement is unconfirmed — best-effort.
 

--- a/agent-profile/agent_profile/cli.py
+++ b/agent-profile/agent_profile/cli.py
@@ -649,19 +649,16 @@ def _launch_isolated(
     colors: _Colors,
     out: Any,
 ) -> NoReturn:
-    """Closed-world launch (spec curd 6 / D6): build the ccp-parity flags,
-    inject the profile env, exec the harness. Isolated profiles are
-    claude-only (the flags are claude's); any other harness fails loud."""
+    """Closed-world launch (spec D1): dispatch to the per-harness isolation
+    builder, inject the profile env, exec the harness. claude/codex/opencode
+    each build the closed world by a different mechanism behind one
+    ``(flags, env)`` contract; cursor/copilot/crush have no isolation lever
+    and fail loud (``IsolationError`` -> ``CliError``)."""
     from agent_profile.env import EnvResolutionError
-    from agent_profile.overlay import IsolationError, build_isolated_flags
+    from agent_profile.overlay import IsolationError, build_isolated_launch
 
-    if harness != "claude":
-        raise CliError(
-            f"{colors.RED}ap launch: profile '{manifest.name}' is isolated; "
-            f"isolation is claude-only (got '{harness}'){colors.NC}"
-        )
     try:
-        flags, env = build_isolated_flags(manifest, profile_dir)
+        flags, env = build_isolated_launch(manifest, profile_dir, harness)
     except (IsolationError, EnvResolutionError) as exc:
         raise CliError(f"{colors.RED}{exc}{colors.NC}")
 

--- a/agent-profile/agent_profile/overlay.py
+++ b/agent-profile/agent_profile/overlay.py
@@ -55,6 +55,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 import tempfile
 from pathlib import Path
@@ -237,6 +238,20 @@ def _codex_toml_value(value: object) -> str:
     return json.dumps(value, ensure_ascii=False)
 
 
+_BARE_TOML_KEY = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+def _codex_toml_key(key: str) -> str:
+    """Render a TOML key (MCP name, env/header key) safely.
+
+    A TOML bare key allows only ``[A-Za-z0-9_-]``; an unquoted key with a space
+    fails to parse and one with a dot silently nests into a sub-table. Bare-safe
+    keys pass through verbatim; anything else is quoted via the same
+    string-quoting path as values (``[mcp_servers."has space"]``,
+    ``"my.dotted" = ...``)."""
+    return key if _BARE_TOML_KEY.match(key) else _codex_toml_value(key)
+
+
 def _codex_mcp_tables(manifest: Manifest) -> str:
     """Render the profile's MCPs as ``[mcp_servers.<n>]`` TOML tables.
 
@@ -253,7 +268,7 @@ def _codex_mcp_tables(manifest: Manifest) -> str:
     lines: list[str] = []
     for raw in manifest.mcps:
         mcp = resolve_item_env(raw, dotenv)
-        name = mcp["name"]
+        name = _codex_toml_key(mcp["name"])
         lines.append(f"[mcp_servers.{name}]")
         if mcp.get("url") or mcp.get("type") in ("http", "sse"):
             lines.append(f"url = {_codex_toml_value(mcp['url'])}")
@@ -264,7 +279,7 @@ def _codex_mcp_tables(manifest: Manifest) -> str:
             if isinstance(headers, dict) and headers:
                 lines.append(f"\n[mcp_servers.{name}.http_headers]")
                 for key, val in headers.items():
-                    lines.append(f"{key} = {_codex_toml_value(str(val))}")
+                    lines.append(f"{_codex_toml_key(key)} = {_codex_toml_value(str(val))}")
         else:
             lines.append(f"command = {_codex_toml_value(mcp['command'])}")
             if mcp.get("args") is not None:
@@ -273,7 +288,7 @@ def _codex_mcp_tables(manifest: Manifest) -> str:
             if isinstance(env, dict) and env:
                 lines.append(f"\n[mcp_servers.{name}.env]")
                 for key, val in env.items():
-                    lines.append(f"{key} = {_codex_toml_value(str(val))}")
+                    lines.append(f"{_codex_toml_key(key)} = {_codex_toml_value(str(val))}")
         lines.append("")
     return "\n".join(lines)
 
@@ -306,6 +321,21 @@ def _write_codex_config(
     (codex_home / "config.toml").write_text("\n".join(sections))
 
 
+def _codex_cache_base() -> Path:
+    """Parent dir for the per-launch ``CODEX_HOME``, under the user cache (not
+    ``/tmp``).
+
+    codex 0.135.0 refuses to install its PATH-helper binaries when
+    ``CODEX_HOME`` is under a temp dir, printing a "could not update PATH"
+    warning every isolated launch (``tempfile.mkdtemp``'s ``/tmp`` default
+    tripped this). Rooting under ``$XDG_CACHE_HOME`` / ``~/.cache`` clears the
+    warning and restores the PATH-helper install while keeping per-launch
+    ephemeral accumulation (``ap launch`` execs and can't clean up post-exec)."""
+    base = Path(os.environ.get("XDG_CACHE_HOME") or Path.home() / ".cache") / "ap-codex"
+    base.mkdir(parents=True, exist_ok=True)
+    return base
+
+
 def _build_isolated_codex(
     manifest: Manifest,
     profile_dir: Path,
@@ -325,9 +355,11 @@ def _build_isolated_codex(
     ``~/.codex/auth.json`` (``FileAuthStorage`` reads ``<CODEX_HOME>/auth.json``
     and follows symlinks). ``scratch`` (the isolated home) matches the claude
     path's ephemeral-dir convention: a fresh ``tempfile.mkdtemp`` per launch
-    that outlives this call so the exec'd codex can read it. ``ap launch``
-    execs and cannot clean up post-exec, so these accumulate exactly like the
-    claude path's generated ``.mcp.json`` / ``settings.json`` dirs.
+    that outlives this call so the exec'd codex can read it — rooted under the
+    user cache (:func:`_codex_cache_base`), not ``/tmp`` (codex refuses its
+    PATH-helper install under a temp dir). ``ap launch`` execs and cannot clean
+    up post-exec, so these accumulate exactly like the claude path's generated
+    ``.mcp.json`` / ``settings.json`` dirs.
 
     Caveats (also in the module docstring):
 
@@ -353,7 +385,7 @@ def _build_isolated_codex(
             _warn_ignored(name, "codex")
 
     if scratch is None:
-        scratch = Path(tempfile.mkdtemp(prefix=f"ap-{manifest.name}-codex-"))
+        scratch = Path(tempfile.mkdtemp(dir=_codex_cache_base(), prefix=f"ap-{manifest.name}-codex-"))
 
     auth = Path.home() / ".codex" / "auth.json"
     link = scratch / "auth.json"

--- a/agent-profile/agent_profile/overlay.py
+++ b/agent-profile/agent_profile/overlay.py
@@ -1,4 +1,4 @@
-"""overlay.py — launch-time isolation overlay (spec curd 6, decision D6).
+"""overlay.py — launch-time isolation overlay, dispatched per harness.
 
 The retired ``ccp`` zsh function launched ``claude`` as a closed world:
 strict MCP scoping (``--strict-mcp-config --mcp-config <generated>``),
@@ -6,31 +6,64 @@ inherited settings stripped (``--setting-sources ""``), a tool whitelist
 (``--tools``), a profile system-prompt append, a generated settings file
 carrying ``permissions.deny``, per-profile env, and verbatim extra args.
 
-This module rebuilds that overlay from an ``isolated: true`` profile so the
-behaviour lives inside ``ap`` instead of zsh. :func:`build_isolated_flags`
-materializes the two ephemeral files (``.mcp.json`` + ``settings.json``)
-into a tmp dir and returns the assembled ``claude`` flag list plus the env
-mapping to inject; ``cli.cmd_launch`` execvp's with them.
+This module rebuilds that closed world from an ``isolated: true`` profile so
+the behaviour lives inside ``ap`` instead of zsh. The three isolating
+harnesses reach the closed world by *different mechanisms* but fit one
+``(flags, env)`` contract:
 
-Only ``claude`` supports these flags; an isolated profile launched against
-another harness fails loud (parity with ``ccp`` being claude-only).
+- **claude** carries isolation in CLI flags (the original ccp parity).
+- **codex** carries it in CLI ``-c`` overrides (no whole-file MCP flag exists).
+- **opencode** carries it in launch env vars (``OPENCODE_CONFIG_CONTENT`` +
+  ``OPENCODE_PERMISSION``), since opencode has no "ignore inherited config"
+  flag — isolation is an inline highest-layer override.
+
+:func:`build_isolated_launch` selects a per-harness builder from
+:data:`_ISOLATION_BUILDERS` and returns ``(flags, env)``;
+``cli._launch_isolated`` injects ``env`` into ``os.environ`` then execs
+``harness + flags + exec_args`` identically for all three. cursor/copilot/
+crush have no runtime-isolation levers, so an isolated launch against them
+raises :class:`IsolationError` on the dispatch miss (fail loud).
+
+Per-harness caveats (also in AGENTS.md § Profile System):
+
+- **codex drops tool/permission restriction.** Codex has no per-launch
+  built-in-tool whitelist; an isolated codex profile gets the closed MCP
+  world + no-user-config + ephemeral, but *not* a ``--tools`` analog. The
+  profile's ``tools`` / ``permissions_deny`` / ``enabled_plugins`` are
+  ignored-with-warning. Tracked in a follow-up ticket.
+- **codex ``/etc/codex/config.toml``** still loads under
+  ``--ignore-user-config`` (it drops only the *user* layer). On a machine
+  with a system config that can inject servers/approvals. Out of scope.
+- **opencode cannot suppress project ``AGENTS.md`` / ``CLAUDE.md``
+  auto-load** — the profile's system prompt is *appended* via
+  ``instructions``; an isolated opencode launch is not a fully-closed
+  instruction world.
+- **opencode MCP-tool deny keys** (``mcp__*`` as ``OPENCODE_PERMISSION``
+  freeform keys) are syntactically accepted but enforcement is unconfirmed —
+  best-effort.
 """
 
 from __future__ import annotations
 
 import json
 import os
+import sys
 import tempfile
 from pathlib import Path
 
 from agent_profile.env import load_dotenv, resolve_env_value, resolve_item_env
 from agent_profile.parse import Manifest
 from agent_profile.renderers.base import mcp_server_entry
+from agent_profile.renderers.opencode import (
+    _OPENCODE_MCP_DEFAULT,
+    _mcp_server_record,
+)
 
 
 class IsolationError(Exception):
-    """Raised when an isolated profile is launched against a non-claude
-    harness (only claude supports the ccp-parity flags)."""
+    """Raised when an isolated profile is launched against a harness with no
+    runtime-isolation mechanism (cursor/copilot/crush) — there is no builder
+    in :data:`_ISOLATION_BUILDERS` for it, so the closed world can't be built."""
 
 
 def _dotenv() -> dict[str, str]:
@@ -40,6 +73,16 @@ def _dotenv() -> dict[str, str]:
         os.environ.get("DOTFILES_DIR") or str(Path.home() / "Dev/dotfiles")
     )
     return load_dotenv(repo_root / ".env")
+
+
+def _warn_ignored(name: str, harness: str) -> None:
+    """Print the ignore-with-warning line for a claude-only / codex-dropped
+    profile field (spec D3). Never fails, never silently drops — the operator
+    sees exactly which field had no effect on this harness."""
+    print(f"    ap: field {name} ignored for harness {harness}", file=sys.stderr)
+
+
+# ─── claude (original ccp parity) ────────────────────────────────────
 
 
 def _server_record(mcp: dict) -> dict:
@@ -108,7 +151,7 @@ def _write_settings(manifest: Manifest, scratch: Path) -> Path | None:
     return path
 
 
-def build_isolated_flags(
+def _build_isolated_claude(
     manifest: Manifest,
     profile_dir: Path,
     scratch: Path | None = None,
@@ -163,3 +206,267 @@ def build_isolated_flags(
     flags += [resolve_env_value(a, proc_env) for a in manifest.extra_args]
 
     return flags, dict(manifest.env)
+
+
+# ─── codex (CLI -c overrides; no whole-file MCP flag) ────────────────
+
+
+def _codex_toml_value(value: object) -> str:
+    """Render a Python value as the RHS of a codex ``-c key=<value>`` override.
+
+    Codex parses the value as TOML, falling back to the raw string literal
+    when it doesn't parse (config_override.rs). A JSON-encoded string and a
+    JSON-encoded list of strings are valid TOML scalars/arrays, so
+    :func:`json.dumps` produces the correct ``"npx"`` / ``["-y","x"]`` forms
+    in one call."""
+    return json.dumps(value)
+
+
+def _codex_mcp_overrides(manifest: Manifest) -> list[str]:
+    """Lower the profile's MCPs to ``-c mcp_servers.<n>.*`` override flags.
+
+    Codex has no ``--mcp-config <file>`` analog, so each server is injected
+    key-by-key. Inline ``${VAR}`` env refs resolve from ``.env`` (D4), failing
+    loud when unset — parity with the claude path. HTTP/SSE MCPs carry
+    ``url``/``type`` instead of ``command``/``args``; stdio MCPs carry
+    ``command`` and optional ``args``/``env``."""
+    dotenv = _dotenv()
+    flags: list[str] = []
+    for raw in manifest.mcps:
+        mcp = resolve_item_env(raw, dotenv)
+        name = mcp["name"]
+        prefix = f"mcp_servers.{name}"
+        if mcp.get("url") or mcp.get("type") in ("http", "sse"):
+            flags += ["-c", f"{prefix}.url={_codex_toml_value(mcp['url'])}"]
+            flags += [
+                "-c",
+                f"{prefix}.type={_codex_toml_value(mcp.get('type') or 'http')}",
+            ]
+        else:
+            flags += [
+                "-c",
+                f"{prefix}.command={_codex_toml_value(mcp['command'])}",
+            ]
+            if mcp.get("args") is not None:
+                flags += [
+                    "-c",
+                    f"{prefix}.args={_codex_toml_value(mcp['args'])}",
+                ]
+        env = mcp.get("env")
+        if isinstance(env, dict):
+            for key, val in env.items():
+                flags += [
+                    "-c",
+                    f"{prefix}.env.{key}={_codex_toml_value(str(val))}",
+                ]
+    return flags
+
+
+def _codex_system_prompt(manifest: Manifest, profile_dir: Path) -> list[str]:
+    """Inject the profile's system prompt as codex's ``instructions`` config.
+
+    Codex's ``instructions`` key takes the system-instruction *content*
+    string, not a file path (config_toml.rs). There is no documented
+    ``instructions_file`` key, so the file is read and passed inline; codex's
+    ``-c`` parser falls back to a raw string literal when the markdown body
+    isn't valid TOML (config_override.rs), so arbitrary content round-trips."""
+    if not manifest.system_prompt:
+        return []
+    sp = profile_dir / manifest.system_prompt
+    if not sp.is_file():
+        raise IsolationError(
+            f"system_prompt file not found for profile '{manifest.name}': {sp}"
+        )
+    return ["-c", f"instructions={_codex_toml_value(sp.read_text())}"]
+
+
+def _build_isolated_codex(
+    manifest: Manifest,
+    profile_dir: Path,
+    scratch: Path | None = None,
+) -> tuple[list[str], dict[str, str]]:
+    """Assemble the codex closed-world ``-c`` overrides for an isolated profile.
+
+    ``--ignore-user-config`` drops the user ``config.toml`` layer (the
+    ``--setting-sources ""`` analog); ``--ephemeral`` skips session-rollout
+    persistence; ``-c mcp_servers.<n>.*`` injects the profile's MCP world
+    inline; ``-c instructions=<content>`` injects the system prompt.
+
+    Tool/permission restriction is dropped (codex has no per-launch built-in
+    tool whitelist — see module docstring + follow-up ticket): ``tools``,
+    ``permissions_deny`` and ``enabled_plugins`` are ignored-with-warning, as
+    are the claude-only ``extra_args`` (D3)."""
+    for name, present in (
+        ("tools", bool(manifest.tools)),
+        ("permissions_deny", bool(manifest.permissions_deny)),
+        ("enabled_plugins", bool(manifest.enabled_plugins)),
+        ("extra_args", bool(manifest.extra_args)),
+    ):
+        if present:
+            _warn_ignored(name, "codex")
+
+    flags = ["--ignore-user-config", "--ephemeral"]
+    flags += _codex_mcp_overrides(manifest)
+    flags += _codex_system_prompt(manifest, profile_dir)
+    return flags, dict(manifest.env)
+
+
+# ─── opencode (launch env vars; inline highest-layer override) ───────
+
+# Claude permission token -> opencode permission key. NotebookEdit has no
+# opencode equivalent (dropped + logged). ``mcp__*`` deny entries pass
+# through as freeform keys verbatim (best-effort; enforcement unconfirmed).
+_CLAUDE_TO_OPENCODE_PERM = {
+    "Edit": "edit",
+    "Write": "edit",
+    "Read": "read",
+    "Grep": "grep",
+    "Glob": "glob",
+    "Bash": "bash",
+}
+
+
+def _inherited_opencode_mcps() -> list[str]:
+    """The MCP server names opencode inherits from its global config —
+    i.e. every registry server whose membership includes ``opencode``.
+
+    An isolated opencode launch sets each of these ``enabled: false`` in
+    ``OPENCODE_CONFIG_CONTENT.mcp`` so the global-config servers (layer 2,
+    not suppressible) don't leak into the closed world. Read from the same
+    ``agents/mcp/registry.yaml`` the renderers use, applying opencode's MCP
+    membership default. A missing/unparseable registry yields an empty list
+    (the profile's own servers still render — the closed world just doesn't
+    explicitly disable inherited ones)."""
+    import yaml
+
+    from agent_profile.renderers.base import includes_harness
+
+    repo_root = Path(
+        os.environ.get("DOTFILES_DIR") or str(Path.home() / "Dev/dotfiles")
+    )
+    registry = repo_root / "agents" / "mcp" / "registry.yaml"
+    if not registry.is_file():
+        return []
+    try:
+        data = yaml.safe_load(registry.read_text()) or {}
+    except yaml.YAMLError:
+        return []
+    mcps = data.get("mcps")
+    if not isinstance(mcps, dict):
+        return []
+    names: list[str] = []
+    for name, entry in mcps.items():
+        item = entry if isinstance(entry, dict) else {}
+        if includes_harness(item, "opencode", _OPENCODE_MCP_DEFAULT):
+            names.append(name)
+    return names
+
+
+def _opencode_mcp_block(manifest: Manifest) -> dict:
+    """Build ``OPENCODE_CONFIG_CONTENT.mcp``: the profile's own servers plus
+    every inherited server pinned ``enabled: false``.
+
+    The profile servers reuse the opencode renderer's record shape (``type:
+    local`` + ``{env:VAR}`` placeholder rewrite). Inherited servers the
+    profile also declares are NOT disabled — the profile's own (enabled)
+    record wins, matching opencode's deep-merge override."""
+    block: dict[str, dict] = {}
+    own = {mcp["name"] for mcp in manifest.mcps}
+    for name in _inherited_opencode_mcps():
+        if name not in own:
+            block[name] = {"enabled": False}
+    for mcp in manifest.mcps:
+        block[mcp["name"]] = _mcp_server_record(mcp)
+    return block
+
+
+def _opencode_permission(manifest: Manifest) -> dict:
+    """Translate the profile's ``permissions_deny`` to an ``OPENCODE_PERMISSION``
+    block (spec D2 — keeps ``review`` genuinely read-only on opencode).
+
+    ``Edit``/``Write`` -> ``edit: deny``; ``Read``/``Grep``/``Glob``/``Bash``
+    -> their opencode key. ``NotebookEdit`` has no opencode equivalent
+    (dropped + logged). ``mcp__*`` entries pass through verbatim as freeform
+    permission keys (best-effort). Returns ``{}`` when nothing maps."""
+    perm: dict[str, str] = {}
+    for entry in manifest.permissions_deny:
+        if entry.startswith("mcp__"):
+            perm[entry] = "deny"
+            continue
+        mapped = _CLAUDE_TO_OPENCODE_PERM.get(entry)
+        if mapped is None:
+            _warn_ignored(f"permissions_deny[{entry}]", "opencode")
+            continue
+        perm[mapped] = "deny"
+    return perm
+
+
+def _build_isolated_opencode(
+    manifest: Manifest,
+    profile_dir: Path,
+    scratch: Path | None = None,
+) -> tuple[list[str], dict[str, str]]:
+    """Assemble the opencode closed-world launch env for an isolated profile.
+
+    opencode has no isolation CLI flag, so ``flags`` is empty and isolation
+    rides in the env: ``OPENCODE_CONFIG_CONTENT`` (highest non-managed layer —
+    suppresses the global-config seed write) carries the profile MCP world
+    (own servers + inherited servers ``enabled: false``) and the system
+    prompt as an additive ``instructions`` file path; ``OPENCODE_PERMISSION``
+    carries the ``permissions_deny`` translation (omitted when nothing maps).
+    The profile's ``env`` is injected alongside.
+
+    ``enabled_plugins`` (claude marketplace) and ``extra_args`` (raw claude
+    flags) are claude-only — ignored-with-warning (D3)."""
+    for name, present in (
+        ("enabled_plugins", bool(manifest.enabled_plugins)),
+        ("extra_args", bool(manifest.extra_args)),
+    ):
+        if present:
+            _warn_ignored(name, "opencode")
+
+    config: dict = {"mcp": _opencode_mcp_block(manifest)}
+    if manifest.system_prompt:
+        sp = profile_dir / manifest.system_prompt
+        if not sp.is_file():
+            raise IsolationError(
+                f"system_prompt file not found for profile '{manifest.name}': {sp}"
+            )
+        config["instructions"] = [str(sp)]
+
+    env: dict[str, str] = {"OPENCODE_CONFIG_CONTENT": json.dumps(config)}
+    permission = _opencode_permission(manifest)
+    if permission:
+        env["OPENCODE_PERMISSION"] = json.dumps(permission)
+    env.update(manifest.env)
+    return [], env
+
+
+# ─── dispatch ────────────────────────────────────────────────────────
+
+_ISOLATION_BUILDERS = {
+    "claude": _build_isolated_claude,
+    "codex": _build_isolated_codex,
+    "opencode": _build_isolated_opencode,
+}
+
+
+def build_isolated_launch(
+    manifest: Manifest,
+    profile_dir: Path,
+    harness: str,
+    scratch: Path | None = None,
+) -> tuple[list[str], dict[str, str]]:
+    """Build an isolated profile's ``(flags, env)`` for ``harness``.
+
+    Selects the per-harness builder from :data:`_ISOLATION_BUILDERS`. A
+    harness with no builder (cursor/copilot/crush — no runtime-isolation
+    lever) raises :class:`IsolationError`; the caller lowers it to a clean
+    ``CliError``."""
+    builder = _ISOLATION_BUILDERS.get(harness)
+    if builder is None:
+        raise IsolationError(
+            f"isolated profile '{manifest.name}': isolation unsupported for "
+            f"harness '{harness}'"
+        )
+    return builder(manifest, profile_dir, scratch)

--- a/agent-profile/agent_profile/overlay.py
+++ b/agent-profile/agent_profile/overlay.py
@@ -12,7 +12,9 @@ harnesses reach the closed world by *different mechanisms* but fit one
 ``(flags, env)`` contract:
 
 - **claude** carries isolation in CLI flags (the original ccp parity).
-- **codex** carries it in CLI ``-c`` overrides (no whole-file MCP flag exists).
+- **codex** carries it in a redirected ``CODEX_HOME`` (a fresh dir with a
+  generated ``config.toml`` + an ``auth.json`` symlink), since codex 0.135.0
+  has no top-level no-user-config flag.
 - **opencode** carries it in launch env vars (``OPENCODE_CONFIG_CONTENT`` +
   ``OPENCODE_PERMISSION``), since opencode has no "ignore inherited config"
   flag — isolation is an inline highest-layer override.
@@ -28,12 +30,18 @@ Per-harness caveats (also in AGENTS.md § Profile System):
 
 - **codex drops tool/permission restriction.** Codex has no per-launch
   built-in-tool whitelist; an isolated codex profile gets the closed MCP
-  world + no-user-config + ephemeral, but *not* a ``--tools`` analog. The
+  world + a redirected ``CODEX_HOME``, but *not* a ``--tools`` analog. The
   profile's ``tools`` / ``permissions_deny`` / ``enabled_plugins`` are
   ignored-with-warning. Tracked in a follow-up ticket.
-- **codex ``/etc/codex/config.toml``** still loads under
-  ``--ignore-user-config`` (it drops only the *user* layer). On a machine
-  with a system config that can inject servers/approvals. Out of scope.
+- **codex auth.json symlink is File-mode only.** Login is preserved by
+  symlinking ``<CODEX_HOME>/auth.json`` -> ``~/.codex/auth.json``, which
+  works for ``File`` auth-storage mode. Keyring users must set
+  ``CODEX_ACCESS_TOKEN`` instead — known limitation.
+- **codex ``/etc/codex/config.toml``** (system config) still loads
+  regardless of ``CODEX_HOME`` (it is a separate load path). On a machine
+  with one it can inject servers/approvals. Out of scope. Project
+  ``.codex/config.toml`` is loaded but inert (the fresh config trusts no
+  projects).
 - **opencode cannot suppress project ``AGENTS.md`` / ``CLAUDE.md``
   auto-load** — the profile's system prompt is *appended* via
   ``instructions``; an isolated opencode launch is not a fully-closed
@@ -208,84 +216,94 @@ def _build_isolated_claude(
     return flags, dict(manifest.env)
 
 
-# ─── codex (CLI -c overrides; no whole-file MCP flag) ────────────────
+# ─── codex (CODEX_HOME redirect + generated config.toml) ────────
 
 
 def _codex_toml_value(value: object) -> str:
-    """Render a Python value as the RHS of a codex ``-c key=<value>`` override.
+    """Render a Python value as the RHS of a ``key = <value>`` line in the
+    generated ``config.toml``.
 
-    Codex parses the value as TOML, falling back to the raw string literal
-    when it doesn't parse (config_override.rs). A JSON-encoded string and a
-    JSON-encoded list of strings are valid TOML scalars/arrays, so
-    :func:`json.dumps` produces the correct ``"npx"`` / ``["-y","x"]`` forms
-    in one call.
+    A JSON-encoded string and a JSON-encoded list of strings are valid TOML
+    scalars/arrays, so :func:`json.dumps` produces the correct ``"npx"`` /
+    ``["-y","x"]`` forms for an MCP ``command`` / ``args`` / ``env`` value in
+    one call.
 
     ``ensure_ascii=False`` is required, not cosmetic: with the default,
-    :func:`json.dumps` emits a non-BMP character (e.g. an emoji in a system
-    prompt) as a UTF-16 surrogate-pair backslash-u escape, which TOML
-    rejects -- a unicode escape must be a single Unicode scalar value, and a
-    surrogate code point is not. Emitting the literal UTF-8 character keeps a
-    TOML basic string parseable, so arbitrary system-prompt content
-    round-trips."""
+    :func:`json.dumps` emits a non-BMP character (e.g. an emoji in an MCP
+    arg or env value) as a UTF-16 surrogate-pair backslash-u escape, which
+    TOML rejects -- a unicode escape must be a single Unicode scalar value,
+    and a surrogate code point is not. Emitting the literal UTF-8 character
+    keeps a TOML basic string parseable, so arbitrary content round-trips."""
     return json.dumps(value, ensure_ascii=False)
 
 
-def _codex_mcp_overrides(manifest: Manifest) -> list[str]:
-    """Lower the profile's MCPs to ``-c mcp_servers.<n>.*`` override flags.
+def _codex_mcp_tables(manifest: Manifest) -> str:
+    """Render the profile's MCPs as ``[mcp_servers.<n>]`` TOML tables.
 
-    Codex has no ``--mcp-config <file>`` analog, so each server is injected
-    key-by-key. Inline ``${VAR}`` env refs resolve from ``.env`` (D4), failing
-    loud when unset — parity with the claude path. HTTP/SSE MCPs carry
-    ``url``/``type`` instead of ``command``/``args``; stdio MCPs carry
-    ``command`` and optional ``args``/``env``."""
+    Codex loads MCP servers from ``$CODEX_HOME/config.toml`` (it has no
+    ``--mcp-config <file>`` flag), so the closed MCP world is generated into
+    the isolated home's config rather than passed as ``-c`` overrides. Inline
+    ``${VAR}`` env refs resolve from ``.env`` (D4), failing loud when unset —
+    parity with the claude path. stdio MCPs carry ``command`` + optional
+    ``args``/``env`` (an ``[mcp_servers.<n>.env]`` sub-table); HTTP/SSE MCPs
+    carry ``url``/``type`` + optional ``headers`` (an
+    ``[mcp_servers.<n>.http_headers]`` sub-table — verified against codex
+    0.135.0 ``codex mcp get``)."""
     dotenv = _dotenv()
-    flags: list[str] = []
+    lines: list[str] = []
     for raw in manifest.mcps:
         mcp = resolve_item_env(raw, dotenv)
         name = mcp["name"]
-        prefix = f"mcp_servers.{name}"
+        lines.append(f"[mcp_servers.{name}]")
         if mcp.get("url") or mcp.get("type") in ("http", "sse"):
-            flags += ["-c", f"{prefix}.url={_codex_toml_value(mcp['url'])}"]
-            flags += [
-                "-c",
-                f"{prefix}.type={_codex_toml_value(mcp.get('type') or 'http')}",
-            ]
+            lines.append(f"url = {_codex_toml_value(mcp['url'])}")
+            lines.append(
+                f"type = {_codex_toml_value(mcp.get('type') or 'http')}"
+            )
+            headers = mcp.get("headers")
+            if isinstance(headers, dict) and headers:
+                lines.append(f"\n[mcp_servers.{name}.http_headers]")
+                for key, val in headers.items():
+                    lines.append(f"{key} = {_codex_toml_value(str(val))}")
         else:
-            flags += [
-                "-c",
-                f"{prefix}.command={_codex_toml_value(mcp['command'])}",
-            ]
+            lines.append(f"command = {_codex_toml_value(mcp['command'])}")
             if mcp.get("args") is not None:
-                flags += [
-                    "-c",
-                    f"{prefix}.args={_codex_toml_value(mcp['args'])}",
-                ]
-        env = mcp.get("env")
-        if isinstance(env, dict):
-            for key, val in env.items():
-                flags += [
-                    "-c",
-                    f"{prefix}.env.{key}={_codex_toml_value(str(val))}",
-                ]
-    return flags
+                lines.append(f"args = {_codex_toml_value(mcp['args'])}")
+            env = mcp.get("env")
+            if isinstance(env, dict) and env:
+                lines.append(f"\n[mcp_servers.{name}.env]")
+                for key, val in env.items():
+                    lines.append(f"{key} = {_codex_toml_value(str(val))}")
+        lines.append("")
+    return "\n".join(lines)
 
 
-def _codex_system_prompt(manifest: Manifest, profile_dir: Path) -> list[str]:
-    """Inject the profile's system prompt as codex's ``instructions`` config.
+def _write_codex_config(
+    manifest: Manifest, profile_dir: Path, codex_home: Path
+) -> None:
+    """Generate ``<codex_home>/config.toml`` for the isolated launch.
 
-    Codex's ``instructions`` key takes the system-instruction *content*
-    string, not a file path (config_toml.rs). There is no documented
-    ``instructions_file`` key, so the file is read and passed inline; codex's
-    ``-c`` parser falls back to a raw string literal when the markdown body
-    isn't valid TOML (config_override.rs), so arbitrary content round-trips."""
-    if not manifest.system_prompt:
-        return []
-    sp = profile_dir / manifest.system_prompt
-    if not sp.is_file():
-        raise IsolationError(
-            f"system_prompt file not found for profile '{manifest.name}': {sp}"
+    Sets ``model_instructions_file`` to the profile's system-prompt file
+    (an absolute path — codex's ``instructions`` key is reserved/noop, and
+    ``model_instructions_file`` is the documented way to inject a custom
+    system prompt; verified in the live ``~/.codex/config.toml``). Appends
+    the profile's MCP world as ``[mcp_servers.<n>]`` tables. The fresh config
+    trusts no projects, so any ``.codex/config.toml`` in the working tree is
+    loaded but inert."""
+    sections: list[str] = []
+    if manifest.system_prompt:
+        sp = profile_dir / manifest.system_prompt
+        if not sp.is_file():
+            raise IsolationError(
+                f"system_prompt file not found for profile '{manifest.name}': {sp}"
+            )
+        sections.append(
+            f"model_instructions_file = {_codex_toml_value(str(sp))}\n"
         )
-    return ["-c", f"instructions={_codex_toml_value(sp.read_text())}"]
+    tables = _codex_mcp_tables(manifest)
+    if tables:
+        sections.append(tables)
+    (codex_home / "config.toml").write_text("\n".join(sections))
 
 
 def _build_isolated_codex(
@@ -293,12 +311,33 @@ def _build_isolated_codex(
     profile_dir: Path,
     scratch: Path | None = None,
 ) -> tuple[list[str], dict[str, str]]:
-    """Assemble the codex closed-world ``-c`` overrides for an isolated profile.
+    """Assemble the codex closed world via a redirected ``CODEX_HOME``.
 
-    ``--ignore-user-config`` drops the user ``config.toml`` layer (the
-    ``--setting-sources ""`` analog); ``--ephemeral`` skips session-rollout
-    persistence; ``-c mcp_servers.<n>.*`` injects the profile's MCP world
-    inline; ``-c instructions=<content>`` injects the system prompt.
+    Codex 0.135.0 has no top-level ``--ignore-user-config`` / ``--ephemeral``
+    (those are ``codex exec`` subcommand flags — rejected by the bare
+    interactive ``codex`` the launcher execs). Isolation is instead achieved
+    by pointing ``CODEX_HOME`` at a fresh per-launch dir holding a generated
+    ``config.toml`` (the profile's MCP world + ``model_instructions_file``).
+    With ``CODEX_HOME`` redirected, the user's ``~/.codex/config.toml`` is not
+    loaded; ``flags`` is therefore empty and codex launches interactive.
+
+    Login is preserved by symlinking ``<home>/auth.json`` -> the real
+    ``~/.codex/auth.json`` (``FileAuthStorage`` reads ``<CODEX_HOME>/auth.json``
+    and follows symlinks). ``scratch`` (the isolated home) matches the claude
+    path's ephemeral-dir convention: a fresh ``tempfile.mkdtemp`` per launch
+    that outlives this call so the exec'd codex can read it. ``ap launch``
+    execs and cannot clean up post-exec, so these accumulate exactly like the
+    claude path's generated ``.mcp.json`` / ``settings.json`` dirs.
+
+    Caveats (also in the module docstring):
+
+    - The ``auth.json`` symlink only works for ``File`` auth-storage mode.
+      Keyring users (``cli_auth_credentials_store_mode = keyring``) must set
+      ``CODEX_ACCESS_TOKEN`` instead — known limitation.
+    - ``/etc/codex/config.toml`` (system config) still loads regardless of
+      ``CODEX_HOME``; on a machine with one it can inject servers/approvals.
+    - Project ``.codex/config.toml`` is loaded but inert (the fresh config
+      trusts no projects).
 
     Tool/permission restriction is dropped (codex has no per-launch built-in
     tool whitelist — see module docstring + follow-up ticket): ``tools``,
@@ -313,10 +352,18 @@ def _build_isolated_codex(
         if present:
             _warn_ignored(name, "codex")
 
-    flags = ["--ignore-user-config", "--ephemeral"]
-    flags += _codex_mcp_overrides(manifest)
-    flags += _codex_system_prompt(manifest, profile_dir)
-    return flags, dict(manifest.env)
+    if scratch is None:
+        scratch = Path(tempfile.mkdtemp(prefix=f"ap-{manifest.name}-codex-"))
+
+    auth = Path.home() / ".codex" / "auth.json"
+    link = scratch / "auth.json"
+    if auth.is_file() and not link.exists():
+        link.symlink_to(auth)
+
+    _write_codex_config(manifest, profile_dir, scratch)
+
+    env = {"CODEX_HOME": str(scratch), **dict(manifest.env)}
+    return [], env
 
 
 # ─── opencode (launch env vars; inline highest-layer override) ───────
@@ -422,7 +469,10 @@ def _build_isolated_opencode(
     (own servers + inherited servers ``enabled: false``) and the system
     prompt as an additive ``instructions`` file path; ``OPENCODE_PERMISSION``
     carries the ``permissions_deny`` translation (omitted when nothing maps).
-    The profile's ``env`` is injected alongside.
+    ``OPENCODE_DISABLE_PROJECT_CONFIG`` keeps a project-level ``opencode.json``
+    in the working tree from leaking its MCPs into the closed world (the
+    inherited-disable list only covers the global registry). The profile's
+    ``env`` is injected alongside.
 
     ``enabled_plugins`` (claude marketplace) and ``extra_args`` (raw claude
     flags) are claude-only — ignored-with-warning (D3)."""
@@ -442,7 +492,10 @@ def _build_isolated_opencode(
             )
         config["instructions"] = [str(sp)]
 
-    env: dict[str, str] = {"OPENCODE_CONFIG_CONTENT": json.dumps(config)}
+    env: dict[str, str] = {
+        "OPENCODE_CONFIG_CONTENT": json.dumps(config),
+        "OPENCODE_DISABLE_PROJECT_CONFIG": "true",
+    }
     permission = _opencode_permission(manifest)
     if permission:
         env["OPENCODE_PERMISSION"] = json.dumps(permission)

--- a/agent-profile/agent_profile/overlay.py
+++ b/agent-profile/agent_profile/overlay.py
@@ -64,8 +64,8 @@ from agent_profile.env import load_dotenv, resolve_env_value, resolve_item_env
 from agent_profile.parse import Manifest
 from agent_profile.renderers.base import mcp_server_entry
 from agent_profile.renderers.opencode import (
-    _OPENCODE_MCP_DEFAULT,
-    _mcp_server_record,
+    OPENCODE_MCP_DEFAULT,
+    mcp_server_record,
 )
 
 
@@ -271,7 +271,10 @@ def _codex_mcp_tables(manifest: Manifest) -> str:
         name = _codex_toml_key(mcp["name"])
         lines.append(f"[mcp_servers.{name}]")
         if mcp.get("url") or mcp.get("type") in ("http", "sse"):
-            lines.append(f"url = {_codex_toml_value(mcp['url'])}")
+            url = mcp.get("url")
+            if not url:
+                raise IsolationError(f"http MCP '{name}' missing url")
+            lines.append(f"url = {_codex_toml_value(url)}")
             lines.append(
                 f"type = {_codex_toml_value(mcp.get('type') or 'http')}"
             )
@@ -433,10 +436,20 @@ def _inherited_opencode_mcps() -> list[str]:
     )
     registry = repo_root / "agents" / "mcp" / "registry.yaml"
     if not registry.is_file():
+        print(
+            f"ap: could not read opencode registry {registry} (file not found);"
+            " inherited global MCPs may not be sealed",
+            file=sys.stderr,
+        )
         return []
     try:
         data = yaml.safe_load(registry.read_text()) or {}
-    except yaml.YAMLError:
+    except yaml.YAMLError as exc:
+        print(
+            f"ap: could not read opencode registry {registry} ({exc});"
+            " inherited global MCPs may not be sealed",
+            file=sys.stderr,
+        )
         return []
     mcps = data.get("mcps")
     if not isinstance(mcps, dict):
@@ -444,7 +457,7 @@ def _inherited_opencode_mcps() -> list[str]:
     names: list[str] = []
     for name, entry in mcps.items():
         item = entry if isinstance(entry, dict) else {}
-        if includes_harness(item, "opencode", _OPENCODE_MCP_DEFAULT):
+        if includes_harness(item, "opencode", OPENCODE_MCP_DEFAULT):
             names.append(name)
     return names
 
@@ -463,7 +476,7 @@ def _opencode_mcp_block(manifest: Manifest) -> dict:
         if name not in own:
             block[name] = {"enabled": False}
     for mcp in manifest.mcps:
-        block[mcp["name"]] = _mcp_server_record(mcp)
+        block[mcp["name"]] = mcp_server_record(mcp)
     return block
 
 

--- a/agent-profile/agent_profile/overlay.py
+++ b/agent-profile/agent_profile/overlay.py
@@ -218,8 +218,16 @@ def _codex_toml_value(value: object) -> str:
     when it doesn't parse (config_override.rs). A JSON-encoded string and a
     JSON-encoded list of strings are valid TOML scalars/arrays, so
     :func:`json.dumps` produces the correct ``"npx"`` / ``["-y","x"]`` forms
-    in one call."""
-    return json.dumps(value)
+    in one call.
+
+    ``ensure_ascii=False`` is required, not cosmetic: with the default,
+    :func:`json.dumps` emits a non-BMP character (e.g. an emoji in a system
+    prompt) as a UTF-16 surrogate-pair backslash-u escape, which TOML
+    rejects -- a unicode escape must be a single Unicode scalar value, and a
+    surrogate code point is not. Emitting the literal UTF-8 character keeps a
+    TOML basic string parseable, so arbitrary system-prompt content
+    round-trips."""
+    return json.dumps(value, ensure_ascii=False)
 
 
 def _codex_mcp_overrides(manifest: Manifest) -> list[str]:

--- a/agent-profile/agent_profile/renderers/opencode.py
+++ b/agent-profile/agent_profile/renderers/opencode.py
@@ -33,6 +33,7 @@ from agent_profile.shared import agent_is_read_only, strip_frontmatter, track_fi
 
 # opencode's MCP membership default (matches the bash select default).
 _OPENCODE_MCP_DEFAULT = ("claude", "codex", "opencode")
+OPENCODE_MCP_DEFAULT = _OPENCODE_MCP_DEFAULT
 
 _SCHEMA_STUB = {"$schema": "https://opencode.ai/config.json"}
 
@@ -87,6 +88,9 @@ def _mcp_server_record(mcp: dict[str, Any]) -> dict[str, Any]:
             k: _to_opencode_env(str(v)) for k, v in mcp["env"].items()
         }
     return record
+
+
+mcp_server_record = _mcp_server_record
 
 
 class OpencodeRenderer:

--- a/agent-profile/tests/test_overlay.py
+++ b/agent-profile/tests/test_overlay.py
@@ -770,83 +770,127 @@ def test_dispatch_table_keys_are_the_three_isolating_harnesses(tmp_path):
 # ─── codex builder (#221) ────────────────────────────────────────
 
 
-def test_codex_emits_no_user_config_and_ephemeral(tmp_path, monkeypatch):
+def _codex_config(env: dict) -> dict:
+    """Parse the generated ``<CODEX_HOME>/config.toml`` via a real TOML parser.
+
+    Asserts the builder set CODEX_HOME and that the file parses (the B1
+    lesson: a config the codex Rust `toml` crate would reject is a broken
+    launch, not a passing test). tomllib stands in for codex's parser — both
+    implement TOML 1.0."""
+    import tomllib
+
+    home = env["CODEX_HOME"]
+    cfg = Path(home) / "config.toml"
+    assert cfg.is_file(), "isolated codex launch wrote no config.toml"
+    return tomllib.loads(cfg.read_text())
+
+
+def test_codex_redirects_home_with_empty_flags(tmp_path, monkeypatch):
+    """Isolation rides in a redirected CODEX_HOME, not flags. The launch argv
+    is bare interactive codex — NO exec-only --ephemeral/--ignore-user-config
+    (rejected by codex 0.135.0's top-level parser)."""
     monkeypatch.setenv("DOTFILES_DIR", str(tmp_path))  # no .env
     m = _claude_manifest(tmp_path, system_prompt="CLAUDE.md")
     (tmp_path / "CLAUDE.md").write_text("codex sp\n")
     flags, env = overlay.build_isolated_launch(m, tmp_path, "codex")
-    assert flags[0] == "--ignore-user-config"
-    assert flags[1] == "--ephemeral"
-    assert env == {}
+    assert flags == []
+    assert "--ephemeral" not in flags
+    assert "--ignore-user-config" not in flags
+    assert env["CODEX_HOME"]
+    assert Path(env["CODEX_HOME"]).is_dir()
 
 
-def test_codex_mcp_overrides_are_c_pairs(tmp_path, monkeypatch):
-    """Each profile MCP lowers to -c mcp_servers.<n>.command/args overrides
-    (codex has no whole-file --mcp-config flag). Values are JSON/TOML-encoded
-    so command is a quoted string and args a list literal."""
+def test_codex_auth_json_symlinked_into_home(tmp_path, monkeypatch):
+    """Login is preserved by symlinking <CODEX_HOME>/auth.json -> the real
+    ~/.codex/auth.json (File auth-storage mode)."""
+    monkeypatch.setenv("DOTFILES_DIR", str(tmp_path))
+    fake_home = tmp_path / "home"
+    (fake_home / ".codex").mkdir(parents=True)
+    (fake_home / ".codex" / "auth.json").write_text('{"tokens": "x"}\n')
+    monkeypatch.setattr(overlay.Path, "home", classmethod(lambda cls: fake_home))
+    m = _claude_manifest(tmp_path)
+    _, env = overlay.build_isolated_launch(m, tmp_path, "codex")
+    link = Path(env["CODEX_HOME"]) / "auth.json"
+    assert link.is_symlink()
+    assert link.resolve() == (fake_home / ".codex" / "auth.json").resolve()
+
+
+def test_codex_auth_symlink_skipped_when_no_auth(tmp_path, monkeypatch):
+    """Keyring users have no ~/.codex/auth.json; the builder must not create a
+    dangling symlink (it would orphan auth either way — documented limitation)."""
+    monkeypatch.setenv("DOTFILES_DIR", str(tmp_path))
+    fake_home = tmp_path / "home"
+    (fake_home / ".codex").mkdir(parents=True)  # no auth.json
+    monkeypatch.setattr(overlay.Path, "home", classmethod(lambda cls: fake_home))
+    m = _claude_manifest(tmp_path)
+    _, env = overlay.build_isolated_launch(m, tmp_path, "codex")
+    assert not (Path(env["CODEX_HOME"]) / "auth.json").exists()
+
+
+def test_codex_mcp_servers_are_toml_tables(tmp_path, monkeypatch):
+    """Each profile MCP lands as an [mcp_servers.<n>] table in the generated
+    config.toml with command + args (codex loads MCPs from config.toml, not a
+    --mcp-config flag). Asserted by parsing the file, not substring-matching."""
     monkeypatch.setenv("DOTFILES_DIR", str(tmp_path))
     m = _claude_manifest(tmp_path)
-    flags, _ = overlay.build_isolated_launch(m, tmp_path, "codex")
-    assert "-c" in flags
-    overrides = [flags[i + 1] for i, f in enumerate(flags) if f == "-c"]
-    assert 'mcp_servers.tilth.command="tilth"' in overrides
-    assert 'mcp_servers.tilth.args=["--mcp"]' in overrides
+    _, env = overlay.build_isolated_launch(m, tmp_path, "codex")
+    cfg = _codex_config(env)
+    assert cfg["mcp_servers"]["tilth"] == {
+        "command": "tilth",
+        "args": ["--mcp"],
+    }
 
 
-def test_codex_system_prompt_injected_as_instructions(tmp_path, monkeypatch):
-    """The profile's system_prompt content is injected via -c instructions=
-    (codex's instructions key takes content, not a file path)."""
+def test_codex_system_prompt_is_model_instructions_file(tmp_path, monkeypatch):
+    """The system prompt is injected via model_instructions_file (an absolute
+    path), NOT the reserved/noop `instructions` key."""
     monkeypatch.setenv("DOTFILES_DIR", str(tmp_path))
     m = _claude_manifest(tmp_path, system_prompt="CLAUDE.md")
     (tmp_path / "CLAUDE.md").write_text("be a good codex\n")
-    flags, _ = overlay.build_isolated_launch(m, tmp_path, "codex")
-    overrides = [flags[i + 1] for i, f in enumerate(flags) if f == "-c"]
-    instr = [o for o in overrides if o.startswith("instructions=")]
-    assert len(instr) == 1
-    assert "be a good codex" in instr[0]
+    _, env = overlay.build_isolated_launch(m, tmp_path, "codex")
+    cfg = _codex_config(env)
+    mif = cfg["model_instructions_file"]
+    assert Path(mif).is_absolute()
+    assert mif == str(tmp_path / "CLAUDE.md")
+    assert "instructions" not in cfg  # the noop key is never emitted
 
 
-def test_codex_instructions_roundtrip_through_toml_parser(tmp_path, monkeypatch):
-    """The -c instructions=<content> value must survive codex's TOML parse and
-    decode back to the byte-identical CLAUDE.md. The cooked claim ("arbitrary
-    markdown round-trips") is the contract: a real system prompt carries
-    TOML-special chars (`=`, `[ ]`, quotes, backslashes, `#`) AND non-ASCII —
-    the user's own CLAUDE.md is full of 🧀. tomllib stands in for codex's Rust
-    `toml` crate; both implement TOML 1.0, where a `\\u` escape must be a single
-    Unicode scalar value, so a surrogate-pair escape (json.dumps' default for
-    non-BMP chars) is rejected at parse time."""
-    import tomllib
-
+def test_codex_config_is_valid_toml_with_adversarial_mcp_values(tmp_path, monkeypatch):
+    """The generated config.toml must parse as TOML 1.0 AND round-trip its
+    mcp_servers string values when an MCP arg/env carries TOML-special chars
+    (`=`, `[ ]`, quotes, backslashes, `#`) and non-BMP unicode. This locks the
+    `_codex_toml_value` ensure_ascii=False fix: a surrogate-pair \\u escape
+    (json.dumps' default for non-BMP) is rejected by TOML 1.0 at parse time,
+    so the whole config would fail to load."""
     monkeypatch.setenv("DOTFILES_DIR", str(tmp_path))
-    content = (
-        "# Heading = not a comment\n"
-        'Use key = "value" and [section] headers.\n'
-        "Path C:\\Users\\x, regex \\d+, em dash — café ✓, cheese 🧀 lord.\n"
-        'A """triple""" quoted block and an it\'s apostrophe.\n'
+    nasty_arg = '= [section] "q" \\ # café 🧀'
+    m = Manifest(
+        name="p",
+        isolated=True,
+        mcps=[{"name": "weird", "command": "npx",
+               "args": ["-y", nasty_arg],
+               "env": {"NOTE": "em — dash 🧀 lord, regex \\d+, key = val"},
+               "_source_dir": str(tmp_path)}],
     )
-    m = _claude_manifest(tmp_path, system_prompt="CLAUDE.md")
-    (tmp_path / "CLAUDE.md").write_text(content)
-    flags, _ = overlay.build_isolated_launch(m, tmp_path, "codex")
-    overrides = [flags[i + 1] for i, f in enumerate(flags) if f == "-c"]
-    instr = [o for o in overrides if o.startswith("instructions=")]
-    assert len(instr) == 1
-    rhs = instr[0][len("instructions=") :]
-    parsed = tomllib.loads(f"instructions={rhs}")
-    assert parsed["instructions"] == content, "codex -c instructions did not round-trip"
+    _, env = overlay.build_isolated_launch(m, tmp_path, "codex")
+    cfg = _codex_config(env)  # raises if the TOML is invalid
+    server = cfg["mcp_servers"]["weird"]
+    assert server["args"] == ["-y", nasty_arg], "mcp arg did not round-trip"
+    assert server["env"]["NOTE"] == "em — dash 🧀 lord, regex \\d+, key = val"
 
 
-def test_codex_no_system_prompt_omits_instructions(tmp_path, monkeypatch):
+def test_codex_no_system_prompt_omits_model_instructions_file(tmp_path, monkeypatch):
     monkeypatch.setenv("DOTFILES_DIR", str(tmp_path))
     m = _claude_manifest(tmp_path)  # no system_prompt
-    flags, _ = overlay.build_isolated_launch(m, tmp_path, "codex")
-    overrides = [flags[i + 1] for i, f in enumerate(flags) if f == "-c"]
-    assert not any(o.startswith("instructions=") for o in overrides)
+    _, env = overlay.build_isolated_launch(m, tmp_path, "codex")
+    cfg = _codex_config(env)
+    assert "model_instructions_file" not in cfg
 
 
 def test_codex_drops_tools_perms_plugins_with_warning(tmp_path, monkeypatch, capsys):
     """D2/D3: codex can't restrict built-in tools — tools/permissions_deny/
     enabled_plugins/extra_args are ignored-with-warning, never silently
-    dropped, never fatal."""
+    dropped, never fatal, never leaked into flags."""
     monkeypatch.setenv("DOTFILES_DIR", str(tmp_path))
     m = _claude_manifest(
         tmp_path,
@@ -859,15 +903,12 @@ def test_codex_drops_tools_perms_plugins_with_warning(tmp_path, monkeypatch, cap
     err = capsys.readouterr().err
     for field in ("tools", "permissions_deny", "enabled_plugins", "extra_args"):
         assert f"field {field} ignored for harness codex" in err
-    # none of the dropped fields leak into the flags
-    assert "--tools" not in flags
-    assert "Edit" not in flags and "Write" not in flags
-    assert "--foo" not in flags
+    assert flags == []  # nothing leaks into the launch argv
 
 
 def test_codex_mcp_env_resolved_from_dotenv(tmp_path, monkeypatch):
     """${VAR} in a codex MCP env block resolves from .env at launch (D4),
-    matching the claude path."""
+    matching the claude path, and lands in the config.toml env sub-table."""
     dots = tmp_path / "dots"
     dots.mkdir()
     (dots / ".env").write_text("CTX=ctx-secret\n")
@@ -879,9 +920,9 @@ def test_codex_mcp_env_resolved_from_dotenv(tmp_path, monkeypatch):
                "env": {"CONTEXT7_API_KEY": "${CTX}"},
                "_source_dir": str(tmp_path)}],
     )
-    flags, _ = overlay.build_isolated_launch(m, tmp_path, "codex")
-    overrides = [flags[i + 1] for i, f in enumerate(flags) if f == "-c"]
-    assert 'mcp_servers.context7.env.CONTEXT7_API_KEY="ctx-secret"' in overrides
+    _, env = overlay.build_isolated_launch(m, tmp_path, "codex")
+    cfg = _codex_config(env)
+    assert cfg["mcp_servers"]["context7"]["env"]["CONTEXT7_API_KEY"] == "ctx-secret"
 
 
 def test_codex_mcp_env_unset_fails_loud(tmp_path, monkeypatch):
@@ -901,7 +942,8 @@ def test_codex_mcp_env_unset_fails_loud(tmp_path, monkeypatch):
         overlay.build_isolated_launch(m, tmp_path, "codex")
 
 
-def test_codex_http_mcp_uses_url_overrides(tmp_path, monkeypatch):
+def test_codex_http_mcp_uses_url_table(tmp_path, monkeypatch):
+    """HTTP MCPs land as a url/type table, no command key."""
     monkeypatch.setenv("DOTFILES_DIR", str(tmp_path))
     m = Manifest(
         name="p",
@@ -910,22 +952,46 @@ def test_codex_http_mcp_uses_url_overrides(tmp_path, monkeypatch):
                "url": "https://mcp.notion.com/mcp",
                "_source_dir": str(tmp_path)}],
     )
-    flags, _ = overlay.build_isolated_launch(m, tmp_path, "codex")
-    overrides = [flags[i + 1] for i, f in enumerate(flags) if f == "-c"]
-    assert 'mcp_servers.notion.url="https://mcp.notion.com/mcp"' in overrides
-    assert 'mcp_servers.notion.type="http"' in overrides
-    assert not any(o.startswith("mcp_servers.notion.command") for o in overrides)
+    _, env = overlay.build_isolated_launch(m, tmp_path, "codex")
+    server = _codex_config(env)["mcp_servers"]["notion"]
+    assert server["url"] == "https://mcp.notion.com/mcp"
+    assert server["type"] == "http"
+    assert "command" not in server
+
+
+def test_codex_http_mcp_carries_headers(tmp_path, monkeypatch):
+    """L2: an HTTP MCP's headers lower to an http_headers sub-table (verified
+    against codex 0.135.0). The claude path carried headers; codex now does too."""
+    monkeypatch.setenv("DOTFILES_DIR", str(tmp_path))
+    m = Manifest(
+        name="p",
+        isolated=True,
+        mcps=[{"name": "authed", "type": "http",
+               "url": "https://example.com/mcp",
+               "headers": {"X-Api-Key": "secret", "Authorization": "Bearer t"},
+               "_source_dir": str(tmp_path)}],
+    )
+    _, env = overlay.build_isolated_launch(m, tmp_path, "codex")
+    server = _codex_config(env)["mcp_servers"]["authed"]
+    assert server["http_headers"] == {
+        "X-Api-Key": "secret",
+        "Authorization": "Bearer t",
+    }
 
 
 def test_codex_launch_does_not_hard_fail(env, monkeypatch):
-    """`dots profile launch codex <iso>` builds + execs, no longer erroring."""
+    """`dots profile launch codex <iso>` builds + execs bare interactive codex
+    (no exec-only flags), with CODEX_HOME injected into the process env."""
     write_isolated_todo(env.profiles)
     rec = _capture_exec(monkeypatch)
     with pytest.raises(SystemExit):
         cli.main(["launch", "codex", "todo", "--target", str(env.target)])
     assert rec["file"] == "codex"
-    assert "--ignore-user-config" in rec["args"]
-    assert "--ephemeral" in rec["args"]
+    assert rec["args"] == ["codex"]  # bare interactive, no flags before passthrough
+    assert "--ephemeral" not in rec["args"]
+    assert "--ignore-user-config" not in rec["args"]
+    assert cli.os.environ.get("CODEX_HOME")
+    assert (Path(cli.os.environ["CODEX_HOME"]) / "config.toml").is_file()
 
 
 # ─── opencode builder (#222) ─────────────────────────────────────
@@ -944,6 +1010,16 @@ def test_opencode_emits_config_content_env(tmp_path, monkeypatch):
         "enabled": True,
         "command": ["tilth", "--mcp"],
     }
+
+
+def test_opencode_disables_project_config(tmp_path, monkeypatch):
+    """L1: OPENCODE_DISABLE_PROJECT_CONFIG=true so a project-level opencode.json
+    in the working tree can't leak its MCPs into the closed world (the
+    inherited-disable list only covers the global registry)."""
+    monkeypatch.setenv("DOTFILES_DIR", str(tmp_path))
+    m = _claude_manifest(tmp_path)
+    _, env = overlay.build_isolated_launch(m, tmp_path, "opencode")
+    assert env["OPENCODE_DISABLE_PROJECT_CONFIG"] == "true"
 
 
 def test_opencode_disables_inherited_registry_servers(tmp_path, monkeypatch):
@@ -1129,14 +1205,14 @@ def test_real_review_profile_read_only_on_opencode(monkeypatch, tmp_path):
 def test_real_review_profile_on_codex_drops_perms_with_caveat(monkeypatch, tmp_path, capsys):
     """The shipped review profile on codex builds the MCP world but CANNOT
     enforce its read-only deny list (codex caveat) — it's ignored-with-warning,
-    and the closed MCP world is still injected via -c overrides."""
+    and the closed MCP world is still injected via the generated config.toml."""
     _hermetic_dotenv(monkeypatch, tmp_path)
     pdir = find_profile_dir("review")
     assert pdir is not None
     m = parse_manifest(pdir)
-    flags, _ = overlay.build_isolated_launch(m, pdir, "codex")
+    _, env = overlay.build_isolated_launch(m, pdir, "codex")
     err = capsys.readouterr().err
     assert "field permissions_deny ignored for harness codex" in err
-    overrides = [flags[i + 1] for i, f in enumerate(flags) if f == "-c"]
+    servers = _codex_config(env)["mcp_servers"]
     for server in ("tilth", "code-review-graph", "context7"):
-        assert any(o.startswith(f"mcp_servers.{server}.") for o in overrides), server
+        assert server in servers, server

--- a/agent-profile/tests/test_overlay.py
+++ b/agent-profile/tests/test_overlay.py
@@ -806,6 +806,35 @@ def test_codex_system_prompt_injected_as_instructions(tmp_path, monkeypatch):
     assert "be a good codex" in instr[0]
 
 
+def test_codex_instructions_roundtrip_through_toml_parser(tmp_path, monkeypatch):
+    """The -c instructions=<content> value must survive codex's TOML parse and
+    decode back to the byte-identical CLAUDE.md. The cooked claim ("arbitrary
+    markdown round-trips") is the contract: a real system prompt carries
+    TOML-special chars (`=`, `[ ]`, quotes, backslashes, `#`) AND non-ASCII —
+    the user's own CLAUDE.md is full of 🧀. tomllib stands in for codex's Rust
+    `toml` crate; both implement TOML 1.0, where a `\\u` escape must be a single
+    Unicode scalar value, so a surrogate-pair escape (json.dumps' default for
+    non-BMP chars) is rejected at parse time."""
+    import tomllib
+
+    monkeypatch.setenv("DOTFILES_DIR", str(tmp_path))
+    content = (
+        "# Heading = not a comment\n"
+        'Use key = "value" and [section] headers.\n'
+        "Path C:\\Users\\x, regex \\d+, em dash — café ✓, cheese 🧀 lord.\n"
+        'A """triple""" quoted block and an it\'s apostrophe.\n'
+    )
+    m = _claude_manifest(tmp_path, system_prompt="CLAUDE.md")
+    (tmp_path / "CLAUDE.md").write_text(content)
+    flags, _ = overlay.build_isolated_launch(m, tmp_path, "codex")
+    overrides = [flags[i + 1] for i, f in enumerate(flags) if f == "-c"]
+    instr = [o for o in overrides if o.startswith("instructions=")]
+    assert len(instr) == 1
+    rhs = instr[0][len("instructions=") :]
+    parsed = tomllib.loads(f"instructions={rhs}")
+    assert parsed["instructions"] == content, "codex -c instructions did not round-trip"
+
+
 def test_codex_no_system_prompt_omits_instructions(tmp_path, monkeypatch):
     monkeypatch.setenv("DOTFILES_DIR", str(tmp_path))
     m = _claude_manifest(tmp_path)  # no system_prompt
@@ -1041,6 +1070,31 @@ def test_opencode_launch_injects_config_env(env, monkeypatch):
     assert cli.os.environ.get("OPENCODE_CONFIG_CONTENT")
     config = json.loads(cli.os.environ["OPENCODE_CONFIG_CONTENT"])
     assert "todoist" in config["mcp"]
+
+
+def test_opencode_launch_profile_wins_name_collision(env, monkeypatch):
+    """Full launch path: when a profile MCP name collides with an inherited
+    registry server, the profile's enabled record wins end-to-end (not just in
+    the _opencode_mcp_block unit). Drive `launch opencode todo` with a registry
+    that declares todoist (the profile's own server) AND hallouminate
+    (inherited-only); the injected OPENCODE_CONFIG_CONTENT must keep todoist
+    enabled with the profile command and pin hallouminate enabled:false."""
+    write_isolated_todo(env.profiles)
+    dots = env.tmp / "empty-dots"  # the env fixture's DOTFILES_DIR
+    (dots / "agents" / "mcp").mkdir(parents=True)
+    (dots / "agents" / "mcp" / "registry.yaml").write_text(
+        "mcps:\n"
+        "  todoist:\n    command: should-be-overridden\n"  # collides with profile
+        "  hallouminate:\n    command: hallouminate\n    args: [serve]\n"
+    )
+    rec = _capture_exec(monkeypatch)
+    with pytest.raises(SystemExit):
+        cli.main(["launch", "opencode", "todo", "--target", str(env.target)])
+    assert rec["file"] == "opencode"
+    mcp = json.loads(cli.os.environ["OPENCODE_CONFIG_CONTENT"])["mcp"]
+    assert mcp["todoist"]["enabled"] is True, "profile server lost to inherited disable"
+    assert mcp["todoist"]["command"] == ["npx", "-y", "@doist/todoist-ai"]
+    assert mcp["hallouminate"] == {"enabled": False}
 
 
 # ─── migrated-profile fidelity on non-claude harnesses ────────────────

--- a/agent-profile/tests/test_overlay.py
+++ b/agent-profile/tests/test_overlay.py
@@ -161,11 +161,14 @@ def test_isolated_launch_passthrough_appended_last(env, monkeypatch):
     assert args.index("--dangerously-skip-permissions") < args.index("--resume")
 
 
-def test_isolated_launch_non_claude_harness_rejected(env, capsys):
+def test_isolated_launch_unsupported_harness_rejected(env, capsys):
+    """cursor/copilot/crush have no runtime-isolation lever: an isolated
+    launch against one fails loud (IsolationError -> CliError). codex and
+    opencode are now SUPPORTED — see their own tests."""
     write_isolated_todo(env.profiles)
-    rc = cli.main(["launch", "codex", "todo", "--target", str(env.target)])
+    rc = cli.main(["launch", "cursor", "todo", "--target", str(env.target)])
     assert rc == 1
-    assert "isolated" in capsys.readouterr().err.lower()
+    assert "unsupported" in capsys.readouterr().err.lower()
 
 
 def test_isolated_without_system_prompt_omits_flag(env, monkeypatch):
@@ -379,7 +382,7 @@ def test_build_isolated_flags_unit(tmp_path):
     )
     (tmp_path / "CLAUDE.md").write_text("sp\n")
     profile_dir = tmp_path
-    flags, env = overlay.build_isolated_flags(m, profile_dir)
+    flags, env = overlay.build_isolated_launch(m, profile_dir, "claude")
     assert "--strict-mcp-config" in flags
     assert "--setting-sources" in flags
     assert flags[flags.index("--tools") + 1] == "Read,Skill"
@@ -406,7 +409,7 @@ def test_flag_groups_emitted_in_spec_order(tmp_path):
         extra_args=["--dangerously-skip-permissions"],
     )
     (tmp_path / "CLAUDE.md").write_text("sp\n")
-    flags, _ = overlay.build_isolated_flags(m, tmp_path)
+    flags, _ = overlay.build_isolated_launch(m, tmp_path, "claude")
 
     order = [
         flags.index("--strict-mcp-config"),
@@ -437,7 +440,7 @@ def test_extra_args_trail_all_generated_flags(tmp_path):
         isolated=True,
         extra_args=["--verbose", "--foo"],
     )
-    flags, _ = overlay.build_isolated_flags(m, tmp_path)
+    flags, _ = overlay.build_isolated_launch(m, tmp_path, "claude")
     assert flags[-2:] == ["--verbose", "--foo"]
     assert flags.index("--verbose") > flags.index("--setting-sources")
 
@@ -662,7 +665,7 @@ def test_real_review_profile_locks_security_contract(monkeypatch, tmp_path):
     assert pdir is not None, "real profiles/review not found"
     m = parse_manifest(pdir)
     assert m.isolated is True
-    flags, _ = overlay.build_isolated_flags(m, pdir)
+    flags, _ = overlay.build_isolated_launch(m, pdir, "claude")
 
     settings_path = flags[flags.index("--settings") + 1]
     deny = set(json.loads(Path(settings_path).read_text())["permissions"]["deny"])
@@ -697,7 +700,7 @@ def test_real_todo_profile_is_closed_todoist_world(monkeypatch, tmp_path):
     assert pdir is not None, "real profiles/todo not found"
     m = parse_manifest(pdir)
     assert m.isolated is True
-    flags, env = overlay.build_isolated_flags(m, pdir)
+    flags, env = overlay.build_isolated_launch(m, pdir, "claude")
 
     mcp_path = flags[flags.index("--mcp-config") + 1]
     servers = json.loads(Path(mcp_path).read_text())["mcpServers"]
@@ -713,7 +716,7 @@ def test_real_notion_profile_is_http_shape(monkeypatch, tmp_path):
     pdir = find_profile_dir("notion")
     assert pdir is not None, "real profiles/notion not found"
     m = parse_manifest(pdir)
-    flags, _ = overlay.build_isolated_flags(m, pdir)
+    flags, _ = overlay.build_isolated_launch(m, pdir, "claude")
     servers = json.loads(
         Path(flags[flags.index("--mcp-config") + 1]).read_text()
     )["mcpServers"]
@@ -732,4 +735,354 @@ def test_isolated_missing_system_prompt_fails_loud(tmp_path):
         system_prompt="MISSING.md",
     )
     with pytest.raises(overlay.IsolationError, match="system_prompt file not found"):
-        overlay.build_isolated_flags(m, tmp_path)
+        overlay.build_isolated_launch(m, tmp_path, "claude")
+
+
+# ─── dispatch table (D1) ────────────────────────────────────────
+
+
+def _claude_manifest(tmp_path, **over):
+    """A minimal isolated manifest with one stdio MCP, overridable per test."""
+    base = dict(
+        name="p",
+        mcps=[{"name": "tilth", "command": "tilth", "args": ["--mcp"],
+               "_source_dir": str(tmp_path)}],
+        isolated=True,
+    )
+    base.update(over)
+    return Manifest(**base)
+
+
+@pytest.mark.parametrize("harness", ["cursor", "copilot", "crush", "bogus"])
+def test_dispatch_unsupported_harness_raises(tmp_path, harness):
+    """Every harness without an isolation builder fails loud on dispatch."""
+    m = _claude_manifest(tmp_path)
+    with pytest.raises(overlay.IsolationError, match="isolation unsupported"):
+        overlay.build_isolated_launch(m, tmp_path, harness)
+
+
+def test_dispatch_table_keys_are_the_three_isolating_harnesses(tmp_path):
+    """The closed-world contract is claude/codex/opencode only; cursor/
+    copilot/crush are deliberately absent (no runtime-isolation lever)."""
+    assert set(overlay._ISOLATION_BUILDERS) == {"claude", "codex", "opencode"}
+
+
+# ─── codex builder (#221) ────────────────────────────────────────
+
+
+def test_codex_emits_no_user_config_and_ephemeral(tmp_path, monkeypatch):
+    monkeypatch.setenv("DOTFILES_DIR", str(tmp_path))  # no .env
+    m = _claude_manifest(tmp_path, system_prompt="CLAUDE.md")
+    (tmp_path / "CLAUDE.md").write_text("codex sp\n")
+    flags, env = overlay.build_isolated_launch(m, tmp_path, "codex")
+    assert flags[0] == "--ignore-user-config"
+    assert flags[1] == "--ephemeral"
+    assert env == {}
+
+
+def test_codex_mcp_overrides_are_c_pairs(tmp_path, monkeypatch):
+    """Each profile MCP lowers to -c mcp_servers.<n>.command/args overrides
+    (codex has no whole-file --mcp-config flag). Values are JSON/TOML-encoded
+    so command is a quoted string and args a list literal."""
+    monkeypatch.setenv("DOTFILES_DIR", str(tmp_path))
+    m = _claude_manifest(tmp_path)
+    flags, _ = overlay.build_isolated_launch(m, tmp_path, "codex")
+    assert "-c" in flags
+    overrides = [flags[i + 1] for i, f in enumerate(flags) if f == "-c"]
+    assert 'mcp_servers.tilth.command="tilth"' in overrides
+    assert 'mcp_servers.tilth.args=["--mcp"]' in overrides
+
+
+def test_codex_system_prompt_injected_as_instructions(tmp_path, monkeypatch):
+    """The profile's system_prompt content is injected via -c instructions=
+    (codex's instructions key takes content, not a file path)."""
+    monkeypatch.setenv("DOTFILES_DIR", str(tmp_path))
+    m = _claude_manifest(tmp_path, system_prompt="CLAUDE.md")
+    (tmp_path / "CLAUDE.md").write_text("be a good codex\n")
+    flags, _ = overlay.build_isolated_launch(m, tmp_path, "codex")
+    overrides = [flags[i + 1] for i, f in enumerate(flags) if f == "-c"]
+    instr = [o for o in overrides if o.startswith("instructions=")]
+    assert len(instr) == 1
+    assert "be a good codex" in instr[0]
+
+
+def test_codex_no_system_prompt_omits_instructions(tmp_path, monkeypatch):
+    monkeypatch.setenv("DOTFILES_DIR", str(tmp_path))
+    m = _claude_manifest(tmp_path)  # no system_prompt
+    flags, _ = overlay.build_isolated_launch(m, tmp_path, "codex")
+    overrides = [flags[i + 1] for i, f in enumerate(flags) if f == "-c"]
+    assert not any(o.startswith("instructions=") for o in overrides)
+
+
+def test_codex_drops_tools_perms_plugins_with_warning(tmp_path, monkeypatch, capsys):
+    """D2/D3: codex can't restrict built-in tools — tools/permissions_deny/
+    enabled_plugins/extra_args are ignored-with-warning, never silently
+    dropped, never fatal."""
+    monkeypatch.setenv("DOTFILES_DIR", str(tmp_path))
+    m = _claude_manifest(
+        tmp_path,
+        tools=["Read", "Bash"],
+        permissions_deny=["Edit", "Write"],
+        enabled_plugins={"x@y": True},
+        extra_args=["--foo"],
+    )
+    flags, _ = overlay.build_isolated_launch(m, tmp_path, "codex")
+    err = capsys.readouterr().err
+    for field in ("tools", "permissions_deny", "enabled_plugins", "extra_args"):
+        assert f"field {field} ignored for harness codex" in err
+    # none of the dropped fields leak into the flags
+    assert "--tools" not in flags
+    assert "Edit" not in flags and "Write" not in flags
+    assert "--foo" not in flags
+
+
+def test_codex_mcp_env_resolved_from_dotenv(tmp_path, monkeypatch):
+    """${VAR} in a codex MCP env block resolves from .env at launch (D4),
+    matching the claude path."""
+    dots = tmp_path / "dots"
+    dots.mkdir()
+    (dots / ".env").write_text("CTX=ctx-secret\n")
+    monkeypatch.setenv("DOTFILES_DIR", str(dots))
+    m = Manifest(
+        name="p",
+        isolated=True,
+        mcps=[{"name": "context7", "command": "npx", "args": ["-y", "c7"],
+               "env": {"CONTEXT7_API_KEY": "${CTX}"},
+               "_source_dir": str(tmp_path)}],
+    )
+    flags, _ = overlay.build_isolated_launch(m, tmp_path, "codex")
+    overrides = [flags[i + 1] for i, f in enumerate(flags) if f == "-c"]
+    assert 'mcp_servers.context7.env.CONTEXT7_API_KEY="ctx-secret"' in overrides
+
+
+def test_codex_mcp_env_unset_fails_loud(tmp_path, monkeypatch):
+    dots = tmp_path / "dots"
+    dots.mkdir()  # no .env
+    monkeypatch.setenv("DOTFILES_DIR", str(dots))
+    m = Manifest(
+        name="p",
+        isolated=True,
+        mcps=[{"name": "context7", "command": "npx",
+               "env": {"CONTEXT7_API_KEY": "${MISSING_C7}"},
+               "_source_dir": str(tmp_path)}],
+    )
+    from agent_profile.env import EnvResolutionError
+
+    with pytest.raises(EnvResolutionError, match="MISSING_C7"):
+        overlay.build_isolated_launch(m, tmp_path, "codex")
+
+
+def test_codex_http_mcp_uses_url_overrides(tmp_path, monkeypatch):
+    monkeypatch.setenv("DOTFILES_DIR", str(tmp_path))
+    m = Manifest(
+        name="p",
+        isolated=True,
+        mcps=[{"name": "notion", "type": "http",
+               "url": "https://mcp.notion.com/mcp",
+               "_source_dir": str(tmp_path)}],
+    )
+    flags, _ = overlay.build_isolated_launch(m, tmp_path, "codex")
+    overrides = [flags[i + 1] for i, f in enumerate(flags) if f == "-c"]
+    assert 'mcp_servers.notion.url="https://mcp.notion.com/mcp"' in overrides
+    assert 'mcp_servers.notion.type="http"' in overrides
+    assert not any(o.startswith("mcp_servers.notion.command") for o in overrides)
+
+
+def test_codex_launch_does_not_hard_fail(env, monkeypatch):
+    """`dots profile launch codex <iso>` builds + execs, no longer erroring."""
+    write_isolated_todo(env.profiles)
+    rec = _capture_exec(monkeypatch)
+    with pytest.raises(SystemExit):
+        cli.main(["launch", "codex", "todo", "--target", str(env.target)])
+    assert rec["file"] == "codex"
+    assert "--ignore-user-config" in rec["args"]
+    assert "--ephemeral" in rec["args"]
+
+
+# ─── opencode builder (#222) ─────────────────────────────────────
+
+
+def test_opencode_emits_config_content_env(tmp_path, monkeypatch):
+    """opencode isolates via env vars, not flags: flags is empty and the MCP
+    world rides in OPENCODE_CONFIG_CONTENT."""
+    monkeypatch.setenv("DOTFILES_DIR", str(tmp_path))  # no registry -> no inherited
+    m = _claude_manifest(tmp_path)
+    flags, env = overlay.build_isolated_launch(m, tmp_path, "opencode")
+    assert flags == []
+    config = json.loads(env["OPENCODE_CONFIG_CONTENT"])
+    assert config["mcp"]["tilth"] == {
+        "type": "local",
+        "enabled": True,
+        "command": ["tilth", "--mcp"],
+    }
+
+
+def test_opencode_disables_inherited_registry_servers(tmp_path, monkeypatch):
+    """Inherited servers (registry membership includes opencode) are pinned
+    enabled:false so the global config doesn't leak into the closed world;
+    a server the profile ALSO declares stays enabled (profile wins)."""
+    dots = tmp_path / "dots"
+    (dots / "agents" / "mcp").mkdir(parents=True)
+    (dots / "agents" / "mcp" / "registry.yaml").write_text(
+        "mcps:\n"
+        "  hallouminate:\n    command: hallouminate\n    args: [serve]\n"
+        "  serena:\n    command: serena\n    args: [start]\n"
+        "  todoist:\n    command: npx\n    harnesses: []\n"  # scoped out everywhere
+        "  tilth:\n    command: tilth\n"  # profile also declares this
+    )
+    monkeypatch.setenv("DOTFILES_DIR", str(dots))
+    m = _claude_manifest(tmp_path)  # declares tilth (enabled)
+    _, env = overlay.build_isolated_launch(m, tmp_path, "opencode")
+    mcp = json.loads(env["OPENCODE_CONFIG_CONTENT"])["mcp"]
+    assert mcp["hallouminate"] == {"enabled": False}
+    assert mcp["serena"] == {"enabled": False}
+    assert "todoist" not in mcp  # harnesses: [] -> not an opencode-inherited server
+    assert mcp["tilth"]["enabled"] is True  # profile's own record wins
+
+
+def test_opencode_system_prompt_additive_instructions(tmp_path, monkeypatch):
+    monkeypatch.setenv("DOTFILES_DIR", str(tmp_path))
+    m = _claude_manifest(tmp_path, system_prompt="CLAUDE.md")
+    (tmp_path / "CLAUDE.md").write_text("oc sp\n")
+    _, env = overlay.build_isolated_launch(m, tmp_path, "opencode")
+    config = json.loads(env["OPENCODE_CONFIG_CONTENT"])
+    assert config["instructions"] == [str(tmp_path / "CLAUDE.md")]
+
+
+def test_opencode_permission_maps_deny(tmp_path, monkeypatch):
+    """D2: permissions_deny -> OPENCODE_PERMISSION. Edit/Write -> edit:deny;
+    mcp__* passes through verbatim; NotebookEdit (no opencode key) is
+    dropped+logged."""
+    monkeypatch.setenv("DOTFILES_DIR", str(tmp_path))
+    m = _claude_manifest(
+        tmp_path,
+        permissions_deny=["Edit", "Write", "NotebookEdit",
+                          "mcp__tilth__tilth_write"],
+    )
+    _, env = overlay.build_isolated_launch(m, tmp_path, "opencode")
+    perm = json.loads(env["OPENCODE_PERMISSION"])
+    assert perm["edit"] == "deny"
+    assert perm["mcp__tilth__tilth_write"] == "deny"
+    assert "NotebookEdit" not in perm  # no opencode equivalent
+
+
+def test_opencode_permission_map_covers_each_claude_key(tmp_path, monkeypatch):
+    monkeypatch.setenv("DOTFILES_DIR", str(tmp_path))
+    m = _claude_manifest(
+        tmp_path, permissions_deny=["Read", "Grep", "Glob", "Bash"]
+    )
+    _, env = overlay.build_isolated_launch(m, tmp_path, "opencode")
+    perm = json.loads(env["OPENCODE_PERMISSION"])
+    assert perm == {"read": "deny", "grep": "deny",
+                    "glob": "deny", "bash": "deny"}
+
+
+def test_opencode_no_deny_omits_permission_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("DOTFILES_DIR", str(tmp_path))
+    m = _claude_manifest(tmp_path)  # no permissions_deny
+    _, env = overlay.build_isolated_launch(m, tmp_path, "opencode")
+    assert "OPENCODE_PERMISSION" not in env
+
+
+def test_opencode_notebookedit_only_logs_and_omits_env(tmp_path, monkeypatch, capsys):
+    """A deny list of only-unmappable keys logs the drop and emits no
+    OPENCODE_PERMISSION (nothing mapped)."""
+    monkeypatch.setenv("DOTFILES_DIR", str(tmp_path))
+    m = _claude_manifest(tmp_path, permissions_deny=["NotebookEdit"])
+    _, env = overlay.build_isolated_launch(m, tmp_path, "opencode")
+    assert "OPENCODE_PERMISSION" not in env
+    assert "permissions_deny[NotebookEdit] ignored for harness opencode" \
+        in capsys.readouterr().err
+
+
+def test_opencode_mcp_env_rewritten_to_placeholder(tmp_path, monkeypatch):
+    """opencode doesn't grok ${VAR}; the renderer rewrites it to {env:VAR} so
+    opencode expands at launch and no secret is baked into the env JSON."""
+    monkeypatch.setenv("DOTFILES_DIR", str(tmp_path))
+    m = Manifest(
+        name="p",
+        isolated=True,
+        mcps=[{"name": "context7", "command": "npx", "args": ["-y", "c7"],
+               "env": {"CONTEXT7_API_KEY": "${CONTEXT7_API_KEY}"},
+               "_source_dir": str(tmp_path)}],
+    )
+    _, env = overlay.build_isolated_launch(m, tmp_path, "opencode")
+    mcp = json.loads(env["OPENCODE_CONFIG_CONTENT"])["mcp"]
+    assert mcp["context7"]["environment"]["CONTEXT7_API_KEY"] == "{env:CONTEXT7_API_KEY}"
+
+
+def test_opencode_profile_env_injected_alongside(tmp_path, monkeypatch):
+    monkeypatch.setenv("DOTFILES_DIR", str(tmp_path))
+    m = _claude_manifest(tmp_path, env={"MY_FLAG": "on"})
+    _, env = overlay.build_isolated_launch(m, tmp_path, "opencode")
+    assert env["MY_FLAG"] == "on"
+    assert "OPENCODE_CONFIG_CONTENT" in env
+
+
+def test_opencode_drops_plugins_and_extra_args_with_warning(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("DOTFILES_DIR", str(tmp_path))
+    m = _claude_manifest(
+        tmp_path, enabled_plugins={"x@y": True}, extra_args=["--foo"]
+    )
+    overlay.build_isolated_launch(m, tmp_path, "opencode")
+    err = capsys.readouterr().err
+    assert "field enabled_plugins ignored for harness opencode" in err
+    assert "field extra_args ignored for harness opencode" in err
+
+
+def test_opencode_launch_injects_config_env(env, monkeypatch):
+    """`dots profile launch opencode <iso>` injects OPENCODE_CONFIG_CONTENT
+    and execs opencode with empty isolation flags."""
+    write_isolated_todo(env.profiles)
+    rec = _capture_exec(monkeypatch)
+    with pytest.raises(SystemExit):
+        cli.main(["launch", "opencode", "todo", "--target", str(env.target)])
+    assert rec["file"] == "opencode"
+    assert cli.os.environ.get("OPENCODE_CONFIG_CONTENT")
+    config = json.loads(cli.os.environ["OPENCODE_CONFIG_CONTENT"])
+    assert "todoist" in config["mcp"]
+
+
+# ─── migrated-profile fidelity on non-claude harnesses ────────────────
+
+
+def test_real_review_profile_read_only_on_opencode(monkeypatch, tmp_path):
+    """The shipped review profile launched on opencode must stay read-only:
+    OPENCODE_PERMISSION denies edit (from Edit/Write) and every serena
+    mutator + tilth_write appears as an mcp__* deny key. Closed MCP world is
+    exactly tilth + code-review-graph + context7 (own, enabled)."""
+    _hermetic_dotenv(monkeypatch, tmp_path)
+    pdir = find_profile_dir("review")
+    assert pdir is not None, "real profiles/review not found"
+    m = parse_manifest(pdir)
+    _, env = overlay.build_isolated_launch(m, pdir, "opencode")
+
+    perm = json.loads(env["OPENCODE_PERMISSION"])
+    assert perm["edit"] == "deny"
+    for mutator in (
+        "mcp__tilth__tilth_write",
+        "mcp__serena__replace_symbol_body",
+        "mcp__serena__rename_symbol",
+        "mcp__serena__safe_delete_symbol",
+    ):
+        assert perm[mutator] == "deny", f"review lost opencode deny: {mutator}"
+
+    config = json.loads(env["OPENCODE_CONFIG_CONTENT"])
+    own = {n for n, rec in config["mcp"].items() if rec.get("enabled") is not False}
+    assert own == {"tilth", "code-review-graph", "context7"}
+
+
+def test_real_review_profile_on_codex_drops_perms_with_caveat(monkeypatch, tmp_path, capsys):
+    """The shipped review profile on codex builds the MCP world but CANNOT
+    enforce its read-only deny list (codex caveat) — it's ignored-with-warning,
+    and the closed MCP world is still injected via -c overrides."""
+    _hermetic_dotenv(monkeypatch, tmp_path)
+    pdir = find_profile_dir("review")
+    assert pdir is not None
+    m = parse_manifest(pdir)
+    flags, _ = overlay.build_isolated_launch(m, pdir, "codex")
+    err = capsys.readouterr().err
+    assert "field permissions_deny ignored for harness codex" in err
+    overrides = [flags[i + 1] for i, f in enumerate(flags) if f == "-c"]
+    for server in ("tilth", "code-review-graph", "context7"):
+        assert any(o.startswith(f"mcp_servers.{server}.") for o in overrides), server

--- a/agent-profile/tests/test_overlay.py
+++ b/agent-profile/tests/test_overlay.py
@@ -1036,6 +1036,19 @@ def test_codex_http_mcp_carries_headers(tmp_path, monkeypatch):
     }
 
 
+def test_codex_http_mcp_missing_url_raises_isolation_error(tmp_path, monkeypatch):
+    """A type:http MCP with no url raises IsolationError, not KeyError."""
+    monkeypatch.setenv("DOTFILES_DIR", str(tmp_path))
+    m = Manifest(
+        name="p",
+        isolated=True,
+        mcps=[{"name": "broken", "type": "http",
+               "_source_dir": str(tmp_path)}],
+    )
+    with pytest.raises(overlay.IsolationError, match="http MCP 'broken' missing url"):
+        overlay.build_isolated_launch(m, tmp_path, "codex")
+
+
 def test_codex_launch_does_not_hard_fail(env, monkeypatch):
     """`dots profile launch codex <iso>` builds + execs bare interactive codex
     (no exec-only flags), with CODEX_HOME injected into the process env."""
@@ -1100,6 +1113,29 @@ def test_opencode_disables_inherited_registry_servers(tmp_path, monkeypatch):
     assert mcp["serena"] == {"enabled": False}
     assert "todoist" not in mcp  # harnesses: [] -> not an opencode-inherited server
     assert mcp["tilth"]["enabled"] is True  # profile's own record wins
+
+
+def test_opencode_missing_registry_warns_on_stderr(tmp_path, monkeypatch, capsys):
+    """When the opencode registry is absent, a warning fires on stderr."""
+    monkeypatch.setenv("DOTFILES_DIR", str(tmp_path))  # no registry.yaml here
+    m = _claude_manifest(tmp_path)
+    overlay.build_isolated_launch(m, tmp_path, "opencode")
+    err = capsys.readouterr().err
+    assert "could not read opencode registry" in err
+    assert "inherited global MCPs may not be sealed" in err
+
+
+def test_opencode_unparseable_registry_warns_on_stderr(tmp_path, monkeypatch, capsys):
+    """When the opencode registry contains invalid YAML, a warning fires on stderr."""
+    dots = tmp_path / "dots"
+    (dots / "agents" / "mcp").mkdir(parents=True)
+    (dots / "agents" / "mcp" / "registry.yaml").write_text(": {bad: [yaml\n")
+    monkeypatch.setenv("DOTFILES_DIR", str(dots))
+    m = _claude_manifest(tmp_path)
+    overlay.build_isolated_launch(m, tmp_path, "opencode")
+    err = capsys.readouterr().err
+    assert "could not read opencode registry" in err
+    assert "inherited global MCPs may not be sealed" in err
 
 
 def test_opencode_system_prompt_additive_instructions(tmp_path, monkeypatch):

--- a/agent-profile/tests/test_overlay.py
+++ b/agent-profile/tests/test_overlay.py
@@ -879,6 +879,63 @@ def test_codex_config_is_valid_toml_with_adversarial_mcp_values(tmp_path, monkey
     assert server["env"]["NOTE"] == "em — dash 🧀 lord, regex \\d+, key = val"
 
 
+def test_codex_home_is_not_under_tmp(tmp_path, monkeypatch):
+    """CODEX_HOME must be rooted under the user cache, not the system temp dir:
+    codex 0.135.0 refuses to install its PATH-helper binaries when CODEX_HOME
+    is under a temp dir (a "could not update PATH" warning every isolated
+    launch). The builder bases the per-launch home under $XDG_CACHE_HOME (or
+    ~/.cache), NOT tempfile.mkdtemp's gettempdir() default.
+
+    The cache base is asserted directly rather than via 'not under
+    gettempdir()' because pytest's own tmp_path lives under /tmp, so a cache
+    redirected into tmp_path would be a /tmp descendant by test scaffolding,
+    not by the builder. Two cases pin the real invariant: an explicit
+    XDG_CACHE_HOME is honoured, and the unset default is ~/.cache (a fake
+    home), proving the base is never gettempdir()."""
+    import tempfile
+
+    # Sanity: the builder's default base is the cache dir, never the temp dir.
+    assert Path(tempfile.gettempdir()).resolve() != (Path.home() / ".cache").resolve()
+
+    # Case 1: explicit XDG_CACHE_HOME is honoured.
+    cache = tmp_path / "cache"
+    monkeypatch.setenv("XDG_CACHE_HOME", str(cache))
+    monkeypatch.setenv("DOTFILES_DIR", str(tmp_path))
+    m = _claude_manifest(tmp_path)
+    _, env = overlay.build_isolated_launch(m, tmp_path, "codex")
+    assert cache / "ap-codex" in Path(env["CODEX_HOME"]).parents
+
+    # Case 2: unset XDG_CACHE_HOME falls back to ~/.cache, not gettempdir().
+    monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setattr(overlay.Path, "home", classmethod(lambda cls: fake_home))
+    _, env2 = overlay.build_isolated_launch(m, tmp_path, "codex")
+    assert fake_home / ".cache" / "ap-codex" in Path(env2["CODEX_HOME"]).parents
+
+
+def test_codex_quotes_non_bare_safe_keys(tmp_path, monkeypatch):
+    """An MCP name or env key with a space or dot is not a valid TOML bare key
+    (a space fails to parse, a dot silently nests). The builder quotes such
+    keys so the generated config.toml still parses with the intended structure
+    instead of corrupting the table layout."""
+    monkeypatch.setenv("DOTFILES_DIR", str(tmp_path))
+    m = Manifest(
+        name="p",
+        isolated=True,
+        mcps=[{"name": "my.dotted server", "command": "npx",
+               "env": {"has space": "v1", "a.b.c": "v2"},
+               "_source_dir": str(tmp_path)}],
+    )
+    _, env = overlay.build_isolated_launch(m, tmp_path, "codex")
+    cfg = _codex_config(env)  # raises if the TOML is invalid
+    # The dotted/space name is one server key, NOT a nested table.
+    assert set(cfg["mcp_servers"]) == {"my.dotted server"}
+    server = cfg["mcp_servers"]["my.dotted server"]
+    assert server["command"] == "npx"
+    assert server["env"] == {"has space": "v1", "a.b.c": "v2"}
+
+
 def test_codex_no_system_prompt_omits_model_instructions_file(tmp_path, monkeypatch):
     monkeypatch.setenv("DOTFILES_DIR", str(tmp_path))
     m = _claude_manifest(tmp_path)  # no system_prompt


### PR DESCRIPTION
## Summary

Extends `ap` isolated profiles from claude-only to **codex (#221)** and **opencode (#222)** via a per-harness `(flags, env)` dispatch behind `_ISOLATION_BUILDERS`. `_launch_isolated` no longer special-cases claude; cursor/copilot/crush fail loud via `IsolationError`.

### codex (#221)

Interactive-TUI closed-world isolation via:

- `CODEX_HOME` redirected to a per-launch cache dir (`$XDG_CACHE_HOME/ap-codex/…`, not `/tmp`)
- `auth.json` symlinked from `~/.codex/auth.json` (preserves login)
- generated `config.toml` with `[mcp_servers.<n>]` tables (incl. `http_headers` for HTTP MCPs) and `model_instructions_file = <abs path>`

This replaces an initial mechanism (`codex --ignore-user-config --ephemeral` + `-c instructions=<content>`) that does **not** work on the installed codex 0.135.0 — both flags are `codex exec`-subcommand-only and the `instructions` config key is a noop. The corrected mechanism was grounded against the live CLI + codex source and validated empirically (`codex mcp list` loads all servers, no PATH-helper warning).

### opencode (#222)

- `OPENCODE_CONFIG_CONTENT` — profile MCP servers + inherited registry servers disabled + additive instructions
- `OPENCODE_PERMISSION` — mapped from `permissions_deny` (the `review` profile's read-only contract is enforced and tested)
- `OPENCODE_DISABLE_PROJECT_CONFIG=true` — prevents a project `opencode.json` from leaking MCPs into the closed world

## Caveats (documented in overlay.py + wiki)

- codex auth symlink works only for `File` auth-storage mode; keyring users need `CODEX_ACCESS_TOKEN`
- `/etc/codex/config.toml` (system config) still loads regardless of `CODEX_HOME`
- project `.codex/config.toml` loads but is inert (fresh config trusts no projects)

## Tests

agent-profile pytest **612 passed**. Codex tests parse the generated `config.toml` via `tomllib` (assert validity, not flag-presence — the lesson from the runtime bug), incl. adversarial TOML-special / non-BMP-unicode values and non-bare-safe key quoting. Full opencode launch-path collision + permission-map coverage.

## Notes

- `agent-profile/ap` runs live from the clone — no `dots sync` required for these changes.
- Follow-up: #305 (revisit codex per-tool restriction for isolated profiles).

Closes #221
Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)
