### PR TITLE
feat(ap): codex_native cross-harness plugin support

### DIFF
--- a/.hallouminate/wiki/architecture/cross-harness-plugins.md
+++ b/.hallouminate/wiki/architecture/cross-harness-plugins.md
@@ -115,6 +115,7 @@ plugins:
 
     harnesses: [claude, codex, opencode, cursor, copilot, crush]
     claude_native: true   # Claude gets native marketplace install
+    codex_native: true    # Codex gets native marketplace install (codex CLI)
     gate_unless: MY_ENV_VAR   # optional gate
     description: Human-readable description
 ```
@@ -133,20 +134,31 @@ membership taxes every per-request MCP-schema token budget. See
 [[architecture/mcp-secret-handling]] for the token-cost tradeoff and
 [[architecture/agent-profile]] for how harnesses membership flows.
 
-**`claude_native`** — when `true`, the decomposer also produces a
-`native_plugins` record so the claude renderer can register the plugin's
-marketplace. DEDUP removes `claude` from decomposed MCP harnesses (Claude gets
-the plugin via native install, not bare user MCP). Skills carry
-`_from_native_plugin=True` so renderers skip them for Claude scope.
+**`claude_native` / `codex_native`** — two **independent** native-install flags.
+When either is `true`, the decomposer emits a single `native_plugins` record
+carrying *both* booleans (`claude_native`, `codex_native`) plus the marketplace
+root/name; each renderer consumes only its own flag.
 
-When `false` (or omitted), Claude receives decomposed primitives like all other
-harnesses. This is the right choice when a plugin's marketplace.json is absent
-or the plugin is not ready for the marketplace (e.g. hallouminate, where the
-well-known `mcp__hallouminate__*` namespace must be preserved).
+- `claude_native: true` → the claude renderer registers the plugin's
+  marketplace and enables it. DEDUP removes `claude` from decomposed MCP
+  harnesses; skills carry `_from_native_plugin=True` so claude renderers skip
+  them at user scope.
+- `codex_native: true` → the codex renderer installs the plugin via the codex
+  CLI (`codex plugin marketplace add` + `codex plugin add`). DEDUP removes
+  `codex` from decomposed MCP harnesses; skills carry a **separate**
+  `_from_codex_native_plugin=True` so the codex renderer skips them. The flag is
+  deliberately separate from `_from_native_plugin` — reusing claude's flag would
+  make the claude renderer wrongly skip a codex-only-native plugin's skills.
+
+When both are `false` (or omitted), every harness receives decomposed primitives.
+That is the right choice when a plugin's marketplace.json is absent or the plugin
+is not ready for native install (e.g. hallouminate, where the well-known
+`mcp__hallouminate__*` namespace must be preserved — a native install would
+rescope it to `mcp__plugin_hallouminate_hallouminate__*`).
 
 **`gate_unless`** — propagates to the decomposed MCP's `gate_unless` field,
 using the same semantics as the MCP registry gate (see [[agents-dir]]). It
-gates only the decomposed MCP items, not the Claude-native install path.
+gates only the decomposed MCP items, not the native install paths.
 
 ---
 
@@ -154,8 +166,8 @@ gates only the decomposed MCP items, not the Claude-native install path.
 
 | Harness | Receives | Loses |
 |---|---|---|
-| claude | native marketplace install — full plugin | nothing |
-| codex | MCP + skills + hooks | custom `/commands` (WARN+skip) |
+| claude | native marketplace install when `claude_native` — full plugin | nothing |
+| codex | native marketplace install when `codex_native`; else MCP + skills + hooks | custom `/commands` (decomposed path only) |
 | opencode | MCP + skills + agents | hooks, atomic install |
 | cursor | MCP + skills + agents + commands + hooks | — |
 | copilot | skills + hooks + agents; MCP only if `harnesses` includes copilot | custom `/commands` (WARN+skip) |
@@ -163,48 +175,82 @@ gates only the decomposed MCP items, not the Claude-native install path.
 
 ---
 
-## The hybrid decision: Claude native + decompose rest
+## The hybrid decision: native where available, decompose the rest
 
 Claude Code has a native plugin system (marketplace install, plugin-scoped
 `mcp__plugin_<name>_<server>__*` tool names, plugin-owned commands/hooks). The
 other harnesses have no equivalent atomic install — they only accept
 primitives via their config renderers.
 
-The chosen model: Claude gets the native install for `claude_native: true`
-entries; every other harness gets decomposed primitives via the existing
-renderers. No renderer changes are needed for the decomposed path.
+The chosen model: each harness with a native plugin system gets the native
+install when its flag is set (`claude_native` → claude, `codex_native` → codex);
+every other harness gets decomposed primitives via the existing renderers. No
+renderer changes are needed for the decomposed path. The two native paths are
+independent — a plugin can be claude-native, codex-native, both, or neither.
 
-For entries with `claude_native: false`, Claude also receives decomposed
-primitives, same as other harnesses.
-
----
-
-## DEDUP: preventing double-registration for claude_native
-
-When `claude_native: true`, Claude gets the plugin's MCP tools via the native
-marketplace install (at plugin scope, prefixed `mcp__plugin_<name>_<server>__*`).
-Adding the same server to Claude's user-scope MCP config too would cause
-tool-name collision and double token cost.
-
-DEDUP removes `claude` from the decomposed MCP's `harnesses` list. Skills carry
-`_from_native_plugin=True` so `_write_skills` skips them (Claude gets skills
-at plugin scope). `_write_agents` and `_write_commands` also skip
-`_from_native_plugin` items.
+For entries where a harness's native flag is `false`/omitted, that harness
+receives decomposed primitives, same as the non-native harnesses. Copilot,
+opencode, cursor, and crush have no usable native-install CLI, so they always
+decompose.
 
 ---
 
-## Claude renderer: native plugin pass
+## DEDUP: preventing double-registration for native installs
 
-`_render_native_plugins()` in `claude.py`:
+When a harness gets the plugin via its native install, adding the same MCP
+server to that harness's decomposed config too would cause tool-name collision
+and double token cost. DEDUP removes the natively-served harness from the
+decomposed MCP's `harnesses` list:
 
-1. Reads `entry["marketplace_root"]` and `entry["marketplace_name"]` from the
-   native descriptor.
+- `claude_native` removes `claude` (native tools are `mcp__plugin_<name>_<server>__*`).
+- `codex_native` removes `codex` (codex's MCP filter `mcps_for(..., "codex")`
+  then naturally excludes the server from `config.toml`).
+- Both flags strip both harnesses; if the result is empty, an empty `harnesses`
+  list is emitted so the renderers' membership filter skips the item.
+
+Skills carry a per-path skip flag so the natively-served harness's renderer does
+not also copy them:
+
+- `_from_native_plugin=True` → claude's `_write_skills` / `_write_agents` /
+  `_write_commands` skip the item.
+- `_from_codex_native_plugin=True` → codex's `_write_skills` skips the item.
+
+The two skill flags are **independent on purpose**. A codex-only-native plugin
+stamps only `_from_codex_native_plugin`, so claude (decomposed) still gets its
+skills; reusing `_from_native_plugin` would wrongly hide them from claude.
+
+---
+
+## Native renderer passes
+
+**Claude** — `_render_native_plugins()` in `claude.py` consumes descriptors with
+`claude_native: True`:
+
+1. Reads `entry["marketplace_root"]` and `entry["marketplace_name"]`.
 2. Writes `extraKnownMarketplaces[marketplace_name] = {source: {source: "directory", path: <marketplace_root>}}`.
 3. Writes `enabledPlugins[f"{name}@{marketplace_name}"] = True`.
 4. Calls `claude plugin marketplace add <marketplace_root>` to prime the CLI's
    resolution cache (writing settings.json alone is not sufficient).
 
 `clean()` un-merges by `marketplace_name` (not registry YAML key).
+
+**Codex** — `_render_native_plugins()` in `codex.py` consumes descriptors with
+`codex_native: True`, hooked into `render()` right after `_write_mcps`:
+
+1. `codex plugin marketplace add <marketplace_root>` — the codex CLI accepts a
+   local path (the git cache dir or local checkout) as a marketplace source.
+2. `codex plugin add <name>@<marketplace_name>` — installs from that marketplace.
+
+Both calls go through `_codex_cli()`, which runs `subprocess.run(check=False)`:
+idempotent on re-sync (a repeated add/remove does not hard-fail), a missing
+`codex` binary is a silent no-op (nothing was decomposed, so nothing is left
+inconsistent), and a nonzero exit warns loud rather than swallowing. `clean()`
+un-registers via `codex plugin remove <name>@<marketplace_name>` +
+`codex plugin marketplace remove <marketplace_name>`.
+
+Unlike claude, codex stores no native-plugin state in a renderer-owned settings
+file — the codex CLI owns `~/.codex/config.toml`'s plugin tables. Codex clone-
+cache pruning is not handled in `clean()` (tracked as a possible follow-up).
 
 ---
 
@@ -271,6 +317,24 @@ loading interacts with secret passthrough.
   add <marketplace_root>` CLI call primes the resolution cache (handled by
   `_render_native_plugins`). Without it, a freshly-added local plugin fails
   to install on first sync.
