### PR TITLE
feat(ap): unified native: plugin field + Copilot native path

### DIFF
--- a/.hallouminate/wiki/architecture/cross-harness-plugins.md
+++ b/.hallouminate/wiki/architecture/cross-harness-plugins.md
@@ -122,8 +122,8 @@ plugins:
     path: ~/Dev/myplugin               # local checkout marketplace root
 
     harnesses: [claude, codex, opencode, cursor, copilot, crush]
-    claude_native: true   # Claude gets native marketplace install
-    codex_native: true    # Codex gets native marketplace install (codex CLI)
+    native: true              # native install on every drivable harness here
+                              # ({claude, codex, copilot}); or false / [list]
     gate_unless: MY_ENV_VAR   # optional gate
     description: Human-readable description
 ```
@@ -144,28 +144,62 @@ harnesses that support that primitive. See [[architecture/mcp-secret-handling]]
 for the token-cost tradeoff and [[architecture/agent-profile]] for how harnesses
 membership flows.
 
-**`claude_native` / `codex_native`** — two **independent** native-install flags.
-When either is `true`, the decomposer emits a single `native_plugins` record
-carrying *both* booleans (`claude_native`, `codex_native`) plus the marketplace
-root/name; each renderer consumes only its own flag.
+**`native:`** — the unified native-install field. Resolves (via
+`resolved_native_harnesses` in `ingest.py`) to the set of harnesses that get the
+native marketplace install instead of decomposed primitives:
 
-- `claude_native: true` → the claude renderer registers the plugin's
-  marketplace and enables it. DEDUP removes `claude` from decomposed MCP,
-  skill, agent, and hook harnesses; skills/agents also carry
-  `_from_native_plugin=True` so claude renderers skip any native-served item.
-- `codex_native: true` → the codex renderer installs the plugin via the codex
-  CLI (`codex plugin marketplace add` + `codex plugin add`). DEDUP removes
-  `codex` from decomposed MCP, skill, agent, and hook harnesses; skills/agents
-  carry a **separate** `_from_codex_native_plugin=True` so the codex renderer
-  skips them. The flag is deliberately separate from `_from_native_plugin` —
-  reusing claude's flag would make the claude renderer wrongly skip a
-  codex-only-native plugin's skills or agents.
+- `true` → every **drivable** harness in this entry's `harnesses`. `DRIVABLE = {claude, codex, copilot}` — the three harnesses with a CLI-drivable local install. opencode/cursor/crush are never native (no drivable install; ruled out by cited mechanism in [[harnesses/index]]).
+- `false` / absent → decomposed everywhere (default).
+- `[claude, ...]` → only the listed harnesses. Validated **fail-loud**: a member that is not in `DRIVABLE`, or not in this entry's `harnesses`, raises `ParseError` (a silent no-op is the failure this guards).
 
-When both are `false` (or omitted), every harness receives decomposed primitives.
-That is the right choice when a plugin's marketplace.json is absent or the plugin
-is not ready for native install (e.g. hallouminate, where the well-known
-`mcp__hallouminate__*` namespace must be preserved — a native install would
-rescope it to `mcp__plugin_hallouminate_hallouminate__*`).
+Legacy `claude_native` / `codex_native` booleans still parse — each `true` OR's
+its harness into the resolved set.
+
+The decomposer emits one `native_plugins` record per entry with a non-empty set,
+carrying `claude_native` / `codex_native` / `copilot_native` (derived from the
+set), the MCP `servers` list, and the marketplace root/name. **Each renderer
+consumes only its own flag** — a `native: [copilot]` plugin is installed by the
+copilot renderer alone; the claude/codex native passes filter it out.
+
+For every harness `h` in the set: DEDUP removes `h` from the decomposed MCP /
+skill / agent / hook harness lists, and skills/agents are stamped with a
+**per-harness** marker — `_from_native_plugin` (claude), `_from_codex_native_plugin`
+(codex), `_from_copilot_native_plugin` (copilot) — so each harness's renderer skips
+exactly its own native-served items. The markers are independent on purpose:
+reusing claude's flag would make the claude renderer wrongly skip a
+copilot-only-native plugin's skills/agents.
+
+Native install (per drivable harness):
+
+- **claude** → registers the marketplace + enables the plugin in `settings.json`, primes via `claude plugin marketplace add`.
+- **codex** → `codex plugin marketplace add` + `codex plugin add` (CLI-driven).
+- **copilot** → `copilot plugin marketplace add` + `copilot plugin install` (CLI-driven, tolerant of re-runs). NOT a settings-write: declarative `enabledPlugins` doesn't auto-install (upstream `copilot-cli#2249`) and the `directory` marketplace-source shape is unconfirmed.
+
+### Native re-namespacing + the renderer-side rewrite (Phase 4)
+
+A native install re-namespaces the plugin's MCP tools to
+`mcp__plugin_<plugin>_<server>__*` **on the native harness only**. Decomposed
+harnesses keep the bare `mcp__<server>__*` (claude/cursor grammar) or the lowered
+`<server>_<tool>` / `mcp_<server>_<tool>` (opencode/crush). So the canonical
+permission/skill references cannot be a single literal.
+
+Resolution (**design A — renderer-side rewrite, canonical source untouched**):
+`permissions.native_mcp_server_plugins(native_plugins, harness)` builds a
+`server → plugin` map for plugins native on that harness, and
+`rewrite_native_mcp_rules` rewrites `mcp__<server>__*` → `mcp__plugin_<plugin>_<server>__*`
+before each renderer lowers it (claude `_merge_root_settings`, copilot
+`launch_flags`). It is a **no-op on decomposed harnesses** (empty map).
+`rewrite_skill_allowed_tools` does the same for a skill's `allowed-tools`
+frontmatter, but **only in the claude renderer's own `.claude/skills/` copy** —
+`allowed-tools` is a Claude-enforced field and codex's skills live in a shared
+`.agents/skills/` dir that cannot be safely per-harness rewritten. Codex tool
+scopes are **not** rewritten: they apply to config.toml-managed (decomposed)
+servers keyed by bare name; a native plugin's server is never in `[mcp_servers]`.
+
+`hallouminate` is `native: true` (claude+codex+copilot): its `mcp__hallouminate__*`
+becomes `mcp__plugin_hallouminate_hallouminate__*` on those three, stays bare on
+cursor, and lowers on opencode/crush — all via the rewrite, with no edit to
+`profiles/_permissions/profile.yaml` or `skills/rennet/SKILL.md`.
 
 **`gate_unless`** — propagates to the decomposed MCP's `gate_unless` field,
 using the same semantics as the MCP registry gate (see [[agents-dir]]). It

