### PR TITLE
fix(macos): disable input-source switching shortcuts (Control+Space)

### DIFF
--- a/macos/.sync
+++ b/macos/.sync
@@ -28,6 +28,14 @@ defaults write com.apple.AppleMultitouchMouse mouseButtonMode -string TwoButton
 # output open in your default browser."
 defaults write com.cmuxterm.app browserOpenTerminalLinksInCmuxBrowser -bool false
 
+# Disable the input-source switching shortcuts so they free up Control+Space
+# for the tmux prefix. ID 60 = "Select the previous input source" (⌃Space),
+# ID 61 = "Select next source in Input menu" (⌃⇧Space, the reverse).
+defaults write com.apple.symbolichotkeys AppleSymbolicHotKeys -dict-add 60 "{enabled = 0;}"
+defaults write com.apple.symbolichotkeys AppleSymbolicHotKeys -dict-add 61 "{enabled = 0;}"
+# Reload the symbolic-hotkey settings so the change takes effect without re-login.
+/System/Library/PrivateFrameworks/SystemAdministration.framework/Resources/activateSettings -u || true
+
 for plist in "$SCRIPT_DIR"/*.plist; do
     [[ -f "$plist" ]] || continue
     name="${plist##*/}"


### PR DESCRIPTION
## What

Disables two macOS keyboard shortcuts in `macos/.sync`:

- **Select the previous input source** — `Control+Space` (`AppleSymbolicHotKeys` ID 60)
- **Select next source in Input menu** — `Control+Shift+Space`, the reverse (ID 61)

## Why

These system shortcuts conflict with the tmux `C-Space` prefix (see recent tmux prefix work in `6431897` / `bd6daa5`). Disabling them frees `Control+Space` system-wide so the prefix lands reliably.

## How

Appends two `defaults write com.apple.symbolichotkeys ... -dict-add <id> "{enabled = 0;}"` lines to the existing `macos/.sync` script (already gated by the `uname -s != Darwin` guard, runs as part of `dots sync`). Reloads symbolic-hotkey settings via `activateSettings -u` so the change applies without a re-login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)