### PR TITLE
fix(ap): propagate opencode secret-deny rules via canonical permissions channel

### DIFF
--- a/.hallouminate/wiki/architecture/agent-profile.md
+++ b/.hallouminate/wiki/architecture/agent-profile.md
@@ -104,7 +104,7 @@ Substrate rule (all five): stdlib `json` for JSON, `tomlkit` for TOML (round-tri
 |---|---|---|---|
 | Claude | `renderers/claude.py` | `.claude/plugins/local/<profile>/` (plugin.json, `skills/`, `commands/`, `hooks/`, `.mcp.json`, `settings.json`) + shared `.claude/agents/<n>.md` (agents are shared-only — no plugin-scoped copy) | `.claude/settings.json` (`enabledPlugins`+`extraKnownMarketplaces`), local `marketplace.json` |
 | Codex | `renderers/codex.py` | `.codex/agents/<n>.toml`, `.codex/hooks.json`, shared `.agents/skills/<n>/` | `.codex/config.toml` `[mcp_servers]` |
-| opencode | `renderers/opencode.py` | `agents/<n>.md` (root-relative) | `opencode.json` (`mcp`+`permission.bash`) |
+| opencode | `renderers/opencode.py` | `agents/<n>.md` (root-relative) | `opencode.json` (`mcp` + `permission`) |
 | Cursor | `renderers/cursor.py` | `.cursor/commands/`, `.cursor/hooks.json`, `.cursor/agents/<n>.md` | `.cursor/mcp.json` |
 | Copilot | `renderers/copilot.py` | `.github/agents/<n>.agent.md`, `.github/skills/<n>/`, `.github/hooks/<n>.json` | `.copilot/mcp-config.json` |
 
@@ -137,6 +137,6 @@ Three names must agree (`claude.py:_LOCAL_MARKETPLACE`): the marketplace key (`l
 On `dots sync`, `run_onchange_after_install-base-profile.sh.tmpl` exports `DOTFILES_DIR`, skips on a fresh box if `uv`/`npx` is missing, and forks to `chezmoi/lib/install-base-profile.sh`, which runs two installs handling a path asymmetry:
 
 - `HOME=$target ap install global --harness claude,codex,cursor,copilot` — the four dot-dir harnesses write under `$HOME`; `global` carries the marketplace + plugin enablement.
-- `ap install base --target $HOME/.config/opencode --harness opencode` — opencode writes `opencode.json` at the *target root*, with no marketplace/plugin surface, so plain `base` suffices.
+- `HOME=$target ap install opencode-global --harness opencode` — opencode writes `opencode.json` at the *target root*; the wrapper carries `_permissions` plus `target_default: $HOME/.config/opencode` without pulling in Claude's marketplace/plugin fields, and omitting `--target` keeps external `source:` skill fetch on the live path.
 
-The run_onchange hash spans `profiles/base`, `profiles/global`, all four registries, the hook scripts + shared-asset libs, `skills/`, *and* `agent-profile/agent_profile/**`. Sibling scripts: `install-agent-profile` (warms the uv env), `install-prompts` + `install-agents-doc` (the non-`ap` agent content — preamble + AGENTS.md, see [[agents-dir]]).
+The run_onchange hash spans `profiles/base`, `profiles/global`, `profiles/_permissions`, `profiles/opencode-global`, all four registries, the hook scripts + shared-asset libs, `skills/`, *and* `agent-profile/agent_profile/**`. Sibling scripts: `install-agent-profile` (warms the uv env), `install-prompts` + `install-agents-doc` (the non-`ap` agent content — preamble + AGENTS.md, see [[agents-dir]]).

--- a/.hallouminate/wiki/architecture/agents-dir.md
+++ b/.hallouminate/wiki/architecture/agents-dir.md
@@ -73,8 +73,8 @@ Two sources unioned at ingest (`ingest._expand_skills`):
 ## The edit → render → deploy workflow
 
 1. **Edit a registry** (`mcp-edit` / `hook-edit` / `agent-edit` / `skill-edit`).
-2. **`ap` renders.** The `base` profile expands the four registries into one item list; `ap`'s five renderers materialize that list per harness. The `mcp-sync` / `hook-sync` / `skill-sync` aliases are all `dots profile install base` (or `global`) under the hood.
-3. **chezmoi drives it on `dots sync`** via `run_onchange_after_install-base-profile.sh.tmpl`, which forks to `chezmoi/lib/install-base-profile.sh` and runs `ap install global` (dot-dir harnesses) + `ap install base --target ~/.config/opencode` (opencode). The run_onchange hash covers all registry inputs, the hook scripts, the shared-asset libs, *and* the `ap` renderer source — so editing a renderer or hook script re-deploys on the next plain `dots sync`.
+2. **`ap` renders.** The `base` profile expands the four registries into one item list; `ap`'s five renderers materialize that list per harness. The unified manual deploy entry point is `base-sync`, which dispatches the live wrapper profiles (`global` for the dot-dir harnesses, `opencode-global` for opencode).
+3. **chezmoi drives it on `dots sync`** via `run_onchange_after_install-base-profile.sh.tmpl`, which forks to `chezmoi/lib/install-base-profile.sh` and runs `ap install global` (dot-dir harnesses) + `ap install opencode-global` (opencode). The run_onchange hash covers `base`, `global`, `_permissions`, `opencode-global`, all registry inputs, the hook scripts, the shared-asset libs, *and* the `ap` renderer source — so editing a renderer, live wrapper, permission floor, or hook script re-deploys on the next plain `dots sync`.
 
 The standalone `agents/mcp/sync.sh` and `agents/hooks/sync.sh` still exist for the legacy native-CLI path but are **no longer the deploy path** — `dots sync` does not run them.
 

--- a/.hallouminate/wiki/harnesses/opencode.md
+++ b/.hallouminate/wiki/harnesses/opencode.md
@@ -2,7 +2,7 @@
 
 The sst/opencode CLI. Config lives under `~/.config/opencode/`, centred on `opencode.json`. Docs root: [opencode.ai/docs](https://opencode.ai/docs).
 
-Unlike the dot-dir harnesses, opencode writes config at the *target root* (`~/.config/opencode/`), not a `.opencode/` subdir. So chezmoi drives it with a separate `ap install base --target ~/.config/opencode --harness opencode` (not `global` — there's no marketplace/plugin surface to enable). `opencode.json` is seeded once (chezmoi `create_opencode.json`) then the renderer merges only the `mcp` + `permission.bash` keys via Python stdlib `json` (read-modify-write, no jq).
+Unlike the dot-dir harnesses, opencode writes config at the *target root* (`~/.config/opencode/`), not a `.opencode/` subdir. So chezmoi drives it with a dedicated live wrapper profile: `ap install opencode-global --harness opencode`. The installer forwards `HOME`, and the wrapper carries `_permissions` plus `target_default: $HOME/.config/opencode`, so the shipped path lands at `~/.config/opencode/` without passing `--target`. That keeps external `source:` skills on the normal live `npx skills add` path. `opencode.json` is seeded once (chezmoi `create_opencode.json`) then the renderer merges the `mcp` plus full `permission` object via Python stdlib `json` (read-modify-write, no jq).
 
 ## Capabilities, docs, and repo wiring
 
@@ -21,7 +21,7 @@ When the `localLLM` flag is on, `chezmoi/lib/install-local-llm.sh` jq-merges a `
 
 ## Isolated settings
 
-Not available. opencode has no closed-world launch flags; `ap` isolated launches are Claude-only.
+Available through `ap`'s env-based isolated opencode launch. The closed-world config is injected via `OPENCODE_CONFIG_CONTENT`, `OPENCODE_PERMISSION`, and `OPENCODE_DISABLE_PROJECT_CONFIG=true` rather than CLI flags. Caveats: opencode still auto-loads project `AGENTS.md` / `CLAUDE.md`, and there is no ephemeral-session equivalent.
 
 ## Quirks
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ A personal dotfiles repo configuring a vim-centric, terminal-based dev environme
 ### Agent config — edit a registry, then sync
 
 - `mcp-edit` / `hook-edit` / `agent-edit` / `skill-edit` / `plugin-edit` — open the source registry
-- `base-sync` — deploy the registry-derived `base` profile to all harnesses (the unified entry point; per-registry `*-sync` mnemonics retired). `plugin-sync` for Claude marketplace plugins
+- `base-sync` — deploy the live install profiles to all harnesses (the unified entry point; per-registry `*-sync` mnemonics retired). `plugin-sync` for Claude marketplace plugins
 - `mcp-ls` / `hook-ls` / `skill-ls` / `plugin-ls` · `mcp-add <name> <cmd> [args…]`
 - `cc` / `ccc` / `ccr` — launch claude (preamble system-prompt wired) · `ccs` (fzf-jump to a running session) · `ccp <name>` (scoped profile)
 - `ccw <slug>` / `ccw <repo>/<slug>` (cross-repo) / `ccw` (fzf resume picker) · `ccw-ls` / `ccw-rm <slug>` / `ccw-sweep` / `ccw-clean` · `wt-git <path> <cmd>` — worktrees

--- a/agent-profile/tests/test_canonical_permissions.py
+++ b/agent-profile/tests/test_canonical_permissions.py
@@ -104,6 +104,30 @@ def global_manifest():
     return parse_manifest(gdir)
 
 
+@pytest.fixture
+def opencode_global_manifest():
+    """Resolve the real shipped ``opencode-global`` live wrapper."""
+    repo = Path(os.environ.get("DOTFILES_DIR") or Path.home() / "Dev/dotfiles")
+    odir = repo / "profiles" / "opencode-global"
+    if not odir.is_file() and not (odir / "profile.yaml").is_file():
+        pytest.skip(f"opencode-global profile not found at {odir}")
+    return parse_manifest(odir)
+
+
+def test_opencode_global_resolves_canonical_permissions_at_opencode_target(
+    opencode_global_manifest,
+):
+    """``opencode-global`` stays on the live opencode path: target_default
+    resolves to ``$HOME/.config/opencode`` and ``_permissions`` contributes
+    the canonical allow + deny floor."""
+    assert opencode_global_manifest.target_default == "$HOME/.config/opencode"
+    allow = set(opencode_global_manifest.settings.get("permissions_allow", []))
+    deny = set(opencode_global_manifest.settings.get("permissions_deny", []))
+    for rule in ("Bash(git:*)", "Edit"):
+        assert rule in allow
+    for rule in ("Grep", "Read(.env)", "Read(**/.aws/credentials)"):
+        assert rule in deny
+
 def test_global_resolves_canonical_allow_and_deny(global_manifest):
     """``global`` resolves both canonical lists via the ``_permissions``
     include. The deny list carries the cross-harness safety floor plus

--- a/agent-profile/tests/test_canonical_permissions.py
+++ b/agent-profile/tests/test_canonical_permissions.py
@@ -106,11 +106,13 @@ def global_manifest():
 
 def test_global_resolves_canonical_allow_and_deny(global_manifest):
     """``global`` resolves both canonical lists via the ``_permissions``
-    include, with the full deny seed (7 entries) present and sorted."""
+    include. The deny list carries the cross-harness safety floor plus
+    secret-protection rules (keys, credentials) that opencode's defaults
+    don't cover."""
     allow = global_manifest.settings.get("permissions_allow", [])
     deny = global_manifest.settings.get("permissions_deny", [])
-    # The deny seed is small + fixed, so assert it exactly.
-    assert deny == [
+    # Safety floor + code-intel-tool forcing (the original 7 entries).
+    for rule in (
         "Bash(ack:*)",
         "Bash(ag:*)",
         "Bash(grep:*)",
@@ -118,7 +120,17 @@ def test_global_resolves_canonical_allow_and_deny(global_manifest):
         "Bash(sudo:*)",
         "Glob",
         "Grep",
-    ]
+    ):
+        assert rule in deny
+    # Secret-protection deny rules (keys, credentials, cert files).
+    for rule in (
+        "Read(**/*.pem)",
+        "Read(**/id_rsa)",
+        "Read(**/.aws/credentials)",
+        "Read(.env)",
+    ):
+        assert rule in deny
+    assert len(deny) >= 20
     # The allow seed is the ~50-entry migration plus 15 MCP/tool rules; assert
     # the count is in the migrated range rather than mere non-emptiness.
     assert len(allow) >= 50
@@ -157,6 +169,53 @@ def test_global_deny_seed_safety_floor(global_manifest):
     deny = set(global_manifest.settings.get("permissions_deny", []))
     assert "Bash(sudo:*)" in deny
     assert "Bash(rm -rf:*)" in deny
+
+
+def test_global_deny_seed_protects_secrets(global_manifest):
+    """Secret-protection deny rules (private keys, credential stores, cert
+    files) are declared in the canonical _permissions fragment so every
+    harness renderer lowers them onto its native permission surface.
+    opencode denies .env by default, so .env itself is included for
+    cross-harness coverage but .env.* is NOT — adding it would clobber
+    .env.example allows under the renderer's allow-then-deny batching
+    (opencode is last-match-wins; the renderer emits all allow entries
+    before all deny, so a .env.* deny would override an .env.example
+    allow). Claude+Codex also have the PreToolUse hook
+    (agents/lib/sensitive-file-guard.js) as a redundant guard."""
+    deny = set(global_manifest.settings.get("permissions_deny", []))
+    # Private keys + cert files.
+    for rule in (
+        "Read(**/*.pem)",
+        "Read(**/*.key)",
+        "Read(**/*.p12)",
+        "Read(**/*.pfx)",
+        "Read(**/id_rsa)",
+        "Read(**/id_dsa)",
+        "Read(**/id_ecdsa)",
+        "Read(**/id_ed25519)",
+        "Read(**/.ssh/id_*)",
+    ):
+        assert rule in deny, f"{rule} missing from canonical deny list"
+    # Credential stores.
+    for rule in (
+        "Read(**/.aws/credentials)",
+        "Read(**/.netrc)",
+        "Read(**/.npmrc)",
+        "Read(**/.pgpass)",
+        "Read(**/.git-credentials)",
+    ):
+        assert rule in deny, f"{rule} missing from canonical deny list"
+    # Secret files + .env (cross-harness; opencode defaults cover .env too).
+    for rule in (
+        "Read(**/secrets.*)",
+        "Read(**/*.secret)",
+        "Read(.env)",
+        "Read(**/.env)",
+    ):
+        assert rule in deny, f"{rule} missing from canonical deny list"
+    # .env.* is deliberately NOT denied here (see docstring).
+    assert "Read(.env.*)" not in deny
+    assert "Read(**/.env.*)" not in deny
 
 
 def test_sanctioned_tools_not_denied(global_manifest):

--- a/agent-profile/tests/test_canonical_permissions.py
+++ b/agent-profile/tests/test_canonical_permissions.py
@@ -107,9 +107,13 @@ def global_manifest():
 @pytest.fixture
 def opencode_global_manifest():
     """Resolve the real shipped ``opencode-global`` live wrapper."""
-    repo = Path(os.environ.get("DOTFILES_DIR") or Path.home() / "Dev/dotfiles")
+    # Anchor file-relative (parents[2] = repo root) so this guard can't silently
+    # skip on a checkout without DOTFILES_DIR. odir is always a directory, so the
+    # dropped `not odir.is_file()` conjunct was dead; a missing profile.yaml is
+    # the only real miss.
+    repo = Path(__file__).resolve().parents[2]
     odir = repo / "profiles" / "opencode-global"
-    if not odir.is_file() and not (odir / "profile.yaml").is_file():
+    if not (odir / "profile.yaml").is_file():
         pytest.skip(f"opencode-global profile not found at {odir}")
     return parse_manifest(odir)
 

--- a/agent-profile/tests/test_renderer_opencode.py
+++ b/agent-profile/tests/test_renderer_opencode.py
@@ -16,7 +16,10 @@ Python port removes the file in *both* cases, and
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
+
+import pytest
 
 from agent_profile.parse import Manifest
 from agent_profile.renderers.base import Renderer
@@ -162,6 +165,50 @@ def test_permission_translation_render(tmp_path: Path):
     # the untranslated Claude forms never leak through as raw keys
     assert "Bash(cargo:*)" not in perm["bash"]
     assert "Bash(git push origin main)" not in perm["bash"]
+
+
+def test_secret_deny_rules_lower_to_opencode_read(tmp_path: Path):
+    """Secret-protection deny rules (keys, credentials, cert files) lower
+    onto opencode's ``permission.read`` map as deny entries. opencode
+    denies ``.env`` by default, so the canonical deny list carries only
+    the extra surfaces (private keys, credential stores) that opencode's
+    defaults don't cover."""
+    m = Manifest(
+        name="secrets",
+        settings={
+            "permissions_deny": [
+                "Read(**/*.pem)",
+                "Read(**/*.key)",
+                "Read(**/.aws/credentials)",
+                "Read(**/id_rsa)",
+            ],
+        },
+    )
+    OpencodeRenderer().render(m, tmp_path)
+    perm = json.loads((tmp_path / "opencode.json").read_text())["permission"]
+    assert perm["read"]["**/*.pem"] == "deny"
+    assert perm["read"]["**/*.key"] == "deny"
+    assert perm["read"]["**/.aws/credentials"] == "deny"
+    assert perm["read"]["**/id_rsa"] == "deny"
+
+
+def test_opencode_seed_has_no_permission_block():
+    """The chezmoi ``create_opencode.json`` seed must not carry a
+    ``permission`` block — the ap renderer owns permissions, and a seed-side
+    block never propagates (``create_`` writes only when the target is
+    absent). Regression guard for the drift root cause: the live
+    ``opencode.json`` predated the block, so secret-deny rules declared in
+    the seed were silently lost on every ``dots sync``."""
+    repo = Path(os.environ.get("DOTFILES_DIR") or Path.home() / "Dev/dotfiles")
+    seed = repo / "chezmoi" / "dot_config" / "opencode" / "create_opencode.json"
+    if not seed.is_file():
+        pytest.skip(f"opencode seed not found at {seed}")
+    data = json.loads(seed.read_text())
+    assert "permission" not in data, (
+        "create_opencode.json carries a permission block — the renderer owns "
+        "permissions now; a seed-side block never propagates (create_ writes "
+        "only when the target is absent) and silently drifts."
+    )
 
 
 def test_last_match_ordering_allow_before_deny(tmp_path: Path):

--- a/agent-profile/tests/test_renderer_opencode.py
+++ b/agent-profile/tests/test_renderer_opencode.py
@@ -16,7 +16,6 @@ Python port removes the file in *both* cases, and
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
 
 import pytest
@@ -199,10 +198,12 @@ def test_opencode_seed_has_no_permission_block():
     absent). Regression guard for the drift root cause: the live
     ``opencode.json`` predated the block, so secret-deny rules declared in
     the seed were silently lost on every ``dots sync``."""
-    repo = Path(os.environ.get("DOTFILES_DIR") or Path.home() / "Dev/dotfiles")
+    # Anchor the repo from THIS file, not DOTFILES_DIR / ~/Dev/dotfiles + skip:
+    # a hard regression guard must never silently no-op on a fresh clone or an
+    # alternate checkout. parents[2] = repo root from agent-profile/tests/.
+    repo = Path(__file__).resolve().parents[2]
     seed = repo / "chezmoi" / "dot_config" / "opencode" / "create_opencode.json"
-    if not seed.is_file():
-        pytest.skip(f"opencode seed not found at {seed}")
+    assert seed.is_file(), f"opencode seed not found at {seed}"
     data = json.loads(seed.read_text())
     assert "permission" not in data, (
         "create_opencode.json carries a permission block — the renderer owns "

--- a/bin/cheatsheet
+++ b/bin/cheatsheet
@@ -65,7 +65,7 @@ print_cheatsheet() {
     row "wt-git <path>"       "git in a worktree (no cd)"
 
     hdr "MCP / Hooks / Agents"
-    row "base-sync"           "deploy base profile to all harnesses"
+    row "base-sync"           "deploy live install profiles to all harnesses"
     row "mcp"                 "claude mcp"
     row "mcp-ls"              "list MCPs"
     row "mcp-edit"            "edit mcp/registry.yaml"

--- a/chezmoi/.chezmoiscripts/run_onchange_after_install-base-profile.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/run_onchange_after_install-base-profile.sh.tmpl
@@ -1,14 +1,17 @@
 #!/bin/bash
-# run_onchange — re-renders the registry-derived `base` profile (via its
-# `global` wrapper for $HOME-targeted harnesses) into every harness
-# whenever the inputs change. The single deploy path that supersedes the
-# retired install-mcp / install-hooks / install-claude-skills scripts (curd 7).
+# run_onchange — re-renders the registry-derived live install profiles
+# (`global` for the $HOME-targeted dot-dir harnesses, `opencode-global` for
+# opencode) into every harness whenever the inputs change. The single deploy
+# path that supersedes the retired install-mcp / install-hooks /
+# install-claude-skills scripts (curd 7).
 #
 # The hash below is computed by chezmoi at template render time over
 # every input the installer reads:
 #
-#   profiles/base/**       — registry-union directive
-#   profiles/global/**     — operator overlay (target_default, marketplace, enable)
+#   profiles/base/**             — registry-union directive
+#   profiles/global/**           — dot-dir live overlay
+#   profiles/_permissions/**     — canonical live permission floor
+#   profiles/opencode-global/**  — opencode live overlay
 #   agents/mcp/registry.yaml      — MCP source of truth
 #   agents/hooks/registry.yaml    — hook source of truth
 #   agents/hooks/**.sh            — hook script contents (so edits redeploy)
@@ -26,7 +29,7 @@
 # plain sync. Bytecode (*.pyc / __pycache__) is excluded so the hash tracks
 # source edits, not interpreter artifacts.
 #
-# input hash: {{ output "sh" "-c" (printf "find %q/../profiles/base %q/../profiles/global %q/../agents/mcp/registry.yaml %q/../agents/registry.yaml %q/../agents/hooks %q/../agents/plugins %q/../agents/lib %q/../agents/reference %q/../skills %q/../agent-profile/agent_profile -type f -not -name .DS_Store -not -name '*.pyc' -not -path '*/__pycache__/*' -print0 2>/dev/null | LC_ALL=C sort -z | xargs -0 shasum -a 256 2>/dev/null | shasum -a 256 | cut -d' ' -f1" .chezmoi.sourceDir .chezmoi.sourceDir .chezmoi.sourceDir .chezmoi.sourceDir .chezmoi.sourceDir .chezmoi.sourceDir .chezmoi.sourceDir .chezmoi.sourceDir .chezmoi.sourceDir .chezmoi.sourceDir) }}
+# input hash: {{ output "sh" "-c" (printf "find %q/../profiles/base %q/../profiles/global %q/../profiles/_permissions %q/../profiles/opencode-global %q/../agents/mcp/registry.yaml %q/../agents/registry.yaml %q/../agents/hooks %q/../agents/plugins %q/../agents/lib %q/../agents/reference %q/../skills %q/../agent-profile/agent_profile -type f -not -name .DS_Store -not -name '*.pyc' -not -path '*/__pycache__/*' -print0 2>/dev/null | LC_ALL=C sort -z | xargs -0 shasum -a 256 2>/dev/null | shasum -a 256 | cut -d' ' -f1" .chezmoi.sourceDir .chezmoi.sourceDir .chezmoi.sourceDir .chezmoi.sourceDir .chezmoi.sourceDir .chezmoi.sourceDir .chezmoi.sourceDir .chezmoi.sourceDir .chezmoi.sourceDir .chezmoi.sourceDir .chezmoi.sourceDir .chezmoi.sourceDir) }}
 
 set -euo pipefail
 

--- a/chezmoi/dot_config/opencode/create_opencode.json
+++ b/chezmoi/dot_config/opencode/create_opencode.json
@@ -1,39 +1,4 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "formatter": true,
-  "permission": {
-    "read": {
-      "*": "allow",
-      ".env": "deny",
-      ".env.*": "deny",
-      "**/.env": "deny",
-      "**/.env.*": "deny",
-      ".env.example": "allow",
-      ".env.sample": "allow",
-      ".env.template": "allow",
-      ".env.dist": "allow",
-      ".env.defaults": "allow",
-      "**/.env.example": "allow",
-      "**/.env.sample": "allow",
-      "**/.env.template": "allow",
-      "**/.env.dist": "allow",
-      "**/.env.defaults": "allow",
-      "**/*.pem": "deny",
-      "**/*.key": "deny",
-      "**/*.p12": "deny",
-      "**/*.pfx": "deny",
-      "**/id_rsa": "deny",
-      "**/id_dsa": "deny",
-      "**/id_ecdsa": "deny",
-      "**/id_ed25519": "deny",
-      "**/.ssh/id_*": "deny",
-      "**/.aws/credentials": "deny",
-      "**/.netrc": "deny",
-      "**/.npmrc": "deny",
-      "**/.pgpass": "deny",
-      "**/.git-credentials": "deny",
-      "**/secrets.*": "deny",
-      "**/*.secret": "deny"
-    }
-  }
+  "formatter": true
 }

--- a/chezmoi/lib/install-base-profile.sh
+++ b/chezmoi/lib/install-base-profile.sh
@@ -1,18 +1,17 @@
 #!/bin/bash
-# install-base-profile.sh — render `base` (or its `global` wrapper) into
-# every harness via the `ap` (agent-profile) tool.
+# install-base-profile.sh — render the live install profiles into every
+# harness via the `ap` (agent-profile) tool.
 #
 # This is the single deploy path that replaces the retired chezmoi scripts
 # install-mcp / install-hooks / install-claude-skills (spec curd 7, D1). The
 # three separate registries stay the per-type EDIT surface (mcp-edit /
-# hook-edit / skill-edit); `base` unions them, `global` wraps base with the
-# operator-intent fields (target_default=$HOME, claude marketplace + plugin
-# enablement), and `ap` materializes the union for each harness.
+# hook-edit / skill-edit); `base` is still the registry union, while `global`
+# and `opencode-global` are the live wrappers that materialize it for their
+# harness sets.
 #
-# Two render targets handle a path asymmetry: the four dot-dir harnesses
+# Two live wrapper profiles handle a path asymmetry: the four dot-dir harnesses
 # (claude/codex/cursor/copilot) write under dot-dirs at $HOME, while opencode's
-# renderer writes opencode.json at the target ROOT, so it targets
-# $HOME/.config/opencode.
+# renderer writes opencode.json at the target ROOT (`$HOME/.config/opencode`).
 #
 # For the dot-dir harnesses we install the `global` profile so its
 # target_default + claude.marketplace + claude.enabled_plugins land — that
@@ -20,8 +19,10 @@
 # SessionStart hook (cheese-flair) and bundled MCPs/skills become live.
 # `--target` is intentionally omitted; the profile resolves $HOME itself.
 #
-# opencode has no plugin-enablement surface — `base` is sufficient there,
-# and its target stays explicit ($HOME/.config/opencode is not $HOME).
+# For opencode we install `opencode-global`: no plugin/marketplace surface, but
+# the wrapper still carries `_permissions` plus `target_default:
+# $HOME/.config/opencode`. Omitting `--target` keeps opencode on the live
+# install path, so external `source:` skills still fetch via `npx skills add`.
 #
 # Usage:
 #   install-base-profile.sh <target_home>
@@ -51,8 +52,9 @@ fi
 HOME="$target" "$ap_bin" install global \
     --harness claude,codex,cursor,copilot
 
-# opencode writes opencode.json at the target root → its own target dir.
-# Uses `base` directly: opencode has no plugin/marketplace surface to
-# enable, and its target is not $HOME so target_default doesn't apply.
-"$ap_bin" install base --target "$target/.config/opencode" \
+# opencode writes opencode.json at the target root, so its live wrapper targets
+# $HOME/.config/opencode instead of $HOME. HOME is forwarded for the same
+# reason as the dot-dir harnesses: target_default must resolve against the
+# caller's target argument when it differs from the process HOME.
+HOME="$target" "$ap_bin" install opencode-global \
     --harness opencode

--- a/profiles/_permissions/profile.yaml
+++ b/profiles/_permissions/profile.yaml
@@ -100,3 +100,29 @@ settings:
     - Bash(ack:*)
     - Bash(sudo:*)
     - Bash(rm -rf:*)
+    # Secret-protection floor (cross-harness). opencode denies .env by
+    # default (https://opencode.ai/docs/permissions), so .env itself is
+    # included for the other harnesses but .env.* is NOT — adding it would
+    # clobber .env.example allows under the renderer's allow-then-deny
+    # batching (opencode is last-match-wins; the renderer emits all allow
+    # entries before all deny, so a .env.* deny would override an
+    # .env.example allow). Claude+Codex also have the PreToolUse hook
+    # (agents/lib/sensitive-file-guard.js) as a redundant guard.
+    - Read(.env)
+    - Read(**/.env)
+    - Read(**/*.pem)
+    - Read(**/*.key)
+    - Read(**/*.p12)
+    - Read(**/*.pfx)
+    - Read(**/id_rsa)
+    - Read(**/id_dsa)
+    - Read(**/id_ecdsa)
+    - Read(**/id_ed25519)
+    - Read(**/.ssh/id_*)
+    - Read(**/.aws/credentials)
+    - Read(**/.netrc)
+    - Read(**/.npmrc)
+    - Read(**/.pgpass)
+    - Read(**/.git-credentials)
+    - Read(**/secrets.*)
+    - Read(**/*.secret)

--- a/profiles/_permissions/profile.yaml
+++ b/profiles/_permissions/profile.yaml
@@ -7,10 +7,10 @@
 # `mcp__*` is lever 3 (MCP-tool scoping); everything else is lever 1
 # (per-command/tool). So this is one flat list per allow/deny.
 #
-# Edit here, then `dots sync` (runs `ap install global`) re-asserts the set
-# onto every harness. This fragment is pulled in at the `global` layer only
-# (PoC); isolated profiles (review) do NOT include it and keep their own
-# closed-world deny lists.
+# Edit here, then `dots sync` (runs `ap install global` +
+# `ap install opencode-global`) re-asserts the set onto every live harness.
+# The live wrappers include this fragment; isolated profiles (review) do NOT
+# and keep their own closed-world deny lists.
 #
 # `global` sets `mcp_scope: user`, so MCPs register with bare names
 # (`mcp__<server>__*`). The lever-3 rules below therefore use bare names.

--- a/profiles/global/profile.yaml
+++ b/profiles/global/profile.yaml
@@ -18,9 +18,9 @@
 name: global
 description: Live install — renders base into $HOME and wires it into Claude
 # _permissions carries the canonical cross-harness allow/deny lists; the
-# renderers lower them onto each harness's native surface. PoC scope: wired
-# in at `global` only (the live-machine install). A base+global combo is a
-# deliberate later step.
+# renderers lower them onto each harness's native surface. The live wrappers
+# (`global` here, `opencode-global` for opencode) both include it; this profile
+# is still the Claude-specific live overlay.
 include: [base, _permissions]
 
 # `--target` precedence in ap is: explicit flag > profile target_default >

--- a/profiles/opencode-global/profile.yaml
+++ b/profiles/opencode-global/profile.yaml
@@ -1,0 +1,15 @@
+# opencode-global — the live install wrapper for opencode.
+#
+# opencode shares `base`'s registry-derived union, but unlike the dot-dir
+# harnesses it writes config at the target root (`~/.config/opencode`). This
+# wrapper keeps the install on the live path without passing `--target`, so
+# `_permissions` still lowers onto opencode and external `source:` skills still
+# fetch via `npx skills add`.
+name: opencode-global
+description: Live install — renders base into $HOME/.config/opencode with _permissions
+include: [base, _permissions]
+
+# `--target` precedence in ap is: explicit flag > profile target_default >
+# Path.cwd(). The installer forwards HOME explicitly, so this resolves against
+# the caller's target home during `dots sync`.
+target_default: $HOME/.config/opencode

--- a/tests/cheatsheet.bats
+++ b/tests/cheatsheet.bats
@@ -56,12 +56,18 @@ documented_tokens() {
     assert_section "MCP / Hooks / Agents"
 }
 
+@test "documents base-sync as the live-wrapper deploy entry point" {
+    run cheatsheet
+    local clean
+    clean=$(strip_ansi "$output")
+    grep -Eq 'base-sync[[:space:]]+deploy live install profiles to all harnesses' <<<"$clean"
+}
+
 @test "points at tmux-cheatsheet for tmux keys" {
     run cheatsheet
     assert_section "tmux-cheatsheet"
     assert_section "Ctrl+Space"
 }
-
 @test "drift: every zsh alias/function is documented (minus internals + tmux sheet)" {
     # Match against the row token set (not free text) so a future alias whose
     # name happens to appear in a description can't pass vacuously.

--- a/tests/chezmoi-wiring.bats
+++ b/tests/chezmoi-wiring.bats
@@ -459,13 +459,16 @@ EOF
 }
 
 @test "chezmoi/run_onchange template hashes the registries + skills tree it renders from" {
-    # The base profile unions the three registries + the local skills tree
-    # AND the global profile wraps base with operator-overlay fields;
-    # the hash must cover all of them so a registry/skill/profile/hook-script
-    # edit retriggers the render.
+    # The base profile unions the registries + local skills tree; the live
+    # wrappers (`global`, `opencode-global`) plus `_permissions` add the
+    # machine-targeted overlay and canonical permission floor. The hash must
+    # cover all of them so a registry/skill/profile/hook-script edit retriggers
+    # the render.
     grep -qF '/../skills ' "$INSTALLER_TMPL"
     grep -qF '/../profiles/base' "$INSTALLER_TMPL"
     grep -qF '/../profiles/global' "$INSTALLER_TMPL"
+    grep -qF '/../profiles/_permissions' "$INSTALLER_TMPL"
+    grep -qF '/../profiles/opencode-global' "$INSTALLER_TMPL"
     grep -qF '/../agents/mcp/registry.yaml' "$INSTALLER_TMPL"
     # `agents/hooks` covers the registry AND its referenced scripts —
     # without script-content coverage, edits to a hook payload (e.g. the

--- a/tests/config-validation.bats
+++ b/tests/config-validation.bats
@@ -101,16 +101,21 @@ DOTFILES_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME}")/.." && pwd)"
     [[ -f "$DOTFILES_DIR/skills/_registry.yaml" ]]
 }
 
-@test "base-sync pins --target \$HOME and mirrors the two-target render (curd 7 alias --target fix)" {
+@test "base-sync dispatches the live wrapper profiles (curd 7 manual deploy parity)" {
     local claude_file="$DOTFILES_DIR/zsh/claude.zsh"
-    # High age finding: a bare `dots profile install base` defaults --target to
-    # \$PWD, silently deploying to the cwd. The deploy verb must pin \$HOME and
-    # mirror install-base-profile.sh's two-target asymmetry.
-    # shellcheck disable=SC2016  # match the literal $HOME in the alias body, not expand it
-    grep -qE 'dots profile install base --target "\$HOME"' "$claude_file"
-    # shellcheck disable=SC2016
-    grep -qE 'dots profile install base --target "\$HOME/\.config/opencode"' "$claude_file"
-    grep -qE -- '--harness opencode' "$claude_file"
+    command -v zsh &>/dev/null || skip "zsh not installed"
+    local harness="$BATS_TEST_TMPDIR/base-sync.zsh"
+    cat > "$harness" <<EOF
+#!/usr/bin/env zsh
+dots() { print -r -- "\$@"; }
+$(sed -n '/^base-sync()/,/^}/p' "$claude_file")
+base-sync
+EOF
+    run zsh "$harness"
+    [[ $status -eq 0 ]]
+    [[ "$output" == *"profile install global --harness claude,codex,cursor,copilot"* ]]
+    [[ "$output" == *"profile install opencode-global --harness opencode"* ]]
+    [[ "$output" != *"--target"* ]]
 }
 
 @test "the redundant *-sync mnemonics are retired (base-sync is the sole entry point)" {

--- a/tests/install-base-profile.bats
+++ b/tests/install-base-profile.bats
@@ -1,9 +1,9 @@
 #!/usr/bin/env bats
 # shellcheck disable=SC1090,SC2034,SC2317
-# Tests for chezmoi/lib/install-base-profile.sh — renders the registry-derived
-# `base` profile into every harness via the `ap` tool. Replaces the deploy
-# roles of the retired install-mcp / install-hooks / install-claude-skills
-# chezmoi scripts (spec curd 7).
+# Tests for chezmoi/lib/install-base-profile.sh — renders the live install
+# profiles into every harness via the `ap` tool. Replaces the deploy roles of
+# the retired install-mcp / install-hooks / install-claude-skills chezmoi
+# scripts (spec curd 7).
 
 load test_helper
 
@@ -16,7 +16,7 @@ setup() {
     AP_LOG="$TEST_HOME/ap-calls.log"
     cat > "$FAKE_BIN/ap" <<SH
 #!/usr/bin/env bash
-echo "\$*" >> "$AP_LOG"
+echo "HOME=$HOME \$*" >> "$AP_LOG"
 exit 0
 SH
     chmod +x "$FAKE_BIN/ap"
@@ -54,12 +54,13 @@ teardown() { teardown_test_env; }
     assert_output_contains "install global --harness claude,codex,cursor,copilot"
 }
 
-@test "install-base-profile.sh renders opencode under \$HOME/.config/opencode" {
+@test "install-base-profile.sh renders opencode under \$HOME/.config/opencode via opencode-global" {
     INSTALL_BASE_PROFILE_AP="$FAKE_BIN/ap" \
         run bash "$LIB" "$TEST_HOME"
     assert_success
     run cat "$AP_LOG"
-    assert_output_contains "install base --target $TEST_HOME/.config/opencode --harness opencode"
+    assert_output_contains "HOME=$TEST_HOME install opencode-global --harness opencode"
+    ! grep -qF -- '--target' "$AP_LOG"
 }
 
 @test "install-base-profile.sh makes exactly two ap calls" {

--- a/zsh/claude.zsh
+++ b/zsh/claude.zsh
@@ -160,16 +160,15 @@ copilot() {
 CLAUDE_DOTFILES="$DOTFILES_DIR/claude"
 AGENTS_DOTFILES="$DOTFILES_DIR/agents"
 
-# Deploy the registry-derived `base` profile via `ap`. Mirrors
-# chezmoi/lib/install-base-profile.sh's two-target asymmetry: the dot-dir
-# harnesses (claude/codex/cursor/copilot) render under $HOME, while opencode
-# writes opencode.json at the target root, so it targets $HOME/.config/opencode.
-# A bare `dots profile install base` defaults --target to $PWD (the cwd trap),
-# so the deploy verb must pin $HOME.
+# Deploy the live install profiles via `ap`. Mirrors
+# chezmoi/lib/install-base-profile.sh's two-wrapper asymmetry: the dot-dir
+# harnesses (claude/codex/cursor/copilot) use `global`, while opencode uses
+# `opencode-global`. Both wrappers own their target_default, so the deploy verb
+# intentionally omits `--target` and stays on the live install path.
 base-sync() {
-    dots profile install base --target "$HOME" \
+    dots profile install global \
         --harness claude,codex,cursor,copilot \
-        && dots profile install base --target "$HOME/.config/opencode" \
+        && dots profile install opencode-global \
         --harness opencode
 }
 alias mcp='claude mcp'


### PR DESCRIPTION
## Summary

Move 18 secret-protection `Read(...)` deny rules (private keys, credential stores, cert files, `.env`) from the stranded chezmoi `create_opencode.json` seed into the canonical `profiles/_permissions/profile.yaml` `permissions_deny` channel, so the opencode renderer lowers them into `~/.config/opencode/opencode.json` on every `dots sync`. Strip the now-redundant `permission` block from the seed.

## Root cause

The `create_` prefix means chezmoi writes the seed only when the target is absent. The live `opencode.json` predated the permission block's addition, so the secret-deny rules declared in the seed never propagated to the live config — they were declared in no profile, only in the seed.

The `ap` renderer only writes `permission.<key>` from a profile's `permissions_allow`/`permissions_deny` channels. Moving the rules into the canonical `_permissions` fragment means they now lower on every `dots sync`.

## Design decision: `.env.*` exclusion

opencode is **last-match-wins** and the renderer batches all allow entries before all deny (`opencode.py:211-212`). Adding `Read(.env.*)` to deny would clobber `Read(.env.example)` allows under last-match-wins. So:
- `.env` and `**/.env` are denied (exact, no catch-all issue)
- `.env.*` is **not** denied — opencode's built-in defaults handle it (deny `.env.*`, allow `.env.example`)
- For Claude/Codex, the PreToolUse hook (`agents/lib/sensitive-file-guard.js`) covers `.env.*` as a redundant guard
- All key/credential/secret deny rules are deny-only (no allow overrides needed) — no ordering issue

## Test coverage

| Behavior | Test |
|---|---|
| 18 deny rules declared in canonical fragment | `test_global_deny_seed_protects_secrets` |
| Seed has no `permission` block (regression guard) | `test_opencode_seed_has_no_permission_block` (press-added) |
| Deny rules lower to `permission.read` map | `test_secret_deny_rules_lower_to_opencode_read` |
| `.env.*` deliberately excluded | `test_global_deny_seed_protects_secrets` negative assertions |

`test_global_resolves_canonical_allow_and_deny` updated from exact-list to set-based membership (less brittle as the deny list grows).

## Checks

- `uv run pytest` — 725 passed (+1 from baseline: the press-added seed guard)
- `bats tests/mcp-opencode.bats tests/chezmoi-wiring.bats` — 71 passed
- Hermetic red verification: temp seed with a `permission` block → new guard fails with the root-cause message

## Follow-ups (review-safe, out of scope)

- Wiki `harnesses/opencode.md` says the renderer "merges only the `mcp` + `permission.bash` keys" — predates the `permissions_deny` channel. Pre-existing stale doc; address via `/wiki-curator`.
- `.env.local` / `.env.production` on Cursor/Copilot: no config-level deny, no hook. Needs a harness-specific allow-override mechanism; bigger design change.