--- a/agent-profile/agent_profile/ingest.py
+++ b/agent-profile/agent_profile/ingest.py
@@ -104,42 +104,52 @@ def resolved_native_harnesses(body: dict[str, Any], *, plugin: str) -> set[str]:
 
     ``native: true`` → every drivable harness in this entry's ``harnesses``;
     ``native: [list]`` → exactly the listed harnesses (must be ⊆ drivable and
-    ⊆ ``harnesses``, else ParseError); ``false`` / absent → none. Legacy bools
-    OR into the result. See ``agents/plugins/registry.yaml`` for the schema.
+    ⊆ ``harnesses``, else ParseError); ``false`` / absent → none. The legacy
+    ``claude_native`` / ``codex_native`` bools fold in BEFORE that validation,
+    so they share the same ⊆ drivable / ⊆ ``harnesses`` gate. See
+    ``agents/plugins/registry.yaml`` for the schema.
     """
     from agent_profile._validate import ParseError
 
     drivable = set(DRIVABLE_NATIVE)
     requested = set(_as_list(body.get("harnesses")))
     native = body.get("native", False)
+
+    # Legacy aliases fold into the resolved set up front so a contradictory
+    # claude_native: true on an entry whose harnesses exclude claude fails loud
+    # like the native: list form, rather than silently forcing a native install
+    # on an excluded harness.
+    legacy: set[str] = set()
+    if body.get("claude_native"):
+        legacy.add("claude")
+    if body.get("codex_native"):
+        legacy.add("codex")
+
     if native is True:
-        resolved = (drivable & requested) if requested else set(drivable)
+        resolved = ((drivable & requested) if requested else set(drivable)) | legacy
     elif isinstance(native, list):
-        resolved = {str(h) for h in native}
-        bad = resolved - drivable
-        if bad:
-            raise ParseError(
-                f"ap: plugin '{plugin}': native: {sorted(bad)} not drivable "
-                f"(drivable = {sorted(drivable)}); those harnesses stay decomposed."
-            )
-        if requested:
-            outside = resolved - requested
-            if outside:
-                raise ParseError(
-                    f"ap: plugin '{plugin}': native: {sorted(outside)} not in this "
-                    f"entry's harnesses {sorted(requested)} — would be a silent no-op."
-                )
+        resolved = {str(h) for h in native} | legacy
     elif native in (False, None):
-        resolved = set()
+        resolved = set(legacy)
     else:
         raise ParseError(
             f"ap: plugin '{plugin}': native must be true, false, or a list of "
             f"harnesses, got {type(native).__name__}."
         )
-    if body.get("claude_native"):
-        resolved.add("claude")
-    if body.get("codex_native"):
-        resolved.add("codex")
+
+    bad = resolved - drivable
+    if bad:
+        raise ParseError(
+            f"ap: plugin '{plugin}': native: {sorted(bad)} not drivable "
+            f"(drivable = {sorted(drivable)}); those harnesses stay decomposed."
+        )
+    if requested:
+        outside = resolved - requested
+        if outside:
+            raise ParseError(
+                f"ap: plugin '{plugin}': native: {sorted(outside)} not in this "
+                f"entry's harnesses {sorted(requested)} — would be a silent no-op."
+            )
     return resolved
 
 

--- a/agent-profile/agent_profile/ingest.py
+++ b/agent-profile/agent_profile/ingest.py
@@ -83,20 +83,81 @@ _SKILL_HARNESSES = ("claude", "codex", "opencode", "cursor", "copilot")
 _HOOK_HARNESSES = ("claude", "codex", "cursor", "copilot")
 _COMMAND_HOOK_HARNESSES = ("claude", "codex")
 
+# Harnesses whose native marketplace install is drivable from `ap`. A plugin's
+# `native:` field may only name these; the rest always get decomposed primitives.
+DRIVABLE_NATIVE = ("claude", "codex", "copilot")
+
+# Per-harness marker stamped on a native-served skill/agent so that harness's
+# renderer skips the decomposed copy (the plugin delivers it at plugin scope).
+# The claude/codex names are historical and kept for back-compat.
+_NATIVE_MARKERS = {
+    "claude": "_from_native_plugin",
+    "codex": "_from_codex_native_plugin",
+    "copilot": "_from_copilot_native_plugin",
+}
+
+
+def resolved_native_harnesses(body: dict[str, Any], *, plugin: str) -> set[str]:
+    """Resolve a plugin entry's ``native:`` field (plus the legacy
+    ``claude_native`` / ``codex_native`` aliases) to the set of harnesses that
+    get the NATIVE marketplace install instead of decomposed primitives.
+
+    ``native: true`` → every drivable harness in this entry's ``harnesses``;
+    ``native: [list]`` → exactly the listed harnesses (must be ⊆ drivable and
+    ⊆ ``harnesses``, else ParseError); ``false`` / absent → none. Legacy bools
+    OR into the result. See ``agents/plugins/registry.yaml`` for the schema.
+    """
+    from agent_profile._validate import ParseError
+
+    drivable = set(DRIVABLE_NATIVE)
+    requested = set(_as_list(body.get("harnesses")))
+    native = body.get("native", False)
+    if native is True:
+        resolved = (drivable & requested) if requested else set(drivable)
+    elif isinstance(native, list):
+        resolved = {str(h) for h in native}
+        bad = resolved - drivable
+        if bad:
+            raise ParseError(
+                f"ap: plugin '{plugin}': native: {sorted(bad)} not drivable "
+                f"(drivable = {sorted(drivable)}); those harnesses stay decomposed."
+            )
+        if requested:
+            outside = resolved - requested
+            if outside:
+                raise ParseError(
+                    f"ap: plugin '{plugin}': native: {sorted(outside)} not in this "
+                    f"entry's harnesses {sorted(requested)} — would be a silent no-op."
+                )
+    elif native in (False, None):
+        resolved = set()
+    else:
+        raise ParseError(
+            f"ap: plugin '{plugin}': native must be true, false, or a list of "
+            f"harnesses, got {type(native).__name__}."
+        )
+    if body.get("claude_native"):
+        resolved.add("claude")
+    if body.get("codex_native"):
+        resolved.add("codex")
+    return resolved
+
+
+def _stamp_native_markers(item: dict[str, Any], native_harnesses: set[str]) -> None:
+    for harness in native_harnesses:
+        marker = _NATIVE_MARKERS.get(harness)
+        if marker:
+            item[marker] = True
+
 
 def _effective_plugin_harnesses(
     requested: list[str],
     supported: tuple[str, ...],
     *,
-    claude_native: bool,
-    codex_native: bool,
+    native_harnesses: set[str],
 ) -> list[str]:
     out = [h for h in (requested or list(supported)) if h in supported]
-    if claude_native:
-        out = [h for h in out if h != "claude"]
-    if codex_native:
-        out = [h for h in out if h != "codex"]
-    return out
+    return [h for h in out if h not in native_harnesses]
 
 
 def _parse_plugin_agent_frontmatter(path: Path, plugin: str) -> dict[str, Any]:
@@ -126,8 +187,7 @@ def _plugin_agents(
     source_dir: str,
     harnesses: list[str],
     *,
-    claude_native: bool,
-    codex_native: bool,
+    native_harnesses: set[str],
 ) -> list[dict[str, Any]]:
     agents_dir = payload_root / "agents"
     if not agents_dir.is_dir():
@@ -137,8 +197,7 @@ def _plugin_agents(
     effective_harnesses = _effective_plugin_harnesses(
         harnesses,
         _AGENT_HARNESSES,
-        claude_native=claude_native,
-        codex_native=codex_native,
+        native_harnesses=native_harnesses,
     )
     for agent_file in sorted(agents_dir.glob("*.md")):
         frontmatter = _parse_plugin_agent_frontmatter(agent_file, plugin)
@@ -168,10 +227,7 @@ def _plugin_agents(
         if models:
             item["models"] = models
 
-        if claude_native:
-            item["_from_native_plugin"] = True
-        if codex_native:
-            item["_from_codex_native_plugin"] = True
+        _stamp_native_markers(item, native_harnesses)
         out.append(item)
     return out
 
@@ -222,8 +278,7 @@ def _plugin_hooks(
     source_dir: str,
     harnesses: list[str],
     *,
-    claude_native: bool,
-    codex_native: bool,
+    native_harnesses: set[str],
 ) -> list[dict[str, Any]]:
     import json as _json
     from agent_profile._validate import ParseError
@@ -242,8 +297,7 @@ def _plugin_hooks(
     script_harnesses = _effective_plugin_harnesses(
         harnesses,
         _HOOK_HARNESSES,
-        claude_native=claude_native,
-        codex_native=codex_native,
+        native_harnesses=native_harnesses,
     )
     out: list[dict[str, Any]] = []
     for event, entries in hooks.items():
@@ -281,8 +335,7 @@ def _plugin_hooks(
                     item_harnesses = _effective_plugin_harnesses(
                         harnesses,
                         _COMMAND_HOOK_HARNESSES,
-                        claude_native=claude_native,
-                        codex_native=codex_native,
+                        native_harnesses=native_harnesses,
                     )
                     if not item_harnesses:
                         continue
@@ -623,8 +676,7 @@ def _expand_plugins(
         marketplace_name: str = market_data.get("name") or name
         harnesses: list[str] = _as_list(body.get("harnesses"))
         gate_unless = body.get("gate_unless")
-        claude_native = bool(body.get("claude_native", False))
-        codex_native = bool(body.get("codex_native", False))
+        native_harnesses = resolved_native_harnesses(body, plugin=name)
         description = body.get("description") or ""
 
         meta = market_data.get("metadata")
@@ -638,6 +690,7 @@ def _expand_plugins(
         )
 
         matched = False
+        plugin_servers: list[str] = []
         for plugin_entry in market_data.get("plugins") or []:
             if not isinstance(plugin_entry, dict):
                 continue
@@ -663,6 +716,7 @@ def _expand_plugins(
                 for server_name, server_body in (raw_mcp.get("mcpServers") or {}).items():
                     if not isinstance(server_body, dict):
                         continue
+                    plugin_servers.append(server_name)
                     item: dict[str, Any] = {
                         "name": server_name,
                         "command": server_body.get("command", ""),
@@ -684,14 +738,10 @@ def _expand_plugins(
                     if server_body.get("optional") is not None:
                         item["optional"] = server_body["optional"]
                     effective_harnesses = harnesses
-                    if harnesses:
-                        skip = set()
-                        if claude_native:
-                            skip.add("claude")
-                        if codex_native:
-                            skip.add("codex")
-                        if skip:
-                            effective_harnesses = [h for h in harnesses if h not in skip]
+                    if harnesses and native_harnesses:
+                        effective_harnesses = [
+                            h for h in harnesses if h not in native_harnesses
+                        ]
                     if effective_harnesses:
                         item["harnesses"] = effective_harnesses
                     elif harnesses and not effective_harnesses:
@@ -705,15 +755,11 @@ def _expand_plugins(
             skill_harnesses = _effective_plugin_harnesses(
                 harnesses,
                 _SKILL_HARNESSES,
-                claude_native=claude_native,
-                codex_native=codex_native,
+                native_harnesses=native_harnesses,
             )
             for skill in plugin_skills:
                 skill["harnesses"] = skill_harnesses
-                if claude_native:
-                    skill["_from_native_plugin"] = True
-                if codex_native:
-                    skill["_from_codex_native_plugin"] = True
+                _stamp_native_markers(skill, native_harnesses)
             out_skills.extend(plugin_skills)
 
             out_agents.extend(
@@ -722,8 +768,7 @@ def _expand_plugins(
                     payload_root,
                     source_dir,
                     harnesses,
-                    claude_native=claude_native,
-                    codex_native=codex_native,
+                    native_harnesses=native_harnesses,
                 )
             )
             out_hooks.extend(
@@ -732,8 +777,7 @@ def _expand_plugins(
                     payload_root,
                     source_dir,
                     harnesses,
-                    claude_native=claude_native,
-                    codex_native=codex_native,
+                    native_harnesses=native_harnesses,
                 )
             )
 
@@ -749,12 +793,14 @@ def _expand_plugins(
                 "match a plugins[].name in marketplace.json."
             )
 
-        if claude_native or codex_native:
+        if native_harnesses:
             out_native.append(
                 {
                     "name": name,
-                    "claude_native": claude_native,
-                    "codex_native": codex_native,
+                    "claude_native": "claude" in native_harnesses,
+                    "codex_native": "codex" in native_harnesses,
+                    "copilot_native": "copilot" in native_harnesses,
+                    "servers": plugin_servers,
                     "marketplace_root": str(marketplace_root),
                     "marketplace_name": marketplace_name,
                     "description": description,

--- a/agent-profile/agent_profile/permissions.py
+++ b/agent-profile/agent_profile/permissions.py
@@ -92,6 +92,89 @@ def named_mcp_tools(rules: list[str]) -> dict[str, set[str]]:
     return out
 
 
+def native_mcp_server_plugins(native_plugins: list[dict], harness: str) -> dict[str, str]:
+    """Map ``server_name -> plugin_name`` for plugins native on ``harness``.
+
+    A plugin installed natively on a harness has its MCP tools re-namespaced by
+    that harness to ``mcp__plugin_<plugin>_<server>__*`` (Claude-compat layout,
+    e.g. ``mcp__plugin_hallouminate_hallouminate__*``). Renderers use this map
+    to rewrite the canonical ``mcp__<server>__*`` permission rules for harnesses
+    where the plugin is native, leaving decomposed harnesses on the bare form.
+    """
+    flag = f"{harness}_native"
+    out: dict[str, str] = {}
+    for entry in native_plugins:
+        if not entry.get(flag):
+            continue
+        plugin = entry.get("name")
+        for server in entry.get("servers") or []:
+            out[server] = plugin
+    return out
+
+
+def rewrite_native_mcp_rule(rule: str, server_plugins: dict[str, str]) -> str:
+    """Rewrite one ``mcp__<server>__<tool>`` rule to the plugin-namespaced form
+    ``mcp__plugin_<plugin>_<server>__<tool>`` when ``<server>`` belongs to a
+    native plugin in ``server_plugins``. Non-MCP rules and servers absent from
+    the map pass through unchanged."""
+    parsed = parse_mcp_rule(rule)
+    if parsed is None:
+        return rule
+    server, tool = parsed
+    plugin = server_plugins.get(server)
+    if plugin is None:
+        return rule
+    return f"{_MCP_PREFIX}plugin_{plugin}_{server}__{tool}"
+
+
+def rewrite_native_mcp_rules(rules: list[str], server_plugins: dict[str, str]) -> list[str]:
+    """Apply :func:`rewrite_native_mcp_rule` across a rule list. A no-op (copy)
+    when ``server_plugins`` is empty — i.e. no plugin is native on the harness."""
+    if not server_plugins:
+        return list(rules)
+    return [rewrite_native_mcp_rule(rule, server_plugins) for rule in rules]
+
+
+def rewrite_skill_allowed_tools(text: str, server_plugins: dict[str, str]) -> str:
+    """Rewrite ``mcp__<server>__*`` entries in a skill's inline ``allowed-tools:``
+    frontmatter line to the plugin-namespaced form for native plugins.
+
+    Claude Code is the only harness that enforces a skill's ``allowed-tools``,
+    and it reads its own ``.claude/skills/`` copy, so the claude renderer applies
+    this to that copy alone. Operates only on the comma-separated inline form
+    inside the leading ``---`` frontmatter block; returns ``text`` unchanged when
+    there is no such line, no frontmatter, or no native plugin to rewrite for."""
+    if not server_plugins or not text.startswith("---"):
+        return text
+    lines = text.splitlines(keepends=True)
+    end = next(
+        (i for i in range(1, len(lines)) if lines[i].rstrip("\n") == "---"), None
+    )
+    if end is None:
+        return text
+    for i in range(1, end):
+        bare = lines[i].rstrip("\n")
+        inline = re.match(r"^allowed-tools:\s*(\S.*?)\s*$", bare)
+        if inline:
+            items = [tok.strip() for tok in inline.group(1).split(",")]
+            rewritten = [rewrite_native_mcp_rule(tok, server_plugins) for tok in items]
+            trailing = "\n" if lines[i].endswith("\n") else ""
+            lines[i] = "allowed-tools: " + ", ".join(rewritten) + trailing
+            return "".join(lines)
+        if re.match(r"^allowed-tools:\s*$", bare):
+            # YAML block-list form: rewrite each following "  - <entry>" line.
+            for j in range(i + 1, end):
+                item = re.match(r"^(\s*-\s*)(\S.*?)\s*$", lines[j].rstrip("\n"))
+                if not item:
+                    break
+                trailing = "\n" if lines[j].endswith("\n") else ""
+                lines[j] = item.group(1) + rewrite_native_mcp_rule(
+                    item.group(2), server_plugins
+                ) + trailing
+            return "".join(lines)
+    return text
+
+
 def whole_server_mcp_allows(rules: list[str]) -> set[str]:
     """Collect the servers ``rules`` allows whole via ``mcp__<server>__*``.
 

