### PR TITLE
fix(tmux): C-Space prefix under Ghostty + cc --new flag

### DIFF
--- a/bin/cc-session-name
+++ b/bin/cc-session-name
@@ -10,7 +10,17 @@
 # to the same session as its root (de-sprawl). A worktree's own toplevel IS the
 # worktree dir, whose path carries /.worktrees/<slug> — that's how repo+slug are
 # recovered without colliding across repos.
+#
+# --unique (must precede the path): if a live tmux session already owns the
+# computed name, append the lowest free "-N" suffix (-2, -3, …). This backs
+# `cc --new`, which wants a fresh session past the default -A reattach.
 set -euo pipefail
+
+unique=0
+if [[ "${1:-}" == "--unique" ]]; then
+    unique=1
+    shift
+fi
 
 path="${1:-$PWD}"
 path="${path%/}"
@@ -32,7 +42,19 @@ fi
 if [[ "$base" == */.worktrees/* ]]; then
     slug="${base##*/}"
     repo_path="${base%/.worktrees/*}"
-    sanitize "${repo_path##*/}-${slug}"
+    name="$(sanitize "${repo_path##*/}-${slug}")"
 else
-    sanitize "${base##*/}"
+    name="$(sanitize "${base##*/}")"
 fi
+
+# --unique: bump past any live session that already holds the base name.
+# Exact-match target (=name) so "dotfiles" doesn't prefix-match "dotfiles-2".
+if (( unique )) && command -v tmux >/dev/null 2>&1 && tmux has-session -t "=$name" 2>/dev/null; then
+    i=2
+    while tmux has-session -t "=${name}-${i}" 2>/dev/null; do
+        i=$((i + 1))
+    done
+    name="${name}-${i}"
+fi
+
+printf '%s' "$name"

--- a/tests/cc-session-name.bats
+++ b/tests/cc-session-name.bats
@@ -72,3 +72,41 @@ export PATH="$DOTFILES_DIR/bin:$PATH"
     [ "$output" = "plain-dir" ]
     rm -rf "$parent"
 }
+
+@test "--unique returns the base name when no session owns it" {
+    local bindir parent repo
+    bindir="$(mktemp -d)"
+    cat > "$bindir/tmux" <<'EOF'
+#!/usr/bin/env bash
+# has-session always fails -> nothing is taken
+exit 1
+EOF
+    chmod +x "$bindir/tmux"
+    parent="$(mktemp -d)"; repo="$parent/cleanrepo"
+    mkdir -p "$repo"; git -C "$repo" init -q
+    PATH="$bindir:$PATH" run cc-session-name --unique "$repo"
+    [ "$status" -eq 0 ]
+    [ "$output" = "cleanrepo" ]
+    rm -rf "$parent" "$bindir"
+}
+
+@test "--unique appends the lowest free -N suffix when sessions are taken" {
+    local bindir parent repo
+    bindir="$(mktemp -d)"
+    cat > "$bindir/tmux" <<'EOF'
+#!/usr/bin/env bash
+# "cleanrepo" and "cleanrepo-2" are taken; "cleanrepo-3" is free.
+[[ "$1" == has-session ]] || exit 0
+case "$3" in
+  "=cleanrepo"|"=cleanrepo-2") exit 0 ;;
+  *) exit 1 ;;
+esac
+EOF
+    chmod +x "$bindir/tmux"
+    parent="$(mktemp -d)"; repo="$parent/cleanrepo"
+    mkdir -p "$repo"; git -C "$repo" init -q
+    PATH="$bindir:$PATH" run cc-session-name --unique "$repo"
+    [ "$status" -eq 0 ]
+    [ "$output" = "cleanrepo-3" ]
+    rm -rf "$parent" "$bindir"
+}

--- a/tmux.conf
+++ b/tmux.conf
@@ -30,6 +30,18 @@ set -g default-terminal "tmux-256color"
 set -sa terminal-overrides ",xterm-256color:RGB"
 
 # ---------------------------------------------------------------------------
+# Extended keys (C-Space prefix under kitty-protocol terminals)
+# ---------------------------------------------------------------------------
+# Ghostty ($TERM=xterm-ghostty) defaults to the kitty keyboard protocol and
+# encodes Ctrl+Space as a CSI-u sequence, not the legacy NUL byte tmux reads
+# as C-Space. Advertise extkeys so tmux negotiates an encoding it recognizes.
+# The xterm* glob also covers iTerm2 (xterm-256color). 'on' (not 'always')
+# only forwards extended keys to inner apps that opt in — keeps Ctrl+C/Z/L safe.
+set -as terminal-features 'xterm*:extkeys'
+set -s extended-keys on
+set -s extended-keys-format csi-u
+
+# ---------------------------------------------------------------------------
 # Popups
 # ---------------------------------------------------------------------------
 set -g popup-border-lines rounded

