### PR TITLE
feat(ap): git-source option for cross-harness plugins

### DIFF
--- a/.hallouminate/wiki/architecture/cross-harness-plugins.md
+++ b/.hallouminate/wiki/architecture/cross-harness-plugins.md
@@ -14,7 +14,7 @@ profile dir IS a Claude plugin dir). Cross-harness plugins add a 5th registry
 
 ## Path model: marketplace root vs payload root
 
-**Critical distinction** — the `path:` in `registry.yaml` is the **marketplace
+**Critical distinction** — the `path:` or git-cloned cache in `registry.yaml` resolves to the **marketplace
 root**, not the plugin payload root.
 
 ```
@@ -101,15 +101,32 @@ it fails under repo-root stamping.
 
 ## Registry schema (`agents/plugins/registry.yaml`)
 
+Each entry requires exactly one source field — `git:` or `path:` (both or neither is a `ParseError`):
+
 ```yaml
 plugins:
   <name>:
-    path: ~/Dev/myplugin   # marketplace root (holds .claude-plugin/marketplace.json)
+    # Source: exactly one required
+    git: https://github.com/org/repo   # clone URL; cached in ~/.cache/ap/plugins/<name>
+    branch: main                        # optional; default: main. Only with git:
+    subdir: nested/subdir               # optional; only if marketplace root is nested in repo
+    # -or-
+    path: ~/Dev/myplugin               # local checkout marketplace root
+
     harnesses: [claude, codex, opencode, cursor, copilot, crush]
     claude_native: true   # Claude gets native marketplace install
     gate_unless: MY_ENV_VAR   # optional gate
     description: Human-readable description
 ```
+
+**`git:` vs `path:` mutual exclusivity** — exactly one is required per entry. `git:` is the
+portable form: the repo is shallow-cloned into `~/.cache/ap/plugins/<KEY>` on first use and
+refreshed on subsequent runs. If the network fetch fails but a populated cache exists,
+`ap install base` warns and uses the cache (does not abort). `path:` is the dev-machine
+form for local checkouts. The two are mutually exclusive so the resolution is never ambiguous.
+
+**`subdir:`** — optional; only needed when `marketplace.json` lives inside a subdirectory of
+the cloned repo rather than the repo root. Relative paths only; `..` is rejected loud.
 
 **`harnesses`** — explicit MCP membership list. Deliberate: blanket-wide
 membership taxes every per-request MCP-schema token budget. See
@@ -224,10 +241,11 @@ loading interacts with secret passthrough.
 
 ## Gotchas
 
-- **`path:` must be marketplace root, not payload** — `registry.yaml path:` must
-  point at the directory containing `.claude-plugin/marketplace.json`. Pointing
-  at the payload subdirectory (which has `.mcp.json` but no `marketplace.json`)
-  raises `ParseError` at ingest.
+- **Source must resolve to marketplace root, not payload** — the `path:` value
+  (or the git-cloned cache dir + `subdir:` if set) must point at the directory
+  containing `.claude-plugin/marketplace.json`. Pointing at the payload
+  subdirectory (which has `.mcp.json` but no `marketplace.json`) raises
+  `ParseError` at ingest.
 - **`_source_dir` mis-stamping** — must be the payload root (where `.mcp.json`
   and `skills/` live). The unit test explicitly proves the failure mode. If you
   see a renderer failing to find a skill file, check `_source_dir` on the item first.
@@ -258,31 +276,33 @@ loading interacts with secret passthrough.
 
 ## Worked example: milknado
 
-**Marketplace root** (the registry `path:`): `~/Dev/milknado`
+**Marketplace root** (git-cloned cache): `~/.cache/ap/plugins/milknado/`
+(cloned from `https://github.com/paulnsorensen/milknado`, branch `main`)
 
 **Payload root** (from `marketplace.json` `source: ./plugins/milknado`):