--- a/agent-profile/agent_profile/renderers/claude.py
+++ b/agent-profile/agent_profile/renderers/claude.py
@@ -41,6 +41,11 @@ from typing import NamedTuple
 
 from agent_profile import shared
 from agent_profile.parse import Manifest
+from agent_profile.permissions import (
+    native_mcp_server_plugins,
+    rewrite_native_mcp_rules,
+    rewrite_skill_allowed_tools,
+)
 from agent_profile.renderers.base import (
     agents_for,
     body_abs,
@@ -140,6 +145,8 @@ class ClaudeRenderer:
         markets = data.setdefault("extraKnownMarketplaces", {})
         enabled = data.setdefault("enabledPlugins", {})
         for entry in manifest.native_plugins:
+            if not entry.get("claude_native"):
+                continue  # native on other harnesses only — not a claude install
             name = entry["name"]
             marketplace_name = entry["marketplace_name"]
             marketplace_root = entry["marketplace_root"]
@@ -195,6 +202,8 @@ class ClaudeRenderer:
                 enabled.pop(plugin_id, None)
             # Un-merge native plugin enabledPlugins entries (<name>@<marketplace_name>).
             for entry in manifest.native_plugins:
+                if not entry.get("claude_native"):
+                    continue
                 marketplace_name = entry.get("marketplace_name", entry["name"])
                 enabled.pop(f"{entry['name']}@{marketplace_name}", None)
             if not enabled:
@@ -206,6 +215,8 @@ class ClaudeRenderer:
                 markets.pop(name, None)
             # Un-merge native plugin marketplace entries (keyed by marketplace_name).
             for entry in manifest.native_plugins:
+                if not entry.get("claude_native"):
+                    continue
                 marketplace_name = entry.get("marketplace_name", entry["name"])
                 markets.pop(marketplace_name, None)
             if not markets:
@@ -297,6 +308,7 @@ class ClaudeRenderer:
         target: Path,
         out: list[str],
     ) -> None:
+        server_plugins = native_mcp_server_plugins(manifest.native_plugins, "claude")
         for item in skills_for(manifest, "claude"):
             if item.get("_from_native_plugin"):
                 continue  # native plugin delivers skills at plugin scope, not user scope
@@ -307,6 +319,22 @@ class ClaudeRenderer:
             src = Path(item["_source_dir"]) / path
             if src.is_dir():
                 shared.write_shared_claude_skill(target, name, src, out)
+                if server_plugins:
+                    self._rewrite_skill_allowed_tools(target, name, server_plugins)
+
+    @staticmethod
+    def _rewrite_skill_allowed_tools(
+        target: Path, name: str, server_plugins: dict[str, str]
+    ) -> None:
+        """Re-namespace mcp__<server>__* in the copied skill's allowed-tools line
+        for plugins native on claude (the only harness that enforces it)."""
+        skill_md = Path(str(target).rstrip("/")) / ".claude" / "skills" / name / "SKILL.md"
+        if not skill_md.is_file():
+            return
+        original = skill_md.read_text()
+        rewritten = rewrite_skill_allowed_tools(original, server_plugins)
+        if rewritten != original:
+            skill_md.write_text(rewritten)
 
     def _write_commands(
         self,
@@ -601,8 +629,15 @@ class ClaudeRenderer:
         ``create_settings.json`` won't overwrite it later (``create_``
         semantics), so the operator is responsible for filling in the rest if
         they're skipping ``dots sync``."""
