### PR TITLE
feat(ap): add crush as a 6th MCP-only harness (#223)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,14 +15,14 @@ Before non-trivial work touching agent config, harness wiring, `ap`, the registr
 
 ## Repository Overview
 
-A personal dotfiles repo configuring a vim-centric, terminal-based dev environment (macOS-oriented): zsh shell, git, and a harness-agnostic AI-agent config system. One source of truth (`agents/` registries) renders into Claude Code, Codex, opencode, Cursor, and Copilot via the `ap` tool. chezmoi handles templated / per-machine / secret files; the rest deploys via `dots sync`.
+A personal dotfiles repo configuring a vim-centric, terminal-based dev environment (macOS-oriented): zsh shell, git, and a harness-agnostic AI-agent config system. One source of truth (`agents/` registries) renders into Claude Code, Codex, opencode, Cursor, Copilot, and crush via the `ap` tool. crush (charmbracelet/crush) is the 6th harness: **MCP-only** (the registry union's skills/hooks/agents/permissions surfaces do not map to it) and **non-isolated** (no config-suppression lever exists, so isolated profiles fail loud for crush). chezmoi handles templated / per-machine / secret files; the rest deploys via `dots sync`.
 
 ## Topic Map
 
 | Topic | Wiki page |
 |---|---|
 | `agents/` registry system (MCP / hook / sub-agent / skill registries, system-prompt body) | [[architecture/agents-dir]] |
-| `ap` tool — profiles (base / global / isolated), the five renderers, install vs launch, chezmoi drive | [[architecture/agent-profile]] |
+| `ap` tool — profiles (base / global / isolated), the six renderers, install vs launch, chezmoi drive | [[architecture/agent-profile]] |
 | MCP `${VAR}` secret passthrough | [[architecture/mcp-secret-handling]] |
 | Config drift + the `settings.json` self-heal (`/harness-doctor`) | [[architecture/config-drift]] |
 | Cross-harness guards (git-guard + Claude pre-tool guards) | [[architecture/cross-harness-guards]] |

--- a/agent-profile/agent_profile/cli.py
+++ b/agent-profile/agent_profile/cli.py
@@ -34,7 +34,7 @@ from agent_profile.renderers.base import (
     includes_harness,
 )
 
-ALL_HARNESSES = ["claude", "codex", "opencode", "cursor", "copilot"]
+ALL_HARNESSES = ["claude", "codex", "opencode", "cursor", "copilot", "crush"]
 
 # Harness-name -> Renderer. Populated by the wiring barrel; tests inject
 # stubs via set_renderers(). Empty by default (seed phase ships no
@@ -437,6 +437,7 @@ def _fetch_external_skills(
     installed to all harnesses at once. ``path:`` skills are copied by the
     renderers, so they are excluded here."""
     from agent_profile.fetch import (
+        SKILL_AGENT,
         SkillFetchError,
         external_skills,
         fetch_external_source,
@@ -444,6 +445,17 @@ def _fetch_external_skills(
 
     ext = external_skills(manifest.skills)
     if not ext:
+        return
+
+    # Skills-fetch is only valid for harnesses that map to a `skills` CLI
+    # --agent ID (the skill_agents.txt / SKILL_AGENT map). Skill-less harnesses
+    # (crush, by design) carry no agent ID, so they are filtered out here
+    # before `skill_agent_for` is consulted (D2) — otherwise the fetch would
+    # raise SkillFetchError on an `ap install --harness crush`. A genuine typo
+    # is still caught upstream by `_validate_harnesses` (render-step fail-loud);
+    # this filter only drops harnesses that are valid but skill-less.
+    skill_harnesses = [h for h in harnesses if h in SKILL_AGENT]
+    if not skill_harnesses:
         return
 
     # Group items by source repo. A bare `source:` (no name) means "all skills"
@@ -473,11 +485,11 @@ def _fetch_external_skills(
             label = "*" if names is None else ", ".join(names)
             print(
                 f"  {colors.BLUE}↳{colors.NC} fetching skills "
-                f"{source} ({label}) -> {', '.join(harnesses)}",
+                f"{source} ({label}) -> {', '.join(skill_harnesses)}",
                 file=out,
             )
             fetch_external_source(
-                source, names, g["pin"], harnesses, _skill_fetch_runner
+                source, names, g["pin"], skill_harnesses, _skill_fetch_runner
             )
     except SkillFetchError as exc:
         raise CliError(f"{colors.RED}{exc}{colors.NC}") from exc
@@ -785,7 +797,7 @@ def _validate_harnesses(harnesses: list[str], colors: _Colors) -> None:
         if h not in ALL_HARNESSES:
             raise CliError(
                 f"{colors.RED}ap: unknown harness '{h}' "
-                f"(valid: claude|codex|opencode|cursor|copilot){colors.NC}"
+                f"(valid: claude|codex|opencode|cursor|copilot|crush){colors.NC}"
             )
 
 

--- a/agent-profile/agent_profile/renderers/crush.py
+++ b/agent-profile/agent_profile/renderers/crush.py
@@ -1,0 +1,145 @@
+"""crush.py — render an agent profile into charmbracelet/crush's config (#223).
+
+crush is the 6th harness and the simplest renderer: **MCP-only** and
+**non-isolated**.
+
+- **MCP-only.** The registry union's skills/hooks/agents/permissions surfaces
+  do not map to crush — crush has no native skill/hook/subagent/permission
+  config. This renderer touches only the ``mcp`` block of ``crush.json``.
+- **Non-isolated.** crush exposes no config-suppression lever (``-c`` is
+  ``--cwd``; ``CRUSH_GLOBAL_CONFIG`` relocates but does not suppress inherited
+  layers), so an isolated launch fails loud — crush is deliberately absent from
+  ``overlay._ISOLATION_BUILDERS``. Nothing here participates in isolation.
+
+crush.json is a merged, user-editable file (XDG global ``~/.config/crush/``,
+merged with project/workspace layers). Like opencode/cursor/copilot this
+renderer reads the existing object, sets its own ``mcp`` entries, writes, and
+returns ``[]`` (never tracked as a whole-file artefact — undone in :meth:`clean`).
+
+Server shape (crush v0.76.0, https://charm.land/crush.json): top-level key is
+``mcp`` (not ``mcpServers``); each server is
+``{type: "stdio", command, args?, env?}`` with snake_case fields. All current
+registry MCPs are stdio, so only the stdio shape is emitted.
+
+Env expansion: crush expands env values via the ``$(echo $VAR)`` shell-eval
+form (charmbracelet/crush README), NOT opencode's ``{env:VAR}``. :func:`_to_crush_env`
+rewrites each ``${VAR}`` to ``$(echo $VAR)`` so the secret resolves at launch
+and nothing is baked into ``crush.json``. (README-derived — confirmed against
+the upstream docs; not yet exercised against a live ``crush`` launch on this
+machine, where the binary is not installed.)
+
+Substrate: stdlib :mod:`json` only (own your keys; ``pop`` for surgical removal).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from agent_profile.env import VAR_RE
+from agent_profile.parse import Manifest
+from agent_profile.renderers.base import mcps_for, read_json_object
+
+# crush's MCP membership default. crush includes itself so an MCP that omits
+# `harnesses` (the coding default-include set) flows into crush — parity with
+# the other coding harnesses (D1: default-include).
+_CRUSH_MCP_DEFAULT = ("claude", "codex", "opencode", "cursor", "crush")
+
+_SCHEMA_STUB = {"$schema": "https://charm.land/crush.json"}
+
+
+def _to_crush_env(value: str) -> str:
+    """Rewrite every ``${VAR}`` in an env value to crush's ``$(echo $VAR)``
+    shell-eval form.
+
+    crush does NOT understand the ``${VAR}`` shell syntax the registry carries
+    (nor opencode's ``{env:VAR}``); its documented expansion token is
+    ``$(echo $VAR)``. Plain literals (no ``${}``) pass through unchanged; a bare
+    ``$VAR`` or a malformed ``${}`` is left untouched (only the ``${IDENT}``
+    form is rewritten, so non-secret literals are never corrupted)."""
+    return VAR_RE.sub(lambda m: f"$(echo ${m.group(1)})", value)
+
+
+def _mcp_server_record(mcp: dict[str, Any]) -> dict[str, Any]:
+    """The crush mcp-server shape: ``{type: "stdio", command, args?, env?}``.
+
+    ``args`` and ``env`` are included only when present. Env values carry the
+    literal ``${VAR}`` from ingest; each is rewritten to crush's
+    ``$(echo $VAR)`` placeholder so crush expands it at launch."""
+    record: dict[str, Any] = {"type": "stdio", "command": mcp["command"]}
+    if mcp.get("args") is not None:
+        record["args"] = mcp["args"]
+    if mcp.get("env") is not None:
+        record["env"] = {
+            k: _to_crush_env(str(v)) for k, v in mcp["env"].items()
+        }
+    return record
+
+
+class CrushRenderer:
+    """Renderer for the merged ``crush.json`` mcp surface (MCP-only).
+
+    Implements the :class:`~agent_profile.renderers.base.Renderer` protocol.
+    ``crush.json`` is a merged file: it is never returned from :meth:`render`
+    (the install manifest must not track it) and is surgically un-merged in
+    :meth:`clean`."""
+
+    name = "crush"
+    mcp_default = _CRUSH_MCP_DEFAULT
+
+    def render(self, manifest: Manifest, target: Path) -> list[str]:
+        """Merge this profile's crush MCPs into ``<target>/crush.json``,
+        bootstrapping the schema stub when the file is absent. Returns ``[]`` —
+        the merged file is undone in :meth:`clean`, never tracked."""
+        mcps = mcps_for(manifest, "crush", _CRUSH_MCP_DEFAULT)
+        if not mcps:
+            return []
+
+        cfg = Path(str(target).rstrip("/")) / "crush.json"
+        data: dict[str, Any] = (
+            read_json_object(cfg, "crush.json")
+            if cfg.is_file()
+            else dict(_SCHEMA_STUB)
+        )
+
+        section = data.setdefault("mcp", {})
+        for mcp in mcps:
+            section[mcp["name"]] = _mcp_server_record(mcp)
+
+        cfg.parent.mkdir(parents=True, exist_ok=True)
+        cfg.write_text(json.dumps(data, indent=2) + "\n")
+        return []
+
+    def clean(self, manifest: Manifest, target: Path) -> None:
+        """Surgically remove this profile's mcp entries from
+        ``<target>/crush.json``, then prune the empty container.
+
+        If the file reduces to ``{}`` or to ``{"$schema": ...}`` (the bootstrap
+        stub), it is removed — the profile owned it (opencode's /age-fix
+        parity)."""
+        cfg = Path(str(target).rstrip("/")) / "crush.json"
+        if not cfg.is_file():
+            return
+
+        data = read_json_object(cfg, "crush.json")
+        ours = {m["name"] for m in mcps_for(manifest, "crush", _CRUSH_MCP_DEFAULT)}
+
+        section = data.get("mcp")
+        if isinstance(section, dict):
+            for name in ours:
+                section.pop(name, None)
+            if not section:
+                data.pop("mcp", None)
+
+        if data == {} or list(data.keys()) == ["$schema"]:
+            cfg.unlink()
+            return
+
+        cfg.write_text(json.dumps(data, indent=2) + "\n")
+
+    def prune_mcps(self, manifest: Manifest, target: Path) -> None:
+        """Evict dropped MCP servers from crush.json's ``mcp`` block (install
+        reconcile). crush's clean is MCP-only, so this delegates to it;
+        ``manifest`` holds only the dropped servers."""
+        self.clean(manifest, target)

--- a/agent-profile/agent_profile/renderers/registry.py
+++ b/agent-profile/agent_profile/renderers/registry.py
@@ -1,8 +1,8 @@
-"""registry.py — barrel that wires the five harness renderers into the CLI.
+"""registry.py — barrel that wires the six harness renderers into the CLI.
 
 The CLI ships an empty :data:`agent_profile.cli.RENDERERS` so tests can inject
 stubs via ``set_renderers``. This barrel builds the production registry from the
-five renderer classes and installs it; ``__main__`` calls :func:`install`
+six renderer classes and installs it; ``__main__`` calls :func:`install`
 before dispatching ``cli.main``.
 """
 
@@ -14,17 +14,19 @@ from agent_profile.renderers.claude import ClaudeRenderer
 from agent_profile.renderers.codex import CodexRenderer
 from agent_profile.renderers.copilot import CopilotRenderer
 from agent_profile.renderers.cursor import CursorRenderer
+from agent_profile.renderers.crush import CrushRenderer
 from agent_profile.renderers.opencode import OpencodeRenderer
 
 
 def build_registry() -> dict[str, Renderer]:
-    """Return the harness-name -> renderer map for the five production renderers."""
+    """Return the harness-name -> renderer map for the six production renderers."""
     renderers: list[Renderer] = [
         ClaudeRenderer(),
         CodexRenderer(),
         OpencodeRenderer(),
         CursorRenderer(),
         CopilotRenderer(),
+        CrushRenderer(),
     ]
     return {renderer.name: renderer for renderer in renderers}
 

--- a/agent-profile/tests/fixtures/golden/strings/errors.json
+++ b/agent-profile/tests/fixtures/golden/strings/errors.json
@@ -1,7 +1,7 @@
 {
   "describe_missing": "ap: profile 'nope' not found",
   "install_noname": "ap install: profile name required",
-  "install_unknown_harness": "ap: unknown harness 'bogus' (valid: claude|codex|opencode|cursor|copilot)",
+  "install_unknown_harness": "ap: unknown harness 'bogus' (valid: claude|codex|opencode|cursor|copilot|crush)",
   "unknown_subcommand": "ap: unknown subcommand 'frobnicate'",
   "install_traversal_first_line": "ap_parse: invalid profile name '../foo' in ap_find_profile_dir (must match [A-Za-z0-9._-]+)",
   "install_slash_first_line": "ap_parse: invalid profile name 'x/y' in ap_find_profile_dir (must match [A-Za-z0-9._-]+)"

--- a/agent-profile/tests/test_cli.py
+++ b/agent-profile/tests/test_cli.py
@@ -496,6 +496,39 @@ def test_install_mixed_harness_fetches_skill_bearing_only(
     assert "crush" not in argv
 
 
+def test_install_mixed_harness_log_omits_skill_less_harness(
+    env, capsys, stub_renderers, monkeypatch
+):
+    """WHY: the D2 filter rewrote the fetch log to print `skill_harnesses`, not
+    the caller's `harnesses`. With `--harness claude,crush` the `↳ fetching
+    skills … -> …` line must name only the skill-bearing harness (claude) — a
+    regression that reverted the log to `harnesses` would print `claude, crush`
+    and advertise a fetch into a harness that has no skill agent. The argv test
+    above can't catch that: the log is a separate print, asserted here."""
+    _profile_with_external_skill(env, "foo")
+    monkeypatch.setattr(cli, "_skill_fetch_runner", lambda argv: 0)
+    assert (
+        run(
+            [
+                "install",
+                "foo",
+                "--target",
+                str(env.target),
+                "--harness",
+                "claude,crush",
+            ]
+        )
+        == 0
+    )
+    out = capsys.readouterr().out
+    fetch_lines = [ln for ln in out.splitlines() if "fetching skills" in ln]
+    assert len(fetch_lines) == 1, out
+    # The destination list after `->` names claude and NOT crush.
+    dest = fetch_lines[0].split("->", 1)[1]
+    assert "claude" in dest
+    assert "crush" not in dest
+
+
 def test_install_unknown_harness_still_fails_loud(env, capsys, stub_renderers):
     """WHY: the D2 filter intersects with SKILL_AGENT for the *fetch* step, but
     a genuine typo must still fail at validation. ``--harness crsuh`` (typo) is

--- a/agent-profile/tests/test_cli.py
+++ b/agent-profile/tests/test_cli.py
@@ -423,3 +423,87 @@ def test_describe_isolated_surfaces_overlay(env, capsys):
     assert parsed["permissions"] == {"allow": [], "deny": ["Edit", "Write"]}
     assert parsed["enabled_plugins"] == {"todoist-flow@todoist-flow": True}
     assert parsed["extra_args"] == ["--dangerously-skip-permissions"]
+
+
+# ─── skills-fetch exclusion for skill-less harnesses (crush, #223 D2) ───
+
+
+def _profile_with_external_skill(env, name):
+    """A profile carrying one external (``source:``) skill, scoped to a
+    skill-bearing harness (claude) and a skill-less one (crush)."""
+    write_profile(
+        env.profiles,
+        name,
+        f"name: {name}\n"
+        "description: profile with an external skill\n"
+        "skills:\n"
+        "  - name: mold\n"
+        "    source: paulnsorensen/easy-cheese\n",
+    )
+
+
+def test_install_crush_with_external_skill_does_not_raise(
+    env, capsys, stub_renderers, monkeypatch
+):
+    """WHY: crush is skill-less by design (absent from skill_agents.txt), so
+    ``skill_agent_for('crush')`` raises SkillFetchError. Installing
+    ``--harness crush`` on a profile that carries an external skill must NOT
+    raise — crush is filtered out of the skills-fetch harness list (D2) before
+    the agent map is consulted. Without the filter this install exits 1."""
+    _profile_with_external_skill(env, "foo")
+    calls = []
+    monkeypatch.setattr(
+        cli, "_skill_fetch_runner", lambda argv: calls.append(argv) or 0
+    )
+    assert (
+        run(["install", "foo", "--target", str(env.target), "--harness", "crush"])
+        == 0
+    )
+    # crush has no skill agent, so the fetch is a no-op for a crush-only install.
+    assert calls == []
+
+
+def test_install_mixed_harness_fetches_skill_bearing_only(
+    env, capsys, stub_renderers, monkeypatch
+):
+    """WHY: the D2 filter must drop ONLY the skill-less harness, not the whole
+    fetch. With ``--harness claude,crush`` the external skill still installs to
+    claude (its ``--agent claude-code`` reaches npx) while crush is excluded —
+    no crush agent ever appears in the argv (it would silently no-op at exit
+    0)."""
+    _profile_with_external_skill(env, "foo")
+    calls = []
+    monkeypatch.setattr(
+        cli, "_skill_fetch_runner", lambda argv: calls.append(argv) or 0
+    )
+    assert (
+        run(
+            [
+                "install",
+                "foo",
+                "--target",
+                str(env.target),
+                "--harness",
+                "claude,crush",
+            ]
+        )
+        == 0
+    )
+    assert len(calls) == 1
+    argv = calls[0]
+    agents = [argv[i + 1] for i, t in enumerate(argv) if t == "--agent"]
+    assert agents == ["claude-code"], "only the skill-bearing harness fetches"
+    assert "crush" not in argv
+
+
+def test_install_unknown_harness_still_fails_loud(env, capsys, stub_renderers):
+    """WHY: the D2 filter intersects with SKILL_AGENT for the *fetch* step, but
+    a genuine typo must still fail at validation. ``--harness crsuh`` (typo) is
+    rejected by _validate_harnesses before any render — the filter never
+    swallows an unknown harness."""
+    make_basic_profile(env.profiles, "foo")
+    assert (
+        run(["install", "foo", "--target", str(env.target), "--harness", "crsuh"])
+        == 1
+    )
+    assert "unknown harness 'crsuh'" in capsys.readouterr().err

--- a/agent-profile/tests/test_renderer_crush.py
+++ b/agent-profile/tests/test_renderer_crush.py
@@ -332,3 +332,113 @@ def test_corrupt_config_raises_clean_error(tmp_path: Path):
         CrushRenderer().render(_manifest(), tmp_path)
     with pytest.raises(MergedConfigError):
         CrushRenderer().clean(_manifest(), tmp_path)
+
+
+# ─── real-registry contract (spec acceptance, #223 D1) ──────────────────
+#
+# The tests above drive a synthetic two-MCP manifest. The spec's central
+# acceptance criterion is a property of the SHIPPED registry: rendering the
+# real `base` profile (the union that reads agents/mcp/registry.yaml) into
+# crush must yield EXACTLY the six coding MCPs and exclude todoist. Nothing
+# above locks that — a registry edit that scoped a coding MCP away from the
+# default-include set, or dropped `harnesses: []` from todoist, would leak
+# past every synthetic test. This loads the real registry the same way
+# test_overlay's `test_real_*_profile` tests do (DOTFILES_DIR -> repo root,
+# parse the base profile). The renderer rewrites `${VAR}` -> `$(echo $VAR)`
+# but does NOT resolve it, so no .env / credential stub is needed.
+
+# Repo root: agent-profile/tests/test_renderer_crush.py -> ../../ is the clone.
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# The exact MCP set crush must receive: every registry MCP that omits
+# `harnesses` (default-include) flows to crush; todoist (`harnesses: []`) does
+# not. Mirrors the spec acceptance bullet verbatim.
+_CRUSH_REGISTRY_MCPS = {
+    "tilth",
+    "hallouminate",
+    "context7",
+    "tavily",
+    "code-review-graph",
+    "serena",
+}
+
+
+def _real_base_manifest(monkeypatch) -> Manifest:
+    """Parse the shipped `base` profile against the real repo registry."""
+    from agent_profile.discover import find_profile_dir
+    from agent_profile.parse import parse_manifest
+
+    monkeypatch.setenv("DOTFILES_DIR", str(REPO_ROOT))
+    monkeypatch.delenv("AP_EXTRA_SEARCH_PATHS", raising=False)
+    pdir = find_profile_dir("base")
+    assert pdir is not None, "real profiles/base not found"
+    return parse_manifest(pdir)
+
+
+def test_real_registry_renders_exactly_the_coding_mcp_set(tmp_path, monkeypatch):
+    """The shipped registry, rendered into crush, is EXACTLY the six coding
+    MCPs — no more (a future MCP added without `harnesses` flows in and would
+    trip this) and no fewer (a coding MCP scoped away would trip this)."""
+    m = _real_base_manifest(monkeypatch)
+    CrushRenderer().render(m, tmp_path)
+    data = json.loads((tmp_path / "crush.json").read_text())
+    assert set(data["mcp"]) == _CRUSH_REGISTRY_MCPS
+
+
+def test_real_registry_excludes_todoist(tmp_path, monkeypatch):
+    """todoist carries `harnesses: []` (scoped out of every harness); it must
+    not reach crush. A regression that dropped the empty list would fall back
+    to the default-include set and leak todoist's ~38k-token tool footprint
+    into every crush session."""
+    m = _real_base_manifest(monkeypatch)
+    CrushRenderer().render(m, tmp_path)
+    data = json.loads((tmp_path / "crush.json").read_text())
+    assert "todoist" not in data["mcp"]
+
+
+def test_real_registry_secrets_render_as_crush_shell_eval(tmp_path, monkeypatch):
+    """The credentialed MCPs (context7, tavily) carry a `${VAR}` env ref in the
+    real registry. Rendered into crush each must become `$(echo $VAR)` — the
+    documented crush expansion form — and NO resolved secret value may land on
+    disk. This is the env-rewrite contract exercised against the real registry
+    values, not a synthetic `${CONTEXT7_API_KEY}` literal. (Live-launch
+    resolution stays verify-in-deploy: the crush binary is not installed here.)"""
+    m = _real_base_manifest(monkeypatch)
+    CrushRenderer().render(m, tmp_path)
+    raw = (tmp_path / "crush.json").read_text()
+    data = json.loads(raw)
+    assert data["mcp"]["context7"]["env"] == {
+        "CONTEXT7_API_KEY": "$(echo $CONTEXT7_API_KEY)"
+    }
+    assert data["mcp"]["tavily"]["env"] == {
+        "TAVILY_API_KEY": "$(echo $TAVILY_API_KEY)"
+    }
+    # No bare `${VAR}` and no resolved key survives into the rendered file.
+    assert "${CONTEXT7_API_KEY}" not in raw
+    assert "${TAVILY_API_KEY}" not in raw
+
+
+def test_real_registry_serena_context_resolves_to_crush(tmp_path, monkeypatch):
+    """serena's `--context={{ $h }}` template must resolve to `--context=crush`
+    for this harness — proving crush flows through the per-harness templating
+    pass with ZERO per-MCP registry edits (the D1 default-include claim). A
+    regression that hardcoded a context, or failed to pass `crush` as `$h`,
+    would surface here."""
+    m = _real_base_manifest(monkeypatch)
+    CrushRenderer().render(m, tmp_path)
+    data = json.loads((tmp_path / "crush.json").read_text())
+    assert "--context=crush" in data["mcp"]["serena"]["args"]
+
+
+def test_real_registry_clean_round_trip_removes_bootstrapped_file(
+    tmp_path, monkeypatch
+):
+    """Render the real coding set onto a fresh target, then clean: every one of
+    ours is removed and the bootstrapped file (schema-stub only) is unlinked —
+    the install/uninstall parity with opencode, exercised on the real set."""
+    m = _real_base_manifest(monkeypatch)
+    r = CrushRenderer()
+    r.render(m, tmp_path)
+    assert (tmp_path / "crush.json").exists()
+    r.clean(m, tmp_path)
+    assert not (tmp_path / "crush.json").exists()

--- a/agent-profile/tests/test_renderer_crush.py
+++ b/agent-profile/tests/test_renderer_crush.py
@@ -1,0 +1,334 @@
+"""test_renderer_crush.py — crush.json merge + surgical clean (spec #223).
+
+crush is the 6th harness: MCP-only (no skills/hooks/agents/permissions) and
+non-isolated. The renderer mirrors :class:`OpencodeRenderer` minus those
+surfaces — it merges the registry's coding MCPs into ``crush.json`` under the
+top-level ``mcp`` key, with crush's own server shape
+(``{type: "stdio", command, args?, env?}``) and crush's ``$(echo $VAR)``
+env-expansion form.
+
+The clean parity follows opencode's /age fix: a bootstrapped file that
+reduces to ``{}`` OR ``{"$schema": ...}`` is removed; user keys survive a
+render+clean round-trip.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agent_profile.parse import Manifest
+from agent_profile.renderers.base import MergedConfigError, Renderer
+from agent_profile.renderers.crush import CrushRenderer
+
+SCHEMA = "https://charm.land/crush.json"
+
+
+def _manifest() -> Manifest:
+    """A manifest with one crush-scoped MCP (undeclared harnesses -> the
+    default-include set, which contains crush) and one claude-only MCP that
+    must be skipped."""
+    return Manifest(
+        name="rust",
+        mcps=[
+            {
+                "name": "serena",
+                "command": "serena",
+                "args": ["start-mcp-server"],
+                # No `harnesses` -> default-include flows to crush.
+            },
+            {"name": "claude-only", "command": "co", "harnesses": ["claude"]},
+        ],
+    )
+
+
+def test_implements_renderer_protocol():
+    r = CrushRenderer()
+    assert isinstance(r, Renderer)
+    assert r.name == "crush"
+
+
+def test_mcp_default_includes_self_for_undeclared_flow():
+    """D1: crush must be in its own ``mcp_default`` so an MCP that omits
+    ``harnesses`` flows into crush (default-include parity with the other
+    coding harnesses)."""
+    assert "crush" in CrushRenderer().mcp_default
+
+
+def test_merge_bootstrap_writes_schema_and_mcp_block(tmp_path: Path):
+    """Fresh target: renderer bootstraps the crush schema stub then merges
+    its server entry under the top-level ``mcp`` key."""
+    CrushRenderer().render(_manifest(), tmp_path)
+    got = json.loads((tmp_path / "crush.json").read_text())
+    assert got["$schema"] == SCHEMA
+    assert got["mcp"]["serena"] == {
+        "type": "stdio",
+        "command": "serena",
+        "args": ["start-mcp-server"],
+    }
+
+
+def test_claude_only_mcp_never_reaches_crush(tmp_path: Path):
+    """An MCP scoped to ``harnesses: [claude]`` must not render into crush."""
+    CrushRenderer().render(_manifest(), tmp_path)
+    got = json.loads((tmp_path / "crush.json").read_text())
+    assert "claude-only" not in got["mcp"]
+
+
+def test_empty_harnesses_mcp_excluded(tmp_path: Path):
+    """An MCP with ``harnesses: []`` (e.g. todoist) is scoped out of every
+    harness, crush included — the empty list never falls back to the
+    default-include set."""
+    m = Manifest(
+        name="x",
+        mcps=[{"name": "todoist", "command": "npx", "harnesses": []}],
+    )
+    CrushRenderer().render(m, tmp_path)
+    assert not (tmp_path / "crush.json").exists()
+
+
+def test_merge_preserves_user_entries(tmp_path: Path):
+    """Pre-existing user crush.json: ours merge in, user's stay."""
+    (tmp_path / "crush.json").write_text(
+        json.dumps(
+            {
+                "$schema": SCHEMA,
+                "options": {"context_paths": ["CRUSH.md"]},
+                "mcp": {
+                    "user-mcp": {"type": "stdio", "command": "my-tool"}
+                },
+            }
+        )
+    )
+    CrushRenderer().render(_manifest(), tmp_path)
+    got = json.loads((tmp_path / "crush.json").read_text())
+    assert got["options"] == {"context_paths": ["CRUSH.md"]}
+    assert got["mcp"]["user-mcp"] == {"type": "stdio", "command": "my-tool"}
+    assert got["mcp"]["serena"]["command"] == "serena"
+
+
+def test_render_does_not_track_merged_file(tmp_path: Path):
+    """crush.json is a merged file, never a whole-file artefact — it must
+    not appear in the returned manifest paths (clean undoes it)."""
+    written = CrushRenderer().render(_manifest(), tmp_path)
+    assert written == []
+
+
+def test_no_mcps_writes_nothing(tmp_path: Path):
+    """Empty crush scope: no file bootstrapped (parity with opencode's
+    early-return)."""
+    CrushRenderer().render(Manifest(name="empty"), tmp_path)
+    assert not (tmp_path / "crush.json").exists()
+
+
+def test_mcp_without_env_omits_env_key(tmp_path: Path):
+    """No ``env`` -> no ``env`` key on the server record."""
+    m = Manifest(
+        name="noenv",
+        mcps=[{"name": "noenv", "command": "foo"}],
+    )
+    CrushRenderer().render(m, tmp_path)
+    server = json.loads((tmp_path / "crush.json").read_text())["mcp"]["noenv"]
+    assert "env" not in server
+    assert server == {"type": "stdio", "command": "foo"}
+
+
+def test_mcp_without_args_omits_args_key(tmp_path: Path):
+    """No ``args`` -> no ``args`` key (crush defaults it; we omit when absent)."""
+    m = Manifest(
+        name="noargs",
+        mcps=[{"name": "noargs", "command": "foo"}],
+    )
+    CrushRenderer().render(m, tmp_path)
+    server = json.loads((tmp_path / "crush.json").read_text())["mcp"]["noargs"]
+    assert "args" not in server
+
+
+def test_mcp_env_rewrites_var_to_crush_shell_eval(tmp_path: Path):
+    """crush expands env via ``$(echo $VAR)`` shell-eval (charmbracelet/crush
+    README), NOT opencode's ``{env:VAR}``. Each ``${VAR}`` is rewritten to
+    ``$(echo $VAR)``; a plain literal passes through untouched, and no
+    resolved secret lands on disk."""
+    m = Manifest(
+        name="withvar",
+        mcps=[
+            {
+                "name": "withvar",
+                "command": "npx",
+                "env": {
+                    "CONTEXT7_API_KEY": "${CONTEXT7_API_KEY}",
+                    "CRG_TOOLS": "build,review",
+                },
+            }
+        ],
+    )
+    CrushRenderer().render(m, tmp_path)
+    raw = (tmp_path / "crush.json").read_text()
+    server = json.loads(raw)["mcp"]["withvar"]
+    assert server["env"] == {
+        "CONTEXT7_API_KEY": "$(echo $CONTEXT7_API_KEY)",
+        "CRG_TOOLS": "build,review",
+    }
+    assert "${CONTEXT7_API_KEY}" not in raw
+
+
+def test_mcp_env_rewrites_embedded_var(tmp_path: Path):
+    """A ``${VAR}`` embedded in a larger value is rewritten in place; only the
+    ``${VAR}`` token is touched, surrounding text is preserved."""
+    m = Manifest(
+        name="embed",
+        mcps=[
+            {
+                "name": "embed",
+                "command": "foo",
+                "env": {"URL": "https://x/${TOKEN}/y"},
+            }
+        ],
+    )
+    CrushRenderer().render(m, tmp_path)
+    server = json.loads((tmp_path / "crush.json").read_text())["mcp"]["embed"]
+    assert server["env"]["URL"] == "https://x/$(echo $TOKEN)/y"
+
+
+def test_mcp_env_bare_dollar_and_boundaries_untouched(tmp_path: Path):
+    """Only the ``${IDENT}`` form is rewritten. A bare ``$VAR`` (no braces), a
+    literal ``$`` (a price), and a malformed ``${}`` pass through untouched —
+    the rewrite must not broaden into shell expansion or it corrupts
+    non-secret literals. Multiple tokens in one value are each rewritten."""
+    m = Manifest(
+        name="bounds",
+        mcps=[
+            {
+                "name": "bounds",
+                "command": "foo",
+                "env": {
+                    "BARE": "$NOT_A_REF",
+                    "PRICE": "costs $5.00 USD",
+                    "MALFORMED": "${}",
+                    "MULTI": "${A}-${B}",
+                },
+            }
+        ],
+    )
+    CrushRenderer().render(m, tmp_path)
+    env = json.loads((tmp_path / "crush.json").read_text())["mcp"]["bounds"]["env"]
+    assert env["BARE"] == "$NOT_A_REF"
+    assert env["PRICE"] == "costs $5.00 USD"
+    assert env["MALFORMED"] == "${}"
+    assert env["MULTI"] == "$(echo $A)-$(echo $B)"
+
+
+def test_clean_keeps_user_entries(tmp_path: Path):
+    """Install over user content, then clean: only ours are removed."""
+    (tmp_path / "crush.json").write_text(
+        json.dumps(
+            {
+                "$schema": SCHEMA,
+                "options": {"context_paths": ["CRUSH.md"]},
+                "mcp": {
+                    "user-mcp": {"type": "stdio", "command": "my-tool"}
+                },
+            }
+        )
+    )
+    r = CrushRenderer()
+    m = _manifest()
+    r.render(m, tmp_path)
+    r.clean(m, tmp_path)
+    got = json.loads((tmp_path / "crush.json").read_text())
+    assert "serena" not in got["mcp"]
+    assert got["mcp"]["user-mcp"]["command"] == "my-tool"
+    assert got["options"] == {"context_paths": ["CRUSH.md"]}
+
+
+def test_clean_missing_file_is_noop(tmp_path: Path):
+    """Clean on a target with no crush.json does nothing, no error."""
+    CrushRenderer().clean(_manifest(), tmp_path)
+    assert not (tmp_path / "crush.json").exists()
+
+
+def test_clean_is_idempotent_on_user_file(tmp_path: Path):
+    """Cleaning twice leaves the user-owned file identical the second time."""
+    (tmp_path / "crush.json").write_text(
+        json.dumps(
+            {
+                "$schema": SCHEMA,
+                "mcp": {"user-mcp": {"type": "stdio", "command": "my-tool"}},
+            }
+        )
+    )
+    r = CrushRenderer()
+    m = _manifest()
+    r.render(m, tmp_path)
+    r.clean(m, tmp_path)
+    once = (tmp_path / "crush.json").read_text()
+    r.clean(m, tmp_path)
+    twice = (tmp_path / "crush.json").read_text()
+    assert once == twice
+    assert json.loads(twice)["mcp"]["user-mcp"]["command"] == "my-tool"
+
+
+def test_clean_removes_bootstrapped_schema_only(tmp_path: Path):
+    """Round-trip on a fresh target: install bootstraps the schema stub,
+    clean strips ours back to ``{"$schema": ...}`` and removes the file."""
+    r = CrushRenderer()
+    m = _manifest()
+    r.render(m, tmp_path)
+    assert (tmp_path / "crush.json").exists()
+    r.clean(m, tmp_path)
+    assert not (tmp_path / "crush.json").exists()
+
+
+def test_clean_removes_bootstrapped_empty_braces(tmp_path: Path):
+    """A target whose crush.json reduces to a bare ``{}`` after surgical
+    removal (no ``$schema`` key) is removed (opencode's /age-fix parity)."""
+    (tmp_path / "crush.json").write_text(
+        json.dumps(
+            {
+                "mcp": {
+                    "serena": {
+                        "type": "stdio",
+                        "command": "serena",
+                        "args": ["start-mcp-server"],
+                    }
+                }
+            }
+        )
+    )
+    CrushRenderer().clean(_manifest(), tmp_path)
+    assert not (tmp_path / "crush.json").exists()
+
+
+def test_prune_mcps_delegates_to_clean(tmp_path: Path):
+    """prune_mcps removes the dropped server's entry (D3: delegates to clean)."""
+    (tmp_path / "crush.json").write_text(
+        json.dumps(
+            {
+                "$schema": SCHEMA,
+                "mcp": {
+                    "serena": {"type": "stdio", "command": "serena"},
+                    "user-mcp": {"type": "stdio", "command": "my-tool"},
+                },
+            }
+        )
+    )
+    dropped = Manifest(
+        name="rust",
+        mcps=[{"name": "serena", "command": "serena"}],
+    )
+    CrushRenderer().prune_mcps(dropped, tmp_path)
+    got = json.loads((tmp_path / "crush.json").read_text())
+    assert "serena" not in got["mcp"]
+    assert "user-mcp" in got["mcp"]
+
+
+def test_corrupt_config_raises_clean_error(tmp_path: Path):
+    """A hand-corrupted crush.json surfaces MergedConfigError on render and
+    clean, not an uncaught JSONDecodeError traceback."""
+    (tmp_path / "crush.json").write_text("{not valid json")
+    with pytest.raises(MergedConfigError):
+        CrushRenderer().render(_manifest(), tmp_path)
+    with pytest.raises(MergedConfigError):
+        CrushRenderer().clean(_manifest(), tmp_path)

--- a/chezmoi/lib/install-base-profile.sh
+++ b/chezmoi/lib/install-base-profile.sh
@@ -20,8 +20,8 @@
 # SessionStart hook (cheese-flair) and bundled MCPs/skills become live.
 # `--target` is intentionally omitted; the profile resolves $HOME itself.
 #
-# opencode has no plugin-enablement surface — `base` is sufficient there,
-# and its target stays explicit ($HOME/.config/opencode is not $HOME).
+# opencode and crush have no plugin-enablement surface — `base` is sufficient,
+# and their XDG targets are not $HOME, so target_default doesn't apply.
 #
 # Usage:
 #   install-base-profile.sh <target_home>
@@ -56,3 +56,9 @@ HOME="$target" "$ap_bin" install global \
 # enable, and its target is not $HOME so target_default doesn't apply.
 "$ap_bin" install base --target "$target/.config/opencode" \
     --harness opencode
+
+# crush also writes crush.json at its target root (XDG global), so it targets
+# $HOME/.config/crush. crush is MCP-only and non-isolated — `base` carries the
+# registry's coding MCPs, which is crush's entire config surface.
+"$ap_bin" install base --target "$target/.config/crush" \
+    --harness crush

--- a/tests/install-base-profile.bats
+++ b/tests/install-base-profile.bats
@@ -62,10 +62,20 @@ teardown() { teardown_test_env; }
     assert_output_contains "install base --target $TEST_HOME/.config/opencode --harness opencode"
 }
 
-@test "install-base-profile.sh makes exactly two ap calls" {
+@test "install-base-profile.sh renders crush under \$HOME/.config/crush" {
+    # crush is the 6th harness: MCP-only + non-isolated, XDG global like
+    # opencode, so `base` (not `global`) into $HOME/.config/crush.
+    INSTALL_BASE_PROFILE_AP="$FAKE_BIN/ap" \
+        run bash "$LIB" "$TEST_HOME"
+    assert_success
+    run cat "$AP_LOG"
+    assert_output_contains "install base --target $TEST_HOME/.config/crush --harness crush"
+}
+
+@test "install-base-profile.sh makes exactly three ap calls" {
     INSTALL_BASE_PROFILE_AP="$FAKE_BIN/ap" bash "$LIB" "$TEST_HOME"
     run wc -l < "$AP_LOG"
-    [[ "$(echo "$output" | tr -d ' ')" == "2" ]]
+    [[ "$(echo "$output" | tr -d ' ')" == "3" ]]
 }
 
 @test "install-base-profile.sh fails loud when an ap render fails" {


### PR DESCRIPTION
## Summary

Adds **crush** (charmbracelet/crush) as a 6th `ap` harness (#223): MCP-only and non-isolated.

`CrushRenderer` merges the registry's coding MCPs into `crush.json` under the top-level `mcp` key as `{type: "stdio", command, args?, env?}` records, using crush's `$(echo $VAR)` shell-eval env-expansion form for secrets. Wires:

- `ALL_HARNESSES` + the renderer registry (six renderers)
- the skills-fetch exclusion — crush has no skills agent, so `_fetch_external_skills` intersects requested harnesses with `SKILL_AGENT` keys (crush drops out; a genuine typo still fails loud via `_validate_harnesses`)
- the chezmoi XDG install line (`base` profile — crush is non-isolated)
- `AGENTS.md`

`clean`/`prune_mcps` mirror the opencode renderer (surgical pop, unlink when reduced to `{}`/`{"$schema"}`). crush stays absent from `_ISOLATION_BUILDERS`, so an isolated crush launch fails loud (spec 1's contract).

## Stacked PR

Based on `feat/non-claude-isolated-profiles` (#307) — that PR shares `cli.py` (different hunks). Merge #307 first; this diff shows only the crush changes. GitHub will retarget to `main` when #307 merges.

## Tests

agent-profile pytest **641 passed**; `install-base-profile` + `skills-external` bats green. Coverage locks the real-registry MCP set (6 servers, todoist excluded), the `$(echo $VAR)` rewrite edge cases, the stdio record shape, clean/prune round-trips, and the D2 skills-fetch log/behavior.

## Caveat

The `crush` binary is not installed on this machine, so live-launch secret resolution is **verify-in-deploy**. The `$(echo $VAR)` form and the `crush.json` schema are confirmed against the crush README/llms.txt (Context7); the rendered output is locked correct against the shipped registry.

Closes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)
