### PR TITLE
chore(agents): harden sub-agent tiers and close grep escape hatch

### DIFF
--- a/agents/agent_definitions/coder.md
+++ b/agents/agent_definitions/coder.md
@@ -55,6 +55,7 @@ When you approach ~120k tokens of context — or run out before finishing — th
 - Tests encode *why* the behavior matters, not just *what* it does. A test that can't fail when business logic changes is wrong.
 - Run code for anything code can compute (counts, diffs, arithmetic) instead of eyeballing it.
 - De-slop before handoff — run the `de-slop` checklist against what you wrote.
+- A denied search is a routing signal, not an obstacle: when `grep`/`find`/`cat` is denied, switch to `cheez-search`/`cheez-read` (tilth). Never retry the same search through `rtk proxy` or another shell wrapper — that bypass is closed.
 - If the correct fix needs scope you weren't granted, stop and say so. Don't ship a band-aid and call it done.
 - Commit only when asked; when committing, use the `commit` skill (specific files by name, meaningful message, no `--no-verify`).
 - You may be dispatched on a scoped *slice* of a larger task with a context reference (an artifact path), not the whole job — treat that slice as your full boundary: read the reference, implement only the slice, don't re-derive or touch the rest.

--- a/agents/registry.yaml
+++ b/agents/registry.yaml
@@ -13,15 +13,15 @@ agents:
   fromage-age-arch:
     description: Complexity and structure reviewer. Enforces complexity budgets (line counts, params, nesting) and Sliced Bread file organization. Does NOT cover encapsulation, dead code, or bugs.
     models:
-      claude: sonnet
+      claude: opus
       codex: gpt-5-codex
-      cursor: claude-sonnet
+      cursor: auto
     disallowedTools:
     - Edit
     - Write
     - NotebookEdit
     color: red
-    effort: high
+    effort: medium
     skills:
     - scout
     - cheez-search
@@ -47,9 +47,10 @@ agents:
   fromage-fort:
     description: PR review comment responder. Triages both inline review threads AND PR-level review body comments using severity tiers (blocker/high/medium/low) — fixes high-severity items, pushes back on bad suggestions, asks about uncertain ones. Named for the strong cheese made from leftover scraps — it takes leftover review comments and turns them into something useful. Spawnable as a parallel agent for move-my-cheese and cheese-convoy workflows.
     models:
-      claude: sonnet
+      claude: opus
       codex: gpt-5-codex
-      cursor: claude-sonnet
+      cursor: auto
+    effort: low
     tools:
     - Read
     - Write
@@ -66,24 +67,26 @@ agents:
   fromage-secaudit:
     description: Security and dependency health auditor. Scans for vulnerabilities, unused/overweight deps, stdlib alternatives, and OWASP issues. Read-only. Returns stake-grouped findings (high/medium) with file:line citations and one-line recommendations — ~2 KB digest, no severity rewriting, no auto-fixes. Used as an easy-cheese fork target when /age needs evidence on the security dimension.
     models:
-      claude: sonnet
+      claude: opus
       codex: gpt-5-codex
-      cursor: claude-sonnet
+      cursor: auto
     disallowedTools:
     - Write
     - Edit
     - NotebookEdit
     - AskUserQuestion
     color: red
+    effort: medium
     skills:
     - scout
     body_path: agents/agent_definitions/fromage-secaudit.md
   ghostbuster:
     description: Forensic examination of expired cheese — finds code that's gone off, specs pointing at empty shelves, and curds that never set. Dead code detector + spec cross-referencer. Categorizes findings as DEAD, ZOMBIE, GHOST, or DORMANT with severity-tier scoring. Read-only — never modifies code. Returns a categorized findings digest (~2 KB). Suitable as an easy-cheese fork target when /age needs evidence on the deslop dimension.
     models:
-      claude: sonnet
+      claude: opus
       codex: gpt-5-codex
-      cursor: claude-sonnet
+      cursor: auto
+    effort: low
     disallowedTools:
     - Edit
     - NotebookEdit