-        allow = manifest.settings.get("permissions_allow") or []
-        deny = manifest.settings.get("permissions_deny") or []
+        # Rewrite mcp__<server>__* → mcp__plugin_<plugin>_<server>__* for plugins
+        # native on claude (their tools are re-namespaced by the native install).
+        server_plugins = native_mcp_server_plugins(manifest.native_plugins, "claude")
+        allow = rewrite_native_mcp_rules(
+            manifest.settings.get("permissions_allow") or [], server_plugins
+        )
+        deny = rewrite_native_mcp_rules(
+            manifest.settings.get("permissions_deny") or [], server_plugins
+        )
         if (
             not manifest.enabled_plugins
             and not manifest.marketplaces

--- a/agent-profile/agent_profile/renderers/codex.py
+++ b/agent-profile/agent_profile/renderers/codex.py
@@ -688,6 +688,11 @@ def _collect_mcp_tool_scopes(
     independent — ``disabled_tools`` for that server survives. Only servers
     that gain at least one named tool (after the whole-server drop) reach the
     result."""
+    # Tool scopes apply to config.toml-managed (decomposed) servers, keyed by
+    # their bare name. A codex-native plugin's MCP is installed via `codex
+    # plugin add` (never in [mcp_servers]) and its tool access is governed by
+    # codex's plugin model, not these scopes — so the canonical mcp__<server>__*
+    # rules are NOT rewritten to the plugin-namespaced form here.
     settings = manifest.settings
     enabled = named_mcp_tools(settings.get("permissions_allow") or [])
     disabled = named_mcp_tools(settings.get("permissions_deny") or [])

--- a/agent-profile/agent_profile/renderers/copilot.py
+++ b/agent-profile/agent_profile/renderers/copilot.py
@@ -30,7 +30,9 @@ trailing newline).
 from __future__ import annotations
 
 import json
+import os
 import shutil
+import subprocess
 import sys
 from pathlib import Path
 from typing import Any
@@ -39,7 +41,9 @@ from agent_profile.parse import Manifest
 from agent_profile.permissions import (
     bash_argv,
     named_mcp_tools,
+    native_mcp_server_plugins,
     parse_mcp_rule,
+    rewrite_native_mcp_rules,
     whole_server_mcp_allows,
 )
 from agent_profile.renderers.base import (
@@ -69,6 +73,7 @@ _AGENT_STRIP_KEYS = (
     "harnesses",
     "_from_native_plugin",
     "_from_codex_native_plugin",
+    "_from_copilot_native_plugin",
 )
 
 # Internal fields stripped before a hook item becomes its JSON payload.
@@ -121,8 +126,13 @@ def launch_flags(manifest: Manifest) -> list[str]:
     internal spaces (``shell(gh pr view)``) — Copilot matches first-level
     subcommands for git/gh."""
     settings = manifest.settings
-    allow_flags = _flags_for(settings.get("permissions_allow") or [], "--allow-tool")
-    deny_flags = _flags_for(settings.get("permissions_deny") or [], "--deny-tool")
+    # Rewrite mcp__<server>__* → mcp__plugin_<plugin>_<server>__* for plugins
+    # native on copilot (the native install re-namespaces their tools).
+    server_plugins = native_mcp_server_plugins(manifest.native_plugins, "copilot")
+    allow = rewrite_native_mcp_rules(settings.get("permissions_allow") or [], server_plugins)
+    deny = rewrite_native_mcp_rules(settings.get("permissions_deny") or [], server_plugins)
+    allow_flags = _flags_for(allow, "--allow-tool")
+    deny_flags = _flags_for(deny, "--deny-tool")
     return allow_flags + deny_flags
 
 
@@ -158,6 +168,7 @@ class CopilotRenderer:
         self._write_skills(manifest, base, out_files)
         self._write_hooks(manifest, base, out_files)
         self._write_mcp(manifest, base)
+        self._render_native_plugins(manifest)
         return out_files
 
     def _warn_unsupported(self, manifest: Manifest) -> None:
@@ -171,6 +182,8 @@ class CopilotRenderer:
         self, manifest: Manifest, base: Path, out_files: list[str]
     ) -> None:
         for agent in agents_for(manifest, "copilot"):
+            if agent.get("_from_copilot_native_plugin"):
+                continue  # native plugin delivers agents via copilot plugin install
             name = agent["name"]
 
             models = agent.get("models") or {}
@@ -204,6 +217,8 @@ class CopilotRenderer:
         self, manifest: Manifest, base: Path, out_files: list[str]
     ) -> None:
         for skill in skills_for(manifest, "copilot"):
+            if skill.get("_from_copilot_native_plugin"):
+                continue  # native plugin delivers skills via copilot plugin install
             path = skill.get("path") or ""
             if not path:
                 continue  # source: (gh-fetched) skill — handled by cmd_install
@@ -311,7 +326,70 @@ class CopilotRenderer:
 
         out.write_text(_dumps(data))
 
+    # ─── native plugins (copilot_native marketplace install) ────────────
+    # Mirrors the codex renderer's native pass rather than claude's: Copilot
+    # CLI installs a plugin via `copilot plugin marketplace add <root>` +
+    # `copilot plugin install <name>@<marketplace>`. The declarative
+    # `enabledPlugins` settings key does NOT auto-install on startup (upstream
+    # bug github/copilot-cli#2249), and the `directory` marketplace-source
+    # object shape is unconfirmed — so ap drives the CLI (which owns
+    # ~/.copilot/settings.json) instead of hand-writing it. Idempotent on
+    # re-sync: marketplace add is skipped when already registered; install is
+    # tolerant of "already installed".
+    def _render_native_plugins(self, manifest: Manifest) -> None:
+        for entry in manifest.native_plugins:
+            if not entry.get("copilot_native"):
+                continue
+            self._install_copilot_native_plugin(entry)
+
+    def _install_copilot_native_plugin(self, entry: dict) -> None:
+        name = entry["name"]
+        marketplace_name = entry.get("marketplace_name", name)
+        expanded = os.path.expandvars(os.path.expanduser(str(entry["marketplace_root"])))
+        # Both steps are tolerant of re-runs. marketplace add is NOT gated on a
+        # `marketplace list` pre-check: the CLI's list output format is
+        # undocumented, so a brittle parse risks a false "not registered" that
+        # would re-add and (on some CLI versions) hard-fail with "already
+        # exists". A benign re-add warning is preferable to a fatal render.
+        self._copilot_cli(
+            ["copilot", "plugin", "marketplace", "add", expanded],
+            f"plugin marketplace add {expanded}",
+        )
+        self._copilot_cli(
+            ["copilot", "plugin", "install", f"{name}@{marketplace_name}"],
+            f"plugin install {name}@{marketplace_name}",
+        )
+
+    def _clean_native_plugins(self, manifest: Manifest) -> None:
+        for entry in manifest.native_plugins:
+            if not entry.get("copilot_native"):
+                continue
+            name = entry["name"]
+            marketplace_name = entry.get("marketplace_name", name)
+            self._copilot_cli(
+                ["copilot", "plugin", "uninstall", f"{name}@{marketplace_name}"],
+                f"plugin uninstall {name}@{marketplace_name}",
+            )
+            self._copilot_cli(
+                ["copilot", "plugin", "marketplace", "remove", marketplace_name, "--force"],
+                f"plugin marketplace remove {marketplace_name}",
+            )
+
+    @staticmethod
+    def _copilot_cli(argv: list[str], label: str) -> None:
+        """Run a copilot plugin CLI command, tolerant of re-runs. check=False
+        so a repeated install/remove (already present / already gone) does not
+        hard-fail the render. A missing copilot binary is a no-op."""
+        try:
+            result = subprocess.run(argv, check=False, capture_output=True, text=True)
+        except FileNotFoundError:
+            return  # copilot CLI not present; nothing to install/clean
+        if result.returncode != 0:
+            detail = (result.stderr or result.stdout or "").strip()
+            _warn(f"    ap: 'copilot {label}' exited {result.returncode}. {detail}")
+
     def clean(self, manifest: Manifest, target: Path) -> None:
+        self._clean_native_plugins(manifest)
         base = Path(str(target).rstrip("/"))
         cfg = base / ".copilot" / "mcp-config.json"
         if not cfg.is_file():

--- a/agent-profile/tests/test_claude_native_plugins.py
+++ b/agent-profile/tests/test_claude_native_plugins.py
@@ -895,3 +895,95 @@ def test_clean_removes_native_plugin_enabled_plugins_entry(tmp_path):
     milknado_keys = [k for k in enabled if "milknado" in k]
     assert milknado_keys == [], f"milknado entries should be removed: {enabled}"
     assert "other-plugin@local" in enabled