--- a/zsh/claude.zsh
+++ b/zsh/claude.zsh
@@ -26,6 +26,21 @@ export ENABLE_CLAUDEAI_MCP_SERVERS=false
 # already inside tmux ($TMUX set) or tmux is not installed.
 # ccw sets _CC_IN_SESSION=1 to trigger the inside-tmux switch-client path.
 _cc_base() {
+    # --new (our flag, not claude's): force a brand-new session instead of the
+    # default -A reattach. Strip it from the args wherever it lands so it works
+    # through cc/ccc/ccr (which prepend --continue/--resume ahead of "$@").
+    local force_new=
+    local -a passthru=()
+    local a
+    for a in "$@"; do
+        if [[ "$a" == --new ]]; then
+            force_new=1
+        else
+            passthru+=("$a")
+        fi
+    done
+    set -- "${passthru[@]}"
+
     local -a flags=()
     [[ -f "$AGENTS_DOTFILES/preamble.md" ]] && flags+=(--system-prompt-file "$AGENTS_DOTFILES/preamble.md")
     local -a cmd=(claude "${flags[@]}" "$@")
@@ -40,13 +55,18 @@ _cc_base() {
     # worktree, <repo> otherwise. Re-running cc/ccw for the same worktree
     # reuses its session instead of spawning another (de-sprawl), and
     # same-named worktrees across different repos no longer collide.
+    # --new asks for the lowest free -N suffix so the session is guaranteed fresh.
+    local -a name_args=()
+    [[ -n "$force_new" ]] && name_args=(--unique)
     local session
-    session="$("${DOTFILES_DIR:-$HOME/Dev/dotfiles}/bin/cc-session-name" "$PWD")"
+    session="$("${DOTFILES_DIR:-$HOME/Dev/dotfiles}/bin/cc-session-name" "${name_args[@]}" "$PWD")"
     if [[ -z "$TMUX" ]]; then
-        # Outside tmux: create-or-attach (-A attaches if it exists; cmd ignored on attach).
+        # Outside tmux: create-or-attach (-A attaches if it exists; cmd ignored
+        # on attach). With --new the name is unique, so -A always creates.
         tmux new-session -A -s "$session" "${(j: :)${(@q)cmd}}"
-    elif [[ -n "$_CC_IN_SESSION" ]]; then
-        # Inside tmux from ccw: dedicate a session and switch-client (never nests).
+    elif [[ -n "$_CC_IN_SESSION" || -n "$force_new" ]]; then
+        # Inside tmux from ccw, or an explicit --new from a plain session:
+        # dedicate a session and switch-client (never nests).
         tmux has-session -t "$session" 2>/dev/null \
             || tmux new-session -d -s "$session" "${(j: :)${(@q)cmd}}"
         tmux switch-client -t "$session"


### PR DESCRIPTION
## Summary

Two related tmux fixes from a "tmux isn't working right" report:

1. **`fix(tmux)`** — Ctrl+Space prefix didn't fire under Ghostty. Ghostty (`$TERM=xterm-ghostty`) defaults to the kitty keyboard protocol and encodes Ctrl+Space as a CSI-u sequence, not the legacy NUL byte tmux reads as `C-Space`. Advertise `extkeys` for `xterm*` terminals (covers Ghostty + iTerm2's `xterm-256color`) and enable `extended-keys on` (not `always` — keeps Ctrl+C/Z/L safe) with `csi-u` format so tmux negotiates an encoding it recognizes.

2. **`feat(cc)`** — add a `cc --new` flag to force a fresh session past the default `new-session -A` reattach. `cc-session-name` gains an opt-in `--unique` flag that appends the lowest free `-N` suffix when a live session already owns the base name; `_cc_base` strips `--new` from the args (so it works through `cc`/`ccc`/`ccr`), requests the unique name, and switches to a fresh session even from inside a plain tmux session.

## Test plan

- `bats tests/cc-session-name.bats` — 10/10 pass (2 new cases mock `tmux has-session` via `$PATH`)
- `zsh -n zsh/claude.zsh`, `bash -n bin/cc-session-name`, `shellcheck bin/cc-session-name` — clean
- `--unique` is opt-in, so existing `cc`/`ccw` paths are unchanged
- tmux fix verified against live `client_termfeatures` (lacked `extkeys` before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)