### PR TITLE
[codex] make codex harness first-class

### DIFF
--- a/.hallouminate/wiki/architecture/codex-first-class-review.md
+++ b/.hallouminate/wiki/architecture/codex-first-class-review.md
@@ -1,0 +1,21 @@
+# Codex first-class review
+
+Codex first-class work now has fixes for user-level hook command resolution, Codex hook-health diagnostics in `harness-doctor`, isolated Codex profile projection, and stale MCP tool-scope cleanup. The remaining known gap is live `PreToolUse` matcher-name verification before changing `agents/hooks/registry.yaml`.[^1]
+
+## Findings and fixes
+
+- **User-level hooks cannot use `.codex/hooks/...` relative commands.** Codex runs hook commands with the session working directory, not the config-file directory; the renderer now writes absolute commands to the copied script, and tests assert resolution from an unrelated cwd.[^2]
+- **Codex hook-health is now visible to `harness-doctor`.** The doctor instructions now include `~/.codex/hooks.json`, flag relative user-level hook commands, and flag duplicate `hooks.json` plus legacy inline `[[hooks.*]]` wiring.[^3]
+- **`ap launch codex <isolated>` now projects Codex-native profile files.** The redirected `CODEX_HOME` gets root `config.toml`, `hooks.json`, `agents/`, `rules/`, selected shared skills, and MCP tool scopes; Codex still has no built-in `--tools` equivalent, so tool whitelist fields remain ignored with warning.[^4]
+- **MCP tool-scope cleanup now uses the previous manifest snapshot.** Install reconcile clears prior Codex `enabled_tools` / `disabled_tools` when the current profile no longer has any matching `mcp__*` rule for that server.[^5]
+
+## Remaining follow-up
+
+Capture real Codex `PreToolUse` payloads for `exec_command`, `apply_patch`, `tilth_read`, and `tilth_write` before changing `agents/hooks/registry.yaml` matcher names. The analytics adapter records those names, but that is not yet evidence of the live CLI hook payload shape.[^6]
+
+[^1]: `.cheese/cure/codex-first-class.md`
+[^2]: `agent-profile/agent_profile/renderers/codex.py:293-351`; `agent-profile/tests/test_renderer_codex.py:225-288`
+[^3]: `skills/harness-doctor/SKILL.md:79-121`
+[^4]: `agent-profile/agent_profile/overlay.py:257-467`; `agent-profile/tests/test_overlay.py:1309-1355`
+[^5]: `agent-profile/agent_profile/cli.py:303-463`; `agent-profile/agent_profile/renderers/codex.py:492-520`; `agent-profile/tests/test_mcp_reconcile.py:264-299`
+[^6]: `.cheese/age/codex-first-class.md:47-51`

--- a/agent-profile/agent_profile/cli.py
+++ b/agent-profile/agent_profile/cli.py
@@ -33,6 +33,7 @@ from agent_profile.renderers.base import (
     Renderer,
     includes_harness,
 )
+from agent_profile.permissions import parse_mcp_rule
 
 ALL_HARNESSES = ["claude", "codex", "opencode", "cursor", "copilot", "crush"]
 
