### PR TITLE
[codex] fix ap harness drift cleanup

### DIFF
--- a/.hallouminate/wiki/architecture/config-drift.md
+++ b/.hallouminate/wiki/architecture/config-drift.md
@@ -157,39 +157,19 @@ was never a real gap — the wiki note "milknado is missing from the copilot
 template" was only relevant during the brief window between #274 and 8b829c0
 when it was a registry MCP.
 
-## Known drift pattern: `harnesses: []` MCPs not pruned by reconcile
+## Known drift pattern: MCPs no longer projected to a harness
 
-**Symptom**: An MCP that had harnesses narrowed to `harnesses: []` (scoped out
-of all harnesses) remains in all merged-file targets — `~/.codex/config.toml`,
-`~/.config/opencode/opencode.json`, `~/.cursor/mcp.json` — and in claude's
-user-scope registrations (`~/.claude.json`) indefinitely. `dots sync` does not
-remove any of them.
+**Symptom**: An MCP remains in a merged-file target even after the current render no longer projects it to that harness — for example a Copilot `mcp-config.json` entry for `tilth`, `context7`, `tavily`, `code-review-graph`, or `serena` after Copilot narrowed to explicit `harnesses: [copilot]` entries.[^copilot-stale-mcp]
 
-**Why it happens**: `cli.py:_reconcile_dropped_mcps` computes:
+**Why it happens**: merged files are read-modify-write surfaces. A current render writes/updates entries that still project to the harness, but a stale entry can persist when the old source was historical template drift or when prior manifest ownership did not prove that the harness once received the MCP.
 
-```python
-current_names = {m.get("name") for m in manifest.mcps}
-```
+**Fix**: `_reconcile_dropped_mcps` handles normal registry drops and `harnesses: []` changes by diffing per-harness projections, not the global `manifest.mcps` set.[^reconcile-projection] Copilot additionally prunes same-name registry MCPs that are present in `.copilot/mcp-config.json` but no longer project to Copilot during `_write_mcp`, preserving unrelated user MCPs.[^copilot-prune-nonprojected]
 
-`manifest.mcps` is the full resolved profile list — an MCP with `harnesses: []`
-is still present there (it's in the registry / profile, just filtered to zero
-harnesses at render time). So the MCP name is in `current_names`, never appears
-in `dropped`, and `prune_mcps` is never called. The stale entry in the merged
-file is invisible to the reconcile.
+**Detection**: Compare the live merged file's server names against the current renderer projection. Same-name registry entries that are live-only are stale; unrelated names are expected-local.
 