-`~/Dev/milknado/plugins/milknado`
+`~/.cache/ap/plugins/milknado/plugins/milknado`
 
 **Layout:**
 
 ```
-~/Dev/milknado/                       ← marketplace root = registry path:
-  .claude-plugin/marketplace.json     ← {plugins: [{name: milknado, source: ./plugins/milknado}]}
-  plugins/milknado/                   ← payload root (the _source_dir stamp)
-    .mcp.json                         ← {command: uvx, args: [milknado-mcp]}
+~/.cache/ap/plugins/milknado/          ← marketplace root (git clone cache)
+  .claude-plugin/marketplace.json      ← {plugins: [{name: milknado, source: ./plugins/milknado}]}
+  plugins/milknado/                    ← payload root (the _source_dir stamp)
+    .mcp.json                          ← {command: uvx, args: [milknado-mcp]}
     skills/
       harvest/SKILL.md
       load-roadmap/SKILL.md
       milknado-config/
         SKILL.md
-        references/flavor-presets.md  ← subfile; NOT a skill itself
+        references/flavor-presets.md   ← subfile; NOT a skill itself
 ```
 
 **Registry entry:**
 
 ```yaml
 milknado:
-  path: ~/Dev/milknado
+  git: https://github.com/paulnsorensen/milknado
+  branch: main
   harnesses: [claude, codex, opencode, cursor, copilot, crush]
   claude_native: true
   description: Mikado execution engine — goal decomposition, batch planning, detached ralph-loop runs

--- a/agent-profile/agent_profile/ingest.py
+++ b/agent-profile/agent_profile/ingest.py
@@ -47,6 +47,8 @@ Registry shapes consumed:
 
 from __future__ import annotations
 
+import logging
+import subprocess
 from pathlib import Path, PurePosixPath
 from typing import Any
 
@@ -241,7 +243,6 @@ def _expand_skills(
             out.extend(_expand_local_skills(target, source_dir))
     return out
 
-
 def _resolve_plugin_path(path_str: str, repo_root: Path) -> Path:
     """Resolve a plugin ``path`` value to an absolute Path.
 
@@ -256,10 +257,67 @@ def _resolve_plugin_path(path_str: str, repo_root: Path) -> Path:
     return repo_root / expanded
 
 
+def _resolve_git_plugin(url: str, branch: str, cache_dir: Path) -> Path:
+    """Clone or refresh a git plugin repo into ``cache_dir``.
+
+    Shallow clone on first visit; fetch+reset on subsequent visits. If the
+    network fails but a populated cache exists, warns and returns the cache
+    (so ``ap install base`` does not abort on non-primary machines with no
+    network access to the repo). If neither clone nor cache yields content,
+    the caller's marketplace.json check will raise ``ParseError``.
+
+    Returns ``cache_dir`` (the marketplace root for this plugin).
+    """
+    log = logging.getLogger(__name__)
+    if cache_dir.is_dir() and any(cache_dir.iterdir()):
+        # Refresh existing cache.
+        try:
+            subprocess.run(
+                ["git", "fetch", "--depth", "1", "origin", branch],
+                cwd=cache_dir,
+                check=True,
+                capture_output=True,
+            )
+            subprocess.run(
+                ["git", "reset", "--hard", f"origin/{branch}"],
+                cwd=cache_dir,
+                check=True,
+                capture_output=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            log.warning(
+                "ap: git plugin refresh failed for %s branch %s — using cached copy. "
+                "Error: %s",
+                url,
+                branch,
+                exc.stderr.decode(errors="replace").strip() if exc.stderr else str(exc),
+            )
+    else:
+        # Fresh clone.
+        cache_dir.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            subprocess.run(
+                ["git", "clone", "--depth", "1", "--branch", branch, url, str(cache_dir)],
+                check=True,
+                capture_output=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            # No cache — let marketplace.json check below raise ParseError.
+            log.warning(
+                "ap: git plugin clone failed for %s branch %s — no cache available. "
+                "Error: %s",
+                url,
+                branch,
+                exc.stderr.decode(errors="replace").strip() if exc.stderr else str(exc),
+            )
+    return cache_dir
+
+
 def _expand_plugins(
     path: Path,
     repo_root: Path,
     dotenv: dict[str, str],
+    cache_root: Path | None = None,
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
     """Decompose every plugin in ``agents/plugins/registry.yaml`` into its
     constituent primitives.
@@ -290,24 +348,46 @@ def _expand_plugins(
     out_mcps: list[dict[str, Any]] = []
     out_skills: list[dict[str, Any]] = []
     out_native: list[dict[str, Any]] = []
+    _cache_root = cache_root or (Path.home() / ".cache" / "ap" / "plugins")
 
     for name, body in plugins.items():
         if not isinstance(body, dict):
             continue
+
+        # ── Validate source: exactly one of git: or path: ──
         path_str = body.get("path")
-        if not path_str:
-            continue
+        git_url = body.get("git")
+        if bool(path_str) == bool(git_url):  # both set, or neither set
+            raise ParseError(
+                f"ap: plugin '{name}': exactly one of 'git:' or 'path:' is required "
+                f"(got {'both' if path_str and git_url else 'neither'})."
+            )
+
+        if git_url:
+            branch = str(body.get("branch") or "main")
+            subdir_raw = body.get("subdir") or ""
+            if isinstance(subdir_raw, str) and (PurePosixPath(subdir_raw).is_absolute() or
+                    ".." in PurePosixPath(subdir_raw).parts):
+                raise ParseError(
+                    f"ap: plugin '{name}': subdir {subdir_raw!r} must be relative "
+                    f"without '..' components."
+                )
+            cache_dir = _cache_root / name
+            _resolve_git_plugin(str(git_url), branch, cache_dir)
+            subdir_parts = PurePosixPath(subdir_raw).parts if subdir_raw else ()
+            marketplace_root = cache_dir.joinpath(*subdir_parts) if subdir_parts else cache_dir
+        else:
+            if not path_str:
+                continue
+            marketplace_root = _resolve_plugin_path(str(path_str), repo_root)
 
         # ── Resolve marketplace root and read marketplace.json ──
-        marketplace_root = _resolve_plugin_path(str(path_str), repo_root)
         marketplace_json = marketplace_root / ".claude-plugin" / "marketplace.json"
         if not marketplace_json.is_file():
             raise ParseError(
                 f"ap: plugin '{name}': expected marketplace.json at "
                 f"{marketplace_json} but it was not found. "
-                f"The registry 'path:' field must point at the marketplace root "
-                f"(the directory containing .claude-plugin/marketplace.json), "
-                f"not at a plugin payload subdirectory."
+                f"The marketplace root must contain .claude-plugin/marketplace.json."
             )
         try:
             market_data = _json.loads(marketplace_json.read_text())

--- a/agent-profile/tests/test_ingest_plugins.py
+++ b/agent-profile/tests/test_ingest_plugins.py
@@ -887,3 +887,222 @@ def test_claude_native_controls_claude_in_decomposed_mcp_harnesses(
     out = expand_registries({"plugins": "agents/plugins/registry.yaml"}, tmp_path, {})
     mcp = next(m for m in out["mcps"] if m["name"] == "myplugin")
     assert ("claude" in mcp["harnesses"]) is claude_kept
+
+
+# ─── tests: git source (portability — no ~/Dev checkout assumption) ────────────────
+
+
+def _make_local_git_repo(repo_dir: Path, name: str) -> Path:
+    """Create a local bare-ish git repo usable as a file:// remote.
+
+    Initialises a real git repo at repo_dir, commits a minimal
+    milknado-style plugin layout (marketplace.json + payload .mcp.json +
+    one skill), and returns the repo_dir path.  Tests point 'git:' at this
+    path so no network access is needed.
+    """
+    import subprocess
+
+    repo_dir.mkdir(parents=True, exist_ok=True)
+
+    # Minimal plugin layout
+    cp = repo_dir / ".claude-plugin"
+    cp.mkdir()
+    (cp / "marketplace.json").write_text(
+        json.dumps({
+            "name": name,
+            "plugins": [{"name": name, "source": f"./plugins/{name}"}],
+        })
+    )
+    payload = repo_dir / "plugins" / name
+    payload.mkdir(parents=True)
+    (payload / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {name: {"command": "uvx", "args": [f"{name}-mcp"]}}})
+    )
+    skill_dir = payload / "skills" / f"{name}-skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(f"# {name}-skill\n")
+
+    env = {"GIT_AUTHOR_NAME": "test", "GIT_AUTHOR_EMAIL": "t@test",
+           "GIT_COMMITTER_NAME": "test", "GIT_COMMITTER_EMAIL": "t@test"}
+    import os
+    env.update(os.environ)
+    subprocess.run(["git", "init"], cwd=repo_dir, check=True, capture_output=True)
+    subprocess.run(["git", "checkout", "-b", "main"], cwd=repo_dir,
+                   check=True, capture_output=True, env=env)
+    subprocess.run(["git", "add", "-A"], cwd=repo_dir, check=True,
+                   capture_output=True, env=env)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=repo_dir,
+                   check=True, capture_output=True, env=env)
+    return repo_dir
+
+
+def test_git_source_resolves_mcp_and_skill(tmp_path):
+    """A git: entry fetches the plugin and decomposes it correctly.
+
+    Motivation: ap install base must not abort on a machine without the
+    ~/Dev checkout. The git source clones into ~/.cache/ap/plugins/<name>
+    and the existing decomposition runs unchanged from that cache dir.
+    """
+    repo = _make_local_git_repo(tmp_path / "repo", "myplugin")
+    cache_root = tmp_path / "cache"
+    _make_plugins_registry(
+        tmp_path,
+        {"myplugin": {
+            "git": str(repo),
+            "branch": "main",
+            "harnesses": ["codex"],
+        }},
+    )
+
+    from agent_profile.ingest import _expand_plugins
+    import yaml
+    reg_path = tmp_path / "agents" / "plugins" / "registry.yaml"
+    out_mcps, out_skills, out_native = _expand_plugins(
+        reg_path, tmp_path, {}, cache_root=cache_root
+    )
+
+    mcp_names = [m["name"] for m in out_mcps]
+    assert "myplugin" in mcp_names, "MCP must decompose from git-cloned repo"
+    skill_names = [s["name"] for s in out_skills]
+    assert "myplugin-skill" in skill_names, "Skill must decompose from git-cloned repo"
+    # Cache dir must exist and contain the plugin
+    assert (cache_root / "myplugin" / ".claude-plugin" / "marketplace.json").is_file()
+
+
+def test_git_source_subdir(tmp_path):
+    """subdir: shifts the marketplace root inside the cloned repo.
+
+    A plugin whose marketplace.json is nested under e.g. 'plugin-root/'
+    in the repo uses subdir: 'plugin-root' to point the decomposer at the
+    right directory instead of the repo root.
+    """
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    # marketplace lives under a 'plugin-root' subdir
+    subdir = repo_dir / "plugin-root"
+    subdir.mkdir()
+    cp = subdir / ".claude-plugin"
+    cp.mkdir()
+    (cp / "marketplace.json").write_text(
+        json.dumps({
+            "name": "nested",
+            "plugins": [{"name": "nested", "source": "./plugins/nested"}],
+        })
+    )
+    payload = subdir / "plugins" / "nested"
+    payload.mkdir(parents=True)
+    (payload / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {"nested": {"command": "uvx", "args": ["nested-mcp"]}}})
+    )
+
+    import subprocess, os
+    env = {"GIT_AUTHOR_NAME": "test", "GIT_AUTHOR_EMAIL": "t@test",
+           "GIT_COMMITTER_NAME": "test", "GIT_COMMITTER_EMAIL": "t@test"}
+    env.update(os.environ)
+    subprocess.run(["git", "init"], cwd=repo_dir, check=True, capture_output=True)
+    subprocess.run(["git", "checkout", "-b", "main"], cwd=repo_dir,
+                   check=True, capture_output=True, env=env)
+    subprocess.run(["git", "add", "-A"], cwd=repo_dir, check=True,
+                   capture_output=True, env=env)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=repo_dir,
+                   check=True, capture_output=True, env=env)
+
+    cache_root = tmp_path / "cache"
+    _make_plugins_registry(
+        tmp_path,
+        {"nested": {
+            "git": str(repo_dir),
+            "branch": "main",
+            "subdir": "plugin-root",
+            "harnesses": ["codex"],
+        }},
+    )
+    from agent_profile.ingest import _expand_plugins
+    reg_path = tmp_path / "agents" / "plugins" / "registry.yaml"
+    out_mcps, _, _ = _expand_plugins(reg_path, tmp_path, {}, cache_root=cache_root)
+    assert "nested" in [m["name"] for m in out_mcps], (
+        "MCP from nested subdir must decompose correctly"
+    )
+    # _source_dir must be inside the subdir, not at the cache root
+    mcp = next(m for m in out_mcps if m["name"] == "nested")
+    assert "plugin-root" in mcp["_source_dir"], (
+        "_source_dir must resolve through subdir into the cloned repo"
+    )
+
+
+def test_git_and_path_both_set_raises(tmp_path):
+    """Both git: and path: in one entry raises ParseError immediately.
+
+    The mutual-exclusivity rule prevents ambiguous resolution and
+    makes misconfigurations fail loud rather than silently picking one.
+    """
+    market_root, _ = _make_plugin_with_marketplace(tmp_path, "myplugin")
+    _make_plugins_registry(
+        tmp_path,
+        {"myplugin": {
+            "git": "https://example.com/repo",
+            "path": str(market_root),
+            "harnesses": ["codex"],
+        }},
+    )
+    with pytest.raises(ParseError, match="exactly one of"):
+        expand_registries({"plugins": "agents/plugins/registry.yaml"}, tmp_path, {})
+
+
+def test_neither_git_nor_path_raises(tmp_path):
+    """An entry with neither git: nor path: raises ParseError immediately.
+
+    A bare entry name with only 'harnesses' is almost always a typo;
+    fail loud rather than silently decomposing nothing.
+    """
+    _make_plugins_registry(
+        tmp_path,
+        {"myplugin": {"harnesses": ["codex"]}},
+    )
+    with pytest.raises(ParseError, match="exactly one of"):
+        expand_registries({"plugins": "agents/plugins/registry.yaml"}, tmp_path, {})
+
+
+def test_git_branch_defaults_to_main(tmp_path):
+    """When branch: is omitted, 'main' is used.
+
+    A plugin entry with only git: (no branch:) must still clone from
+    the 'main' branch and decompose correctly.
+    """
+    repo = _make_local_git_repo(tmp_path / "repo", "myplugin")
+    cache_root = tmp_path / "cache"
+    _make_plugins_registry(
+        tmp_path,
+        {"myplugin": {
+            "git": str(repo),
+            # no branch: — default must be 'main'
+            "harnesses": ["codex"],
+        }},
+    )
+    from agent_profile.ingest import _expand_plugins
+    reg_path = tmp_path / "agents" / "plugins" / "registry.yaml"
+    out_mcps, _, _ = _expand_plugins(reg_path, tmp_path, {}, cache_root=cache_root)
+    assert "myplugin" in [m["name"] for m in out_mcps], (
+        "branch defaults to 'main'; clone must succeed without explicit branch:"
+    )
+
+
+def test_git_cache_reuse_when_network_fails(tmp_path):
+    """If the network fetch fails but a populated cache exists, use the cache.
+
+    Machines without network access (or with the repo gone) must not abort
+    ap install base as long as the cache is populated.
+    """
+    from agent_profile.ingest import _resolve_git_plugin
+
+    # Seed a populated cache dir (simulates a prior successful clone).
+    cache_dir = tmp_path / "cache" / "myplugin"
+    cache_dir.mkdir(parents=True)
+    (cache_dir / "sentinel.txt").write_text("cached")
+
+    # Pointing at a non-existent URL; fetch will fail.
+    result = _resolve_git_plugin("https://invalid.example/nope", "main", cache_dir)
+    # Must return the cache_dir, not raise.
+    assert result == cache_dir
+    # Cached content must still be intact.
+    assert (cache_dir / "sentinel.txt").is_file()

--- a/agents/plugins/registry.yaml
+++ b/agents/plugins/registry.yaml
@@ -16,10 +16,17 @@
 #   KEY:           the entry name (e.g. `milknado`) MUST equal a plugins[].name
 #                  in the marketplace.json — that named plugin is the one
 #                  decomposed. A key/name mismatch fails loud at ingest.
-#   path:          marketplace root (the dir containing .claude-plugin/marketplace.json);
-#                  ~-relative, /absolute, or repo-relative. Payload root(s) are
-#                  resolved from marketplace.json plugins[].source — prefixed by an
-#                  optional metadata.pluginRoot — relative to here.
+#
+#   Source (exactly one required; both or neither raises ParseError):
+#   path:          marketplace root (local checkout); ~-relative, /absolute, or
+#                  repo-relative. Use on machines that have a local dev tree.
+#   git:           clone URL (e.g. https://github.com/org/repo). The repo is
+#                  cloned / refreshed into ~/.cache/ap/plugins/<KEY>.
+#   branch:        branch to clone (optional; default: main). Only with git:.
+#   subdir:        sub-directory inside the repo whose root is the marketplace
+#                  root (i.e. contains .claude-plugin/marketplace.json).
+#                  Optional; default: repo root. Relative paths only; no '..'.
+#
 #   harnesses:     MCP membership list (deliberate; avoids blanket-wide
 #                  per-request token tax). Default = all harnesses.
 #   claude_native: true → Claude gets the native marketplace install
@@ -47,22 +54,22 @@ plugins:
   # Until then, rendered configs will reference the portable form but
   # the MCP will not launch without a local uvx-resolvable install.
   milknado:
-    path: ~/Dev/milknado
+    git: https://github.com/paulnsorensen/milknado
+    branch: main
     harnesses: [claude, codex, opencode, cursor, copilot, crush]
     claude_native: true
     description: Mikado execution engine — goal decomposition, batch planning, detached ralph-loop runs
 
   # hallouminate: per-repo markdown wiki (LLM-authored notes + semantic search).
-  # Payload: 1 MCP (`hallouminate serve`) + 6 skills (install, wiki-ingest,
-  # wiki-init, wiki-query, wiki-reindex, wiki-roadmap).
-  # marketplace.json uses metadata.pluginRoot "./plugins" + source "./hallouminate".
+  # Payload: 1 MCP (`hallouminate serve`) + skills (wiki-ingest, wiki-init, etc).
   # claude_native: false — Claude gets the DECOMPOSED MCP so the well-known
   # mcp__hallouminate__* tool namespace (relied on by the global CLAUDE.md
   # routing) is preserved; a native install would rescope it to
   # mcp__plugin_hallouminate_hallouminate__*. Migrated out of agents/mcp/registry.yaml
   # — the decomposition now provides the MCP; a duplicate there would fail loud.
   hallouminate:
-    path: ~/Dev/hallouminate
+    git: https://github.com/paulnsorensen/hallouminate
+    branch: main
     harnesses: [claude, codex, opencode, cursor, copilot, crush]
     claude_native: false
     description: Per-repo markdown wiki — semantic search + LLM-authored notes; bundles 6 wiki skills


### PR DESCRIPTION
## Problem

Plugin entries in `agents/plugins/registry.yaml` hardcoded dev-checkout marketplace roots (`~/Dev/milknado`, `~/Dev/hallouminate`). On any machine without those checkouts, `_expand_plugins` raised `ParseError` and aborted `ap install base` / `dots sync`. Found via `/harness-doctor` — the render was broken on a non-primary machine.

## Change

Add a `git:` source to the cross-harness plugin registry. The schema previously supported only a local `path:`.

- **`agent-profile/agent_profile/ingest.py`** — new `_resolve_git_plugin(url, branch, cache_dir)`: shallow-clones into `~/.cache/ap/plugins/<name>`, refreshes on repeat (`fetch` + `reset --hard`), and falls back to a populated cache on network failure. `git:` and `path:` are mutually exclusive (fail-loud `ParseError`); optional `subdir:` locates a nested marketplace root and rejects absolute/`..` traversal.
- **`agents/plugins/registry.yaml`** — `milknado` and `hallouminate` switched to `git:` + `branch: main`. No `subdir:` needed (both repos carry `.claude-plugin/marketplace.json` at the repo root). Header comment documents the new schema.
- **`agent-profile/tests/test_ingest_plugins.py`** — 6 new offline tests (git resolve, `subdir:`, both-set/neither-set errors, branch default, cache-reuse-on-network-fail) using local `file://` repos.
- **`.hallouminate/wiki/architecture/cross-harness-plugins.md`** — schema, path model, and gotchas updated for the git source + cache dir.

Render is now portable with no `~/Dev` assumption.

## Verification

- `uv run pytest` (agent-profile): **700 passed**, 0 fail (the prior 6 `ParseError`s were exactly this drift).
- `ap install base` renders clean; both `~/.cache/ap/plugins/<name>/.claude-plugin/marketplace.json` present.
- `dots sync` green; prek gates (incl. Claude-config-synced) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
