### PR TITLE
[codex] default isolated Codex launches to auto perms

### DIFF
--- a/.hallouminate/wiki/harnesses/codex.md
+++ b/.hallouminate/wiki/harnesses/codex.md
@@ -17,7 +17,9 @@ The repo seeds `~/.codex/config.toml` once (chezmoi `install-codex`, first-time 
 
 ## Isolated settings
 
-Not available. Codex has no `--strict-mcp-config` / `--setting-sources` equivalent; `ap` only builds isolated-launch flags for Claude. Per-server enable/disable is the only MCP filtering Codex exposes (no per-tool filtering via `codex mcp`).
+`ap launch codex <profile>` isolates by redirecting `CODEX_HOME` to a fresh generated home, not by passing a `--strict-mcp-config` / `--setting-sources` equivalent. The generated `config.toml` carries the profile MCP world, optional `model_instructions_file`, and the repo's Auto permission defaults: `approval_policy = "on-request"`, `approvals_reviewer = "auto_review"`, and `sandbox_mode = "workspace-write"`.[^isolated-auto-perms] Codex still has no per-launch built-in tool whitelist; per-server enable/disable is the only MCP filtering Codex exposes (no per-tool filtering via `codex mcp`).
+
+[^isolated-auto-perms]: `agent-profile/agent_profile/overlay.py:_write_codex_config`; regression test `agent-profile/tests/test_overlay.py:test_codex_isolated_config_defaults_to_auto_permissions`.
 
 ## Quirks
 

--- a/agent-profile/agent_profile/overlay.py
+++ b/agent-profile/agent_profile/overlay.py
@@ -301,14 +301,15 @@ def _write_codex_config(
 ) -> None:
     """Generate ``<codex_home>/config.toml`` for the isolated launch.
 
-    Sets ``model_instructions_file`` to the profile's system-prompt file
-    (an absolute path — codex's ``instructions`` key is reserved/noop, and
-    ``model_instructions_file`` is the documented way to inject a custom
-    system prompt; verified in the live ``~/.codex/config.toml``). Appends
-    the profile's MCP world as ``[mcp_servers.<n>]`` tables. The fresh config
-    trusts no projects, so any ``.codex/config.toml`` in the working tree is
-    loaded but inert."""
-    sections: list[str] = []
+    Pins Codex's Auto permissions defaults (workspace-write sandbox with
+    on-request approvals) before adding the profile's optional system prompt
+    and MCP world. The fresh config trusts no projects, so any
+    ``.codex/config.toml`` in the working tree is loaded but inert."""
+    sections: list[str] = [
+        'approval_policy = "on-request"\n'
+        'approvals_reviewer = "auto_review"\n'
+        'sandbox_mode = "workspace-write"\n'
+    ]
     if manifest.system_prompt:
         sp = profile_dir / manifest.system_prompt
         if not sp.is_file():

--- a/agent-profile/tests/test_overlay.py
+++ b/agent-profile/tests/test_overlay.py
@@ -841,6 +841,18 @@ def test_codex_mcp_servers_are_toml_tables(tmp_path, monkeypatch):
     }
 
 
+def test_codex_isolated_config_defaults_to_auto_permissions(tmp_path, monkeypatch):
+    """Isolated Codex launches bypass ~/.codex/config.toml, so the generated
+    config must carry the same Auto permissions defaults as the live seed."""
+    monkeypatch.setenv("DOTFILES_DIR", str(tmp_path))
+    m = _claude_manifest(tmp_path)
+    _, env = overlay.build_isolated_launch(m, tmp_path, "codex")
+    cfg = _codex_config(env)
+    assert cfg["approval_policy"] == "on-request"
+    assert cfg["approvals_reviewer"] == "auto_review"
+    assert cfg["sandbox_mode"] == "workspace-write"
+
+
 def test_codex_system_prompt_is_model_instructions_file(tmp_path, monkeypatch):
     """The system prompt is injected via model_instructions_file (an absolute
     path), NOT the reserved/noop `instructions` key."""


### PR DESCRIPTION
## Summary
- pin isolated Codex profile config to Auto permissions defaults
- add regression coverage for generated Codex config
- document the isolated Codex behavior in the wiki

## Validation
- uv run --project agent-profile pytest agent-profile/tests
- prek run --all-files

## Hook evaluation
- No local failing hooks reproduced. pre-commit hooks passed during explicit prek run and again during commit.