+- **codex native install is CLI-only** — `codex_native` entries write no
+  renderer-owned config; install is entirely via `codex plugin marketplace add`
+  - `codex plugin add` (the codex CLI owns `~/.codex/config.toml`'s plugin
+  tables). On a machine without the `codex` binary the pass is a silent no-op,
+  so a render never hard-fails merely because codex is absent.
+- **marketplace-add IS fatal on failure (codex)** — unlike `plugin add` (which
+  warns on nonzero, tolerating "already installed" on re-sync), the codex
+  `marketplace add` step (`_codex_cli_strict`) raises `RuntimeError` on a
+  nonzero exit. Rationale: DEDUP has already stripped `codex` from the decomposed
+  MCP, so a failed marketplace add would leave the plugin in NEITHER the native
+  install NOR the decomposed render — it silently vanishes from codex. Failing
+  loud turns that silent strip into a visible render failure. Idempotency is
+  preserved by probing `codex plugin marketplace list` first and skipping the
+  add when the marketplace is already registered.
+- **two independent native skill flags** — `_from_native_plugin` (claude) and
+  `_from_codex_native_plugin` (codex) must not be conflated. A codex-only-native
+  plugin must NOT stamp the claude flag, or claude (which decomposes it) would
+  lose its skills.
 
 ---
 
@@ -305,6 +369,13 @@ milknado:
   branch: main
   harnesses: [claude, codex, opencode, cursor, copilot, crush]
   claude_native: true
