### PR TITLE
feat(claude): cheese-themed spinner verbs

### DIFF
--- a/chezmoi/dot_claude/create_settings.json
+++ b/chezmoi/dot_claude/create_settings.json
@@ -131,5 +131,34 @@
   "theme": "dark-daltonized",
   "editorMode": "vim",
   "agentPushNotifEnabled": true,
-  "skipAutoPermissionPrompt": true
+  "skipAutoPermissionPrompt": true,
+  "spinnerVerbs": {
+    "mode": "replace",
+    "verbs": [
+      "Curdling",
+      "Culturing",
+      "Renneting",
+      "Coagulating",
+      "Cheddaring",
+      "Draining",
+      "Pressing",
+      "Brining",
+      "Salting",
+      "Waxing",
+      "Aging",
+      "Affining",
+      "Ripening",
+      "Maturing",
+      "Turning",
+      "Melting",
+      "Grating",
+      "Crumbling",
+      "Marbling",
+      "Fermenting",
+      "Wheying",
+      "Rinding",
+      "Mongering",
+      "Fonduing"
+    ]
+  }
 }


### PR DESCRIPTION
## What

Replaces Claude Code's built-in spinner verbs with cheesemaking-process gerunds via the `spinnerVerbs` setting (`mode: "replace"`).

The working spinner now reads `Curdling…`, `Cheddaring…`, `Affining…` etc. instead of the stock set.

## Where

- `chezmoi/dot_claude/create_settings.json` — the `create_` seed, so new machines bootstrap with the cheese verbs.

The live `~/.claude/settings.json` was jq-merged with the same key out-of-band (the sanctioned mutate-in-place path for that file — `create_` won't overwrite an existing target).

## Verbs

`Curdling, Culturing, Renneting, Coagulating, Cheddaring, Draining, Pressing, Brining, Salting, Waxing, Aging, Affining, Ripening, Maturing, Turning, Melting, Grating, Crumbling, Marbling, Fermenting, Wheying, Rinding, Mongering, Fonduing`

## Verified

- `spinnerVerbs` schema shape confirmed against schemastore (`mode` enum `append|replace`, `verbs` required array).
- Seed passes `check-jsonschema` against the official Claude settings schema (prek hook green on commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)