@@ -300,6 +301,7 @@ def cmd_install(
         _union_files(target, name, new_files, harnesses)
 
     _reconcile_dropped_mcps(prior_merged, manifest, harnesses, target, out, colors)
+    _reconcile_dropped_mcp_tool_scopes(prior_merged, manifest, harnesses, target)
 
     manifest_mod.record_merged_json(target, name, merged_dict)
 
@@ -358,6 +360,59 @@ def cmd_perms(
             continue
         renderer_cls().render_project_permissions(manifest, target, local=local)
     return 0
+
+
+def _mcp_rule_servers(settings: dict[str, Any]) -> set[str]:
+    out: set[str] = set()
+    for channel in ("permissions_allow", "permissions_deny"):
+        for rule in settings.get(channel) or []:
+            parsed = parse_mcp_rule(rule)
+            if parsed:
+                out.add(parsed[0])
+    return out
+
+
+def _filter_mcp_rules_for_servers(
+    settings: dict[str, Any], servers: set[str]
+) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for channel in ("permissions_allow", "permissions_deny"):
+        rules = []
+        for rule in settings.get(channel) or []:
+            parsed = parse_mcp_rule(rule)
+            if parsed and parsed[0] in servers:
+                rules.append(rule)
+        if rules:
+            out[channel] = rules
+    return out
+
+
+def _reconcile_dropped_mcp_tool_scopes(
+    prior_merged: dict[str, Any] | None,
+    manifest: Any,
+    harnesses: list[str],
+    target: Path,
+) -> None:
+    """Clear Codex MCP tool-scope keys for servers no longer named by rules.
+
+    Codex stores mcp__server__tool allow/deny rules as merged
+    enabled_tools/disabled_tools keys in ~/.codex/config.toml. Rendering the
+    current manifest can clear stale tools only while a server still has an
+    mcp__* rule. If the profile removes every such rule for a server, the prior
+    manifest snapshot is the only safe signal that those keys were ap-managed.
+    """
+    if "codex" not in harnesses or not prior_merged:
+        return
+    prior_settings = prior_merged.get("settings") or {}
+    dropped = _mcp_rule_servers(prior_settings) - _mcp_rule_servers(manifest.settings)
+    if not dropped:
+        return
+    renderer = RENDERERS.get("codex")
+    cleaner = getattr(renderer, "_clean_mcp_tool_scopes", None)
+    if cleaner is None:
+        return
+    dropped_settings = _filter_mcp_rules_for_servers(prior_settings, dropped)
+    cleaner(replace(manifest, settings=dropped_settings), target)
 
 
 def _reconcile_dropped_mcps(

--- a/agent-profile/agent_profile/overlay.py
+++ b/agent-profile/agent_profile/overlay.py
@@ -28,11 +28,11 @@ raises :class:`IsolationError` on the dispatch miss (fail loud).
 
 Per-harness caveats (also in AGENTS.md § Profile System):
 
-- **codex drops tool/permission restriction.** Codex has no per-launch
-  built-in-tool whitelist; an isolated codex profile gets the closed MCP
-  world + a redirected ``CODEX_HOME``, but *not* a ``--tools`` analog. The
-  profile's ``tools`` / ``permissions_deny`` / ``enabled_plugins`` are
-  ignored-with-warning. Tracked in a follow-up ticket.
+- **codex drops built-in-tool restriction.** Codex has no per-launch
+  built-in-tool whitelist, so an isolated codex profile gets a redirected
+  ``CODEX_HOME`` with generated config, hooks, agents, rules, skills, and MCP
+  tool scopes — but not a ``--tools`` analog. ``tools`` / ``enabled_plugins`` /
+  ``extra_args`` are ignored-with-warning.
 - **codex auth.json symlink is File-mode only.** Login is preserved by
   symlinking ``<CODEX_HOME>/auth.json`` -> ``~/.codex/auth.json``, which
   works for ``File`` auth-storage mode. Keyring users must set
@@ -56,13 +56,15 @@ from __future__ import annotations
 import json
 import os
 import re
+import shutil
 import sys
 import tempfile
+from dataclasses import replace
 from pathlib import Path
-
 from agent_profile.env import load_dotenv, resolve_env_value, resolve_item_env
 from agent_profile.parse import Manifest
 from agent_profile.renderers.base import mcp_server_entry
+from agent_profile.renderers.codex import CodexRenderer, _collect_mcp_tool_scopes
 from agent_profile.renderers.opencode import (
     OPENCODE_MCP_DEFAULT,
     mcp_server_record,
@@ -265,6 +267,7 @@ def _codex_mcp_tables(manifest: Manifest) -> str:
     ``[mcp_servers.<n>.http_headers]`` sub-table — verified against codex
     0.135.0 ``codex mcp get``)."""
     dotenv = _dotenv()
+    scopes = _collect_mcp_tool_scopes(manifest)
     lines: list[str] = []
     for raw in manifest.mcps:
         mcp = resolve_item_env(raw, dotenv)
@@ -278,6 +281,11 @@ def _codex_mcp_tables(manifest: Manifest) -> str:
             lines.append(
                 f"type = {_codex_toml_value(mcp.get('type') or 'http')}"
             )
+            enabled, disabled = scopes.get(mcp["name"], (set(), set()))
+            if enabled:
+                lines.append(f"enabled_tools = {_codex_toml_value(sorted(enabled))}")
+            if disabled:
+                lines.append(f"disabled_tools = {_codex_toml_value(sorted(disabled))}")
             headers = mcp.get("headers")
             if isinstance(headers, dict) and headers:
                 lines.append(f"\n[mcp_servers.{name}.http_headers]")
@@ -287,6 +295,11 @@ def _codex_mcp_tables(manifest: Manifest) -> str:
             lines.append(f"command = {_codex_toml_value(mcp['command'])}")
             if mcp.get("args") is not None:
                 lines.append(f"args = {_codex_toml_value(mcp['args'])}")
+            enabled, disabled = scopes.get(mcp["name"], (set(), set()))
+            if enabled:
+                lines.append(f"enabled_tools = {_codex_toml_value(sorted(enabled))}")
+            if disabled:
+                lines.append(f"disabled_tools = {_codex_toml_value(sorted(disabled))}")
             env = mcp.get("env")
             if isinstance(env, dict) and env:
                 lines.append(f"\n[mcp_servers.{name}.env]")
@@ -325,6 +338,55 @@ def _write_codex_config(
     (codex_home / "config.toml").write_text("\n".join(sections))
 
 
+def _codex_with_isolated_settings(manifest: Manifest) -> Manifest:
+    settings = dict(manifest.settings)
+    if manifest.permissions_allow:
+        settings["permissions_allow"] = sorted(
+            set(settings.get("permissions_allow") or []) | set(manifest.permissions_allow)
+        )
+    if manifest.permissions_deny:
+        settings["permissions_deny"] = sorted(
+            set(settings.get("permissions_deny") or []) | set(manifest.permissions_deny)
+        )
+    return replace(manifest, settings=settings)
+
+
+def _move_codex_dir_child(codex_home: Path, rel: str) -> None:
+    src = codex_home / ".codex" / rel
+    if not src.exists():
+        return
+    dst = codex_home / rel
+    if dst.exists():
+        if dst.is_dir():
+            shutil.rmtree(dst)
+        else:
+            dst.unlink()
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.move(str(src), str(dst))
+
+
+def _rewrite_root_hook_commands(codex_home: Path) -> None:
+    hooks_json = codex_home / "hooks.json"
+    if not hooks_json.is_file():
+        return
+    old = str(codex_home / ".codex" / "hooks")
+    new = str(codex_home / "hooks")
+    hooks_json.write_text(hooks_json.read_text().replace(old, new))
+
+
+def _write_isolated_codex_profile(manifest: Manifest, codex_home: Path) -> None:
+    """Project Codex-native profile files into the redirected CODEX_HOME root."""
+    renderer = CodexRenderer()
+    out: list[str] = []
+    renderer._write_agents(manifest, codex_home, out)
+    renderer._write_skills(manifest, codex_home, out)
+    renderer._write_hooks(manifest, codex_home, out)
+    renderer._write_rules(manifest, codex_home, out)
+    for rel in ("agents", "hooks", "hooks.json", "lib", "reference", "rules"):
+        _move_codex_dir_child(codex_home, rel)
+    _rewrite_root_hook_commands(codex_home)
+
+
 def _codex_cache_base() -> Path:
     """Parent dir for the per-launch ``CODEX_HOME``, under the user cache (not
     ``/tmp``).
@@ -351,7 +413,8 @@ def _build_isolated_codex(
     (those are ``codex exec`` subcommand flags — rejected by the bare
     interactive ``codex`` the launcher execs). Isolation is instead achieved
     by pointing ``CODEX_HOME`` at a fresh per-launch dir holding a generated
-    ``config.toml`` (the profile's MCP world + ``model_instructions_file``).
+    ``config.toml`` plus Codex-native projections for hooks, agents, rules, and
+    shared skills.
     With ``CODEX_HOME`` redirected, the user's ``~/.codex/config.toml`` is not
     loaded; ``flags`` is therefore empty and codex launches interactive.
 
@@ -375,13 +438,13 @@ def _build_isolated_codex(
     - Project ``.codex/config.toml`` is loaded but inert (the fresh config
       trusts no projects).
 
-    Tool/permission restriction is dropped (codex has no per-launch built-in
-    tool whitelist — see module docstring + follow-up ticket): ``tools``,
-    ``permissions_deny`` and ``enabled_plugins`` are ignored-with-warning, as
-    are the claude-only ``extra_args`` (D3)."""
+    Built-in tool restriction is dropped (codex has no per-launch built-in
+    tool whitelist — see module docstring + follow-up ticket): ``tools`` and
+    ``enabled_plugins`` are ignored-with-warning, as are the claude-only
+    ``extra_args`` (D3). Codex-native hooks, agents, rules, skills, and MCP
+    tool scopes are written into the redirected home."""
     for name, present in (
         ("tools", bool(manifest.tools)),
-        ("permissions_deny", bool(manifest.permissions_deny)),
         ("enabled_plugins", bool(manifest.enabled_plugins)),
         ("extra_args", bool(manifest.extra_args)),
     ):
@@ -396,7 +459,9 @@ def _build_isolated_codex(
     if auth.is_file() and not link.exists():
         link.symlink_to(auth)
 
-    _write_codex_config(manifest, profile_dir, scratch)
+    codex_manifest = _codex_with_isolated_settings(manifest)
+    _write_codex_config(codex_manifest, profile_dir, scratch)
+    _write_isolated_codex_profile(codex_manifest, scratch)
 
     env = {"CODEX_HOME": str(scratch), **dict(manifest.env)}
     return [], env

--- a/agent-profile/agent_profile/renderers/codex.py
+++ b/agent-profile/agent_profile/renderers/codex.py
@@ -287,8 +287,9 @@ class CodexRenderer:
     # Codex reads .codex/hooks.json as a JSON object with a top-level
     # "hooks" map: event -> matcher groups -> command handlers. The file is
     # written only when at least one hook is codex-harnessed; the hook script
-    # is copied to .codex/hooks/<basename> so its command resolves relative to
-    # the target.
+    # is copied to .codex/hooks/<basename>; user-level hooks.json stores the
+    # absolute copied path because Codex runs hook commands from the session cwd,
+    # not from ~/.codex.
     def _write_hooks(
         self, manifest: Manifest, target: Path, out_files: list[str]
     ) -> None:
@@ -340,7 +341,7 @@ class CodexRenderer:
             )
 
             group = _codex_hook_group(
-                command=f"bash {rel_script}", matcher=matcher, timeout=timeout
+                command=f"bash {abs_script}", matcher=matcher, timeout=timeout
             )
             hook_groups.setdefault(str(event), []).append(group)
 
@@ -493,8 +494,8 @@ class CodexRenderer:
         from each scoped server, pruning a server table only if it now has no
         keys left (so a server still carrying its user ``command``/``args``
         survives)."""
-        scopes = _collect_mcp_tool_scopes(manifest)
-        if not scopes:
+        managed = _managed_mcp_servers(manifest)
+        if not managed:
             return
         cfg = Path(str(target).rstrip("/")) / ".codex" / "config.toml"
         if not cfg.is_file():
@@ -503,7 +504,7 @@ class CodexRenderer:
         servers = doc.get("mcp_servers")
         if servers is None:
             return
-        for server in scopes:
+        for server in managed:
             entry = servers.get(server)
             if entry is None:
                 continue

--- a/agent-profile/tests/test_mcp_reconcile.py
+++ b/agent-profile/tests/test_mcp_reconcile.py
@@ -259,3 +259,41 @@ def test_mcp_scoped_to_no_harnesses_is_pruned(env, capsys, prod_renderers):
 
     cop = json.loads((t / ".copilot/mcp-config.json").read_text())["mcpServers"]
     assert "srv2" not in cop, "srv2 scoped to harnesses:[] must be pruned from copilot"
+
+
+def _yaml_mcp_tool_scopes(name: str, allow_rules: list[str]) -> str:
+    lines = [
+        f"name: {name}",
+        "description: mcp tool scope reconcile probe",
+        "mcps:",
+        "  - name: srv1",
+        "    command: /bin/true",
+        "    harnesses: [codex]",
+    ]
+    if allow_rules:
+        lines += ["settings:", "  permissions_allow:"]
+        lines += [f"    - {json.dumps(rule)}" for rule in allow_rules]
+    return "\n".join(lines) + "\n"
+
+
+def test_dropped_codex_mcp_tool_scope_is_pruned(env, capsys, prod_renderers):
+    write_profile(
+        env.profiles,
+        "p",
+        _yaml_mcp_tool_scopes("p", ["mcp__srv1__read", "mcp__srv1__write"]),
+    )
+    assert _install(env, "p") == 0
+    capsys.readouterr()
+
+    cfg = env.target / ".codex/config.toml"
+    first = tomlkit.parse(cfg.read_text())
+    assert first["mcp_servers"]["srv1"]["enabled_tools"] == ["read", "write"]
+
+    write_profile(env.profiles, "p", _yaml_mcp_tool_scopes("p", []))
+    assert _install(env, "p") == 0
+    capsys.readouterr()
+
+    after = tomlkit.parse(cfg.read_text())
+    assert "enabled_tools" not in after["mcp_servers"]["srv1"]
+    assert "disabled_tools" not in after["mcp_servers"]["srv1"]
+    assert after["mcp_servers"]["srv1"]["command"] == "/bin/true"

--- a/agent-profile/tests/test_overlay.py
+++ b/agent-profile/tests/test_overlay.py
@@ -956,21 +956,20 @@ def test_codex_no_system_prompt_omits_model_instructions_file(tmp_path, monkeypa
     assert "model_instructions_file" not in cfg
 
 
-def test_codex_drops_tools_perms_plugins_with_warning(tmp_path, monkeypatch, capsys):
-    """D2/D3: codex can't restrict built-in tools — tools/permissions_deny/
-    enabled_plugins/extra_args are ignored-with-warning, never silently
-    dropped, never fatal, never leaked into flags."""
+def test_codex_drops_tools_plugins_extra_args_with_warning(tmp_path, monkeypatch, capsys):
+    """D2/D3: codex can't restrict built-in tools — tools/enabled_plugins/
+    extra_args are ignored-with-warning, never silently dropped, never fatal,
+    never leaked into flags."""
     monkeypatch.setenv("DOTFILES_DIR", str(tmp_path))
     m = _claude_manifest(
         tmp_path,
         tools=["Read", "Bash"],
-        permissions_deny=["Edit", "Write"],
         enabled_plugins={"x@y": True},
         extra_args=["--foo"],
     )
     flags, _ = overlay.build_isolated_launch(m, tmp_path, "codex")
     err = capsys.readouterr().err
-    for field in ("tools", "permissions_deny", "enabled_plugins", "extra_args"):
+    for field in ("tools", "enabled_plugins", "extra_args"):
         assert f"field {field} ignored for harness codex" in err
     assert flags == []  # nothing leaks into the launch argv
 
@@ -1307,17 +1306,64 @@ def test_real_review_profile_read_only_on_opencode(monkeypatch, tmp_path):
     assert own == {"tilth", "code-review-graph", "context7"}
 
 
-def test_real_review_profile_on_codex_drops_perms_with_caveat(monkeypatch, tmp_path, capsys):
-    """The shipped review profile on codex builds the MCP world but CANNOT
-    enforce its read-only deny list (codex caveat) — it's ignored-with-warning,
-    and the closed MCP world is still injected via the generated config.toml."""
+def test_real_review_profile_on_codex_projects_permission_rules(monkeypatch, tmp_path, capsys):
+    """The shipped review profile on codex builds the MCP world and projects
+    Codex-native permission surfaces into the redirected home."""
     _hermetic_dotenv(monkeypatch, tmp_path)
     pdir = find_profile_dir("review")
     assert pdir is not None
     m = parse_manifest(pdir)
     _, env = overlay.build_isolated_launch(m, pdir, "codex")
     err = capsys.readouterr().err
-    assert "field permissions_deny ignored for harness codex" in err
+    assert "field permissions_deny ignored for harness codex" not in err
     servers = _codex_config(env)["mcp_servers"]
     for server in ("tilth", "code-review-graph", "context7"):
         assert server in servers, server
+    assert "tilth_write" in servers["tilth"]["disabled_tools"]
+
+
+def test_codex_isolated_home_projects_hooks_agents_rules_and_skills(tmp_path, monkeypatch):
+    monkeypatch.setenv("DOTFILES_DIR", str(tmp_path))
+    (tmp_path / "hooks").mkdir()
+    (tmp_path / "hooks" / "h.sh").write_text("#!/bin/bash\nexit 0\n")
+    assets = tmp_path / "agents"
+    (assets / "lib").mkdir(parents=True)
+    (assets / "lib" / "cheese-flair.sh").write_text("# assets\n")
+    (assets / "reference").mkdir()
+    (assets / "reference" / "cheese-flair.md").write_text("# bank\n")
+    (tmp_path / "agents" / "reviewer.md").write_text("Review code.\n")
+    skill = tmp_path / "skills" / "probe"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("# Probe\n")
+    m = _claude_manifest(
+        tmp_path,
+        agents=[{"name": "reviewer", "description": "Reviews", "body_path": "agents/reviewer.md", "_source_dir": str(tmp_path)}],
+        hooks=[
+            {
+                "event": "PreToolUse",
+                "matcher": "Bash",
+                "script": "hooks/h.sh",
+                "harnesses": ["codex"],
+                "shared_assets": ["agents/lib/cheese-flair.sh", "agents/reference/cheese-flair.md"],
+                "_source_dir": str(tmp_path),
+            }
+        ],
+        skills=[{"name": "probe", "path": "skills/probe", "_source_dir": str(tmp_path)}],
+        settings={
+            "permissions_allow": ["Bash(git status:*)", "mcp__tilth__read"],
+        },
+    )
+
+    _, env = overlay.build_isolated_launch(m, tmp_path, "codex")
+    home = Path(env["CODEX_HOME"])
+
+    assert (home / "agents/reviewer.toml").is_file()
+    assert (home / ".agents/skills/probe/SKILL.md").is_file()
+    assert (home / "rules/ap-canonical.rules").is_file()
+    hooks = json.loads((home / "hooks.json").read_text())
+    command = hooks["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
+    assert command == f"bash {home / 'hooks/h.sh'}"
+    assert (home / "lib/cheese-flair.sh").read_text() == "# assets\n"
+    assert (home / "reference/cheese-flair.md").read_text() == "# bank\n"
+    cfg = _codex_config(env)
+    assert cfg["mcp_servers"]["tilth"]["enabled_tools"] == ["read"]

--- a/agent-profile/tests/test_renderer_codex.py
+++ b/agent-profile/tests/test_renderer_codex.py
@@ -253,12 +253,39 @@ def test_codex_hook_writes_hooks_json_and_script(renderer, src, target):
                 {
                     "matcher": "Bash",
                     "hooks": [
-                        {"type": "command", "command": "bash .codex/hooks/h.sh"}
+                        {"type": "command", "command": f"bash {copied}"}
                     ],
                 }
             ]
         }
     }
+
+
+def test_codex_hook_command_resolves_from_unrelated_cwd(renderer, src, target, tmp_path):
+    (src / "hooks").mkdir()
+    (src / "hooks" / "h.sh").write_text("#!/bin/bash\necho hi\n")
+    m = _manifest(
+        src,
+        hooks=[
+            {
+                "event": "PreToolUse",
+                "matcher": "Bash",
+                "script": "hooks/h.sh",
+                "harnesses": ["codex"],
+            }
+        ],
+    )
+    renderer.render(m, target)
+
+    unrelated_cwd = tmp_path / "session"
+    unrelated_cwd.mkdir()
+    command = json.loads((target / ".codex" / "hooks.json").read_text())["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
+    argv = command.split()
+    assert argv[0] == "bash"
+    script = Path(argv[1])
+    assert script.is_absolute()
+    assert script.is_file()
+    assert not (unrelated_cwd / ".codex" / "hooks" / "h.sh").exists()
 
 
 def test_claude_only_hook_does_not_write_hooks_json(renderer, src, target):

--- a/profiles/_permissions/profile.yaml
+++ b/profiles/_permissions/profile.yaml
@@ -21,6 +21,7 @@ settings:
   # plus lever 3 — MCP tools (bare names). Renderers classify by `mcp__` prefix.
   permissions_allow:
     - Bash(git:*)
+    - Bash(approve:*)
     - Bash(rtk:*)
     - Bash(ls:*)
     - Bash(head:*)

--- a/skills/harness-doctor/SKILL.md
+++ b/skills/harness-doctor/SKILL.md
@@ -79,7 +79,7 @@ Read the live files per harness (use `cheez-read`/`jq`, not blind cat):
 | Harness | Live files |
 |---|---|
 | claude | `~/.claude/settings.json`, `~/.claude/plugins/local/global/.claude-plugin/plugin.json`, `~/.claude/plugins/local/global/.mcp.json` |
-| codex | `~/.codex/config.toml` (`[mcp_servers]`, `[[hooks.*]]`) |
+| codex | `~/.codex/config.toml` (`[mcp_servers]`, `[[hooks.*]]`), `~/.codex/hooks.json` |
 | opencode | `~/.config/opencode/opencode.json` (`mcp`, `provider`) |
 | cursor | `~/.cursor/mcp.json`, `~/.cursor/hooks.json` |
 | copilot | `~/.copilot/mcp-config.json`, `~/.copilot/hooks/` |
@@ -113,6 +113,8 @@ Walk every difference and bucket it (first match wins):
 2. **Dotfiles bug** — the repo source is itself wrong. Checks:
    - A `script:` in `agents/hooks/registry.yaml` whose file is missing.
    - A hook `event:` not in `HOOK_EVENTS_VALID` (`agents/hooks/lib.sh`).
+   - A Codex user-level `~/.codex/hooks.json` command that starts with `bash .codex/hooks/` or otherwise names a relative hook script path. User-level Codex hooks run from the session cwd, so repo-relative commands are unsafe drift.
+   - Duplicate Codex hook wiring: the same managed hook basename appears in both `~/.codex/hooks.json` and legacy `[[hooks.<event>]]` blocks in `~/.codex/config.toml`.
    - An MCP referencing an unset `${VAR}` but not marked `optional: true`.
    - A skill dir without a `SKILL.md`, or a registry `body_path` that 404s.
    - The wiki index failing to rebuild (`hallouminate index` errors).


### PR DESCRIPTION
## Summary

- Render Codex hooks with absolute user-level commands and add regression coverage for unrelated session cwd resolution.
- Reconcile dropped Codex MCP tool scopes and project isolated Codex profiles into redirected `CODEX_HOME` with hooks, agents, rules, skills, tool scopes, and hook shared assets.
- Add Codex hook-health coverage to harness-doctor, add the default `Bash(approve:*)` permission, and document the review in the hallouminate wiki.

## Why

Codex was close to first-class, but the prior renderer could strand stale MCP tool restrictions, miss isolated-profile assets, and install hooks that depended on the current working directory.

## Validation

- `uv run --project agent-profile pytest agent-profile/tests/test_renderer_codex.py agent-profile/tests/test_mcp_reconcile.py agent-profile/tests/test_overlay.py` — 148 passed.
- `dots sync` — completed successfully.
- pre-commit hooks — passed during commit.
