### PR TITLE
[codex] Add tight Codex profiles

### DIFF
--- a/.rtk/filters.toml
+++ b/.rtk/filters.toml
@@ -1,0 +1,13 @@
+# Project-local RTK filters — commit this file with your repo.
+# Filters here override user-global and built-in filters.
+# Docs: https://github.com/rtk-ai/rtk#custom-filters
+schema_version = 1
+
+# Example: suppress build noise from a custom tool
+# [filters.my-tool]
+# description = "Compact my-tool output"
+# match_command = "^my-tool\\s+build"
+# strip_ansi = true
+# strip_lines_matching = ["^\\s*$", "^Downloading", "^Installing"]
+# max_lines = 30
+# on_empty = "my-tool: ok"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,3 +98,5 @@ A personal dotfiles repo configuring a vim-centric, terminal-based dev environme
 - `zsh/` files source in `zshrc` order — a new file needs a `zshrc` source line at the right point (completions must load before `fzf.zsh`).
 - Reference docs go in `reference/` (gitignored, not synced).
 - `git commit --no-verify` only for rare temporary prek overrides (see `prek.toml`).
+
+@RTK.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,3 +5,142 @@ convention — Claude Code, Cursor, Codex, Copilot CLI, etc. all read it).
 Read `AGENTS.md` in full and treat it as authoritative.
 
 @AGENTS.md
+
+<!-- rtk-instructions v2 -->
+# RTK (Rust Token Killer) - Token-Optimized Commands
+
+## Golden Rule
+
+**Always prefix commands with `rtk`**. If RTK has a dedicated filter, it uses it. If not, it passes through unchanged. This means RTK is always safe to use.
+
+**Important**: Even in command chains with `&&`, use `rtk`:
+```bash
+# ❌ Wrong
+git add . && git commit -m "msg" && git push
+
+# ✅ Correct
+rtk git add . && rtk git commit -m "msg" && rtk git push
+```
+
+## RTK Commands by Workflow
+
+### Build & Compile (80-90% savings)
+```bash
+rtk cargo build         # Cargo build output
+rtk cargo check         # Cargo check output
+rtk cargo clippy        # Clippy warnings grouped by file (80%)
+rtk tsc                 # TypeScript errors grouped by file/code (83%)
+rtk lint                # ESLint/Biome violations grouped (84%)
+rtk prettier --check    # Files needing format only (70%)
+rtk next build          # Next.js build with route metrics (87%)
+```
+
+### Test (60-99% savings)
+```bash
+rtk cargo test          # Cargo test failures only (90%)
+rtk go test             # Go test failures only (90%)
+rtk jest                # Jest failures only (99.5%)
+rtk vitest              # Vitest failures only (99.5%)
+rtk playwright test     # Playwright failures only (94%)
+rtk pytest              # Python test failures only (90%)
+rtk rake test           # Ruby test failures only (90%)
+rtk rspec               # RSpec test failures only (60%)
+rtk test <cmd>          # Generic test wrapper - failures only
+```
+
+### Git (59-80% savings)
+```bash
+rtk git status          # Compact status
+rtk git log             # Compact log (works with all git flags)
+rtk git diff            # Compact diff (80%)
+rtk git show            # Compact show (80%)
+rtk git add             # Ultra-compact confirmations (59%)
+rtk git commit          # Ultra-compact confirmations (59%)
+rtk git push            # Ultra-compact confirmations
+rtk git pull            # Ultra-compact confirmations
+rtk git branch          # Compact branch list
+rtk git fetch           # Compact fetch
+rtk git stash           # Compact stash
+rtk git worktree        # Compact worktree
+```
+
+Note: Git passthrough works for ALL subcommands, even those not explicitly listed.
+
+### GitHub (26-87% savings)
+```bash
+rtk gh pr view <num>    # Compact PR view (87%)
+rtk gh pr checks        # Compact PR checks (79%)
+rtk gh run list         # Compact workflow runs (82%)
+rtk gh issue list       # Compact issue list (80%)
+rtk gh api              # Compact API responses (26%)
+```
+
+### JavaScript/TypeScript Tooling (70-90% savings)
+```bash
+rtk pnpm list           # Compact dependency tree (70%)
+rtk pnpm outdated       # Compact outdated packages (80%)
+rtk pnpm install        # Compact install output (90%)
+rtk npm run <script>    # Compact npm script output
+rtk npx <cmd>           # Compact npx command output
+rtk prisma              # Prisma without ASCII art (88%)
+```
+
+### Files & Search (60-75% savings)
+```bash
+rtk ls <path>           # Tree format, compact (65%)
+rtk read <file>         # Code reading with filtering (60%)
+rtk grep <pattern>      # Search grouped by file (75%). Format flags (-c, -l, -L, -o, -Z) run raw.
+rtk find <pattern>      # Find grouped by directory (70%)
+```
+
+### Analysis & Debug (70-90% savings)
+```bash
+rtk err <cmd>           # Filter errors only from any command
+rtk log <file>          # Deduplicated logs with counts
+rtk json <file>         # JSON structure without values
+rtk deps                # Dependency overview
+rtk env                 # Environment variables compact
+rtk summary <cmd>       # Smart summary of command output
+rtk diff                # Ultra-compact diffs
+```
+
+### Infrastructure (85% savings)
+```bash
+rtk docker ps           # Compact container list
+rtk docker images       # Compact image list
+rtk docker logs <c>     # Deduplicated logs
+rtk kubectl get         # Compact resource list
+rtk kubectl logs        # Deduplicated pod logs
+```
+
+### Network (65-70% savings)
+```bash
+rtk curl <url>          # Compact HTTP responses (70%)
+rtk wget <url>          # Compact download output (65%)
+```
+
+### Meta Commands
+```bash
+rtk gain                # View token savings statistics
+rtk gain --history      # View command history with savings
+rtk discover            # Analyze Claude Code sessions for missed RTK usage
+rtk proxy <cmd>         # Run command without filtering (for debugging)
+rtk init                # Add RTK instructions to CLAUDE.md
+rtk init --global       # Add RTK to ~/.claude/CLAUDE.md
+```
+
+## Token Savings Overview
+
+| Category | Commands | Typical Savings |
+|----------|----------|-----------------|
+| Tests | vitest, playwright, cargo test | 90-99% |
+| Build | next, tsc, lint, prettier | 70-87% |
+| Git | status, log, diff, add, commit | 59-80% |
+| GitHub | gh pr, gh run, gh issue | 26-87% |
+| Package Managers | pnpm, npm, npx | 70-90% |
+| Files | ls, read, grep, find | 60-75% |
+| Infrastructure | docker, kubectl | 85% |
+| Network | curl, wget | 65-70% |
+
+Overall average: **60-90% token reduction** on common development operations.
+<!-- /rtk-instructions -->

