### PR TITLE
feat(local-llm): pre-warm pool models on opencode-lean launch (#299)

### DIFF
--- a/.hallouminate/wiki/operations/local-llm.md
+++ b/.hallouminate/wiki/operations/local-llm.md
@@ -57,13 +57,17 @@ opencode reaches the stack through the `local-llm` provider (`Local (LiteLLM)`, 
 opencode-lean --model local-llm/local-coder
 ```
 
-It's a one-line wrapper — `OPENCODE_CONFIG="$HOME/local-llm/configs/lean.json" opencode "$@"`. The `lean.json` overlay `mergeDeep`s onto the global config and **only disables the heavy MCP servers** (`code-review-graph`, `hallouminate`, `tavily`), leaving `tilth` + `serena` + `context7` — so the local coder's small context window isn't blown by tool schemas before the first turn. There's no separate "lean" agent or model set; the overlay is purely the MCP trim.
+It runs `OPENCODE_CONFIG="$HOME/local-llm/configs/lean.json" opencode "$@"` behind a preflight + pre-warm wrapper (`scripts/executable_aliases.sh`). The `lean.json` overlay `mergeDeep`s onto the global config and **only disables the heavy MCP servers** (`code-review-graph`, `hallouminate`, `tavily`), leaving `tilth` + `serena` + `context7` — so the local coder's small context window isn't blown by tool schemas before the first turn. There's no separate "lean" agent or model set; the overlay is purely the MCP trim. `lean.json` also sets `model: local-llm/local-coder` so bare `opencode-lean` defaults to the local coder, not a cloud model (#297).
 
-Operational notes (each is also an open improvement issue):
+The wrapper does two things before launch:
 
-- The overlay sets **no default model** — you must pass `--model local-llm/<name>` (opencode's flag is `provider/model`). Bare `opencode-lean` falls back to your global *cloud* default, silently. → #297
-- `opencode-lean` does **not** start the stack — run `llm-up` first (or `llm-ping`); otherwise opencode launches and hard-fails on the first request to a dead `:4000`. → #298
-- Pool models (`local-sonnet`/`local-coder`/`local-vision`) **cold-load on first request** (~15–20s while llama-swap swaps the backend in, held open, no 503). `local-haiku` + `local-embed` are hot and answer instantly. opencode's own request timeout vs. the cold-load window is unverified. → #299
+1. **Preflight** (#298) — probes `:4000`; if down, runs `llm-up` and waits up to `OPENCODE_LEAN_TIMEOUT` seconds (default 30), bailing with a hint instead of launching into a dead stack.
+2. **Pre-warm** (#299) — resolves the effective model (`--model`/`--model=` arg, else `lean.json`'s default; `local-llm/` prefix stripped) and, **only for swap-pool models** (`local-sonnet`/`local-coder`/`local-vision`), fires a backgrounded 1-token completion at `:4000` so the ~15–30s cold-load overlaps opencode's startup, not the first turn. Hot models (`local-haiku`/`local-embed`) and unrecognized models are no-ops. The warm-up is a detached subshell — launch never blocks on it (strictly never worse than no warm-up, since llama-swap holds the request open regardless). `OPENCODE_LEAN_WARM_TIMEOUT` (default 360) caps the curl.
+
+Why pre-warm is safe and no provider-timeout config was added: **opencode applies no default request timeout to custom `@ai-sdk/openai-compatible` providers** (`<certain>`, from sst/opencode `provider.ts` — `AbortSignal.timeout` fires only when `options.timeout` is explicitly set; the built-in `openai` provider gets a 10s `headerTimeout`, custom config providers get nothing). So the first request to a cold pool model waits indefinitely for the first token — nothing kills it, and the feared "first request fails on a too-short default timeout" does not occur. Adding `options.timeout`/`chunkTimeout` to the provider block would be speculative hardening against a hypothetical future opencode default (YAGNI) — out of scope; the pre-warm UX win is the whole fix. (Research slug `.cheese/research/opencode-timeout/`.)
+
+Remaining operational note (open improvement issue):
+
 - `local-embed` shows in the picker but is **embeddings-only** — selecting it as a chat model errors. → #300
 
 ## Adding / tuning a model

--- a/chezmoi/local-llm/scripts/executable_aliases.sh
+++ b/chezmoi/local-llm/scripts/executable_aliases.sh
@@ -38,6 +38,28 @@ alias llm-install-swap='~/local-llm/scripts/install-llama-swap.sh'
 #
 # Pre-flights the local-LLM stack: probes :4000, starts local-llm.target if down,
 # waits up to OPENCODE_LEAN_TIMEOUT seconds (default 30), then bails with a hint.
+# For a swap-pool model (local-sonnet/local-coder/local-vision) it then fires a
+# backgrounded 1-token completion so the ~15-30s cold-load overlaps opencode's
+# own startup and the first real turn is instant. Hot models (local-haiku/
+# local-embed, resident) and unrecognized models get no warm-up.
+
+# Resolve the effective model: --model <m> / --model=<m> wins, else lean.json's
+# default; strip the local-llm/ provider prefix to the bare LiteLLM model_name.
+_opencode_lean_model() {
+  local model=""
+  while (( $# )); do
+    case "$1" in
+      --model=*) model="${1#--model=}" ;;
+      --model)   model="$2"; shift ;;
+    esac
+    shift
+  done
+  if [[ -z "$model" ]]; then
+    model=$(jq -r '.model // empty' "$HOME/local-llm/configs/lean.json" 2>/dev/null)
+  fi
+  printf '%s' "${model#local-llm/}"
+}
+
 opencode-lean() {
   local timeout="${OPENCODE_LEAN_TIMEOUT:-30}"
   if ! curl -s --max-time 1 http://127.0.0.1:4000/v1/models >/dev/null 2>&1; then
@@ -54,6 +76,23 @@ opencode-lean() {
       (( elapsed++ ))
     done
   fi
+
+  # Pre-warm swap-pool models so the cold-load overlaps opencode startup, not
+  # the first turn. Backgrounded + detached — launch never blocks on it.
+  local model
+  model=$(_opencode_lean_model "$@")
+  case "$model" in
+    local-sonnet|local-coder|local-vision)
+      ( curl -s --max-time "${OPENCODE_LEAN_WARM_TIMEOUT:-360}" \
+          http://127.0.0.1:4000/v1/chat/completions \
+          -H 'Authorization: Bearer sk-local' \
+          -H 'Content-Type: application/json' \
+          -d "$(jq -nc --arg m "$model" \
+                '{model:$m, messages:[{role:"user",content:"."}], max_tokens:1}')" \
+          >/dev/null 2>&1 & )
+      ;;
+  esac
+
   OPENCODE_CONFIG="$HOME/local-llm/configs/lean.json" opencode "$@"
 }
 

--- a/tests/local-llm.bats
+++ b/tests/local-llm.bats
@@ -789,3 +789,72 @@ MOCK
     # Must return well under the 10s warm-up sleep — proves it is backgrounded.
     (( end - start < 5 ))
 }
+
+@test "opencode-lean warms the lean.json default model on a bare (no --model) launch" {
+    # Spec acceptance: bare `opencode-lean` resolves the lean.json default
+    # (local-coder, a pool model) and must fire the warm-up — locks the
+    # default-resolution -> warm-up composition, not just the helper in isolation.
+    mkdir -p "$HOME/local-llm/configs"
+    cp "$LEAN" "$HOME/local-llm/configs/lean.json"
+
+    cat > "$MOCK_BIN/opencode" << 'MOCK'
+#!/bin/bash
+echo "opencode-called"
+MOCK
+    chmod +x "$MOCK_BIN/opencode"
+
+    local warm_log="$TEST_HOME/warm.log"
+    cat > "$MOCK_BIN/curl" << MOCK
+#!/bin/bash
+if [[ "\$*" == *chat/completions* ]]; then
+    printf '%s\n' "\$*" > "$warm_log"
+fi
+exit 0
+MOCK
+    chmod +x "$MOCK_BIN/curl"
+
+    # shellcheck disable=SC1090
+    source "$ALIASES"
+    run opencode-lean
+    assert_success
+    assert_output_contains "opencode-called"
+
+    local i=0
+    while [[ ! -f "$warm_log" ]] && (( i < 50 )); do sleep 0.1; (( i++ )); done
+    assert_file_exists "$warm_log"
+    run cat "$warm_log"
+    assert_output_contains "http://127.0.0.1:4000/v1/chat/completions"
+    assert_output_contains '"model":"local-coder"'
+    assert_output_contains '"max_tokens":1'
+}
+
+@test "opencode-lean does NOT warm an unrecognized model (non-pool, non-hot)" {
+    # D3: only the three swap-pool models warm. An unrecognized model id
+    # (here a non-local provider model) must hit the case fall-through = no-op,
+    # distinct from the known-hot-model branch.
+    cat > "$MOCK_BIN/opencode" << 'MOCK'
+#!/bin/bash
+echo "opencode-called"
+MOCK
+    chmod +x "$MOCK_BIN/opencode"
+
+    local warm_log="$TEST_HOME/warm.log"
+    cat > "$MOCK_BIN/curl" << MOCK
+#!/bin/bash
+if [[ "\$*" == *chat/completions* ]]; then
+    echo "\$*" > "$warm_log"
+fi
+exit 0
+MOCK
+    chmod +x "$MOCK_BIN/curl"
+
+    # shellcheck disable=SC1090
+    source "$ALIASES"
+    run opencode-lean --model anthropic/claude-sonnet-4
+    assert_success
+    assert_output_contains "opencode-called"
+
+    # Give any (erroneous) backgrounded warm-up a chance to fire, then confirm none did.
+    sleep 0.5
+    [[ ! -f "$warm_log" ]]
+}

--- a/tests/local-llm.bats
+++ b/tests/local-llm.bats
@@ -666,3 +666,126 @@ MOCK
     assert_failure
     assert_output_contains "timed out"
 }
+
+# ─── pre-warm (#299) ──────────────────────────────────────────────────────────
+
+@test "_opencode_lean_model: --model strips the local-llm/ prefix" {
+    # shellcheck disable=SC1090
+    source "$ALIASES"
+    run _opencode_lean_model --model local-llm/local-sonnet
+    assert_success
+    [[ "$output" == "local-sonnet" ]]
+}
+
+@test "_opencode_lean_model: --model=X form is honoured" {
+    # shellcheck disable=SC1090
+    source "$ALIASES"
+    run _opencode_lean_model --model=local-llm/local-vision
+    assert_success
+    [[ "$output" == "local-vision" ]]
+}
+
+@test "_opencode_lean_model: defaults to lean.json model when no --model arg" {
+    # Deploy the real lean.json into the sandbox HOME so the default path reads it.
+    mkdir -p "$HOME/local-llm/configs"
+    cp "$LEAN" "$HOME/local-llm/configs/lean.json"
+    # shellcheck disable=SC1090
+    source "$ALIASES"
+    run _opencode_lean_model -c .
+    assert_success
+    [[ "$output" == "local-coder" ]]
+}
+
+@test "opencode-lean pre-warms a pool model with a backgrounded 1-token completion" {
+    cat > "$MOCK_BIN/opencode" << 'MOCK'
+#!/bin/bash
+echo "opencode-called"
+MOCK
+    chmod +x "$MOCK_BIN/opencode"
+
+    # curl mock: stack probe is up; chat/completions records the full arg vector
+    # (incl. the -d JSON body) so we can assert the warm-up call shape after it
+    # lands (it is backgrounded).
+    local warm_log="$TEST_HOME/warm.log"
+    cat > "$MOCK_BIN/curl" << MOCK
+#!/bin/bash
+if [[ "\$*" == *chat/completions* ]]; then
+    printf '%s\n' "\$*" > "$warm_log"
+fi
+exit 0
+MOCK
+    chmod +x "$MOCK_BIN/curl"
+
+    # shellcheck disable=SC1090
+    source "$ALIASES"
+    run opencode-lean --model local-llm/local-coder
+    assert_success
+    assert_output_contains "opencode-called"
+
+    # The warm-up is backgrounded — poll briefly for the marker to appear.
+    local i=0
+    while [[ ! -f "$warm_log" ]] && (( i < 50 )); do sleep 0.1; (( i++ )); done
+    assert_file_exists "$warm_log"
+    run cat "$warm_log"
+    assert_output_contains "http://127.0.0.1:4000/v1/chat/completions"
+    # The bare model_name (local-llm/ prefix stripped) is what hits LiteLLM,
+    # as a 1-token completion.
+    assert_output_contains '"model":"local-coder"'
+    assert_output_contains '"max_tokens":1'
+}
+
+@test "opencode-lean does NOT warm a hot model" {
+    cat > "$MOCK_BIN/opencode" << 'MOCK'
+#!/bin/bash
+echo "opencode-called"
+MOCK
+    chmod +x "$MOCK_BIN/opencode"
+
+    local warm_log="$TEST_HOME/warm.log"
+    cat > "$MOCK_BIN/curl" << MOCK
+#!/bin/bash
+if [[ "\$*" == *chat/completions* ]]; then
+    echo "\$*" > "$warm_log"
+fi
+exit 0
+MOCK
+    chmod +x "$MOCK_BIN/curl"
+
+    # shellcheck disable=SC1090
+    source "$ALIASES"
+    run opencode-lean --model local-llm/local-haiku
+    assert_success
+    assert_output_contains "opencode-called"
+
+    # Give any (erroneous) backgrounded warm-up a chance to fire, then confirm none did.
+    sleep 0.5
+    [[ ! -f "$warm_log" ]]
+}
+
+@test "opencode-lean does not block on the warm-up (launch returns while warm-up sleeps)" {
+    cat > "$MOCK_BIN/opencode" << 'MOCK'
+#!/bin/bash
+echo "opencode-called"
+MOCK
+    chmod +x "$MOCK_BIN/opencode"
+
+    # chat/completions sleeps 10s; if the function blocked on it, opencode-lean
+    # would take >10s. The probe stays fast so only the warm-up could stall.
+    cat > "$MOCK_BIN/curl" << 'MOCK'
+#!/bin/bash
+[[ "$*" == *chat/completions* ]] && sleep 10
+exit 0
+MOCK
+    chmod +x "$MOCK_BIN/curl"
+
+    # shellcheck disable=SC1090
+    source "$ALIASES"
+    local start end
+    start=$(date +%s)
+    run opencode-lean --model local-llm/local-sonnet
+    end=$(date +%s)
+    assert_success
+    assert_output_contains "opencode-called"
+    # Must return well under the 10s warm-up sleep — proves it is backgrounded.
+    (( end - start < 5 ))
+}


### PR DESCRIPTION
## Summary

Extends the `opencode-lean` preflight wrapper (#298) to **pre-warm** swap-pool models on launch, so the ~15–30s cold-load overlaps opencode startup instead of landing on the user's first turn (#299).

- `_opencode_lean_model` resolves the effective model — `--model X` / `--model=X` arg wins, else lean.json's default (#297) — and strips the `local-llm/` prefix.
- A pre-warm `case` block after the existing preflight: pool models (`local-sonnet` / `local-coder` / `local-vision`) fire a **backgrounded, detached** 1-token completion at `:4000`; already-hot or unrecognized models are no-ops; launch never blocks on it. `OPENCODE_LEAN_WARM_TIMEOUT` (default 360) caps the curl.

Scope is **pre-warm only** (locked decision) — no provider-timeout config (YAGNI). The warm-up runs only after preflight confirms the stack is up, and degrades silently to the prior cold-load behavior if `:4000` is unreachable (strictly never worse than today).

## Tests

`bats tests/local-llm.bats` **54/54** (8 new, mutation-verified); `shellcheck` clean. Coverage: model resolution (`--model` / `--model=` / lean.json default / prefix strip), pool-fires-warm-up, hot/unrecognized no-op, default→warm composition end-to-end, and the non-blocking guarantee (launch completes <5s against a 10s warm-up).

## Caveat

Live warm-up timing is **verify-in-deploy** — validated by structure + mocked-curl tests, not against a running pool on this host.

Closes #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)