-**Repro**: Add MCP to registry with `harnesses: [cursor]` → `dots sync` (cursor
-gets it) → change to `harnesses: []` → `dots sync` → cursor entry NOT removed.
-
-**Workaround**: Manually remove the stale entry per target — edit the file
-directly for `~/.codex/config.toml`, `~/.config/opencode/opencode.json`, and
-`~/.cursor/mcp.json`; run `claude mcp remove <name>` for `~/.claude.json`
-(user-scope registrations). All are safe — `dots sync` won't re-add them (the
-render produces zero harness targets for the MCP).
-
-**Proper fix**: `_reconcile_dropped_mcps` should compute `current_names`
-per-harness, using only the harness-filtered MCP projection (the same filtering
-`_cursor_mcps` / `_opencode_mcps` apply at render time) rather than the full
-`manifest.mcps` set. See [#265](https://github.com/paulnsorensen/dotfiles/issues/265).
+[^copilot-stale-mcp]: harness-doctor run on 2026-06-24 found Copilot live-only `code-review-graph`, `context7`, `serena`, `tavily`, and `tilth` while the current render produced only `hallouminate` and `milknado`.
+[^reconcile-projection]: agent-profile/agent_profile/cli.py:418-473; agent-profile/tests/test_mcp_reconcile.py:test_mcp_scoped_to_no_harnesses_is_pruned
+[^copilot-prune-nonprojected]: agent-profile/agent_profile/renderers/copilot.py:263-312; agent-profile/tests/test_renderer_copilot.py:test_mcp_prunes_registry_servers_no_longer_projected_to_copilot
 
 ## Known drift pattern: settings.json hook-runner command references non-existent JS file
 
@@ -269,6 +249,21 @@ first `ap install global` run.
 **Fix**: Add `manifest.json` to `agent-profile/.gitignore`. This was added in
 2026-06-11. If the file reappears as untracked, verify the `.gitignore` entry
 is present.
+
+## Known drift pattern: staged `global` installs can mutate live Claude user MCP config
+
+**Symptom**: `ap install global --target /tmp/...` used to look like a safe throwaway render, but still invoked `claude mcp remove/add --scope user` and rewrote `~/.claude.json` when `global` carried `mcp_scope: user`.[^staged-global-mcp]
+
+**Why it happens**: `global` deliberately sets `mcp_scope: user` so live Claude MCP tools keep bare `mcp__<server>__*` names instead of plugin-namespaced names.[^global-mcp-scope] The Claude renderer implements that by registering user-scope MCPs via the Claude CLI and returning without writing plugin `.mcp.json`.[^claude-user-scope-render]
+
+**Fix**: Explicit-target installs are now treated as staging for `mcp_scope: user`: `cmd_install` renders with `mcp_scope: plugin`, records that staged manifest shape, and never calls the Claude CLI. Live installs without `--target` keep user-scope registration.[^staged-global-fix]
+
+**Detection**: During harness-doctor, rendering `global` into `/tmp` is safe after the fix; before that fix, render `base` for comparison.
+
+[^staged-global-mcp]: harness-doctor run on 2026-06-24; `ap install global --target /tmp/harness-doctor-global.nH8lCY` modified `/home/paul/.claude.json` for tilth, context7, tavily, code-review-graph, serena, and hallouminate.
+[^global-mcp-scope]: profiles/global/profile.yaml:65-76
+[^claude-user-scope-render]: agent-profile/agent_profile/renderers/claude.py:488-495,517-538
+[^staged-global-fix]: agent-profile/agent_profile/cli.py:272-307; agent-profile/tests/test_mcp_reconcile.py:test_explicit_target_user_scope_stages_plugin_mcp_without_claude_cli
 
 ## Gotcha: index drift is its own drift class
 

--- a/agent-profile/agent_profile/cli.py
+++ b/agent-profile/agent_profile/cli.py
@@ -269,7 +269,10 @@ def cmd_install(
     print(f"  target:   {target}", file=out)
     print(f"  harness:  {' '.join(harnesses)}", file=out)
 
-    merged_dict = manifest.to_dict()
+    render_manifest = manifest
+    if target_opt is not None and manifest.mcp_scope == "user":
+        render_manifest = replace(manifest, mcp_scope="plugin")
+    merged_dict = render_manifest.to_dict()
 
     manifest_mod.manifest_init(target)
     # Snapshot the prior resolved manifest BEFORE the render loop overwrites
@@ -286,7 +289,7 @@ def cmd_install(
                 f"{colors.RED}ap: no renderer registered for harness "
                 f"'{h}'{colors.NC}"
             )
-        written = renderer.render(manifest, target)
+        written = renderer.render(render_manifest, target)
         all_new_files.extend(written)
 
     _fetch_external_skills(manifest, harnesses, colors, out, live=target_opt is None)
@@ -300,8 +303,8 @@ def cmd_install(
         manifest_mod.diff_and_clean(target, name, new_files, harnesses)
         _union_files(target, name, new_files, harnesses)
 
-    _reconcile_dropped_mcps(prior_merged, manifest, harnesses, target, out, colors)
-    _reconcile_dropped_mcp_tool_scopes(prior_merged, manifest, harnesses, target)
+    _reconcile_dropped_mcps(prior_merged, render_manifest, harnesses, target, out, colors)
+    _reconcile_dropped_mcp_tool_scopes(prior_merged, render_manifest, harnesses, target)
 
     manifest_mod.record_merged_json(target, name, merged_dict)
 

--- a/agent-profile/agent_profile/renderers/copilot.py
+++ b/agent-profile/agent_profile/renderers/copilot.py
@@ -262,18 +262,32 @@ class CopilotRenderer:
 
     def _write_mcp(self, manifest: Manifest, base: Path) -> None:
         mcps = mcps_for(manifest, "copilot", _COPILOT_MCP_DEFAULT)
-        if not mcps:
-            return
-
         out = base / ".copilot" / "mcp-config.json"
-        out.parent.mkdir(parents=True, exist_ok=True)
-
-        data: dict[str, Any]
         if out.is_file():
             data = read_json_object(out, ".copilot/mcp-config.json")
+        elif not mcps:
+            return
         else:
             data = {"mcpServers": {}}
         servers = data.setdefault("mcpServers", {})
+
+        current_names = {mcp["name"] for mcp in mcps}
+        registry_names = {mcp.get("name") for mcp in manifest.mcps}
+        for name in registry_names - current_names:
+            servers.pop(name, None)
+
+        if not mcps:
+            if servers:
+                data["mcpServers"] = servers
+            else:
+                data.pop("mcpServers", None)
+            if data == {}:
+                out.unlink()
+            else:
+                out.write_text(_dumps(data))
+            return
+
+        out.parent.mkdir(parents=True, exist_ok=True)
 
         # Lever 3: each server's `tools` array is derived from the canonical
         # allow list. `mcp__<server>__*` (or no canonical rule for the

--- a/agent-profile/tests/test_mcp_reconcile.py
+++ b/agent-profile/tests/test_mcp_reconcile.py
@@ -137,10 +137,16 @@ def test_claude_prune_unregisters_user_scope(monkeypatch, tmp_path):
     assert removes, f"expected a `claude mcp remove gone`, got {calls}"
 
 
-def _yaml_claude_user(name: str, mcp_names: list[str]) -> str:
+def _yaml_claude_user(
+    name: str, mcp_names: list[str], target_default: str | None = None
+) -> str:
     lines = [
         f"name: {name}",
         "description: reconcile probe",
+    ]
+    if target_default is not None:
+        lines.append(f"target_default: {target_default}")
+    lines += [
         "mcp_scope: user",
         "mcps:",
     ]
@@ -176,14 +182,22 @@ def test_dropped_mcp_unregistered_from_claude_user_scope(
     monkeypatch.setattr(cl.shutil, "which", lambda _: "/usr/bin/claude")
     monkeypatch.setattr(cl.subprocess, "run", fake_run)
 
-    write_profile(env.profiles, "g", _yaml_claude_user("g", ["srv1", "srv2"]))
-    assert _install(env, "g") == 0
+    write_profile(
+        env.profiles,
+        "g",
+        _yaml_claude_user("g", ["srv1", "srv2"], str(env.target)),
+    )
+    assert cli.main(["install", "g"]) == 0
     capsys.readouterr()
     calls.clear()  # discard first-install register churn
 
     # Re-install with srv2 dropped from the registry.
-    write_profile(env.profiles, "g", _yaml_claude_user("g", ["srv1"]))
-    assert _install(env, "g") == 0
+    write_profile(
+        env.profiles,
+        "g",
+        _yaml_claude_user("g", ["srv1"], str(env.target)),
+    )
+    assert cli.main(["install", "g"]) == 0
     capsys.readouterr()
 
     # Reconcile must `claude mcp remove srv2` and never re-add it.
@@ -198,6 +212,22 @@ def test_dropped_mcp_unregistered_from_claude_user_scope(
         c for c in calls if "add" in c and "srv1" in c
     ], f"survivor srv1 must stay registered, got {calls}"
 
+
+def test_explicit_target_user_scope_stages_plugin_mcp_without_claude_cli(
+    env, capsys, monkeypatch, prod_renderers
+):
+    def boom(*a, **k):
+        raise AssertionError("explicit-target render must not call claude CLI")
+
+    monkeypatch.setattr(cl.shutil, "which", boom)
+    monkeypatch.setattr(cl.subprocess, "run", boom)
+
+    write_profile(env.profiles, "g", _yaml_claude_user("g", ["srv1"]))
+    assert _install(env, "g") == 0
+    capsys.readouterr()
+
+    staged = env.target / ".claude/plugins/local/g/.mcp.json"
+    assert json.loads(staged.read_text())["mcpServers"]["srv1"]["command"] == "/bin/true"
 
 def test_claude_prune_noop_for_plugin_scope(monkeypatch, tmp_path):
     def boom(*a, **k):  # would raise if the CLI were touched

--- a/agent-profile/tests/test_renderer_copilot.py
+++ b/agent-profile/tests/test_renderer_copilot.py
@@ -238,6 +238,36 @@ def test_mcp_merges_into_existing_user_file(target, src):
     assert set(parsed["mcpServers"]) == {"user-mcp", "foo"}
 
 
+
+def test_mcp_prunes_registry_servers_no_longer_projected_to_copilot(target, src):
+    cfg = target / ".copilot" / "mcp-config.json"
+    cfg.parent.mkdir(parents=True)
+    cfg.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "tilth": {"command": "old"},
+                    "user-mcp": {"command": "custom"},
+                }
+            }
+        )
+        + "\n"
+    )
+    m = manifest(
+        src,
+        mcps=[
+            {"name": "tilth", "command": "tilth"},
+            {"name": "hallouminate", "command": "hallouminate", "harnesses": ["copilot"]},
+        ],
+    )
+
+    renderer().render(m, target)
+
+    servers = json.loads(cfg.read_text())["mcpServers"]
+    assert "tilth" not in servers
+    assert servers["user-mcp"] == {"command": "custom"}
+    assert servers["hallouminate"]["command"] == "hallouminate"
+
 # ─── hooks ─────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## What changed