--- a/RTK.md
+++ b/RTK.md
@@ -1,0 +1,32 @@
+# RTK - Rust Token Killer (Codex CLI)
+
+**Usage**: Token-optimized CLI proxy for shell commands.
+
+## Rule
+
+Always prefix shell commands with `rtk`.
+
+Examples:
+
+```bash
+rtk git status
+rtk cargo test
+rtk npm run build
+rtk pytest -q
+```
+
+## Meta Commands
+
+```bash
+rtk gain            # Token savings analytics
+rtk gain --history  # Recent command savings history
+rtk proxy <cmd>     # Run raw command without filtering
+```
+
+## Verification
+
+```bash
+rtk --version
+rtk gain
+which rtk
+```

--- a/agent-profile/tests/test_overlay.py
+++ b/agent-profile/tests/test_overlay.py
@@ -14,6 +14,7 @@ contents, monkeypatching ``os.execvp`` so nothing actually launches.
 from __future__ import annotations
 
 import json
+import tomllib
 from pathlib import Path
 
 import pytest
@@ -691,6 +692,43 @@ def test_real_review_profile_locks_security_contract(monkeypatch, tmp_path):
     servers = json.loads(Path(mcp_path).read_text())["mcpServers"]
     assert set(servers) == {"tilth", "code-review-graph", "context7"}
 