+  # codex_native: DISABLED on main. milknado's upstream
+  # .agents/plugins/marketplace.json (the manifest codex's `plugin marketplace
+  # add` parses) has only interface.displayName, no top-level `name`, so
+  # `codex plugin marketplace add` exits 1. With the flag set, DEDUP would strip
+  # codex from the decomposed MCP AND the native add would fail -> milknado
+  # absent from codex entirely. Re-enable once upstream adds `"name": "milknado"`
+  # to that manifest. The renderer machinery is landed + tested regardless.
   description: Mikado execution engine — goal decomposition, batch planning, detached ralph-loop runs
 ```
 
@@ -312,7 +383,13 @@ milknado:
 
 - 1 MCP item: `{name: milknado, command: uvx, args: [milknado-mcp], harnesses: [...], _source_dir: <payload>}`
 - 3 skill items: `harvest`, `load-roadmap`, `milknado-config` each with `_source_dir: <payload>` and `path: skills/<name>`
-- 1 native_plugins descriptor for the claude renderer
+- 1 native_plugins descriptor carrying `claude_native: true` + `codex_native: false`
+  (the claude renderer registers the marketplace; the codex renderer ignores the
+  descriptor since its flag is off). With only `claude_native`, DEDUP strips
+  `claude` from the MCP item's harnesses; `codex` stays, so the decomposed MCP
+  still reaches codex/opencode/cursor/crush (+ copilot if listed). When
+  `codex_native` is re-enabled upstream, DEDUP would additionally strip `codex`
+  and the codex renderer would install via the codex CLI instead.
 
 **PyPI dependency:** `uvx milknado-mcp` requires milknado to be published to
 PyPI. Until then, the rendered config references the portable form but the MCP

--- a/agent-profile/agent_profile/ingest.py
+++ b/agent-profile/agent_profile/ingest.py
@@ -400,6 +400,7 @@ def _expand_plugins(
         harnesses: list[str] = _as_list(body.get("harnesses"))
         gate_unless = body.get("gate_unless")
         claude_native = bool(body.get("claude_native", False))
+        codex_native = bool(body.get("codex_native", False))
         description = body.get("description") or ""
 
         # `metadata.pluginRoot` (optional) is a base dir prefixed onto every
@@ -474,16 +475,25 @@ def _expand_plugins(
                         )
                     if server_body.get("optional") is not None:
                         item["optional"] = server_body["optional"]
-                    # DEDUP: for claude_native plugins, remove claude from decomposed
-                    # MCP harnesses — Claude gets the plugin via native marketplace
-                    # install (mcp__plugin_<name>_<server>__*), not bare user MCP.
+                    # DEDUP: for a harness whose native install delivers the
+                    # plugin (claude_native / codex_native), remove that harness
+                    # from the decomposed MCP harnesses — the harness gets the
+                    # plugin via its native marketplace install, not bare user MCP.
                     effective_harnesses = harnesses
-                    if claude_native and harnesses:
-                        effective_harnesses = [h for h in harnesses if h != "claude"]
+                    if harnesses:
+                        skip = set()
+                        if claude_native:
+                            skip.add("claude")
+                        if codex_native:
+                            skip.add("codex")
+                        if skip:
+                            effective_harnesses = [
+                                h for h in harnesses if h not in skip
+                            ]
                     if effective_harnesses:
                         item["harnesses"] = effective_harnesses
                     elif harnesses and not effective_harnesses:
-                        # All harnesses were claude-only; emit empty list so the
+                        # All harnesses were native-only; emit empty list so the
                         # item exists but renderers' harnesses-filter skips it.
                         item["harnesses"] = []
                     if gate_unless:
@@ -498,6 +508,12 @@ def _expand_plugins(
             if claude_native:
                 for skill in plugin_skills:
                     skill["_from_native_plugin"] = True
+            if codex_native:
+                # Separate flag from claude's: reusing _from_native_plugin would
+                # make the claude renderer wrongly skip a codex-only-native
+                # plugin's skills. Two independent flags, one per native path.
+                for skill in plugin_skills:
+                    skill["_from_codex_native_plugin"] = True
             out_skills.extend(plugin_skills)
 
         # Fail loud when the registry key matched no marketplace plugin. Without
@@ -516,14 +532,16 @@ def _expand_plugins(
                 f"match a plugins[].name in marketplace.json."
             )
 
-        # ── Native plugin descriptor (claude renderer pass) ──
+        # ── Native plugin descriptor (claude / codex renderer passes) ──
         # Carried once per registry entry (not per payload): the marketplace
-        # root and canonical marketplace name are what the renderer needs.
-        if claude_native:
+        # root and canonical marketplace name are what the renderers need.
+        # Carries both native booleans; each renderer consumes only its own.
+        if claude_native or codex_native:
             out_native.append(
                 {
                     "name": name,
-                    "claude_native": True,
+                    "claude_native": claude_native,
+                    "codex_native": codex_native,
                     "marketplace_root": str(marketplace_root),
                     "marketplace_name": marketplace_name,
                     "description": description,

--- a/agent-profile/agent_profile/renderers/codex.py
+++ b/agent-profile/agent_profile/renderers/codex.py
@@ -30,6 +30,7 @@ import json
 import os
 import shutil
 import stat
+import subprocess
 import sys
 from pathlib import Path
 
@@ -92,6 +93,7 @@ class CodexRenderer:
         self._write_skills(manifest, target, out_files)
         self._write_hooks(manifest, target, out_files)
         self._write_mcps(manifest, target)
+        self._render_native_plugins(manifest)
         self._write_rules(manifest, target, out_files)
         self._write_mcp_tool_scopes(manifest, target)
         self._warn_commands(manifest)
@@ -101,6 +103,7 @@ class CodexRenderer:
         self._clean_mcps(manifest, Path(target))
         self._clean_rules(Path(target))
         self._clean_mcp_tool_scopes(manifest, Path(target))
+        self._clean_native_plugins(manifest)
 
     def prune_mcps(self, manifest: Manifest, target: Path) -> None:
         """Evict dropped MCP servers from config.toml's [mcp_servers]
@@ -149,6 +152,8 @@ class CodexRenderer:
         self, manifest: Manifest, target: Path, out_files: list[str]
     ) -> None:
         for item in manifest.skills:
+            if item.get("_from_codex_native_plugin"):
+                continue  # native plugin delivers skills via codex plugin install
             rel_path = item.get("path") or ""
             if not rel_path:
                 continue  # source: (gh-fetched) skill — handled by cmd_install
@@ -161,6 +166,122 @@ class CodexRenderer:
                     f"    codex: skill '{name}' source dir missing: {src}",
                     file=sys.stderr,
                 )
+
+    # ─── native plugins (codex_native marketplace install) ──────────────
+    # Mirrors the claude renderer's native pass: a codex_native plugin is
+    # installed via codex's own CLI (`codex plugin marketplace add <root>` +
+    # `codex plugin add <name>@<marketplace>`) instead of being decomposed
+    # into config.toml MCP + .agents/skills. Codex owns the install; ap only
+    # drives the CLI. Idempotent on re-sync: re-runs use check=False and
+    # tolerate "already added/installed".
+    def _render_native_plugins(self, manifest: Manifest) -> None:
+        for entry in manifest.native_plugins:
+            if not entry.get("codex_native"):
+                continue
+            self._install_codex_native_plugin(entry)
+
+    def _install_codex_native_plugin(self, entry: dict) -> None:
+        name = entry["name"]
+        marketplace_name = entry.get("marketplace_name", name)
+        marketplace_root = entry["marketplace_root"]
+        expanded = os.path.expandvars(os.path.expanduser(str(marketplace_root)))
+        # marketplace add is fatal on failure: if it fails, the plugin gets
+        # NEITHER the native install NOR the decomposed MCP (DEDUP already
+        # stripped codex), so the plugin silently vanishes from codex. Raising
+        # turns that silent strip into a loud render failure. Idempotency is
+        # preserved by skipping the add when the marketplace is already
+        # registered, so a re-sync never re-adds (and never sees the benign
+        # "already exists" nonzero).
+        if not self._marketplace_registered(marketplace_name):
+            self._codex_cli_strict(
+                ["codex", "plugin", "marketplace", "add", expanded],
+                f"marketplace add {expanded}",
+            )
+        # plugin add stays tolerant: "already installed" on re-sync is benign.
+        self._codex_cli(
+            ["codex", "plugin", "add", f"{name}@{marketplace_name}"],
+            f"plugin add {name}@{marketplace_name}",
+        )
+
+    def _clean_native_plugins(self, manifest: Manifest) -> None:
+        for entry in manifest.native_plugins:
+            if not entry.get("codex_native"):
+                continue
+            name = entry["name"]
+            marketplace_name = entry.get("marketplace_name", name)
+            self._codex_cli(
+                ["codex", "plugin", "remove", f"{name}@{marketplace_name}"],
+                f"plugin remove {name}@{marketplace_name}",
+            )
+            self._codex_cli(
+                ["codex", "plugin", "marketplace", "remove", marketplace_name],
+                f"marketplace remove {marketplace_name}",
+            )
+
+    @staticmethod
+    def _marketplace_registered(marketplace_name: str) -> bool:
+        """True if ``marketplace_name`` already appears in
+        ``codex plugin marketplace list``. A missing codex binary or a failed
+        list returns False (let the add attempt run and surface the real error).
+        """
+        try:
+            result = subprocess.run(
+                ["codex", "plugin", "marketplace", "list"],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+        except FileNotFoundError:
+            return False
+        if result.returncode != 0:
+            return False
+        return any(
+            line.split()[:1] == [marketplace_name]
+            for line in result.stdout.splitlines()
+        )
+
+    @staticmethod
+    def _codex_cli_strict(argv: list[str], label: str) -> None:
+        """Run a codex plugin CLI command, failing loud on a nonzero exit.
+
+        Used for the marketplace-add step, whose failure would otherwise strip
+        the plugin from codex silently. A missing codex binary is still a no-op
+        (nothing decomposed, nothing to leave inconsistent); a nonzero exit
+        (e.g. an unparseable marketplace manifest) raises ``RuntimeError`` so
+        the render fails instead of dropping the plugin.
+        """
+        try:
+            result = subprocess.run(
+                argv, check=False, capture_output=True, text=True
+            )
+        except FileNotFoundError:
+            return  # codex CLI not present; nothing to install
+        if result.returncode != 0:
+            detail = (result.stderr or result.stdout or "").strip()
+            raise RuntimeError(
+                f"'codex {label}' exited {result.returncode}. {detail}"
+            )
+
+    @staticmethod
+    def _codex_cli(argv: list[str], label: str) -> None:
+        """Run a codex plugin CLI command, tolerant of re-runs.
+
+        check=False so a repeated add/remove (already present / already gone)
+        does not hard-fail the render. A missing codex binary is a no-op:
+        nothing decomposed into config for the plugin, so there is nothing to
+        leave inconsistent."""
+        try:
+            result = subprocess.run(
+                argv, check=False, capture_output=True, text=True
+            )
+        except FileNotFoundError:
+            return  # codex CLI not present; nothing to install/clean
+        if result.returncode != 0:
+            detail = (result.stderr or result.stdout or "").strip()
+            print(
+                f"    ap: 'codex {label}' exited {result.returncode}. {detail}",
+                file=sys.stderr,
+            )
 
     # ─── hooks ──────────────────────────────────────────────────────────
     # Codex reads .codex/hooks.json as a JSON object with a top-level

--- a/agent-profile/tests/test_ingest_plugins.py
+++ b/agent-profile/tests/test_ingest_plugins.py
@@ -1106,3 +1106,116 @@ def test_git_cache_reuse_when_network_fails(tmp_path):
     assert result == cache_dir
     # Cached content must still be intact.
     assert (cache_dir / "sentinel.txt").is_file()
+
+
+# ─── codex_native cross-harness install ────────────────────────────────────────
+# Mirrors the claude_native ingest contract: codex_native strips `codex` from the
+# decomposed MCP harnesses, stamps a SEPARATE _from_codex_native_plugin skill flag
+# (not _from_native_plugin), and emits a native descriptor carrying codex_native.
+
+
+def test_codex_native_strips_codex_from_mcp_harnesses(tmp_path):
+    """DEDUP: codex is removed from decomposed MCP harnesses for codex_native.
+
+    Codex gets the plugin via its native marketplace install; leaving codex in
+    the decomposed harnesses would double-deliver the MCP into config.toml.
+    """
+    _make_plugin_with_marketplace(tmp_path, "milknado")
+    _make_plugins_registry(
+        tmp_path,
+        {"milknado": {
+            "path": str(tmp_path / "market" / "milknado"),
+            "harnesses": ["claude", "codex", "opencode"],
+            "codex_native": True,
+        }},
+    )
+
+    out = expand_registries({"plugins": "agents/plugins/registry.yaml"}, tmp_path, {})
+    mcps = out["mcps"]
+    assert len(mcps) == 1
+    harnesses = mcps[0].get("harnesses", [])
+    assert "codex" not in harnesses, f"codex should be excluded: {harnesses}"
+    assert "claude" in harnesses, "claude must remain (claude_native not set)"
+    assert "opencode" in harnesses
+
+
+def test_codex_native_and_claude_native_strip_both(tmp_path):
+    """When both native flags are set, both harnesses are stripped independently."""
+    _make_plugin_with_marketplace(tmp_path, "milknado")
+    _make_plugins_registry(
+        tmp_path,
+        {"milknado": {
+            "path": str(tmp_path / "market" / "milknado"),
+            "harnesses": ["claude", "codex", "opencode"],
+            "claude_native": True,
+            "codex_native": True,
+        }},
+    )
+
+    out = expand_registries({"plugins": "agents/plugins/registry.yaml"}, tmp_path, {})
+    harnesses = out["mcps"][0].get("harnesses", [])
+    assert harnesses == ["opencode"], f"both native harnesses must be stripped: {harnesses}"
+
+
+def test_codex_native_skills_carry_codex_flag_only(tmp_path):
+    """codex_native skills carry _from_codex_native_plugin, NOT _from_native_plugin.
+
+    Reusing the claude flag would make the claude renderer wrongly skip a
+    codex-only-native plugin's skills. The two flags must stay independent.
+    """
+    _make_plugin_with_marketplace(
+        tmp_path, "milknado", skill_names=["milknado-skill"]
+    )
+    _make_plugins_registry(
+        tmp_path,
+        {"milknado": {
+            "path": str(tmp_path / "market" / "milknado"),
+            "harnesses": ["claude", "codex"],
+            "codex_native": True,
+        }},
+    )
+
+    out = expand_registries({"plugins": "agents/plugins/registry.yaml"}, tmp_path, {})
+    skills = out["skills"]
+    assert len(skills) == 1
+    assert skills[0].get("_from_codex_native_plugin") is True
+    assert "_from_native_plugin" not in skills[0], (
+        "codex-only-native must NOT stamp the claude flag — "
+        "that would hide the skill from the claude renderer"
+    )
+
+
+def test_codex_native_descriptor_carries_codex_flag(tmp_path):
+    """codex_native=True produces a native_plugins record with codex_native true."""
+    _make_plugin_with_marketplace(tmp_path, "milknado")
+    _make_plugins_registry(
+        tmp_path,
+        {"milknado": {
+            "path": str(tmp_path / "market" / "milknado"),
+            "harnesses": ["codex"],
+            "codex_native": True,
+        }},
+    )
+
+    out = expand_registries({"plugins": "agents/plugins/registry.yaml"}, tmp_path, {})
+    native = out["native_plugins"]
+    assert len(native) == 1
+    assert native[0]["codex_native"] is True
+    assert native[0]["claude_native"] is False
+    assert native[0]["name"] == "milknado"
+    assert native[0]["marketplace_name"] == "milknado"
+
+
+def test_codex_native_false_produces_no_native_record(tmp_path):
+    """A plugin with neither native flag emits no native descriptor."""
+    _make_plugin_with_marketplace(tmp_path, "plain")
+    _make_plugins_registry(
+        tmp_path,
+        {"plain": {
+            "path": str(tmp_path / "market" / "plain"),
+            "harnesses": ["codex"],
+        }},
+    )
+
+    out = expand_registries({"plugins": "agents/plugins/registry.yaml"}, tmp_path, {})
+    assert out.get("native_plugins", []) == []

--- a/agent-profile/tests/test_renderer_codex.py
+++ b/agent-profile/tests/test_renderer_codex.py
@@ -18,6 +18,7 @@ hand-rolled escaping — tomlkit owns the escaping now.
 from __future__ import annotations
 
 import json
+import shutil
 import tomllib
 from pathlib import Path
 
@@ -633,8 +634,12 @@ def test_clean_keeps_file_when_user_table_remains(renderer, src, target):
 
 def test_no_hand_rolled_escaping_in_source():
     """The bash hand-rolled ``_codex_toml_string`` /
-    ``_codex_escape_toml_triple`` and shelled out to jq/yq. None of that
-    machinery may survive the tomlkit port.
+    ``_codex_escape_toml_triple`` and shelled out to jq/yq for config writes.
+    None of that TOML-escaping machinery may survive the tomlkit port.
+
+    (``subprocess`` is intentionally NOT forbidden: the codex_native plugin
+    pass shells out to the ``codex`` CLI, mirroring the claude renderer's
+    native install — that is config delegation, not hand-rolled escaping.)
 
     We inspect *code only* — comments and string literals (incl. the module
     docstring, which legitimately names the removed bash helpers to explain
@@ -655,7 +660,6 @@ def test_no_hand_rolled_escaping_in_source():
     for forbidden in (
         "_codex_toml_string",
         "_codex_escape_toml_triple",
-        "subprocess",
         "jq",
         "yq",
         "replace",  # no str.replace-based manual escaping
@@ -1085,3 +1089,460 @@ def test_clean_leaves_sibling_default_rules_untouched(renderer, src, target):
     assert not (target / _RULES_REL).is_file()
     assert default_rules.is_file()
     assert default_rules.read_text() == "# TUI-owned, ap must not touch\n"
+
+
+# ─── codex_native plugin pass ───────────────────────────────────────────────
+# Mirrors test_claude_native_plugins.py's renderer section: a codex_native plugin
+# installs via the codex CLI (mocked), its decomposed MCP/skills are not written
+# into config.toml / .agents/skills, and clean() un-registers via the CLI.
+
+from unittest.mock import MagicMock, patch  # noqa: E402
+
+
+def _make_codex_native_marketplace(tmp_path, market_name="milknado"):
+    """Build a marketplace root carrying both manifests — .claude-plugin/
+    marketplace.json (read by claude et al.) and .agents/plugins/marketplace.json
+    (the manifest codex's `plugin marketplace add` actually parses) — and a
+    Manifest whose native_plugins entry flags codex_native. Returns
+    (manifest, market_root)."""
+    market_root = tmp_path / "mktplace" / market_name
+    market_root.mkdir(parents=True, exist_ok=True)
+    (market_root / ".claude-plugin").mkdir()
+    (market_root / ".claude-plugin" / "marketplace.json").write_text(
+        json.dumps({
+            "name": market_name,
+            "owner": {"name": "test"},
+            "plugins": [{"name": market_name, "source": f"./plugins/{market_name}"}],
+        })
+    )
+    (market_root / ".agents" / "plugins").mkdir(parents=True)
+    (market_root / ".agents" / "plugins" / "marketplace.json").write_text(
+        json.dumps({
+            "name": market_name,
+            "interface": {"displayName": market_name},
+            "plugins": [{
+                "source": {"source": "local", "path": f"./plugins/{market_name}"},
+            }],
+        })
+    )
+    manifest = Manifest(
+        name="base",
+        native_plugins=[{
+            "name": market_name,
+            "claude_native": False,
+            "codex_native": True,
+            "marketplace_root": str(market_root),
+            "marketplace_name": market_name,
+            "description": "Test plugin",
+        }],
+    )
+    return manifest, market_root
+
+
+def test_codex_native_install_shells_marketplace_and_plugin_add(tmp_path):
+    """render() runs `codex plugin marketplace add <root>` + `codex plugin add
+    <name>@<marketplace>` for a codex_native plugin."""
+    manifest, market_root = _make_codex_native_marketplace(tmp_path)
+    target = tmp_path / "home"
+    target.mkdir()
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0)
+        CodexRenderer().render(manifest, target)
+
+    calls = [c.args[0] for c in mock_run.call_args_list if c.args]
+    assert ["codex", "plugin", "marketplace", "add", str(market_root)] in calls, (
+        f"expected marketplace add with marketplace root, got: {calls}"
+    )
+    assert ["codex", "plugin", "add", "milknado@milknado"] in calls, (
+        f"expected plugin add <name>@<marketplace>, got: {calls}"
+    )
+
+
+def test_codex_native_marketplace_add_uses_root_with_manifest(tmp_path):
+    """The path passed to marketplace add holds the manifest codex actually
+    parses: .agents/plugins/marketplace.json (not .claude-plugin/...)."""
+    manifest, market_root = _make_codex_native_marketplace(tmp_path)
+    target = tmp_path / "home"
+    target.mkdir()
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0)
+        CodexRenderer().render(manifest, target)
+
+    market_calls = [
+        c.args[0] for c in mock_run.call_args_list
+        if c.args and c.args[0][:4] == ["codex", "plugin", "marketplace", "add"]
+    ]
+    assert market_calls
+    passed = market_calls[0][-1]
+    assert (Path(passed) / ".agents" / "plugins" / "marketplace.json").is_file(), (
+        f"marketplace add path {passed} has no .agents/plugins/marketplace.json"
+    )
+
+
+def test_codex_native_skills_skipped(tmp_path):
+    """_write_skills skips items carrying _from_codex_native_plugin."""
+    payload = tmp_path / "payload"
+    skill_src = payload / "skills" / "my-skill"
+    skill_src.mkdir(parents=True)
+    (skill_src / "SKILL.md").write_text("skill content")
+
+    manifest = Manifest(
+        name="base",
+        skills=[{
+            "name": "my-skill",
+            "path": "skills/my-skill",
+            "_source_dir": str(payload),
+            "_from_codex_native_plugin": True,
+        }],
+    )
+    target = tmp_path / "home"
+    target.mkdir()
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0)
+        CodexRenderer().render(manifest, target)
+
+    # codex copies skills into the shared .agents/skills/<name>/ tree.
+    skill_out = target / ".agents" / "skills" / "my-skill"
+    assert not skill_out.exists(), (
+        f"codex_native skill must not be copied (delivered via codex plugin): {skill_out}"
+    )
+
+
+def test_codex_native_plugin_mcp_absent_from_config(tmp_path):
+    """After DEDUP, an MCP with harnesses=[opencode] (codex removed) is not
+    written into config.toml's [mcp_servers] for codex.
+
+    Not vacuous: the item originally carried codex in harnesses; DEDUP removed
+    it. If DEDUP were dropped, mcps_for(..., 'codex') would include it and the
+    server would land in config.toml.
+    """
+    manifest, market_root = _make_codex_native_marketplace(tmp_path)
+    manifest.mcps = [{
+        "name": "milknado",
+        "command": "uvx",
+        "args": ["milknado-mcp"],
+        "harnesses": ["opencode"],  # codex removed by DEDUP
+        "_source_dir": str(market_root),
+    }]
+    target = tmp_path / "home"
+    target.mkdir()
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0)
+        CodexRenderer().render(manifest, target)
+
+    cfg = target / ".codex" / "config.toml"
+    if cfg.is_file():
+        doc = tomllib.loads(cfg.read_text())
+        servers = doc.get("mcp_servers", {})
+        assert "milknado" not in servers, (
+            f"codex_native plugin MCP must not be in config.toml: {servers}"
+        )
+
+
+def test_codex_native_clean_unregisters(tmp_path):
+    """clean() runs `codex plugin remove` + `codex plugin marketplace remove`."""
+    manifest, market_root = _make_codex_native_marketplace(tmp_path)
+    target = tmp_path / "home"
+    target.mkdir()
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0)
+        CodexRenderer().clean(manifest, target)
+
+    calls = [c.args[0] for c in mock_run.call_args_list if c.args]
+    assert ["codex", "plugin", "remove", "milknado@milknado"] in calls, (
+        f"expected plugin remove, got: {calls}"
+    )
+    assert ["codex", "plugin", "marketplace", "remove", "milknado"] in calls, (
+        f"expected marketplace remove, got: {calls}"
+    )
+
+
+def test_codex_native_install_tolerates_missing_cli(tmp_path):
+    """A missing codex binary (FileNotFoundError) is a no-op, not a hard fail."""
+    manifest, _ = _make_codex_native_marketplace(tmp_path)
+    target = tmp_path / "home"
+    target.mkdir()
+
+    with patch("subprocess.run", side_effect=FileNotFoundError):
+        CodexRenderer().render(manifest, target)  # must not raise
+
+
+@pytest.mark.skipif(
+    shutil.which("codex") is None, reason="codex CLI not installed"
+)
+def test_real_codex_rejects_manifest_missing_name(tmp_path):
+    """Non-mocked: the real `codex plugin marketplace add` must reject a
+    .agents/plugins/marketplace.json with no top-level `name`. This is the exact
+    shape that silently stripped milknado from codex; the strict marketplace-add
+    path must turn that into a loud render failure (RuntimeError), not a no-op.
+    """
+    market_root = tmp_path / "mkt"
+    (market_root / ".agents" / "plugins").mkdir(parents=True)
+    (market_root / ".agents" / "plugins" / "marketplace.json").write_text(
+        json.dumps({
+            "interface": {"displayName": "badmkt"},  # no top-level "name"
+            "plugins": [{
+                "source": {"source": "local", "path": "./plugins/badmkt"},
+            }],
+        })
+    )
+    entry = {
+        "name": "badmkt",
+        "marketplace_name": "badmkt-unregistered-xyz",
+        "marketplace_root": str(market_root),
+        "codex_native": True,
+    }
+    with pytest.raises(RuntimeError, match="marketplace add"):
+        CodexRenderer()._install_codex_native_plugin(entry)
+
+
+def test_codex_native_marketplace_add_failure_raises(tmp_path):
+    """A nonzero `marketplace add` is fatal: it raises instead of silently
+    stripping the plugin from codex (DEDUP already dropped its decomposed MCP).
+    """
+    manifest, _ = _make_codex_native_marketplace(tmp_path)
+    target = tmp_path / "home"
+    target.mkdir()
+
+    def fake_run(argv, **kwargs):
+        if argv[:4] == ["codex", "plugin", "marketplace", "add"]:
+            return MagicMock(returncode=1, stderr="invalid marketplace file", stdout="")
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    with patch("subprocess.run", side_effect=fake_run):
+        with pytest.raises(RuntimeError, match="marketplace add"):
+            CodexRenderer().render(manifest, target)
+
+
+def test_codex_native_plugin_add_warns_on_nonzero(tmp_path, capsys):
+    """A nonzero `plugin add` warns loud (does not raise) — "already installed"
+    on re-sync is benign, unlike a failed marketplace add.
+    """
+    manifest, _ = _make_codex_native_marketplace(tmp_path)
+    target = tmp_path / "home"
+    target.mkdir()
+
+    def fake_run(argv, **kwargs):
+        if argv[:3] == ["codex", "plugin", "add"]:
+            return MagicMock(returncode=1, stderr="boom", stdout="")
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    with patch("subprocess.run", side_effect=fake_run):
+        CodexRenderer().render(manifest, target)  # must not raise
+
+    err = capsys.readouterr().err
+    assert "boom" in err and "codex" in err
+
+
+def test_non_codex_native_descriptor_is_ignored(tmp_path):
+    """A native descriptor with codex_native=False triggers no codex CLI calls."""
+    manifest, _ = _make_codex_native_marketplace(tmp_path)
+    manifest.native_plugins[0]["codex_native"] = False
+    manifest.native_plugins[0]["claude_native"] = True
+    target = tmp_path / "home"
+    target.mkdir()
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0)
+        CodexRenderer().render(manifest, target)
+
+    assert mock_run.call_count == 0, (
+        "claude_native-only descriptor must not drive codex CLI installs"
+    )
+
+
+# ─── codex_native hardening: name/marketplace divergence, expansion, order ──
+# marketplace_name comes from marketplace.json's `name`, which can diverge from
+# the registry key (`name`) — exactly as test_claude_native_plugins covers for
+# the claude path. The codex CLI args mix the two (`{name}@{marketplace_name}`,
+# `marketplace remove {marketplace_name}`); these tests pin which value lands in
+# which argument so a name<->marketplace_name swap can't pass silently.
+
+
+def _codex_native_manifest(name, marketplace_name, market_root):
+    return Manifest(
+        name="base",
+        native_plugins=[{
+            "name": name,
+            "claude_native": False,
+            "codex_native": True,
+            "marketplace_root": str(market_root),
+            "marketplace_name": marketplace_name,
+            "description": "Test plugin",
+        }],
+    )
+
+
+def test_codex_native_install_distinguishes_name_from_marketplace(tmp_path):
+    """plugin add uses `<name>@<marketplace_name>` with the two values kept
+    distinct — guards against swapping registry key and marketplace name."""
+    market_root = tmp_path / "mkt"
+    market_root.mkdir()
+    manifest = _codex_native_manifest("milknado", "acme-market", market_root)
+    target = tmp_path / "home"
+    target.mkdir()
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0)
+        CodexRenderer().render(manifest, target)
+
+    calls = [c.args[0] for c in mock_run.call_args_list if c.args]
+    assert ["codex", "plugin", "add", "milknado@acme-market"] in calls, (
+        f"plugin add must be <name>@<marketplace_name>, got: {calls}"
+    )
+    # The wrong-way-round form must NOT appear.
+    assert ["codex", "plugin", "add", "acme-market@milknado"] not in calls
+
+
+def test_codex_native_clean_removes_by_marketplace_name(tmp_path):
+    """clean() removes the plugin by `<name>@<marketplace_name>` and the
+    marketplace by `<marketplace_name>` (not the registry key)."""
+    market_root = tmp_path / "mkt"
+    market_root.mkdir()
+    manifest = _codex_native_manifest("milknado", "acme-market", market_root)
+    target = tmp_path / "home"
+    target.mkdir()
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0)
+        CodexRenderer().clean(manifest, target)
+
+    calls = [c.args[0] for c in mock_run.call_args_list if c.args]
+    assert ["codex", "plugin", "remove", "milknado@acme-market"] in calls, (
+        f"plugin remove must be <name>@<marketplace_name>, got: {calls}"
+    )
+    assert ["codex", "plugin", "marketplace", "remove", "acme-market"] in calls, (
+        f"marketplace remove must use marketplace_name, got: {calls}"
+    )
+    assert ["codex", "plugin", "marketplace", "remove", "milknado"] not in calls
+
+
+def test_codex_native_marketplace_root_is_expanded(tmp_path, monkeypatch):
+    """`~` / `$VAR` in marketplace_root are expanded before reaching the CLI.
+
+    Every other test uses an already-absolute tmp_path, so the
+    expandvars/expanduser call is a silent no-op there. This drives a real
+    unexpanded root and asserts the literal `~`/`$VAR` never reaches codex.
+    """
+    real_root = tmp_path / "caveroot" / "mkt"
+    real_root.mkdir(parents=True)
+    monkeypatch.setenv("AP_TEST_CAVE", str(tmp_path / "caveroot"))
+    manifest = _codex_native_manifest(
+        "milknado", "milknado", "$AP_TEST_CAVE/mkt"
+    )
+    target = tmp_path / "home"
+    target.mkdir()
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0)
+        CodexRenderer().render(manifest, target)
+
+    market_calls = [
+        c.args[0] for c in mock_run.call_args_list
+        if c.args and c.args[0][:4] == ["codex", "plugin", "marketplace", "add"]
+    ]
+    assert market_calls, "no marketplace add call"
+    passed = market_calls[0][-1]
+    assert "$AP_TEST_CAVE" not in passed, f"$VAR not expanded: {passed}"
+    assert passed == str(real_root), f"expected expanded root, got: {passed}"
+
+
+def test_codex_native_marketplace_add_precedes_plugin_add(tmp_path):
+    """marketplace add must run before plugin add — codex can't install a
+    plugin from a marketplace it hasn't registered yet."""
+    manifest, _ = _make_codex_native_marketplace(tmp_path)
+    target = tmp_path / "home"
+    target.mkdir()
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0)
+        CodexRenderer().render(manifest, target)
+
+    calls = [c.args[0] for c in mock_run.call_args_list if c.args]
+    market_idx = next(
+        i for i, a in enumerate(calls)
+        if a[:4] == ["codex", "plugin", "marketplace", "add"]
+    )
+    add_idx = next(
+        i for i, a in enumerate(calls)
+        if a[:3] == ["codex", "plugin", "add"]
+    )
+    assert market_idx < add_idx, (
+        f"marketplace add must precede plugin add, got order: {calls}"
+    )
+
+
+def test_codex_native_clean_remove_order(tmp_path):
+    """clean() removes the plugin before removing its marketplace."""
+    manifest, _ = _make_codex_native_marketplace(tmp_path)
+    target = tmp_path / "home"
+    target.mkdir()
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0)
+        CodexRenderer().clean(manifest, target)
+
+    calls = [c.args[0] for c in mock_run.call_args_list if c.args]
+    remove_idx = next(
+        i for i, a in enumerate(calls)
+        if a[:3] == ["codex", "plugin", "remove"]
+    )
+    mkt_remove_idx = next(
+        i for i, a in enumerate(calls)
+        if a[:4] == ["codex", "plugin", "marketplace", "remove"]
+    )
+    assert remove_idx < mkt_remove_idx, (
+        f"plugin remove must precede marketplace remove, got order: {calls}"
+    )
+
+
+def test_codex_native_installs_only_codex_native_in_mixed_manifest(tmp_path):
+    """With a codex_native entry next to a claude_native-only entry, only the
+    codex_native plugin drives codex CLI installs."""
+    market_root = tmp_path / "mkt"
+    market_root.mkdir()
+    manifest = Manifest(
+        name="base",
+        native_plugins=[
+            {
+                "name": "claude-only",
+                "claude_native": True,
+                "codex_native": False,
+                "marketplace_root": str(market_root),
+                "marketplace_name": "claude-only",
+                "description": "",
+            },
+            {
+                "name": "milknado",
+                "claude_native": False,
+                "codex_native": True,
+                "marketplace_root": str(market_root),
+                "marketplace_name": "milknado",
+                "description": "",
+            },
+        ],
+    )
+    target = tmp_path / "home"
+    target.mkdir()
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0)
+        CodexRenderer().render(manifest, target)
+
+    added = [
+        c.args[0][-1] for c in mock_run.call_args_list
+        if c.args and c.args[0][:3] == ["codex", "plugin", "add"]
+    ]
+    assert added == ["milknado@milknado"], (
+        f"only the codex_native plugin must be installed, got: {added}"
+    )
+    assert not any(
+        "claude-only" in arg
+        for c in mock_run.call_args_list if c.args
+        for arg in c.args[0]
+    ), "claude_native-only plugin must not touch the codex CLI"

--- a/agents/plugins/registry.yaml
+++ b/agents/plugins/registry.yaml
@@ -31,7 +31,11 @@
 #                  per-request token tax). Default = all harnesses.
 #   claude_native: true → Claude gets the native marketplace install
 #                  (atomic plugin install + plugin-scoped mcp__ names).
-#                  Other harnesses always get decomposed primitives.
+#                  Other non-native harnesses always get decomposed primitives.
+#   codex_native:  true → Codex gets the native marketplace install via its own
+#                  CLI (`codex plugin marketplace add` + `codex plugin add`),
+#                  not decomposed MCP/skills. Independent of claude_native:
+#                  each harness's native path is flagged and consumed separately.
 #   gate_unless:   optional env var gate on the decomposed MCP items (same
 #                  semantics as the MCP registry gate). Does NOT gate the
 #                  Claude-native install path — that descriptor carries no gate.
@@ -39,7 +43,8 @@
 #
 # Per-harness reach:
 #   claude   → native marketplace install (full plugin, nothing lost)
-#   codex    → MCP + skills + hooks (loses custom /commands)
+#   codex    → native marketplace install when codex_native; else MCP + skills +
+#              hooks (loses custom /commands)
 #   opencode → MCP + skills + agents
 #   cursor   → MCP + skills + agents + commands + hooks
 #   copilot  → skills + hooks + agents; MCP only if harnesses includes copilot
@@ -58,6 +63,14 @@ plugins:
     branch: main
     harnesses: [claude, codex, opencode, cursor, copilot, crush]
     claude_native: true
+    # codex_native: DISABLED — milknado's upstream .agents/plugins/marketplace.json
+    # (the manifest codex reads) lacks a top-level `name`, so
+    # `codex plugin marketplace add` exits 1 and codex would get NEITHER the
+    # native install NOR the decomposed MCP (DEDUP strips codex when the flag is
+    # set). The renderer machinery (_render_native_plugins) is landed and tested
+    # but stays off until upstream adds `"name": "milknado"` to that manifest;
+    # then set `codex_native: true` and confirm `codex plugin marketplace add`
+    # succeeds against ~/.cache/ap/plugins/milknado.
     description: Mikado execution engine — goal decomposition, batch planning, detached ralph-loop runs
 
   # hallouminate: per-repo markdown wiki (LLM-authored notes + semantic search).


### PR DESCRIPTION
## Summary

Adds a `codex_native` flag for cross-harness plugins in `ap`, mirroring the existing `claude_native` path. A flagged plugin installs into Codex via its native CLI (`codex plugin marketplace add` + `codex plugin add <name>@<market>`) instead of being decomposed into a `config.toml` MCP + `.agents/skills`.

- **`ingest._expand_plugins`** reads `codex_native`, generalizes DEDUP to strip `claude` and/or `codex` from a flagged plugin's decomposed MCP harnesses, stamps a **separate** `_from_codex_native_plugin` skill flag (distinct from claude's `_from_native_plugin`, so the claude renderer doesn't drop a codex-only-native plugin's skills), and emits a `native_plugins` descriptor carrying both native booleans.
- **`renderers/codex.py`** native pass: `marketplace add` is **fatal** (`_codex_cli_strict` → `RuntimeError`) so an unparseable manifest fails the render loudly instead of silently stripping the plugin; `plugin add` and `clean()` stay tolerant. A `_marketplace_registered` probe preserves idempotency by skipping a re-add. `_write_skills` skips codex-native skills; `clean()` un-registers via the CLI.

## Ships disabled (intentional)

milknado is the only candidate plugin, and its upstream `.agents/plugins/marketplace.json` lacks a top-level `name`, so codex rejects it. The renderer machinery is landed and tested but `codex_native` is **off** for milknado, documented inline with the one-line re-enable path once upstream adds `"name"`. hallouminate stays codex-decomposed to preserve its `mcp__hallouminate__*` namespace.

## Why fail-loud + the strict/tolerant split

An earlier iteration warned-and-continued on `marketplace add` failure. Combined with DEDUP stripping `codex` from the decomposed MCP, that silently deleted milknado from Codex on `dots sync` — a regression hidden because the unit tests mocked `subprocess.run`. The fix makes `marketplace add` raise, and adds a real (non-mocked) integration test that rejects a `name`-less manifest.

## Tests

agent-profile pytest: **721 passed**. `dots sync`: exit 0, clean render. Covers ingest DEDUP, dual native/skill flags, the strict/tolerant CLI split, `name` vs `marketplace_name` divergence, root expansion, call ordering, mixed-manifest isolation, and the non-mocked manifest-rejection integration test.

The `test_no_hand_rolled_escaping_in_source` guard is narrowed to allow `subprocess` (native-CLI delegation, mirroring the claude renderer) while keeping its jq/yq/escaping prohibitions.

## Known residual

`_marketplace_registered`'s match-TRUE branch assumes the `codex plugin marketplace list` output format; only the FALSE path is real-CLI-tested. Dormant (no enabled `codex_native` plugin exercises it) — worth pinning when the feature is re-enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)