+
+
+# ── Phase 4: permission-rule rewrite for hallouminate-native ───────────────────
+
+def test_claude_renderer_rewrites_native_mcp_permission_rule(tmp_path):
+    """When hallouminate is claude-native, the canonical mcp__hallouminate__*
+    allow rule is rewritten to the plugin-namespaced form in settings.json;
+    a non-native server's rule (tilth) is left bare."""
+    from agent_profile.parse import Manifest
+    from agent_profile.renderers.claude import ClaudeRenderer
+
+    manifest = Manifest(
+        name="base",
+        settings={
+            "permissions_allow": ["mcp__hallouminate__*", "mcp__tilth__*"],
+            "permissions_deny": [],
+        },
+        native_plugins=[{
+            "name": "hallouminate",
+            "claude_native": True,
+            "codex_native": True,
+            "copilot_native": True,
+            "servers": ["hallouminate"],
+            "marketplace_root": str(tmp_path / "mkt"),
+            "marketplace_name": "hallouminate",
+            "description": "wiki",
+        }],
+    )
+    (tmp_path / "mkt" / ".claude-plugin").mkdir(parents=True)
+    (tmp_path / "mkt" / ".claude-plugin" / "marketplace.json").write_text(
+        json.dumps({"name": "hallouminate", "owner": {"name": "t"},
+                    "plugins": [{"name": "hallouminate", "source": "."}]})
+    )
+    target = tmp_path / "home"
+    target.mkdir()
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        ClaudeRenderer().render(manifest, target)
+
+    data = json.loads((target / ".claude" / "settings.json").read_text())
+    allow = data["permissions"]["allow"]
+    assert "mcp__plugin_hallouminate_hallouminate__*" in allow, allow
+    assert "mcp__hallouminate__*" not in allow, allow
+    assert "mcp__tilth__*" in allow, "non-native server rule must stay bare"
+
+
+def test_claude_renderer_rewrites_skill_allowed_tools(tmp_path):
+    """A skill's inline allowed-tools mcp__hallouminate__* is re-namespaced in the
+    claude skill copy when hallouminate is native; tilth + non-MCP entries stay."""
+    from agent_profile.parse import Manifest
+    from agent_profile.renderers.claude import ClaudeRenderer
+
+    payload = tmp_path / "payload"
+    skill_src = payload / "skills" / "rennet"
+    skill_src.mkdir(parents=True)
+    (skill_src / "SKILL.md").write_text(
+        "---\nname: rennet\n"
+        "allowed-tools: Task, Skill, Bash(gh:*), mcp__hallouminate__*, mcp__tilth__*\n"
+        "---\nbody\n"
+    )
+    manifest = Manifest(
+        name="base",
+        skills=[{
+            "name": "rennet",
+            "path": "skills/rennet",
+            "_source_dir": str(payload),
+            "harnesses": ["claude"],
+        }],
+        native_plugins=[{
+            "name": "hallouminate",
+            "claude_native": True,
+            "codex_native": False,
+            "copilot_native": False,
+            "servers": ["hallouminate"],
+            "marketplace_root": str(tmp_path / "mkt"),
+            "marketplace_name": "hallouminate",
+            "description": "wiki",
+        }],
+    )
+    target = tmp_path / "home"
+    target.mkdir()
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        ClaudeRenderer().render(manifest, target)
+
+    text = (target / ".claude" / "skills" / "rennet" / "SKILL.md").read_text()
+    assert "mcp__plugin_hallouminate_hallouminate__*" in text, text
+    assert "mcp__hallouminate__*" not in text, text
+    assert "mcp__tilth__*" in text
+    assert "Task, Skill, Bash(gh:*)" in text  # non-MCP entries preserved in order