- Treat explicit-target `ap install ... --target <dir>` as staging for Claude `mcp_scope: user` profiles by rendering plugin-scoped `.mcp.json` instead of invoking the Claude CLI.
- Keep live no-`--target` installs on the existing user-scope Claude MCP registration path.
- Prune same-name registry MCPs from Copilot when they no longer project to Copilot, while preserving unrelated user MCPs.
- Update the config-drift wiki with the fixed behavior and drift detection notes.

## Why
`/harness-doctor` found two drift cases:
- A staged `global` render could mutate live `~/.claude.json`.
- Copilot retained stale registry MCPs (`tilth`, `context7`, `tavily`, `code-review-graph`, `serena`) after the current render narrowed Copilot to explicit MCPs.

## Validation
- `uv run --project agent-profile pytest agent-profile/tests/test_mcp_reconcile.py::test_explicit_target_user_scope_stages_plugin_mcp_without_claude_cli agent-profile/tests/test_mcp_reconcile.py::test_dropped_mcp_unregistered_from_claude_user_scope agent-profile/tests/test_renderer_copilot.py::test_mcp_prunes_registry_servers_no_longer_projected_to_copilot`
- `uv run --project agent-profile pytest agent-profile/tests/test_mcp_reconcile.py agent-profile/tests/test_renderer_copilot.py`
- `uv run --project agent-profile pytest agent-profile/tests`
- pre-commit hooks during `git commit`