@@ -95,9 +98,10 @@ agents:
   nih-scanner:
     description: Structural NIH pattern scanner. Uses Serena MCP and ast-grep to find code that reinvents well-known library functionality. Returns JSON candidate list (~2 KB digest) with usage counts and categories. Does not judge — the orchestrator scores and filters. Suitable as an easy-cheese fork target when /age needs evidence on the NIH dimension.
     models:
-      claude: sonnet
+      claude: opus
       codex: gpt-5-codex
-      cursor: claude-sonnet
+      cursor: auto
+    effort: low
     disallowedTools:
     - Edit
     - Write
@@ -251,16 +255,18 @@ agents:
     - cheez-read
     body_path: agents/agent_definitions/reviewer.md
   coder:
-    # Keeps the write surface (Edit/Write) — it mutates the tree — but denies
-    # Agent: a dispatched coder is a level-1 subagent and cannot fan out.
+    # Runs on opus at low effort: the write surface needs judgment but the loop
+    # is bounded. Keeps Edit/Write (it mutates the tree) but denies Agent — a
+    # dispatched coder is a level-1 subagent and cannot fan out.
     description: TDD-disciplined implementer. Takes an approved spec or unambiguous task and drives the contract → cut → implement → taste-test loop, editing through the cheez-write (tilth) skill. Runs the project's test/lint/build gates and applies review fixes. Models the easy-cheese code phase (/cook, /press, /cure). Full write surface — the one phase agent that mutates the tree. Use PROACTIVELY whenever a task requires writing or changing code — implementing a spec, fixing a bug, applying review findings — under /cook, /press, /cure, or any user-installed skill that needs a code change made.
     models:
-      claude: sonnet
+      claude: opus
       codex: gpt-5-codex
       opencode: inherit
     disallowedTools:
     - Agent
     color: green
+    effort: low
     skills:
     - cook
     - press

--- a/chezmoi/dot_claude/create_settings.json
+++ b/chezmoi/dot_claude/create_settings.json
@@ -1,4 +1,6 @@
 {
+  "model": "opus",
+  "effortLevel": "medium",
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
     "ENABLE_TOOL_SEARCH": "true"

--- a/profiles/_permissions/profile.yaml
+++ b/profiles/_permissions/profile.yaml
@@ -98,6 +98,12 @@ settings:
     - Bash(grep:*)
     - Bash(ag:*)
     - Bash(ack:*)
+    # rtk proxy runs a raw command unfiltered, tunneling denied search tools
+    # (grep/git grep) past the deny above. Close that hole — route to tilth.
+    - Bash(rtk proxy grep:*)
+    - Bash(rtk proxy git grep:*)
+    - Bash(rtk proxy ag:*)
+    - Bash(rtk proxy ack:*)
     - Bash(sudo:*)
     - Bash(rm -rf:*)
     # Secret-protection floor (cross-harness). opencode denies .env by


### PR DESCRIPTION
## Summary

Follow-up to #342. Hardens the cheese sub-agent fleet after a session-analytics review.

- **Model/effort tiers** bumped to opus for the review/code fleet: `coder`, `fromage-age-arch`, `fromage-fort`, `fromage-secaudit`, `ghostbuster`, `nih-scanner`.
- **Cursor token → `auto`** for the 5 retiered agents that carry a Cursor mapping (`coder` has none; `ricotta-reducer`/`worktree-triage` left on sonnet — out of scope).
- **Closed a grep escape hatch**: deny `rtk proxy grep|git grep|ag|ack` so agents can't tunnel raw grep past the routing deny. Added a `coder` rule treating a denied search as a routing signal (switch to `cheez-*`).
- **Seeded** `settings.json` with `model: opus` / `effortLevel: medium` for fresh machines (chezmoi `create_` seed — existing machines untouched).

## Verification

- `dots sync` deploys cleanly; rendered Cursor agents carry `model: auto`.
- 790/790 agent-profile tests pass.

## Deferred

Long-term management of the settings.json model-default (keep `create_` seed vs. convert to a managed template) is being designed separately via the `/chezmoi` workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)