--- a/agent-profile/tests/test_copilot_native_plugins.py
+++ b/agent-profile/tests/test_copilot_native_plugins.py
@@ -1,0 +1,222 @@
+"""test_copilot_native_plugins.py — Copilot-native plugin pass (CLI-driven).
+
+Copilot CLI exposes `copilot plugin marketplace add <dir>` + `copilot plugin
+install <name>@<marketplace>` and reads `.claude-plugin/{plugin,marketplace}.json`
+for Claude-Code compatibility (research: copilot-cli-plugin-system). The
+declarative `enabledPlugins` settings key does NOT auto-install on startup
+(upstream bug github/copilot-cli#2249), so — like the codex renderer, and unlike
+claude's settings-write — the copilot native pass drives the CLI directly rather
+than hand-writing ~/.copilot/settings.json (whose `directory` source object shape
+is also unconfirmed).
+
+Covers:
+- Renderer: `copilot plugin marketplace add` uses the marketplace root.
+- Renderer: `copilot plugin install` uses <name>@<marketplace_name>.
+- Renderer: a non-copilot-native descriptor is NOT installed by copilot.
+- Renderer: _write_skills / _write_agents skip _from_copilot_native_plugin items.
+- Renderer: a claude-native (copilot-decomposed) item is still rendered by copilot.
+- clean(): uninstall + marketplace remove for copilot-native plugins.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+from agent_profile.parse import Manifest
+from agent_profile.renderers.copilot import CopilotRenderer
+
+
+def _native_descriptor(market_root: Path, *, copilot_native: bool = True, name: str = "milknado") -> dict:
+    return {
+        "name": name,
+        "claude_native": False,
+        "codex_native": False,
+        "copilot_native": copilot_native,
+        "marketplace_root": str(market_root),
+        "marketplace_name": name,
+        "description": "Mikado engine",
+    }
+
+
+def _argv_calls(mock_run) -> list[list[str]]:
+    return [call.args[0] for call in mock_run.call_args_list if call.args]
+
+
+# ── native install pass ───────────────────────────────────────────────────────
+
+
+def test_copilot_marketplace_add_uses_marketplace_root(tmp_path):
+    """`copilot plugin marketplace add` is called with the marketplace root."""
+    market_root = tmp_path / "mkt" / "milknado"
+    market_root.mkdir(parents=True)
+    manifest = Manifest(name="base", native_plugins=[_native_descriptor(market_root)])
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        CopilotRenderer().render(manifest, tmp_path / "home")
+
+    calls = _argv_calls(mock_run)
+    assert ["copilot", "plugin", "marketplace", "add", str(market_root)] in calls, calls
+
+
+def test_copilot_install_uses_marketplace_name(tmp_path):
+    """`copilot plugin install` is called with <name>@<marketplace_name>."""
+    market_root = tmp_path / "mkt" / "milknado"
+    market_root.mkdir(parents=True)
+    manifest = Manifest(name="base", native_plugins=[_native_descriptor(market_root)])
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        CopilotRenderer().render(manifest, tmp_path / "home")
+
+    calls = _argv_calls(mock_run)
+    assert ["copilot", "plugin", "install", "milknado@milknado"] in calls, calls
+
+
+def test_copilot_skips_non_copilot_native_descriptor(tmp_path):
+    """A claude-only-native descriptor (copilot_native False) is not installed."""
+    market_root = tmp_path / "mkt" / "halloum"
+    market_root.mkdir(parents=True)
+    manifest = Manifest(
+        name="base",
+        native_plugins=[_native_descriptor(market_root, copilot_native=False, name="halloum")],
+    )
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        CopilotRenderer().render(manifest, tmp_path / "home")
+
+    assert _argv_calls(mock_run) == [], "copilot must not touch a non-copilot-native plugin"
+
+
+def test_copilot_marketplace_add_nonzero_exit_does_not_crash(tmp_path):
+    """A re-run where `marketplace add` exits nonzero ("already exists") must be
+    tolerated, not fatal — and install still runs."""
+    market_root = tmp_path / "mkt" / "milknado"
+    market_root.mkdir(parents=True)
+    manifest = Manifest(name="base", native_plugins=[_native_descriptor(market_root)])
+
+    def fake_run(argv, **kwargs):
+        if argv[:4] == ["copilot", "plugin", "marketplace", "add"]:
+            return MagicMock(returncode=1, stdout="", stderr="marketplace already exists")
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    with patch("subprocess.run", side_effect=fake_run) as mock_run:
+        CopilotRenderer().render(manifest, tmp_path / "home")  # must not raise
+
+    calls = _argv_calls(mock_run)
+    assert ["copilot", "plugin", "install", "milknado@milknado"] in calls, calls
+
+
+def test_copilot_missing_cli_is_noop(tmp_path):
+    """No copilot binary → FileNotFoundError is swallowed, render succeeds."""
+    market_root = tmp_path / "mkt" / "milknado"
+    market_root.mkdir(parents=True)
+    manifest = Manifest(name="base", native_plugins=[_native_descriptor(market_root)])
+
+    with patch("subprocess.run", side_effect=FileNotFoundError()):
+        CopilotRenderer().render(manifest, tmp_path / "home")  # must not raise
+
+
+# ── decomposed-path skips ─────────────────────────────────────────────────────
+
+
+def test_copilot_skips_native_plugin_skills(tmp_path):
+    """_write_skills skips skills carrying _from_copilot_native_plugin."""
+    payload = tmp_path / "payload"
+    skill_src = payload / "skills" / "wiki-init"
+    skill_src.mkdir(parents=True)
+    (skill_src / "SKILL.md").write_text("skill content")
+
+    manifest = Manifest(
+        name="base",
+        skills=[{
+            "name": "wiki-init",
+            "path": "skills/wiki-init",
+            "_source_dir": str(payload),
+            "harnesses": ["copilot"],
+            "_from_copilot_native_plugin": True,
+        }],
+    )
+    base = tmp_path / "home"
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        CopilotRenderer().render(manifest, base)
+
+    assert not (base / ".github" / "skills" / "wiki-init").exists()
+
+
+def test_copilot_skips_native_plugin_agents(tmp_path):
+    """_write_agents skips agents carrying _from_copilot_native_plugin."""
+    payload = tmp_path / "payload"
+    payload.mkdir()
+    (payload / "worker.md").write_text("---\nname: worker\n---\nbody\n")
+
+    manifest = Manifest(
+        name="base",
+        agents=[{
+            "name": "worker",
+            "description": "W",
+            "body_path": "worker.md",
+            "_source_dir": str(payload),
+            "harnesses": ["copilot"],
+            "_from_copilot_native_plugin": True,
+        }],
+    )
+    base = tmp_path / "home"
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        CopilotRenderer().render(manifest, base)
+
+    assert not (base / ".github" / "agents" / "worker.agent.md").exists()
+
+
+def test_copilot_renders_other_harness_native_skill(tmp_path):
+    """Marker independence: a claude-native (copilot-decomposed) skill IS rendered.
+
+    Carrying _from_native_plugin (claude's marker) must NOT make the copilot
+    renderer skip the skill — copilot is decomposed for that plugin.
+    """
+    payload = tmp_path / "payload"
+    skill_src = payload / "skills" / "harvest"
+    skill_src.mkdir(parents=True)
+    (skill_src / "SKILL.md").write_text("skill content")
+
+    manifest = Manifest(
+        name="base",
+        skills=[{
+            "name": "harvest",
+            "path": "skills/harvest",
+            "_source_dir": str(payload),
+            "harnesses": ["copilot"],
+            "_from_native_plugin": True,  # claude's marker, not copilot's
+        }],
+    )
+    base = tmp_path / "home"
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        CopilotRenderer().render(manifest, base)
+
+    assert (base / ".github" / "skills" / "harvest").is_dir()
+
+
+# ── clean ─────────────────────────────────────────────────────────────────────
+
+
+def test_copilot_clean_uninstalls_native_plugin(tmp_path):
+    """clean() uninstalls the plugin and removes the marketplace."""
+    market_root = tmp_path / "mkt" / "milknado"
+    market_root.mkdir(parents=True)
+    manifest = Manifest(name="base", native_plugins=[_native_descriptor(market_root)])
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        CopilotRenderer().clean(manifest, tmp_path / "home")
+
+    calls = _argv_calls(mock_run)
+    assert ["copilot", "plugin", "uninstall", "milknado@milknado"] in calls, calls
+    assert ["copilot", "plugin", "marketplace", "remove", "milknado", "--force"] in calls, calls

--- a/agent-profile/tests/test_ingest_plugins.py
+++ b/agent-profile/tests/test_ingest_plugins.py
@@ -1221,6 +1221,191 @@ def test_codex_native_false_produces_no_native_record(tmp_path):
     assert out.get("native_plugins", []) == []
 
 
+# ─── unified native: field ──────────────────────────────────────────────────
+# `native:` (true | false | [list]) replaces the per-harness booleans.
+#   true  → native on every DRIVABLE harness in this entry's `harnesses`
+#           (drivable = claude, codex, copilot).
+#   [list]→ native only on the listed harnesses (⊆ drivable AND ⊆ harnesses).
+# Legacy claude_native / codex_native still OR into the resolved set.
+
+
+def test_native_true_resolves_to_drivable_intersect_harnesses(tmp_path):
+    """native: true → native on claude+codex+copilot; the rest stay decomposed."""
+    _make_plugin_with_marketplace(tmp_path, "halloum", skill_names=["wiki-init"])
+    _make_plugins_registry(
+        tmp_path,
+        {"halloum": {
+            "path": str(tmp_path / "market" / "halloum"),
+            "harnesses": ["claude", "codex", "opencode", "cursor", "copilot", "crush"],
+            "native": True,
+        }},
+    )
+
+    out = expand_registries({"plugins": "agents/plugins/registry.yaml"}, tmp_path, {})
+    # MCP: the three drivable harnesses stripped, decompose-only ones remain.
+    harnesses = out["mcps"][0].get("harnesses", [])
+    assert "claude" not in harnesses and "codex" not in harnesses and "copilot" not in harnesses
+    assert set(harnesses) == {"opencode", "cursor", "crush"}, harnesses
+    # native descriptor carries all three drivable bools.
+    native = out["native_plugins"][0]
+    assert native["claude_native"] is True
+    assert native["codex_native"] is True
+    assert native["copilot_native"] is True
+    # skill carries each native harness's marker flag.
+    skill = out["skills"][0]
+    assert skill.get("_from_native_plugin") is True
+    assert skill.get("_from_codex_native_plugin") is True
+    assert skill.get("_from_copilot_native_plugin") is True
+
+
+def test_native_list_selects_only_listed_harnesses(tmp_path):
+    """native: [claude, copilot] → codex stays decomposed; only listed go native."""
+    _make_plugin_with_marketplace(tmp_path, "milknado", skill_names=["harvest"])
+    _make_plugins_registry(
+        tmp_path,
+        {"milknado": {
+            "path": str(tmp_path / "market" / "milknado"),
+            "harnesses": ["claude", "codex", "opencode", "cursor", "copilot"],
+            "native": ["claude", "copilot"],
+        }},
+    )
+
+    out = expand_registries({"plugins": "agents/plugins/registry.yaml"}, tmp_path, {})
+    harnesses = out["mcps"][0].get("harnesses", [])
+    assert "claude" not in harnesses and "copilot" not in harnesses
+    assert "codex" in harnesses, "codex must stay decomposed when not listed"
+    native = out["native_plugins"][0]
+    assert native["claude_native"] is True
+    assert native["copilot_native"] is True
+    assert native["codex_native"] is False
+    skill = out["skills"][0]
+    assert skill.get("_from_native_plugin") is True
+    assert skill.get("_from_copilot_native_plugin") is True
+    assert "_from_codex_native_plugin" not in skill
+
+
+def test_native_list_non_drivable_fails_loud(tmp_path):
+    """native: [cursor] is a ParseError — cursor has no drivable native install."""
+    _make_plugin_with_marketplace(tmp_path, "milknado")
+    _make_plugins_registry(
+        tmp_path,
+        {"milknado": {
+            "path": str(tmp_path / "market" / "milknado"),
+            "harnesses": ["claude", "cursor"],
+            "native": ["cursor"],
+        }},
+    )
+
+    with pytest.raises(ParseError, match="cursor"):
+        expand_registries({"plugins": "agents/plugins/registry.yaml"}, tmp_path, {})
+
+
+def test_native_list_outside_harnesses_fails_loud(tmp_path):
+    """native: [copilot] but harnesses lacks copilot → ParseError (silent no-op guard)."""
+    _make_plugin_with_marketplace(tmp_path, "milknado")
+    _make_plugins_registry(
+        tmp_path,
+        {"milknado": {
+            "path": str(tmp_path / "market" / "milknado"),
+            "harnesses": ["claude", "codex"],
+            "native": ["copilot"],
+        }},
+    )
+
+    with pytest.raises(ParseError, match="copilot"):
+        expand_registries({"plugins": "agents/plugins/registry.yaml"}, tmp_path, {})
+
+
+def test_copilot_native_skills_carry_copilot_flag_only(tmp_path):
+    """copilot-only native stamps _from_copilot_native_plugin, not the other two.
+
+    Mirrors the codex marker-independence contract: reusing claude's flag would
+    make the claude renderer wrongly skip a copilot-only-native plugin's skills.
+    """
+    _make_plugin_with_marketplace(tmp_path, "milknado", skill_names=["harvest"])
+    _make_plugins_registry(
+        tmp_path,
+        {"milknado": {
+            "path": str(tmp_path / "market" / "milknado"),
+            "harnesses": ["claude", "copilot"],
+            "native": ["copilot"],
+        }},
+    )
+
+    out = expand_registries({"plugins": "agents/plugins/registry.yaml"}, tmp_path, {})
+    skill = out["skills"][0]
+    assert skill.get("_from_copilot_native_plugin") is True
+    assert "_from_native_plugin" not in skill
+    assert "_from_codex_native_plugin" not in skill
+    # claude stays decomposed (only copilot native), so claude keeps the MCP.
+    assert "claude" in out["mcps"][0].get("harnesses", [])
+
+
+def test_legacy_flags_or_into_resolved_native_set(tmp_path):
+    """Legacy claude_native/codex_native add to whatever native: resolves."""
+    _make_plugin_with_marketplace(tmp_path, "milknado")
+    _make_plugins_registry(
+        tmp_path,
+        {"milknado": {
+            "path": str(tmp_path / "market" / "milknado"),
+            "harnesses": ["claude", "codex", "copilot"],
+            "native": ["copilot"],
+            "claude_native": True,
+        }},
+    )
+
+    out = expand_registries({"plugins": "agents/plugins/registry.yaml"}, tmp_path, {})
+    native = out["native_plugins"][0]
+    assert native["copilot_native"] is True
+    assert native["claude_native"] is True
+    assert native["codex_native"] is False
+    harnesses = out["mcps"][0].get("harnesses", [])
+    assert harnesses == ["codex"], f"only codex stays decomposed: {harnesses}"
+
+
+def test_native_descriptor_carries_server_names(tmp_path):
+    """The native descriptor lists the MCP server names the plugin provides.
+
+    Renderers need this to rewrite `mcp__<server>__*` permission rules to the
+    plugin-namespaced form on harnesses where the plugin is native.
+    """
+    _make_plugin_with_marketplace(tmp_path, "halloum")
+    _make_plugins_registry(
+        tmp_path,
+        {"halloum": {
+            "path": str(tmp_path / "market" / "halloum"),
+            "harnesses": ["claude", "codex", "copilot"],
+            "native": True,
+        }},
+    )
+
+    out = expand_registries({"plugins": "agents/plugins/registry.yaml"}, tmp_path, {})
+    native = out["native_plugins"][0]
+    assert native["servers"] == ["halloum"], native
+
+
+def test_native_agents_carry_copilot_flag(tmp_path):
+    """native: [copilot] stamps _from_copilot_native_plugin on agents too."""
+    _market, payload = _make_plugin_with_marketplace(tmp_path, "milknado")
+    _write_plugin_agent(payload, "worker.md", {"name": "worker", "description": "W"})
+    _make_plugins_registry(
+        tmp_path,
+        {"milknado": {
+            "path": str(tmp_path / "market" / "milknado"),
+            "harnesses": ["claude", "copilot"],
+            "native": ["copilot"],
+        }},
+    )
+
+    out = expand_registries({"plugins": "agents/plugins/registry.yaml"}, tmp_path, {})
+    agent = out["agents"][0]
+    assert agent.get("_from_copilot_native_plugin") is True
+    assert "_from_native_plugin" not in agent
+    # copilot stripped from agent harnesses; claude remains.
+    assert "copilot" not in agent["harnesses"]
+    assert "claude" in agent["harnesses"]
+
+
 # ─── plugin agents and hooks ─────────────────────────────────────────────────
 
 

--- a/agent-profile/tests/test_ingest_plugins.py
+++ b/agent-profile/tests/test_ingest_plugins.py
@@ -721,7 +721,7 @@ def test_registry_key_not_matching_marketplace_plugin_name_fails_loud(tmp_path):
             "milknado-engine": {
                 "path": str(market_root),
                 "claude_native": True,
-                "harnesses": ["codex"],
+                "harnesses": ["claude", "codex"],
             }
         },
     )
@@ -1155,6 +1155,24 @@ def test_codex_native_and_claude_native_strip_both(tmp_path):
     out = expand_registries({"plugins": "agents/plugins/registry.yaml"}, tmp_path, {})
     harnesses = out["mcps"][0].get("harnesses", [])
     assert harnesses == ["opencode"], f"both native harnesses must be stripped: {harnesses}"
+
+
+def test_legacy_native_flag_outside_harnesses_fails_loud(tmp_path):
+    """A legacy ``claude_native: true`` on an entry whose ``harnesses`` exclude
+    claude must fail loud, not silently force a native install on an excluded
+    harness — the bug fixed by folding the legacy aliases into the validated set.
+    """
+    _make_plugin_with_marketplace(tmp_path, "milknado")
+    _make_plugins_registry(
+        tmp_path,
+        {"milknado": {
+            "path": str(tmp_path / "market" / "milknado"),
+            "harnesses": ["opencode"],
+            "claude_native": True,
+        }},
+    )
+    with pytest.raises(ParseError, match=r"not in this entry's harnesses"):
+        expand_registries({"plugins": "agents/plugins/registry.yaml"}, tmp_path, {})
 
 
 def test_codex_native_skills_carry_codex_flag_only(tmp_path):

--- a/agent-profile/tests/test_permissions_parse.py
+++ b/agent-profile/tests/test_permissions_parse.py
@@ -8,7 +8,11 @@ import pytest
 from agent_profile.permissions import (
     bash_argv,
     named_mcp_tools,
+    native_mcp_server_plugins,
     parse_mcp_rule,
+    rewrite_native_mcp_rule,
+    rewrite_native_mcp_rules,
+    rewrite_skill_allowed_tools,
     whole_server_mcp_allows,
 )
 
@@ -79,3 +83,78 @@ def test_whole_server_mcp_allows_includes_server_with_both_star_and_named():
 
 def test_whole_server_mcp_allows_empty_for_no_mcp_rules():
     assert whole_server_mcp_allows(["Bash(git:*)", "Edit", "Write"]) == set()
+
+
+# ─── native-plugin MCP rule rewrite (Phase 4 reference migration) ─────────────
+
+_HALLOUM_NATIVE = [{
+    "name": "hallouminate",
+    "claude_native": True,
+    "codex_native": True,
+    "copilot_native": False,
+    "servers": ["hallouminate"],
+}]
+
+
+def test_native_mcp_server_plugins_maps_only_native_harness():
+    assert native_mcp_server_plugins(_HALLOUM_NATIVE, "claude") == {"hallouminate": "hallouminate"}
+    assert native_mcp_server_plugins(_HALLOUM_NATIVE, "codex") == {"hallouminate": "hallouminate"}
+    # copilot_native is False here → no rewrite map for copilot.
+    assert native_mcp_server_plugins(_HALLOUM_NATIVE, "copilot") == {}
+    # cursor never carries a *_native flag → empty.
+    assert native_mcp_server_plugins(_HALLOUM_NATIVE, "cursor") == {}
+
+
+def test_rewrite_native_mcp_rule_namespaces_native_server():
+    m = {"hallouminate": "hallouminate"}
+    assert rewrite_native_mcp_rule("mcp__hallouminate__*", m) == "mcp__plugin_hallouminate_hallouminate__*"
+    assert rewrite_native_mcp_rule("mcp__hallouminate__ground", m) == "mcp__plugin_hallouminate_hallouminate__ground"
+
+
+def test_rewrite_native_mcp_rule_passes_through_non_native_and_non_mcp():
+    m = {"hallouminate": "hallouminate"}
+    assert rewrite_native_mcp_rule("mcp__tilth__*", m) == "mcp__tilth__*"
+    assert rewrite_native_mcp_rule("Bash(git:*)", m) == "Bash(git:*)"
+    assert rewrite_native_mcp_rule("Edit", m) == "Edit"
+
+
+def test_rewrite_native_mcp_rules_empty_map_is_noop():
+    rules = ["mcp__hallouminate__*", "mcp__tilth__*"]
+    assert rewrite_native_mcp_rules(rules, {}) == rules
+
+
+def test_rewrite_native_mcp_rules_rewrites_only_native_entries():
+    rules = ["mcp__hallouminate__*", "mcp__tilth__*", "Bash(gh:*)"]
+    out = rewrite_native_mcp_rules(rules, {"hallouminate": "hallouminate"})
+    assert out == ["mcp__plugin_hallouminate_hallouminate__*", "mcp__tilth__*", "Bash(gh:*)"]
+
+
+def test_rewrite_skill_allowed_tools_rewrites_inline_line():
+    text = "---\nname: rennet\nallowed-tools: Task, mcp__hallouminate__*, mcp__tilth__*\n---\nbody\n"
+    out = rewrite_skill_allowed_tools(text, {"hallouminate": "hallouminate"})
+    assert "allowed-tools: Task, mcp__plugin_hallouminate_hallouminate__*, mcp__tilth__*\n" in out
+    assert "body" in out  # body untouched
+
+
+def test_rewrite_skill_allowed_tools_noops_without_native_or_frontmatter():
+    text = "---\nallowed-tools: mcp__hallouminate__*\n---\n"
+    assert rewrite_skill_allowed_tools(text, {}) == text  # empty map
+    no_fm = "no frontmatter here\nallowed-tools: mcp__hallouminate__*\n"
+    assert rewrite_skill_allowed_tools(no_fm, {"hallouminate": "hallouminate"}) == no_fm
+
+
+def test_rewrite_skill_allowed_tools_noops_when_no_allowed_tools_line():
+    text = "---\nname: x\ndescription: y\n---\nbody\n"
+    assert rewrite_skill_allowed_tools(text, {"hallouminate": "hallouminate"}) == text
+
+
+def test_rewrite_skill_allowed_tools_handles_yaml_block_list():
+    text = (
+        "---\nname: rennet\nallowed-tools:\n"
+        "  - Task\n  - mcp__hallouminate__*\n  - mcp__tilth__*\n---\nbody\n"
+    )
+    out = rewrite_skill_allowed_tools(text, {"hallouminate": "hallouminate"})
+    assert "  - mcp__plugin_hallouminate_hallouminate__*\n" in out
+    assert "  - mcp__hallouminate__*\n" not in out
+    assert "  - mcp__tilth__*\n" in out
+    assert "  - Task\n" in out

--- a/agents/plugins/registry.yaml
+++ b/agents/plugins/registry.yaml
@@ -33,25 +33,32 @@
 #   harnesses:     primitive membership list. MCP membership is explicit to
 #                  avoid blanket-wide per-request token tax; non-MCP plugin
 #                  primitives default to every harness that supports them.
-#   claude_native: true → Claude gets the native marketplace install
-#                  (atomic plugin install + plugin-scoped mcp__ names).
-#                  Other non-native harnesses always get decomposed primitives.
-#   codex_native:  true → Codex gets the native marketplace install via its own
-#                  CLI (`codex plugin marketplace add` + `codex plugin add`),
-#                  not decomposed MCP/skills. Independent of claude_native:
-#                  each harness's native path is flagged and consumed separately.
+#   native:        which harnesses get the NATIVE marketplace install (atomic
+#                  plugin install + plugin-scoped mcp__plugin_<plugin>_<server>__
+#                  tool names) instead of decomposed primitives. Accepts:
+#                    true            → every DRIVABLE harness in `harnesses`
+#                                      (drivable = claude, codex, copilot)
+#                    false / absent  → decomposed everywhere (default)
+#                    [claude, ...]   → only the listed harnesses (must be ⊆
+#                                      drivable AND ⊆ `harnesses`; else fail loud)
+#                  Non-native harnesses always get decomposed primitives. The
+#                  renderers rewrite the canonical mcp__<server>__* permission
+#                  rules + skill allowed-tools to the plugin-namespaced form on
+#                  harnesses where the plugin is native.
+#   claude_native / codex_native: DEPRECATED aliases — true OR's the harness
+#                  into the resolved `native:` set.
 #   gate_unless:   optional env var gate on the decomposed MCP items (same
 #                  semantics as the MCP registry gate). Does NOT gate the
 #                  Claude-native install path — that descriptor carries no gate.
 #   description:   human-readable description
 #
 # Per-harness reach:
-#   claude   → native marketplace install when claude_native; else MCP + skills + agents + hooks
-#   codex    → native marketplace install when codex_native; else MCP + skills + agents + hooks
-#   opencode → MCP + skills + agents
-#   cursor   → MCP + skills + agents + hooks
-#   copilot  → skills + hooks + agents; MCP only if harnesses includes copilot
-#   crush    → MCP only
+#   claude   → native marketplace install when native ∋ claude; else MCP + skills + agents + hooks
+#   codex    → native marketplace install when native ∋ codex; else MCP + skills + agents + hooks
+#   opencode → MCP + skills + agents (never native — no drivable CLI install)
+#   cursor   → MCP + skills + agents + hooks (never native — GUI marketplace only)
+#   copilot  → native marketplace install when native ∋ copilot; else skills + hooks + agents (+ MCP if harnesses ∋ copilot)
+#   crush    → MCP only (never native — no plugin concept)
 #   commands → unsupported on the decomposed path for every harness
 #
 # Edit this file, then run `dots sync` (or `base-sync`) to deploy.
@@ -66,27 +73,30 @@ plugins:
     git: https://github.com/paulnsorensen/milknado
     branch: main
     harnesses: [claude, codex, opencode, cursor, copilot, crush]
-    claude_native: true
-    # codex_native: DISABLED — milknado's upstream .agents/plugins/marketplace.json
+    native: [claude, copilot]
+    # codex omitted from native: — milknado's upstream .agents/plugins/marketplace.json
     # (the manifest codex reads) lacks a top-level `name`, so
     # `codex plugin marketplace add` exits 1 and codex would get NEITHER the
-    # native install NOR the decomposed MCP (DEDUP strips codex when the flag is
-    # set). The renderer machinery (_render_native_plugins) is landed and tested
-    # but stays off until upstream adds `"name": "milknado"` to that manifest;
-    # then set `codex_native: true` and confirm `codex plugin marketplace add`
-    # succeeds against ~/.cache/ap/plugins/milknado.
+    # native install NOR the decomposed MCP (DEDUP strips codex when native).
+    # Re-enable by adding `codex` to the list (or switching to `native: true`)
+    # once upstream adds `"name": "milknado"`, then confirm
+    # `codex plugin marketplace add` succeeds against ~/.cache/ap/plugins/milknado.
     description: Mikado execution engine — goal decomposition, batch planning, detached ralph-loop runs
 
   # hallouminate: per-repo markdown wiki (LLM-authored notes + semantic search).
   # Payload: 1 MCP (`hallouminate serve`) + skills (wiki-ingest, wiki-init, etc).
-  # claude_native: false — Claude gets the DECOMPOSED MCP so the well-known
-  # mcp__hallouminate__* tool namespace (relied on by the global CLAUDE.md
-  # routing) is preserved; a native install would rescope it to
-  # mcp__plugin_hallouminate_hallouminate__*. Migrated out of agents/mcp/registry.yaml
-  # — the decomposition now provides the MCP; a duplicate there would fail loud.
+  # native: true — native on claude+codex+copilot, decomposed on opencode/cursor/crush.
+  # Going native rescopes the MCP tools to mcp__plugin_hallouminate_hallouminate__*
+  # on the native harnesses; the renderers rewrite the canonical
+  # mcp__hallouminate__* permission glob and rennet's allowed-tools accordingly
+  # (renderer-side, no canonical-source edit). Decomposed harnesses keep the
+  # bare mcp__hallouminate__* (claude/cursor grammar) / lowered <server>_<tool>
+  # (opencode/crush). Migrated out of agents/mcp/registry.yaml — the
+  # decomposition provides the MCP on non-native harnesses; a duplicate there
+  # would fail loud.
   hallouminate:
     git: https://github.com/paulnsorensen/hallouminate
     branch: main
     harnesses: [claude, codex, opencode, cursor, copilot, crush]
-    claude_native: false
+    native: true
     description: Per-repo markdown wiki — semantic search + LLM-authored notes; bundles 6 wiki skills

--- a/profiles/plugin/CLAUDE.md
+++ b/profiles/plugin/CLAUDE.md
@@ -19,6 +19,7 @@ Defined in `mcp-scope.yaml` (registry-validated):
 - **tilth** — `mcp__tilth__*` — AST-aware navigation inside `claude/plugins/` and cross-plugin symbol lookup.
 - **code-review-graph** — `mcp__code-review-graph__*` — symbol and flow exploration when wiring a new plugin into existing skills.
 - **context7** — `mcp__context7__*` — Claude Code plugin SDK, MCP spec, and related framework docs.
+- **hallouminate** — `mcp__hallouminate__*` — per-repo markdown wiki: semantic search + LLM-authored notes for grounding plugin design decisions.
 
 Web search / task / design MCPs are out of scope. If you need GitHub code
 search for reference plugin implementations, use `gh search code` directly

--- a/profiles/plugin/profile.yaml
+++ b/profiles/plugin/profile.yaml
@@ -28,3 +28,6 @@ mcps:
     args: ["-y", "@upstash/context7-mcp"]
     env:
       CONTEXT7_API_KEY: "${CONTEXT7_API_KEY}"
+  - name: hallouminate
+    command: hallouminate
+    args: ["serve"]


### PR DESCRIPTION
## Summary

Replaces the per-harness `claude_native` / `codex_native` booleans in `agents/plugins/registry.yaml` with a single unified **`native:`** field, adds **Copilot** as the third CLI-drivable native harness, and migrates hallouminate's MCP-tool namespace per-harness via a renderer-side rewrite. Implements `.cheese/specs/native-plugin-rollout.md` (Phases 1–4; Phase 5 deferred as out-of-core).

`native:` accepts `true` (every drivable harness in `harnesses`), `false`/absent (decomposed everywhere), or `[list]` (only the listed harnesses; fails loud if not ⊆ `{claude, codex, copilot}` or ⊄ the entry's `harnesses`). Legacy `claude_native`/`codex_native` are OR'd-in aliases.

## Phases

- **1 — schema + ingest** (`ingest.py`): `resolved_native_harnesses()`, generalized `_effective_plugin_harnesses`, per-harness marker independence (`_from_copilot_native_plugin` added), native descriptor gains `copilot_native` + `servers`.
- **2 — Copilot native path** (`renderers/copilot.py`): CLI-driven (`copilot plugin marketplace add` + `install`), skip guards, `clean` uninstall. claude/codex native passes now filter their own `*_native` flag (latent-bug fix exposed by the unified field).
- **4 — reference migration** (design A, renderer-side, no canonical-source edit): `permissions.py` rewrites `mcp__<server>__*` → `mcp__plugin_<plugin>_<server>__*` on native harnesses (claude settings + copilot flags); `rewrite_skill_allowed_tools` re-namespaces rennet's `allowed-tools` in claude's own skill copy.
- **3 — registry flip**: `milknado: native: [claude, copilot]` (codex still blocked upstream); `hallouminate: native: true`.

## Deliberate deviations from the spec (sound, verified)

1. **Copilot is CLI-driven, not settings-write.** Upstream bug `copilot-cli#2249` means declarative `enabledPlugins` doesn't auto-install, and the `directory` marketplace-source JSON shape is unconfirmed — so the renderer mirrors codex (drive the CLI, which owns `~/.copilot/settings.json`). Research: `.cheese/research/copilot-cli-plugin-system/`.
2. **`allowed-tools` rewrite is claude-only.** It's a Claude-enforced field, and claude writes to its own (non-shared) `.claude/skills/`; codex's skills live in a shared `.agents/skills/` that can't be per-harness rewritten.

The spec's cited Copilot research doc (`copilot-cli-plugin-install/`) did not exist; it was regenerated/verified against primary docs.github.com sources before implementing.

## Tests

774 agent-profile tests pass (new: `test_copilot_native_plugins.py`, unified-field ingest cases, permission + allowed-tools rewrite helpers). Reviewed fresh-context; 1 medium + 2 low findings fixed (tolerant copilot marketplace-add, YAML block-list `allowed-tools`, reverted a misconceived codex tool-scope rewrite).

## Not yet done / known unverified

- **No live `dots sync` run.** Deploying performs real native installs on the machine (incl. re-namespacing hallouminate's claude tools to `mcp__plugin_hallouminate_hallouminate__*`); left for a deliberate `dots sync` after merge.
- `<speculative>` Copilot's native-MCP allow-tool naming and `marketplace list` output format are undocumented; no installed Copilot CLI here to confirm.
- Wiki page `architecture/cross-harness-plugins.md` still documents the old two-bool schema (separate doc update).

🤖 Generated with [Claude Code](https://claude.com/claude-code)