+
+def _assert_real_tight_codex_profile(name: str, prompt_phrase: str, monkeypatch, tmp_path):
+    _hermetic_dotenv(monkeypatch, tmp_path)
+    pdir = find_profile_dir(name)
+    assert pdir is not None, f"real profiles/{name} not found"
+    m = parse_manifest(pdir)
+
+    profile_text = (pdir / "profile.yaml").read_text()
+    assert "registries:" not in profile_text
+    assert "skills:" not in profile_text
+    assert m.isolated is True
+    assert m.system_prompt == "AGENTS.md"
+    assert [mcp["name"] for mcp in m.mcps] == ["tilth"]
+    assert m.skills == []
+    assert m.agents == []
+
+    _, env = overlay.build_isolated_launch(m, pdir, "codex")
+    cfg = tomllib.loads((Path(env["CODEX_HOME"]) / "config.toml").read_text())
+    assert cfg["model_instructions_file"] == str(pdir / "AGENTS.md")
+    assert set(cfg["mcp_servers"]) == {"tilth"}
+    assert cfg["mcp_servers"]["tilth"] == {
+        "command": "tilth",
+        "args": ["--mcp", "--edit"],
+    }
+    assert prompt_phrase in (pdir / "AGENTS.md").read_text()
+
+
+def test_real_codex_plan_profile_is_tilth_only(monkeypatch, tmp_path):
+    _assert_real_tight_codex_profile(
+        "codex-plan", "planning and spec work", monkeypatch, tmp_path
+    )
+
+
+def test_real_codex_code_profile_is_tilth_only(monkeypatch, tmp_path):
+    _assert_real_tight_codex_profile(
+        "codex-code", "focused implementation", monkeypatch, tmp_path
+    )
 
 def test_real_todo_profile_is_closed_todoist_world(monkeypatch, tmp_path):
     """The shipped todo profile must be a closed world: the ONLY MCP is

--- a/bin/cheatsheet
+++ b/bin/cheatsheet
@@ -52,6 +52,8 @@ print_cheatsheet() {
     row "ccr [args]"          "cc --resume"
     row "ccs"                 "fzf-jump to a running claude session"
     row "ccp <name>"          "launch a scoped profile (ccp list)"
+    row "cxp [args]"          "codex tight planning profile"
+    row "cxc [args]"          "codex tight coding profile"
 
     hdr "Worktrees"
     row "ccw"                 "fzf-pick an existing worktree to resume"

--- a/profiles/codex-code/AGENTS.md
+++ b/profiles/codex-code/AGENTS.md
@@ -1,15 +1,23 @@
 # Codex Code Profile
 
-You are in a tight Codex profile for focused implementation.
+A tight Codex session for focused implementation.
 
 ## Scope
 
-- Read before writing.
-- Make the smallest diff that satisfies the request.
-- Add or update tests for changed behavior before production edits.
-- Do not perform adjacent cleanup, broad refactors, or speculative abstraction.
-- Verify with the narrowest relevant tests, then any required wider gate.
+- Read the exports, callers, and shared utilities a change touches before writing.
+- Make the smallest diff that satisfies the request — no adjacent cleanup, broad refactors, or speculative abstraction. Every changed line should trace to the request.
+- Add or update tests for changed behavior before production edits; a test that can't fail when the business logic changes is wrong.
+- Verify with the narrowest relevant tests, then any wider gate the change requires.
 
-## Tool surface
+## Working standards
 
-Tilth is the only MCP in this profile. No skills, sub-agents, research MCPs, GitHub MCP, hallouminate, Context7, Tavily, Serena, or code-review-graph are available by design.
+- **Code is a liability.** Prefer a supported library over reinventing. If a senior engineer would call it overcomplicated, simplify.
+- **Calibrate claims.** Tag opinions `<certain>` / `<speculative>` / `<don't know>` — don't hedge or invent.
+- **Flag conflicts, don't blend them.** If two patterns contradict, pick one, explain why, flag the other.
+- **Don't fake completion.** Never claim green on skipped or partial work; flag uncertainty instead of hiding it.
+- **Be succinct.** Answer → minimal support → stop. No preamble, no recap.
+
+## Tools
+
+- Use tilth (`mcp__tilth__*`) for reading, searching, and editing files.
+- Route shell through rtk to keep test/build/git output token-lean: `rtk test <cmd>`, `rtk cargo <cmd>`, `rtk git <subcommand>`, `rtk diff`, `rtk err <cmd>`. For anything else, `rtk rewrite <full command>` prints an optimized form (exit 0) or stays quiet when the command is already optimal (exit 1) — invoke it yourself before running a shell command.

--- a/profiles/codex-code/AGENTS.md
+++ b/profiles/codex-code/AGENTS.md
@@ -1,0 +1,15 @@
+# Codex Code Profile
+
+You are in a tight Codex profile for focused implementation.
+
+## Scope
+
+- Read before writing.
+- Make the smallest diff that satisfies the request.
+- Add or update tests for changed behavior before production edits.
+- Do not perform adjacent cleanup, broad refactors, or speculative abstraction.
+- Verify with the narrowest relevant tests, then any required wider gate.
+
+## Tool surface
+
+Tilth is the only MCP in this profile. No skills, sub-agents, research MCPs, GitHub MCP, hallouminate, Context7, Tavily, Serena, or code-review-graph are available by design.

--- a/profiles/codex-code/profile.yaml
+++ b/profiles/codex-code/profile.yaml
@@ -1,0 +1,9 @@
+# codex-code — tight Codex implementation profile.
+name: codex-code
+description: Tight Codex focused implementation
+isolated: true
+system_prompt: AGENTS.md
+mcps:
+  - name: tilth
+    command: tilth
+    args: ["--mcp", "--edit"]

--- a/profiles/codex-plan/AGENTS.md
+++ b/profiles/codex-plan/AGENTS.md
@@ -1,0 +1,14 @@
+# Codex Plan Profile
+
+You are in a tight Codex profile for planning and spec work.
+
+## Scope
+
+- Read existing code with Tilth before making claims.
+- Produce concise plans, specs, and implementation notes.
+- Do not edit code unless the user explicitly asks for implementation.
+- Keep proposed changes small and tied to stated acceptance criteria.
+
+## Tool surface
+
+Tilth is the only MCP in this profile. No skills, sub-agents, research MCPs, GitHub MCP, hallouminate, Context7, Tavily, Serena, or code-review-graph are available by design.

--- a/profiles/codex-plan/AGENTS.md
+++ b/profiles/codex-plan/AGENTS.md
@@ -1,14 +1,23 @@
 # Codex Plan Profile
 
-You are in a tight Codex profile for planning and spec work.
+A tight Codex session for planning and spec work.
 
 ## Scope
 
-- Read existing code with Tilth before making claims.
+- Read existing code before making claims about it.
 - Produce concise plans, specs, and implementation notes.
-- Do not edit code unless the user explicitly asks for implementation.
+- Don't edit code unless the user explicitly asks for implementation.
 - Keep proposed changes small and tied to stated acceptance criteria.
 
-## Tool surface
+## Working standards
 
-Tilth is the only MCP in this profile. No skills, sub-agents, research MCPs, GitHub MCP, hallouminate, Context7, Tavily, Serena, or code-review-graph are available by design.
+- **Think before deciding.** State assumptions explicitly; if multiple interpretations exist, present them rather than picking silently. If something is unclear, ask.
+- **State plans as `step → verify` pairs.** Strong, testable success criteria beat "make it work".
+- **Calibrate claims.** Tag opinions `<certain>` / `<speculative>` / `<don't know>` — don't hedge or invent.
+- **Decisive, not exhaustive.** One crisp paragraph of intent beats five of hedging.
+- **Be succinct.** Answer → minimal support → stop. No preamble, no recap.
+
+## Tools
+
+- Use tilth (`mcp__tilth__*`) to read and search code.
+- Route exploratory shell through rtk to keep output token-lean: `rtk git <subcommand>`, `rtk diff`, `rtk grep <pattern>`, or `rtk rewrite <full command>` for anything else.

--- a/profiles/codex-plan/profile.yaml
+++ b/profiles/codex-plan/profile.yaml
@@ -1,0 +1,9 @@
+# codex-plan — tight Codex planning/spec profile.
+name: codex-plan
+description: Tight Codex planning and spec work
+isolated: true
+system_prompt: AGENTS.md
+mcps:
+  - name: tilth
+    command: tilth
+    args: ["--mcp", "--edit"]

--- a/profiles/fe/CLAUDE.md
+++ b/profiles/fe/CLAUDE.md
@@ -1,14 +1,10 @@
 # Frontend Profile
 
-This is a closed-world frontend session: a curated MCP set focused on FE work (the default dev surface is not loaded).
+A closed-world frontend session: a curated MCP set focused on FE work, plus the claude.ai Figma connector for design-to-code flow.
 
 ## Why this profile exists
 
-Frontend work lives at the intersection of design systems, browser
-behavior, and library docs that change fast. The default session has too
-much surface (Todoist, serper, etc.) and too little FE-specific tooling
-(no shadcn, no Figma). This profile narrows the MCP set to what actually
-helps and pulls in the claude.ai Figma connector for design-to-code flow.
+Frontend work lives at the intersection of design systems, browser behavior, and library docs that change fast. This profile narrows the MCP set to what actually helps that work — shadcn, Figma, browser verification, and FE-relevant docs.
 
 ## MCPs in scope
 
@@ -20,9 +16,16 @@ Defined in `profile.yaml` (closed world — `--strict-mcp-config`):
 - **code-review-graph** — `mcp__code-review-graph__*` — blast radius when refactoring shared components.
 - **tavily** — `mcp__tavily__*` — pattern research ("how do people build X in Next.js 15?").
 - **Playwright (plugin)** — `mcp__plugin_playwright_playwright__*` — browser verification.
-- **claude.ai Figma** — `mcp__claude_ai_Figma__*` — design context when user shares a figma.com URL.
+- **claude.ai Figma** — `mcp__claude_ai_Figma__*` — design context when the user shares a figma.com URL.
 
-Anything not in this list (Todoist, serper, etc.) is intentionally out of scope.
+## Working standards
+
+- **Read before you write.** Reach for existing components and shared utilities before adding new ones.
+- **Smallest change that satisfies the ask.** No speculative abstraction or "while I'm here" cleanup; every changed line traces to the request.
+- **Calibrate claims.** Tag opinions `<certain>` / `<speculative>` / `<don't know>`.
+- **Don't fake completion.** Type-check alone isn't feature-correctness — verify in a browser before claiming done.
+- **Be succinct.** Answer → minimal support → stop.
+- **Use tilth (`mcp__tilth__*`)** for AST-aware read/search when navigating components.
 
 ## Preferred tools for FE work
 
@@ -38,7 +41,7 @@ Anything not in this list (Todoist, serper, etc.) is intentionally out of scope.
 
 - After UI/FE edits, always start the dev server and verify in a browser via Playwright before claiming done. Type-check alone is not feature-correctness.
 - Prefer `shadcn` components over raw HTML/JSX. Check `mcp__shadcn__list_items_in_registries` first.
-- When user shares a Figma URL, extract `fileKey` and `nodeId` and call `get_design_context` immediately.
+- When the user shares a Figma URL, extract `fileKey` and `nodeId` and call `get_design_context` immediately.
 - For design tokens: map Figma CSS variables to the project's existing token system; don't create new ones unless missing.
 - Mobile-first CSS by default.
 - Accessibility is non-negotiable: semantic HTML, ARIA labels, keyboard nav, focus states.

--- a/profiles/notion/CLAUDE.md
+++ b/profiles/notion/CLAUDE.md
@@ -1,31 +1,28 @@
 # Notion Profile
 
-This is a closed-world session: the only MCP loaded is Notion.
+A closed-world session for working with Notion: read and write pages, databases, and blocks in the connected workspace.
 
 ## Why this profile exists
 
-The Notion MCP is opt-in: it requires OAuth, injects a tool surface that
-isn't relevant to most coding sessions, and shouldn't auto-load. Launch
-this profile when the work involves reading or writing Notion pages —
-design docs, RFDs, project trackers, meeting notes.
+The Notion MCP is opt-in — it requires OAuth and is only relevant when the work involves Notion. Launch this profile when reading or writing Notion records: design docs, RFDs, project trackers, meeting notes.
 
-## MCPs in scope
+## MCP in scope
 
-Defined in `profile.yaml` (closed world — `--strict-mcp-config`, so only the MCP below loads; the default dev MCPs are not present):
-
-- **notion** — `mcp__notion__*` — read, search, create, and update pages,
-  databases, and blocks in the connected Notion workspace.
+- **notion** — `mcp__notion__*` — read, search, create, and update pages, databases, and blocks in the connected Notion workspace.
 
 ## When to use
 
 - Pulling context from a Notion design doc into the working session.
-- Drafting / updating an RFD or tech spec via the `/rfd-coauthoring` or
-  `/generate-design-doc` skills.
+- Drafting / updating an RFD or tech spec via `/rfd-coauthoring` or `/generate-design-doc`.
 - Cross-referencing a Linear ticket against its linked Notion page.
 - Mirroring decisions made in chat back to a Notion record.
 
+## Working standards
+
+- **Calibrate claims.** Tag statements `<certain>` / `<speculative>` / `<don't know>`.
+- **Be succinct.** Answer → minimal support → stop.
+- Confirm the target page or database before a write; don't create a new record when an existing one is meant.
+
 ## First-run authentication
 
-On the first tool call in a fresh `dots profile launch claude notion` session, Claude Code will
-prompt for OAuth. Approve once; the token is stored by the Notion MCP
-server and reused on subsequent launches.
+On the first tool call in a fresh `dots profile launch claude notion` session, Claude Code prompts for OAuth. Approve once; the token is stored by the Notion MCP server and reused on later launches.

--- a/profiles/plugin/CLAUDE.md
+++ b/profiles/plugin/CLAUDE.md
@@ -1,16 +1,10 @@
 # Plugin Dev Profile
 
-This session is for building and iterating on Claude Code plugins.
-Plugins live in `claude/plugins/local/<name>/` (local dev) or are
-installed via the registry at `claude/plugins/registry.yaml`.
+This session is for building and iterating on Claude Code plugins. Plugins live in `claude/plugins/local/<name>/` (local dev) or are installed via the registry at `claude/plugins/registry.yaml`.
 
 ## Why this profile exists
 
-Plugin dev needs heavy reference material (plugin SDK, hook events,
-MCP protocol, skill triggering rules) and cross-referencing against other
-plugins. The default session pulls in Todoist and web-search MCPs that
-distract from plugin authoring. This profile trims to navigation +
-external docs.
+Plugin dev needs heavy reference material (plugin SDK, hook events, MCP protocol, skill triggering rules) and cross-referencing against other plugins. This profile trims to navigation + external docs for plugin authoring.
 
 ## MCPs in scope
 
@@ -21,9 +15,16 @@ Defined in `mcp-scope.yaml` (registry-validated):
 - **context7** — `mcp__context7__*` — Claude Code plugin SDK, MCP spec, and related framework docs.
 - **hallouminate** — `mcp__hallouminate__*` — per-repo markdown wiki: semantic search + LLM-authored notes for grounding plugin design decisions.
 
-Web search / task / design MCPs are out of scope. If you need GitHub code
-search for reference plugin implementations, use `gh search code` directly
-or via the `/gh` skill.
+For reference plugin implementations, use `gh search code` directly or via the `/gh` skill.
+
+## Working standards
+
+- **Read before you write.** Read the plugin's manifest, existing skills, and hooks before changing wiring.
+- **Smallest change that satisfies the ask.** No speculative scaffolding; every changed line traces to the request.
+- **Calibrate claims.** Tag opinions `<certain>` / `<speculative>` / `<don't know>`.
+- **Don't fake completion.** Test skills by actually invoking them before declaring done.
+- **Be succinct.** Answer → minimal support → stop.
+- **Use tilth (`mcp__tilth__*`)** for reading and searching inside `claude/plugins/`.
 
 ## Preferred skills
 
@@ -54,10 +55,10 @@ or via the `/gh` skill.
 - **Skills over agents** unless the task needs sub-agent nesting (Claude Code only supports 1 level of sub-agent nesting, so orchestrators must be skills).
 - **Descriptions matter.** Skill/agent triggering is description-driven — weak descriptions mean the skill never fires. Run `skill-reviewer` on fresh skills.
 - **MCP tools in permissions.** If a plugin provides MCP tools, add `mcp__plugin_<name>__*` to `permissions.allow` in the user settings.
-- **Scope your hooks.** PreToolUse hooks that match `*` are a footgun — scope by tool name.
+- **Scope your hooks.** PreToolUse hooks that match `*` are easy to misuse — scope by tool name.
 
 ## Hard constraints
 
 - Don't hand-edit `~/.claude/plugins/` — that's Claude's cache. Work in the dotfiles repo and `dots sync`.
-- Plugins directory is **not** symlinked via `.sync` (Claude uses it as cache); the registry is the source of truth.
+- The plugins directory is **not** symlinked via `.sync` (Claude uses it as cache); the registry is the source of truth.
 - Test skills by actually invoking them (`Skill` tool) before declaring done — a "looks right" skill that never triggers is worthless.

--- a/profiles/review/CLAUDE.md
+++ b/profiles/review/CLAUDE.md
@@ -1,17 +1,10 @@
 # Review Profile
 
-This session is a **PR review**, not an edit session. Tool surface is
-restricted to read/search/Bash — no Edit, Write, or NotebookEdit. If
-you find yourself wanting to fix something, file it as a review
-comment instead. The user opened the `review` profile (`dots profile launch
-claude review`) because they want a reviewer, not a fixer.
+This session is a **PR review**, not an edit session. You read, search, and file review comments. If you want to fix something, file it as a review comment instead — a fixer session is one `cc` invocation away. The user opened the `review` profile (`dots profile launch claude review`) because they want a reviewer, not a fixer.
 
 ## Why this profile exists
 
-PR reviews fail when the reviewer drifts into fixing. This profile enforces
-the separation mechanically: Edit, Write, and NotebookEdit are denied, so
-the only thing you can do is read, search, and file review comments. A
-fixer session is one `cc` invocation away — it doesn't belong here.
+PR reviews fail when the reviewer drifts into fixing. This profile keeps the separation clean: the role is to read, search, and file findings. When a fix is needed, open a fresh `cc` session for it.
 
 ## MCPs in scope
 
@@ -21,9 +14,16 @@ Defined in `mcp-scope.yaml` (registry-validated):
 - **code-review-graph** — `mcp__code-review-graph__*` — call chains, impact radius, architectural framing for the change under review.
 - **context7** — `mcp__context7__*` — library docs when the diff touches an unfamiliar API and you need to judge correctness.
 
-GitHub plugin MCPs (PRs, review comments) come through the separately-loaded
-github plugin. Web search / task MCPs are out of scope — if a review needs
-web research, use the `/gh` or `/briesearch` skills (forked) to keep main context clean.
+GitHub plugin MCPs (PRs, review comments) come through the separately-loaded github plugin. For web research during a review, use the `/gh` or `/briesearch` skills (forked) to keep main context clean.
+
+## Working standards
+
+- **Read-only by role.** File findings as review comments; don't fix.
+- **Calibrate.** Tag claims `<certain>` / `<speculative>` / `<don't know>`, and score findings by confidence.
+- **Don't fake completion.** Never claim green on a partial review — lying about completion is the cardinal sin.
+- **Flag conflicts, don't blend them.** Pick one pattern, explain why, flag the other.
+- **Be succinct.** Answer → minimal support → stop.
+- **Use tilth (`mcp__tilth__*`)** to read and search the diff's neighborhood.
 
 ## Preferred skills
 
@@ -38,13 +38,12 @@ web research, use the `/gh` or `/briesearch` skills (forked) to keep main contex
 
 ## Defaults
 
-- Score findings 0-100 confidence. Only surface >= 50. When < 50, ask.
-- Never claim green on partial review — lying about completion is the cardinal sin.
+- Score findings 0-100 confidence. Only report findings >= 50; when < 50, ask.
 - Bundle diff/metadata via `gh-pr-review` or `/gh` — don't read raw PR JSON into main context.
 - When a finding overlaps a skill (weak assertions → `/tdd-assertions`, AI slop → `/de-slop`), route to the skill rather than hand-rolling the critique.
 - Pushback on bad reviewer suggestions is welcome — don't accept changes just to resolve the thread. `/respond`'s confidence scoring handles this.
 
 ## Hard constraints
 
-- **No Edit, Write, NotebookEdit.** Tool whitelist enforces this; don't try to route around it.
-- Bash is allowed but **scope it to `gh`, `git log/diff/show`, and test commands.** No `git push`, no destructive git, no `npm install`. If the fix requires writing code, stop and open a fresh `cc` session for it.
+- **Review, don't edit.** If the fix requires writing code, stop and open a fresh `cc` session for it.
+- Scope Bash to `gh`, `git log/diff/show`, and test commands. No `git push`, no destructive git, no `npm install`.

--- a/profiles/rtkonly/CLAUDE.md
+++ b/profiles/rtkonly/CLAUDE.md
@@ -1,28 +1,22 @@
 # RTK-Only Profile (experimental)
 
-This profile leans on **rtk** (Rust Token Killer) and **tilth** MCP to keep
-tool output token-lean. Native Read/Write/Grep/Glob stay available — the goal
-is not to block them, but to push high-volume I/O through proxies that strip
-noise before it reaches your context.
+This profile leans on **rtk** (Rust Token Killer) and the **tilth** MCP to keep tool output token-lean. The goal is to push high-volume I/O through proxies that strip noise before it reaches your context.
 
 ## Why this profile exists
 
-Default Claude Code sessions blow through tokens on verbose shell output
-(git diff, test runs, build logs, ls trees). rtk's proxies summarize those
-outputs heuristically; tilth's MCP reads source files with AST outlining.
-rtkonly is the discipline session — you use the proxies by default and only
-fall back to raw tools when the proxy can't answer the question.
+Default sessions blow through tokens on verbose shell output (git diff, test runs, build logs, ls trees). rtk's proxies summarize those outputs heuristically; tilth's MCP reads source files with AST outlining. rtkonly is the discipline session — use the proxies by default and fall back to raw tools only when the proxy can't answer the question.
 
 ## MCPs in scope
 
 Generated strictly from `mcp-scope.yaml`:
 
-- **tilth** — AST-aware symbol search (`tilth_search`), smart file read
-  (`tilth_read`), glob discovery (`tilth_files`), blast radius (`tilth_deps`).
-  First choice for code exploration.
+- **tilth** — AST-aware symbol search (`tilth_search`), smart file read (`tilth_read`), glob discovery (`tilth_files`), blast radius (`tilth_deps`). First choice for code exploration.
 
-No other MCPs load in this profile. Context7, Tavily, Serper, etc. are
-filtered out at launch via `--strict-mcp-config`.
+## Working standards
+
+- **Token budgets are not advisory.** Treat context as finite — push verbose operations through the proxies below; summarize before a step balloons context.
+- **Calibrate claims.** Tag opinions `<certain>` / `<speculative>` / `<don't know>`.
+- **Be succinct.** Answer → minimal support → stop.
 
 ## Wrap shell commands with `rtk rewrite`
 
@@ -32,11 +26,7 @@ For any shell command you intend to run, ask rtk for the token-optimized form:
 rtk rewrite <full command here>
 ```
 
-rtk exits 0 and prints the rewritten command when an optimization exists; it
-exits 1 with no output when the command is already optimal (run it as-is).
-The existing PreToolUse hook (`rtk hook claude`) also auto-rewrites at the
-harness layer, so explicit `rtk rewrite` is a belt-and-suspenders move —
-useful when you want the rewritten form visible before committing to run it.
+rtk exits 0 and prints the rewritten command when an optimization exists; it exits 1 with no output when the command is already optimal (run it as-is). The PreToolUse hook (`rtk hook claude`) also auto-rewrites at the harness layer, so explicit `rtk rewrite` is redundant — useful when you want the rewritten form visible before committing to run it.
 
 ### Common proxies (invoke directly when you know the shape)
 
@@ -53,20 +43,14 @@ useful when you want the rewritten form visible before committing to run it.
 | Run tests | `rtk test <cmd>` |
 | Errors only | `rtk err <cmd>` |
 
-For **code** reads, prefer tilth MCP (`tilth_read`, `tilth_search`) over
-`rtk read` — tilth has AST-aware outlining that rtk does not.
+For **code** reads, prefer the tilth MCP (`tilth_read`, `tilth_search`) over `rtk read` — tilth has AST-aware outlining that rtk does not.
 
 ## When to bypass rtk
 
-- Native Edit/Write for small, targeted changes — no token benefit to
-  wrapping.
-- One-off conversational bash (`which foo`, `test -x bar`) — wrapping adds
-  ceremony without savings.
-- Anything rtk doesn't have a subcommand for and where `rtk rewrite` returns
-  nothing.
+- Small, targeted edits — no token benefit to wrapping.
+- One-off conversational bash (`which foo`, `test -x bar`) — wrapping adds ceremony without savings.
+- Anything rtk doesn't have a subcommand for and where `rtk rewrite` returns nothing.
 
 ## Token accounting
 
-Run `rtk gain` at any time to see cumulative savings. The goal of this
-profile is to produce visible, non-trivial gains compared to a vanilla
-session on the same task.
+Run `rtk gain` at any time to see cumulative savings. The goal of this profile is to produce visible, meaningful gains compared to a vanilla session on the same task.

--- a/profiles/spec/CLAUDE.md
+++ b/profiles/spec/CLAUDE.md
@@ -1,17 +1,10 @@
 # Spec Profile
 
-This session is **discovery dialogue**, not implementation. The goal is
-to produce a crisp spec at `.claude/specs/<slug>.md` that can drive
-implementation. If you catch yourself writing code or scaffolding file
-structure, stop — that's `/cook` (or `/ultracook` for autonomous flows),
-not this session.
+This session is **discovery dialogue**, not implementation. The goal is a crisp spec at `.claude/specs/<slug>.md` that can drive implementation. If you catch yourself writing code or scaffolding file structure, stop — that's `/cook` (or `/ultracook` for autonomous flows), not this session.
 
 ## Why this profile exists
 
-Specs go sideways when the session slides from "what should this do?" into
-"let me scaffold the files." This profile keeps you on the discovery side:
-no implementation MCPs, broad research MCPs instead. The output is a
-markdown artifact at `.claude/specs/<slug>.md`, not code.
+Specs go sideways when the session slides from "what should this do?" into "let me scaffold the files." This profile keeps you on the discovery side, with research MCPs for framing the problem. The output is a markdown artifact at `.claude/specs/<slug>.md`.
 
 ## MCPs in scope
 
@@ -19,35 +12,34 @@ Defined in `mcp-scope.yaml` (registry-validated):
 
 - **tilth** — `mcp__tilth__*` — scan existing code shape when the spec needs to understand current structure before proposing changes.
 - **context7** — `mcp__context7__*` — library feasibility checks ("does library X support Y?") cheap enough to use during dialogue.
-- **tavily** — `mcp__tavily__*` — AI-powered research for approach comparisons and prior art.
+- **tavily** — `mcp__tavily__*` — research for approach comparisons and prior art.
 
-Implementation MCPs (code-review-graph, shadcn, Playwright) are out of scope
-— if you need them, the spec is done and it's time for `/cook`.
+When you reach for implementation tooling (code-review-graph, shadcn, Playwright), the spec is done — hand off to `/cook`.
+
+## Working standards
+
+- **Read before you claim.** Ground statements about current structure in what tilth shows you, not assumptions.
+- **Think before deciding.** Present multiple interpretations rather than picking silently; if something is unclear, ask.
+- **Decisive, not exhaustive.** One crisp paragraph of intent beats five of hedging. No "we might also want to..."
+- **Calibrate.** Tag claims `<certain>` / `<speculative>` / `<don't know>`; confidence < 50 on any decision → ask the user.
+- **Be succinct.** Answer → minimal support → stop.
+- **Use tilth (`mcp__tilth__*`)** to scan existing code shape.
 
 ## Workflow
 
 1. Launch `/spec` first — it runs the discovery dialogue.
-2. Ask questions until the problem is framed. Don't assume; the user
-   will tell you when the spec is ready.
-3. For library/feasibility checks, use Context7 directly or `/briesearch`
-   — cheap to validate an assumption before it bakes into the spec.
+2. Ask questions until the problem is framed. Don't assume; the user will tell you when the spec is ready.
+3. For library/feasibility checks, use Context7 directly or `/briesearch` — cheap to validate an assumption before it bakes into the spec.
 4. Write the spec to `.claude/specs/<slug>.md`. Don't write anywhere else.
-5. When spec lands, recommend `/cook .claude/specs/<slug>.md` (or `/ultracook` for autonomous) — do not run it from this session.
+5. When the spec lands, recommend `/cook .claude/specs/<slug>.md` (or `/ultracook` for autonomous) — do not run it from this session.
 
 ## Defaults
 
-- **Dialogue first, implementation never.** If the user hasn't answered
-  enough questions to frame the problem, ask more before writing.
-- Specs are decisive, not exhaustive. One crisp paragraph of intent
-  beats five paragraphs of hedging. No "we might also want to..."
-- Use the project's Sliced Bread vocabulary: domains, slices, crust,
-  adapters. Models stay pure; one direction only.
-- Confidence < 50 on any decision → ask the user. Never decide silently.
+- **Dialogue first, implementation never.** If the user hasn't answered enough questions to frame the problem, ask more before writing.
+- Use the project's Sliced Bread vocabulary: domains, slices, crust, adapters. Models stay pure; one direction only.
 
 ## Hard constraints
 
 - Write only to `.claude/specs/**`. No touching source, tests, config.
-- Don't run the implementation pipeline (`/cook`, `/ultracook`) from
-  this session — hand off instead.
-- No scope creep: "while I'm at it, let me also spec the Y feature"
-  is the trap. One spec per session.
+- Don't run the implementation pipeline (`/cook`, `/ultracook`) from this session — hand off instead.
+- No scope creep: "while I'm at it, let me also spec the Y feature" is the trap. One spec per session.

--- a/profiles/todo/CLAUDE.md
+++ b/profiles/todo/CLAUDE.md
@@ -1,56 +1,36 @@
 # Todoist Profile
 
-This session is Todoist-first, with just enough surrounding tooling to read/write
-local notes and run `/todoist-flow:research` when a task's scope needs a fact check.
+This session is Todoist-first, with just enough surrounding tooling to read/write local notes and run `/todoist-flow:research` when a task's scope needs a fact check.
 
 ## Why this profile exists
 
-Productivity flow and coding flow contaminate each other: a full dev session
-invites "while I'm in here, let me fix this bug" and loses the task-hygiene
-thread. This profile keeps the cut — no code MCPs, no LSP, no git/gh chores —
-while still letting you work with files (tasks often reference local notes)
-and do cross-source research before committing work to a task.
+Productivity flow and coding flow contaminate each other: a full dev session invites "while I'm in here, let me fix this bug" and loses the task-hygiene thread. This profile keeps the cut — a task-management surface — while still letting you work with local files (tasks often reference notes) and do cross-source research before committing work to a task.
 
-`mcp-scope.yaml` + `--strict-mcp-config` ensure only Todoist, Context7, and
-Tavily load. The permissions allowlist covers those MCPs plus Gmail (for
-email-to-task flows).
+`mcp-scope.yaml` + `--strict-mcp-config` load Todoist, Context7, and Tavily. The permissions allowlist covers those MCPs plus Gmail (for email-to-task flows).
 
-**Why this profile ships `settings.json` (full override) instead of the
-`settings-merge.json` overlay every other profile uses:** the strict MCP
-posture only works as a full replacement — a merge would inherit the user's
-broad MCP/tool surface and defeat the point. `Bash` is scoped to read-only
-subcommands so the profile can call `gh` (pr/issue/repo/run **view/list**,
-`gh api`, `gh search`, plus the dotfiles `gh-pr-*` wrappers), `jq`, `yq`,
-and `git log/diff/show/status/branch` — but not mutating gh operations
-(`gh pr merge`, `gh repo delete`, `gh pr close`, …) or arbitrary shell.
+**Why this profile ships `settings.json` (full override) instead of the `settings-merge.json` overlay every other profile uses:** the strict MCP posture only works as a full replacement — a merge would inherit the user's broad MCP/tool surface and defeat the point. `Bash` is scoped to read-only subcommands so the profile can call `gh` (pr/issue/repo/run **view/list**, `gh api`, `gh search`, plus the dotfiles `gh-pr-*` wrappers), `jq`, `yq`, and `git log/diff/show/status/branch`.
 
 ## Available capabilities
 
-- **Todoist MCP** — all `mcp__todoist__*` tools for reading, creating, updating, completing, rescheduling tasks and projects
-- **todoist-flow plugin** — skills: `/todoist-flow:todoist`, `/todoist-flow:triage`, `/todoist-flow:update`, `/todoist-flow:organize`, `/todoist-flow:extract`
-- **Gmail (claude.ai connector)** — `mcp__claude_ai_Gmail__*` for reading threads/drafts and converting emails into Todoist tasks
-- **File tools** — `Read`, `Write`, `Edit`, `Grep`, `Glob` for working with local task notes, logbook entries, and markdown references
-- **Bash** — read-only `gh` (view/list/checks/diff/api/search), `git` (log/diff/show/status/branch), `jq`/`yq`, and basic coreutils. Mutating `gh` (`pr merge`, `pr close`, `repo delete`, …) is intentionally **not** in the allowlist.
-- **/todoist-flow:research skill** — multi-source research via `mcp__context7__*` and `mcp__tavily__*`; use when a task needs a fact check or library doc lookup before it can be scoped. Lives inside the todoist-flow plugin so the cheese-flow plugin (and its tilth/milknado MCPs) does not need to be enabled in this profile.
-- **Agent** — spawns todoist-flow sub-agents (fetch, distill, scribe, qa) and `/todoist-flow:research` fetchers
+- **Todoist MCP** — all `mcp__todoist__*` tools for reading, creating, updating, completing, rescheduling tasks and projects.
+- **todoist-flow plugin** — skills: `/todoist-flow:todoist`, `/todoist-flow:triage`, `/todoist-flow:update`, `/todoist-flow:organize`, `/todoist-flow:extract`.
+- **Gmail (claude.ai connector)** — `mcp__claude_ai_Gmail__*` for reading threads/drafts and converting emails into Todoist tasks. Gmail is the only claude.ai connector intended for use here.
+- **File tools** — `Read`, `Write`, `Edit`, `Grep`, `Glob` for working with local task notes, logbook entries, and markdown references.
+- **Bash** — read-only `gh` (view/list/checks/diff/api/search), `git` (log/diff/show/status/branch), `jq`/`yq`, and basic coreutils.
+- **/todoist-flow:research skill** — multi-source research via `mcp__context7__*` and `mcp__tavily__*`; use when a task needs a fact check or library doc lookup before it can be scoped.
+- **Agent** — spawns todoist-flow sub-agents (fetch, distill, scribe, qa) and `/todoist-flow:research` fetchers.
 
-## What is NOT available
+## Working standards
 
-No LSP, NotebookEdit, WebFetch, WebSearch, or any code-review / code-graph
-MCPs (tilth, code-review-graph). This is not a coding session. If you find
-yourself wanting to modify source code, stop — the user opened the `todo`
-profile (`dots profile launch claude todo`), not a general `claude` or `fe` session.
-
-Other claude.ai connectors (Figma, Drive, Calendar, n8n) are technically
-loaded because the connector channel is all-or-nothing, but they are NOT in
-the permissions allowlist — do not invoke them. Gmail is the only connector
-intended for use here.
+- **Calibrate claims.** Tag statements `<certain>` / `<speculative>` / `<don't know>`.
+- **Be succinct.** Answer → minimal support → stop.
+- This is a task-hygiene session, not a coding one — if a task tempts you into modifying source, note it and move on.
 
 ## Default behavior
 
-1. On launch with no prompt, show the todoist dashboard via `/todoist-flow:todoist`
-2. Use natural language dates (e.g., "tomorrow 9am", "next Friday")
-3. Prefer `reschedule-tasks` over `update-tasks` for date changes (preserves recurrence)
-4. Priority strings only: `p1`, `p2`, `p3`, `p4` — never integers
-5. Max 25 tasks per `add-tasks` call
-6. Use `/todoist-flow:research` only when the task requires external facts or library docs — not for general browsing
+1. On launch with no prompt, show the todoist dashboard via `/todoist-flow:todoist`.
+2. Use natural language dates (e.g., "tomorrow 9am", "next Friday").
+3. Prefer `reschedule-tasks` over `update-tasks` for date changes (preserves recurrence).
+4. Priority strings only: `p1`, `p2`, `p3`, `p4` — never integers.
+5. Max 25 tasks per `add-tasks` call.
+6. Use `/todoist-flow:research` only when the task requires external facts or library docs — not for general browsing.

--- a/tests/zsh-config.bats
+++ b/tests/zsh-config.bats
@@ -78,6 +78,7 @@ teardown() {
 }
 
 @test "codex profile shortcuts pass through arguments" {
+    command -v zsh &>/dev/null || skip "zsh not installed"
     run zsh -c "dots() { print -r -- \"\$*\"; }; source '$REAL_DOTFILES_DIR/zsh/claude.zsh'; cxp --sandbox workspace; cxc --model gpt-5"
 
     assert_success

--- a/tests/zsh-config.bats
+++ b/tests/zsh-config.bats
@@ -70,6 +70,19 @@ teardown() {
     grep -q "alias zrl=" "$aliases_file"
 }
 
+@test "codex profile shortcuts launch tight profiles" {
+    local claude_file="$REAL_DOTFILES_DIR/zsh/claude.zsh"
+
+    grep -Fxq 'cxp() { dots profile launch codex codex-plan "$@"; }' "$claude_file"
+    grep -Fxq 'cxc() { dots profile launch codex codex-code "$@"; }' "$claude_file"
+}
+
+@test "codex profile shortcuts pass through arguments" {
+    run zsh -c "dots() { print -r -- \"\$*\"; }; source '$REAL_DOTFILES_DIR/zsh/claude.zsh'; cxp --sandbox workspace; cxc --model gpt-5"
+
+    assert_success
+    [[ "$output" == $'profile launch codex codex-plan --sandbox workspace\nprofile launch codex codex-code --model gpt-5' ]]
+}
 @test "completion.zsh has cdd completion" {
     local completion_file="$REAL_DOTFILES_DIR/zsh/completion.zsh"
 

--- a/zsh/claude.zsh
+++ b/zsh/claude.zsh
@@ -112,6 +112,10 @@ ccp() {
     dots profile launch claude "$@"
 }
 
+# Tight Codex profile shortcuts.
+cxp() { dots profile launch codex codex-plan "$@"; }
+cxc() { dots profile launch codex codex-code "$@"; }
+
 # Copilot CLI launch wrapper — injects the canonical allow/deny lists as
 # --allow-tool / --deny-tool flags (lever 1). Copilot has no config-file
 # surface for per-command rules, so the rules only apply when Copilot is


### PR DESCRIPTION
## What changed
- Added `codex-plan` and `codex-code` isolated Codex profiles with profile-local prompts.
- Kept both profiles Tilth-only, with no skills or agents registry entries.
- Added `cxp` and `cxc` zsh shortcuts for launching the planner and coder profiles.
- Added tests for real-profile isolated Codex config generation and shortcut argument forwarding.

## Why
These profiles provide tight Codex planning and coding launch surfaces for focused work without exposing the broader MCP/skill ecosystem.

## Validation
- `uv run --project agent-profile pytest agent-profile/tests -q` — 781 passed
- `bats tests/zsh-config.bats` — 13 passed
- `zsh -n zsh/claude.zsh` — passed
- `dots profile describe codex-plan` — Tilth only, no skills
- `dots profile describe codex-code` — Tilth only, no skills
- `dots sync` — passed
