### PR TITLE
fix(ap): deliver skills into isolated closed-world launches

### DIFF
--- a/agent-profile/agent_profile/cli.py
+++ b/agent-profile/agent_profile/cli.py
@@ -507,6 +507,7 @@ def _fetch_external_skills(
         SkillFetchError,
         external_skills,
         fetch_external_source,
+        group_external_sources,
     )
 
     ext = external_skills(manifest.skills)
@@ -525,31 +526,13 @@ def _fetch_external_skills(
     if not skill_harnesses:
         return
 
-    # Group items by source repo. A bare `source:` (no name) means "all skills"
-    # for that repo (--skill '*') and wins over any explicit names from sibling
-    # items. `pin` is a per-source property. Insertion order is preserved so
-    # output (and test assertions) stay deterministic. Harnesses with no
-    # `npx skills` backend (currently crush) are filtered out here.
-    order: list[str] = []
-    groups: dict[str, dict[str, Any]] = {}
-    for skill in ext:
-        source = skill["source"]
-        if source not in groups:
-            groups[source] = {"names": set(), "all": False, "pin": None}
-            order.append(source)
-        g = groups[source]
-        name = skill.get("name")
-        if name:
-            g["names"].add(name)
-        else:
-            g["all"] = True
-        if skill.get("pin"):
-            g["pin"] = skill["pin"]
-
+    # Group items by source repo (shared rule: a bare `source:` = all skills
+    # for that repo, winning over explicit sibling names; `pin` is per-source;
+    # first-seen order preserved so output/test assertions stay deterministic).
+    # Harnesses with no `npx skills` backend (currently crush) were filtered out
+    # above.
     try:
-        for source in order:
-            g = groups[source]
-            names = None if g["all"] else sorted(g["names"])
+        for source, names, pin in group_external_sources(manifest.skills):
             label = "*" if names is None else ", ".join(names)
             print(
                 f"  {colors.BLUE}↳{colors.NC} fetching skills "
@@ -557,7 +540,7 @@ def _fetch_external_skills(
                 file=out,
             )
             fetch_external_source(
-                source, names, g["pin"], skill_harnesses, _skill_fetch_runner
+                source, names, pin, skill_harnesses, _skill_fetch_runner
             )
     except SkillFetchError as exc:
         raise CliError(f"{colors.RED}{exc}{colors.NC}") from exc

--- a/agent-profile/agent_profile/fetch.py
+++ b/agent-profile/agent_profile/fetch.py
@@ -40,6 +40,7 @@ A ``runner`` callable is injected so the fetch is unit-testable without spawning
 
 from __future__ import annotations
 
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -179,3 +180,79 @@ def external_skills(skills: list[dict[str, Any]]) -> list[dict[str, Any]]:
     skill list. ``path:`` (local-tree) items are excluded — they are copied by
     the renderers, not fetched."""
     return [s for s in skills if s.get("source")]
+
+
+def group_external_sources(
+    skills: list[dict[str, Any]],
+) -> list[tuple[str, list[str] | None, str | None]]:
+    """Group ``source:`` skill items by repo, preserving first-seen order.
+
+    Returns ``[(source, names, pin)]`` where ``names`` is ``None`` for a bare
+    ``source:`` (install every skill = ``--skill '*'``, which wins over any
+    explicit names from sibling items) and a sorted list otherwise; ``pin`` is
+    the per-source git ref. This is the single definition of the grouping rule
+    shared by the install fetch (:func:`cli._fetch_external_skills`) and the
+    closed-world delivery (:func:`overlay._write_skills_plugin`) so the two can
+    never drift on what a source contributes."""
+    order: list[str] = []
+    groups: dict[str, dict[str, Any]] = {}
+    for skill in external_skills(skills):
+        source = skill["source"]
+        if source not in groups:
+            groups[source] = {"names": set(), "all": False, "pin": None}
+            order.append(source)
+        g = groups[source]
+        name = skill.get("name")
+        if name:
+            g["names"].add(name)
+        else:
+            g["all"] = True
+        if skill.get("pin"):
+            g["pin"] = skill["pin"]
+    return [
+        (s, None if groups[s]["all"] else sorted(groups[s]["names"]), groups[s]["pin"])
+        for s in order
+    ]
+
+
+# Global skill store written by ``npx skills add -g``: each skill folder lives
+# at ``<store>/skills/<name>/`` with provenance recorded in
+# ``<store>/.skill-lock.json`` (``skills.<name>.source`` = the ``owner/repo``).
+SKILL_STORE = Path.home() / ".agents"
+
+
+def installed_skill_dir(name: str, store: Path | None = None) -> Path:
+    """Absolute path of a globally-installed skill folder in the ``skills`` CLI
+    store. ``store`` resolves at call time (so the module-level ``SKILL_STORE``
+    stays patchable in tests). Existence is the caller's to check."""
+    return (store or SKILL_STORE) / "skills" / name
+
+
+def source_skill_names(
+    source: str, names: list[str] | None, store: Path | None = None
+) -> list[str]:
+    """Resolve the installed skill folder names that ``source`` contributed,
+    from the ``skills`` CLI lockfile (``<store>/.skill-lock.json``).
+
+    ``names`` restricts to an explicit subset (a ``source:`` item that named
+    specific skills); ``None`` returns every skill the lockfile attributes to
+    ``source`` (a bare ``source:`` = ``--skill '*'``). Returns ``[]`` when the
+    lockfile is absent/unreadable or attributes nothing to ``source`` — the
+    caller degrades (no closed-world delivery for that source) rather than
+    crashing the launch."""
+    lock = (store or SKILL_STORE) / ".skill-lock.json"
+    try:
+        entries = json.loads(lock.read_text())["skills"]
+    except (OSError, ValueError, KeyError, TypeError):
+        return []
+    if not isinstance(entries, dict):
+        return []
+    resolved = [
+        n
+        for n, meta in entries.items()
+        if isinstance(meta, dict) and meta.get("source") == source
+    ]
+    if names is not None:
+        wanted = set(names)
+        resolved = [n for n in resolved if n in wanted]
+    return sorted(resolved)

--- a/agent-profile/agent_profile/overlay.py
+++ b/agent-profile/agent_profile/overlay.py
@@ -162,6 +162,88 @@ def _write_settings(manifest: Manifest, scratch: Path) -> Path | None:
     return path
 
 
+def _collect_plugin_skills(manifest: Manifest) -> list[tuple[str, Path]]:
+    """Resolve ``(name, source_dir)`` for every skill that should ride into the
+    closed world via the generated ``--plugin-dir``.
+
+    Two origins, one destination:
+
+    - **``path:`` skills** are copied from the profile's own tree
+      (``<_source_dir>/<path>``) — always available, no network.
+    - **``source:`` skills** were fetched to the global ``skills`` CLI store by
+      the install half of ``ap launch``; their folders are resolved from the
+      lockfile (:func:`fetch.source_skill_names`) and copied from
+      ``~/.agents/skills/<name>``. Absent from the store (offline / staged
+      install / lockfile drift) → silently skipped, so the launch degrades to
+      the local skills rather than failing.
+
+    Native-plugin skills are excluded (the plugin delivers them itself)."""
+    from agent_profile.fetch import (
+        group_external_sources,
+        installed_skill_dir,
+        source_skill_names,
+    )
+
+    out: list[tuple[str, Path]] = []
+    for s in manifest.skills:
+        if not isinstance(s, dict) or s.get("_from_native_plugin"):
+            continue
+        path = s.get("path")
+        if path:
+            out.append((s["name"], Path(s["_source_dir"]) / path))
+
+    for source, names, _pin in group_external_sources(manifest.skills):
+        for name in source_skill_names(source, names):
+            out.append((name, installed_skill_dir(name)))
+
+    return out
+
+
+def _write_skills_plugin(manifest: Manifest, scratch: Path) -> Path | None:
+    """Project the profile's skills into a scratch plugin tree so a closed-world
+    claude launch can load them.
+
+    ``--setting-sources ""`` strips the user/project setting sources, which is
+    exactly where skills live (``~/.claude/skills/<name>`` for the renderer's
+    ``path:`` copies and ``~/.agents/skills/<name>`` for the ``skills`` CLI's
+    ``source:`` fetches). Without a delivery channel those skills are invisible
+    to the isolated session — MCPs, the system prompt and permissions each have
+    a closed-world channel, but skills did not. A ``--plugin-dir`` tree loads
+    its skills regardless of setting sources (it is how the ``todo`` profile
+    ships ``todoist-flow``), so every resolved skill is copied under
+    ``<scratch>/skills-plugin/skills/<name>/`` and surfaced via ``--plugin-dir``.
+
+    Returns the plugin dir, or ``None`` when no skill resolves to a real source
+    directory (so no empty ``--plugin-dir`` is emitted)."""
+    skills = [(name, src) for name, src in _collect_plugin_skills(manifest) if src.is_dir()]
+    if not skills:
+        return None
+
+    plugin_dir = scratch / "skills-plugin"
+    meta_dir = plugin_dir / ".claude-plugin"
+    meta_dir.mkdir(parents=True, exist_ok=True)
+    (meta_dir / "plugin.json").write_text(
+        json.dumps(
+            {
+                "name": f"{manifest.name}-skills",
+                "description": f"Closed-world skills for the '{manifest.name}' profile",
+                "version": "0.0.0",
+            },
+            indent=2,
+        )
+        + "\n"
+    )
+
+    for name, src in skills:
+        dest = plugin_dir / "skills" / name
+        if dest.exists():
+            continue  # first writer wins (path: before source:); no clobber
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(src, dest)
+
+    return plugin_dir
+
+
 def _build_isolated_claude(
     manifest: Manifest,
     profile_dir: Path,
@@ -182,6 +264,7 @@ def _build_isolated_claude(
         --tools <csv>                          (when tools declared)
         --append-system-prompt-file <profile>/<system_prompt>  (when declared)
         --settings <gen>                       (when permissions/enabledPlugins set)
+        --plugin-dir <gen>                     (when local path: skills declared)
         <extra_args...>
     """
     if scratch is None:
@@ -209,6 +292,13 @@ def _build_isolated_claude(
     settings_path = _write_settings(manifest, scratch)
     if settings_path is not None:
         flags += ["--settings", str(settings_path)]
+
+    # Closed-world skill delivery: --setting-sources "" hides the rendered
+    # skill trees, so the profile's path: and source: skills ride in via a
+    # generated --plugin-dir (which loads regardless of setting sources).
+    skills_plugin = _write_skills_plugin(manifest, scratch)
+    if skills_plugin is not None:
+        flags += ["--plugin-dir", str(skills_plugin)]
 
     # extra_args expand ${VAR} from the process env (DOTFILES_DIR et al.)
     # then .env, matching the retired launch.zsh which used $DOTFILES_DIR

--- a/agent-profile/tests/test_fetch.py
+++ b/agent-profile/tests/test_fetch.py
@@ -11,11 +11,13 @@ The runner is injected so tests assert the exact argv without spawning npx.
 
 from __future__ import annotations
 
+import json
 import subprocess
 import types
 
 import pytest
 
+from agent_profile import fetch
 from agent_profile.fetch import (
     SKILL_AGENT,
     SkillFetchError,
@@ -152,6 +154,62 @@ def test_external_skills_filters_source_items_only():
         tuple(sorted({"name": "mold", "source": "o/r"}.items())),
         tuple(sorted({"source": "o/r2"}.items())),
     }
+
+
+# ─── group_external_sources (shared install/launch grouping rule) ─────
+
+
+def test_group_external_sources_bare_source_means_all():
+    groups = fetch.group_external_sources([
+        {"name": "mold", "source": "o/r"},
+        {"source": "o/r"},  # bare → all, wins over the explicit name
+    ])
+    assert groups == [("o/r", None, None)]
+
+
+def test_group_external_sources_explicit_names_sorted_and_pin():
+    groups = fetch.group_external_sources([
+        {"name": "cook", "source": "o/r", "pin": "v2"},
+        {"name": "age", "source": "o/r"},
+        {"name": "x", "path": "skills/x"},  # local — ignored
+    ])
+    assert groups == [("o/r", ["age", "cook"], "v2")]
+
+
+def test_group_external_sources_preserves_first_seen_order():
+    groups = fetch.group_external_sources([
+        {"source": "b/2"},
+        {"source": "a/1"},
+    ])
+    assert [g[0] for g in groups] == ["b/2", "a/1"]
+
+
+# ─── source_skill_names (lockfile provenance, zero-network) ────────────
+
+
+def _write_lock(store, mapping):
+    (store / "skills").mkdir(parents=True, exist_ok=True)
+    skills = {n: {"source": src} for n, src in mapping.items()}
+    (store / ".skill-lock.json").write_text(json.dumps({"skills": skills}))
+
+
+def test_source_skill_names_all_for_a_source(tmp_path):
+    _write_lock(tmp_path, {"mold": "o/cheese", "cook": "o/cheese", "search": "x/tav"})
+    assert fetch.source_skill_names("o/cheese", None, store=tmp_path) == ["cook", "mold"]
+
+
+def test_source_skill_names_restricts_to_explicit_subset(tmp_path):
+    _write_lock(tmp_path, {"mold": "o/cheese", "cook": "o/cheese"})
+    assert fetch.source_skill_names("o/cheese", ["mold"], store=tmp_path) == ["mold"]
+
+
+def test_source_skill_names_missing_lock_degrades_to_empty(tmp_path):
+    assert fetch.source_skill_names("o/cheese", None, store=tmp_path) == []
+
+
+def test_source_skill_names_unknown_source_is_empty(tmp_path):
+    _write_lock(tmp_path, {"mold": "o/cheese"})
+    assert fetch.source_skill_names("x/none", None, store=tmp_path) == []
 
 
 # ─── _default_runner output scanning (exit-0 false-success detection) ─

--- a/agent-profile/tests/test_overlay.py
+++ b/agent-profile/tests/test_overlay.py
@@ -19,6 +19,7 @@ from pathlib import Path
 import pytest
 
 from agent_profile import cli, overlay
+from agent_profile import fetch as overlay_fetch
 from agent_profile.discover import find_profile_dir
 from agent_profile.parse import Manifest, parse_manifest
 from tests.conftest import write_profile
@@ -426,6 +427,78 @@ def test_flag_groups_emitted_in_spec_order(tmp_path):
     assert flags[1] == "--mcp-config"
     # extra_args land after the generated --settings, never before it.
     assert flags.index("--dangerously-skip-permissions") > flags.index("--settings")
+
+
+def test_isolated_claude_delivers_local_skills_via_plugin_dir(tmp_path):
+    """``--setting-sources ""`` strips the ~/.claude/skills tree, so an isolated
+    claude profile's local ``path:`` skills must ride in through a generated
+    ``--plugin-dir``. Without it the closed world loads MCPs + system prompt but
+    no profile skills (the original skills-doctor bug)."""
+    skill_src = tmp_path / "skills" / "harness-doctor"
+    skill_src.mkdir(parents=True)
+    (skill_src / "SKILL.md").write_text("---\nname: harness-doctor\n---\nbody\n")
+    m = Manifest(
+        name="skills-doctor",
+        mcps=[{"name": "tilth", "command": "tilth", "_source_dir": str(tmp_path)}],
+        skills=[{
+            "name": "harness-doctor",
+            "path": "skills/harness-doctor",
+            "_source_dir": str(tmp_path),
+        }],
+        isolated=True,
+    )
+    flags, _ = overlay.build_isolated_launch(m, tmp_path, "claude")
+
+    assert "--plugin-dir" in flags, f"no skill delivery in flags: {flags}"
+    plugin_dir = Path(flags[flags.index("--plugin-dir") + 1])
+    assert (plugin_dir / ".claude-plugin" / "plugin.json").is_file()
+    copied = plugin_dir / "skills" / "harness-doctor" / "SKILL.md"
+    assert copied.is_file(), "local skill not projected into the plugin tree"
+    # plugin-dir trails the generated groups but precedes extra_args.
+    assert flags.index("--plugin-dir") > flags.index("--setting-sources")
+
+
+def test_isolated_claude_no_plugin_dir_without_any_skills(tmp_path, monkeypatch):
+    """No resolvable skills → no generated ``--plugin-dir`` (no empty flag).
+    A ``source:`` item whose skills aren't in the global store (offline / lock
+    drift) resolves to nothing and must not emit a plugin dir."""
+    monkeypatch.setattr(overlay_fetch, "SKILL_STORE", tmp_path / "empty-store")
+    m = Manifest(
+        name="bare",
+        mcps=[{"name": "tilth", "command": "tilth", "_source_dir": str(tmp_path)}],
+        skills=[{"source": "owner/repo", "_source_dir": str(tmp_path)}],
+        isolated=True,
+    )
+    flags, _ = overlay.build_isolated_launch(m, tmp_path, "claude")
+    assert "--plugin-dir" not in flags
+
+
+def test_isolated_claude_delivers_source_skills_from_lock(tmp_path, monkeypatch):
+    """``source:`` skills fetched to the global store by the install half of
+    ``ap launch`` must ride into the closed world too: resolved via the lockfile
+    and copied from ``~/.agents/skills/<name>`` into the plugin tree."""
+    store = tmp_path / "store"
+    (store / "skills" / "mold").mkdir(parents=True)
+    (store / "skills" / "mold" / "SKILL.md").write_text("---\nname: mold\n---\n")
+    (store / "skills" / "other").mkdir(parents=True)  # different source — excluded
+    (store / "skills" / "other" / "SKILL.md").write_text("---\nname: other\n---\n")
+    (store / ".skill-lock.json").write_text(json.dumps({"skills": {
+        "mold": {"source": "o/cheese"},
+        "other": {"source": "x/unrelated"},
+    }}))
+    monkeypatch.setattr(overlay_fetch, "SKILL_STORE", store)
+
+    m = Manifest(
+        name="cheesy",
+        mcps=[{"name": "tilth", "command": "tilth", "_source_dir": str(tmp_path)}],
+        skills=[{"source": "o/cheese", "_source_dir": str(tmp_path)}],
+        isolated=True,
+    )
+    flags, _ = overlay.build_isolated_launch(m, tmp_path, "claude")
+
+    plugin_dir = Path(flags[flags.index("--plugin-dir") + 1])
+    assert (plugin_dir / "skills" / "mold" / "SKILL.md").is_file()
+    assert not (plugin_dir / "skills" / "other").exists(), "unrelated source leaked in"
 
 
 def test_extra_args_trail_all_generated_flags(tmp_path):

--- a/profiles/skills-doctor/CLAUDE.md
+++ b/profiles/skills-doctor/CLAUDE.md
@@ -1,0 +1,23 @@
+# Skills Doctor Profile
+
+This session is for debugging agent skills, profile rendering, harness config, and tool-surface behavior.
+
+## Why this profile exists
+
+Skill/profile work needs `ap`, local profile files, the repo wiki, and skill-routing context without pulling in unrelated productivity or app-specific surfaces. This profile keeps the MCP scope to code navigation plus the wiki.
+
+## MCPs in scope
+
+- **tilth** — AST-aware read/search/write for dotfiles and skill/profile sources.
+- **hallouminate** — repo wiki grounding for `ap`, harness, and skill-system design decisions.
+
+## Skills in scope
+
+- Local diagnostics: `skill-improver`, `harness-doctor`, `settings-clean`, `tool-efficiency`, `prompt-analytics`, `session-analytics`.
+- Easy-cheese: fetched from `paulnsorensen/easy-cheese` for `/mold`, `/cook`, `/age`, `/cure`, and the cheez-* routing skills.
+
+## Defaults
+
+1. Ground `ap`, harness, plugin, or skill-system claims in the wiki or code before answering.
+2. Edit source registries/profiles only; never hand-edit rendered harness artifacts.
+3. Keep fixes narrow: profile/skill diagnostics first, unrelated dotfiles cleanup out of scope.

--- a/profiles/skills-doctor/profile.yaml
+++ b/profiles/skills-doctor/profile.yaml
@@ -1,0 +1,26 @@
+# skills-doctor — closed-world profile for debugging agent skills/profile behavior.
+name: skills-doctor
+description: Skills/profile diagnostics — closed world with tilth, hallouminate, and easy-cheese
+registries:
+  agents: agents/registry.yaml
+isolated: true
+system_prompt: CLAUDE.md
+env:
+  ENABLE_TOOL_SEARCH: "true"
+mcps:
+  - name: tilth
+    command: tilth
+    args: ["--mcp", "--edit"]
+    scope: user
+  - name: hallouminate
+    command: hallouminate
+    args: ["serve"]
+    scope: user
+skills:
+  - { name: skill-improver, path: skills/skill-improver }
+  - { name: harness-doctor, path: skills/harness-doctor }
+  - { name: settings-clean, path: skills/settings-clean }
+  - { name: tool-efficiency, path: skills/tool-efficiency }
+  - { name: prompt-analytics, path: skills/prompt-analytics }
+  - { name: session-analytics, path: skills/session-analytics }
+  - { source: paulnsorensen/easy-cheese }

--- a/profiles/skills-doctor/skills/harness-doctor
+++ b/profiles/skills-doctor/skills/harness-doctor
@@ -1,0 +1,1 @@
+../../../skills/harness-doctor

--- a/profiles/skills-doctor/skills/prompt-analytics
+++ b/profiles/skills-doctor/skills/prompt-analytics
@@ -1,0 +1,1 @@
+../../../skills/prompt-analytics

--- a/profiles/skills-doctor/skills/session-analytics
+++ b/profiles/skills-doctor/skills/session-analytics
@@ -1,0 +1,1 @@
+../../../skills/session-analytics

--- a/profiles/skills-doctor/skills/settings-clean
+++ b/profiles/skills-doctor/skills/settings-clean
@@ -1,0 +1,1 @@
+../../../skills/settings-clean

--- a/profiles/skills-doctor/skills/skill-improver
+++ b/profiles/skills-doctor/skills/skill-improver
@@ -1,0 +1,1 @@
+../../../skills/skill-improver

--- a/profiles/skills-doctor/skills/tool-efficiency
+++ b/profiles/skills-doctor/skills/tool-efficiency
@@ -1,0 +1,1 @@
+../../../skills/tool-efficiency


### PR DESCRIPTION
## Problem

An `isolated: true` profile launches `claude` with `--setting-sources ""` to build a closed world (`overlay._build_isolated_claude`). That flag strips the user/project setting sources — which is exactly where Claude discovers skills:

- `~/.claude/skills/<name>` — the renderer's `path:` skill copies
- `~/.agents/skills/<name>` — the `skills` CLI's `source:` (gh-fetched) skills

MCPs (`--mcp-config`), the system prompt (`--append-system-prompt-file`), and permissions (`--settings`) each had a closed-world delivery channel. **Skills did not** — so an isolated session loaded MCPs + system prompt but none of the profile's skills. (Reported via the new `skills-doctor` profile: tilth/hallouminate present, CLAUDE.md present, zero profile skills.)

## Fix

Deliver skills through a generated `--plugin-dir`, which loads regardless of setting sources (the same channel the `todo` profile uses for `todoist-flow`).

- **`overlay._collect_plugin_skills`** resolves every closed-world skill from two origins into one plugin tree:
  - `path:` skills from the profile's own tree (no network)
  - `source:` skills from the global `skills`-CLI store, mapped via the `~/.agents/.skill-lock.json` provenance file — **zero network**, since the install half of `ap launch` already fetched them and wrote the lock.
- **`overlay._write_skills_plugin`** copies them into a scratch plugin and `_build_isolated_claude` appends `--plugin-dir`. Missing source skills (offline / staged install / lock drift) degrade silently to the local skills rather than failing the launch.
- **`fetch.group_external_sources`** factors the source-grouping rule out of `cli._fetch_external_skills` so install and launch share one definition and can't drift; **`fetch.source_skill_names`** reads the lockfile.

## Verification

- `agent-profile` suite: **789 passed** (+8 new).
- End-to-end against the real `skills-doctor` profile: all **24** skills delivered into the plugin — 6 local diagnostics + 18 easy-cheese (`mold`, `cook`, `age`, `cure`, `cheez-*`, …), with unrelated sources (tavily) correctly excluded.
- Confirmed live: a relaunched `skills-doctor` session now surfaces the full closed-world skill set.

## Notes

- Second commit adds the `skills-doctor` diagnostics profile — the motivating case and the first isolated profile exercising both `path:` and `source:` skills.
- Out of scope / left untracked: `claude/hooks/package-lock.json` (unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ua5AtUmcpp2LtDKdAc4zbj