### PR TITLE
feat(agents): cap sub-agent agentic turns via maxTurns frontmatter

### DIFF
--- a/agent-profile/agent_profile/shared.py
+++ b/agent-profile/agent_profile/shared.py
@@ -111,8 +111,10 @@ def claude_agent_frontmatter(item: dict[str, Any]) -> dict[str, str]:
     resolves it at user scope (``~/.claude/agents/``, priority 4), which wins
     over the same agent in a plugin tree (priority 5). So the shared file is
     the one Claude actually honors and must carry the full Claude metadata,
-    not a model-neutral subset: ``model`` (claude), ``color``, ``effort`` and
-    ``skills`` are all honored sub-agent frontmatter fields. Cursor reads the
+    not a model-neutral subset: ``model`` (claude), ``color``, ``effort``,
+    ``maxTurns`` and ``skills`` are all honored sub-agent frontmatter fields.
+    (``maxTurns`` caps a runaway sub-agent's agentic turns — it hands its
+    partial digest back to the coordinator at the cap.) Cursor reads the
     same file and ignores the fields it does not recognise; a Cursor-specific
     model still overrides via ``.cursor/agents/<n>.md`` when ``models.cursor``
     is set.
@@ -139,6 +141,9 @@ def claude_agent_frontmatter(item: dict[str, Any]) -> dict[str, str]:
     effort = item.get("effort") or ""
     if effort:
         fm["effort"] = effort
+    max_turns = item.get("maxTurns")
+    if max_turns is not None:
+        fm["maxTurns"] = str(max_turns)
     skills = item.get("skills") or []
     if skills:
         fm["skills"] = f"[{', '.join(skills)}]"

--- a/agent-profile/tests/test_agents_md.py
+++ b/agent-profile/tests/test_agents_md.py
@@ -38,6 +38,14 @@ def test_shared_claude_agent_frontmatter_matches_golden(tmp_path, golden):
     assert out == [".claude/agents/shared-agent.md"]
 
 
+def test_claude_agent_frontmatter_emits_max_turns():
+    # maxTurns flows from the registry field into the Claude frontmatter as a
+    # bare int, and is omitted when unset (caps a runaway sub-agent's turns).
+    fm = shared.claude_agent_frontmatter({"name": "a", "maxTurns": 50})
+    assert fm["maxTurns"] == "50"
+    assert "maxTurns" not in shared.claude_agent_frontmatter({"name": "a"})
+
+
 def test_shared_claude_agent_no_frontmatter_when_empty(tmp_path):
     body = tmp_path / "b.md"
     body.write_text("Reviewer body for foo\n")

--- a/agents/registry.yaml
+++ b/agents/registry.yaml
@@ -25,6 +25,7 @@ agents:
     skills:
     - scout
     - cheez-search
+    maxTurns: 50
     body_path: agents/agent_definitions/fromage-age-arch.md
   fromage-age-history:
     description: Git history analyst. Produces per-file risk scores that the orchestrator uses to adjust sibling findings. Does NOT find bugs or architecture issues — only outputs score modifiers.
@@ -43,6 +44,7 @@ agents:
     effort: high
     skills:
     - scout
+    maxTurns: 50
     body_path: agents/agent_definitions/fromage-age-history.md
   fromage-fort:
     description: PR review comment responder. Triages both inline review threads AND PR-level review body comments using severity tiers (blocker/high/medium/low) — fixes high-severity items, pushes back on bad suggestions, asks about uncertain ones. Named for the strong cheese made from leftover scraps — it takes leftover review comments and turns them into something useful. Spawnable as a parallel agent for move-my-cheese and cheese-convoy workflows.
@@ -62,6 +64,7 @@ agents:
     - scout
     - cheez-write
     - commit
+    maxTurns: 50
     body_path: agents/agent_definitions/fromage-fort.md
   fromage-secaudit:
     description: Security and dependency health auditor. Scans for vulnerabilities, unused/overweight deps, stdlib alternatives, and OWASP issues. Read-only. Returns stake-grouped findings (high/medium) with file:line citations and one-line recommendations — ~2 KB digest, no severity rewriting, no auto-fixes. Used as an easy-cheese fork target when /age needs evidence on the security dimension.
@@ -77,6 +80,7 @@ agents:
     color: red
     skills:
     - scout
+    maxTurns: 50
     body_path: agents/agent_definitions/fromage-secaudit.md
   ghostbuster:
     description: Forensic examination of expired cheese — finds code that's gone off, specs pointing at empty shelves, and curds that never set. Dead code detector + spec cross-referencer. Categorizes findings as DEAD, ZOMBIE, GHOST, or DORMANT with severity-tier scoring. Read-only — never modifies code. Returns a categorized findings digest (~2 KB). Suitable as an easy-cheese fork target when /age needs evidence on the deslop dimension.
@@ -91,6 +95,7 @@ agents:
     - WebFetch
     - AskUserQuestion
     - Write
+    maxTurns: 50
     body_path: agents/agent_definitions/ghostbuster.md
   nih-scanner:
     description: Structural NIH pattern scanner. Uses Serena MCP and ast-grep to find code that reinvents well-known library functionality. Returns JSON candidate list (~2 KB digest) with usage counts and categories. Does not judge — the orchestrator scores and filters. Suitable as an easy-cheese fork target when /age needs evidence on the NIH dimension.
@@ -107,6 +112,7 @@ agents:
     - AskUserQuestion
     skills:
     - cheez-search
+    maxTurns: 50
     body_path: agents/agent_definitions/nih-scanner.md
   ricotta-reducer:
     description: Code simplification and distillation agent. Strips genAI bloat, speculative abstractions, and unnecessary documentation. Produces a simplification report categorized by DELETE, INLINE, UNDOCUMENT, and DECOUPLE with severity-tier scoring. Analysis and detection only — never adds code (de-slop runs in scan mode, not auto-fix).
@@ -124,6 +130,7 @@ agents:
     skills:
     - scout
     - de-slop
+    maxTurns: 50
     body_path: agents/agent_definitions/ricotta-reducer.md
   roquefort-wrecker:
     description: Writes and executes unit, integration, or other tests for new or modified code. Use PROACTIVELY to validate code functionality and find bugs. Adversarial approach with severity-tier scoring per finding.
@@ -140,6 +147,7 @@ agents:
     - mcp__serena__*
     skills:
     - scout
+    maxTurns: 50
     body_path: agents/agent_definitions/roquefort-wrecker.md
   duckdb-expert:
     description: Read-only DuckDB analyst for the coding-agent session-analytics database. Spawned with ONE analytics pack pointer (skills/<skill>/references/<domain>.md) plus a target and a harness filter; runs that single domain's queries and returns one structured ~2 KB digest. Reads queries from the caller's pack and the canonical schema from session-analytics. Built for context isolation — consumer skills fan out one parallel spawn per owned domain. Used by skill-improver, tool-efficiency, prompt-analytics, and work-recovery.
@@ -159,6 +167,7 @@ agents:
     - WebFetch
     skills:
     - session-analytics
+    maxTurns: 50
     body_path: agents/agent_definitions/duckdb-expert.md
   whey-drainer:
     description: Runs existing tests and returns only failures and summary counts (~2 KB digest). Use this agent to validate code without flooding the parent context with verbose test output. Fits easy-cheese's small/fast read-only sub-agent contract — call from /cook taste-test, /press, or /cure post-fix to gate the next step on test pass. Does NOT write tests.
@@ -173,6 +182,7 @@ agents:
     - Grep
     skills:
     - scout
+    maxTurns: 50
     body_path: agents/agent_definitions/whey-drainer.md
   worktree-triage:
     description: Analyzes WARN/DIRTY worktrees to recommend keep, archive, or remove. Checks commit content, diffs, PR status, and staleness to make informed triage decisions. Interviews the user on DIRTY worktrees with unique changes.
@@ -189,6 +199,7 @@ agents:
     skills:
     - scout
     - gh
+    maxTurns: 50
     body_path: agents/agent_definitions/worktree-triage.md
   # ── easy-cheese general phase agents ──────────────────────────────────────
   # Four general-purpose agents that model the easy-cheese workflow: explore
@@ -215,6 +226,7 @@ agents:
     skills:
     - cheez-search
     - cheez-read
+    maxTurns: 50
     body_path: agents/agent_definitions/explorer.md
   researcher:
     description: External-research agent. Answers questions outside the codebase — library/API docs, current web facts, version/changelog checks, best-practice comparisons, GitHub examples — via Context7, Tavily, web fetch, and gh, then writes a durable cited research slug under .cheese/research/. Read-only against code. Returns a condensed claim-level digest (the heavy fetch bodies stay on disk, out of the parent's context). Models the easy-cheese research phase. Use PROACTIVELY before implementing against an unfamiliar library or API, when a claim needs a current source instead of a guess, or whenever a skill (/mold, /cook, /briesearch, or any user-installed skill) would otherwise rely on stale training data.
@@ -231,6 +243,7 @@ agents:
     - briesearch
     - cheez-search
     - cheez-read
+    maxTurns: 50
     body_path: agents/agent_definitions/researcher.md
   reviewer:
     description: Multi-dimension code reviewer. Reviews a diff, PR, branch, or path across the ten /age dimensions (correctness, security, encapsulation, spec, complexity, deslop, assertions, NIH, efficiency, telemetry) and returns a severity-grouped findings report. Read-only — never writes fixes; at the top level it draws on the specialist agents (fromage-*, ghostbuster, ricotta-reducer, nih-scanner) for evidence. Models the easy-cheese review phase. Opus-tier. Use PROACTIVELY before merging or shipping any change, after /cook or /cure, and whenever a user-installed skill produces a diff that should be checked before it lands.
@@ -249,6 +262,7 @@ agents:
     - age
     - cheez-search
     - cheez-read
+    maxTurns: 50
     body_path: agents/agent_definitions/reviewer.md
   coder:
     # Keeps the write surface (Edit/Write) — it mutates the tree — but denies
@@ -271,4 +285,5 @@ agents:
     - de-slop
     - tdd-assertions
     - commit
+    maxTurns: 100
     body_path: agents/agent_definitions/coder.md


### PR DESCRIPTION
## What

Adds a `maxTurns` cap to every rendered **Claude sub-agent** so a runaway agent
returns its partial digest to the coordinator at the cap instead of burning
unbounded agentic turns (and API credits).

Three-part change, mirroring the existing `effort` / `models` per-agent pattern:

1. `claude_agent_frontmatter()` emits `maxTurns` when the registry sets it
   (a Claude-honored frontmatter field). Cursor reads the same shared file and
   ignores the unknown key; codex/opencode/copilot build their own agent
   frontmatter and are unaffected.
2. `agents/registry.yaml` sets the cap per agent: **coder 100, all 14 others 50**.
3. Unit test covers emission (when set) and omission (when unset).

## Why

Sub-agents were uncapped — default is unbounded turns. `maxTurns` is harness-
enforced (mechanical, returns control to the coordinator gracefully) rather than
a prompt-level "be frugal" instruction that drifts.

## Caps (all rendered agents)

| Agent | maxTurns |
|---|---|
| coder | 100 |
| explorer, researcher, reviewer, ghostbuster, nih-scanner, ricotta-reducer, roquefort-wrecker, fromage-age-arch, fromage-age-history, fromage-fort, fromage-secaudit, duckdb-expert, whey-drainer, worktree-triage | 50 |

Investigation was grounded in `/session-analytics` per-agent turn-count
distributions (732 sub-agent invocations); the committed values are a
deliberate, conservative tightening rather than the raw p95s.

## Out of scope — built-in agents

`general-purpose`, `Explore`, and `Plan` are Claude Code **built-ins**, not
rendered by this pipeline. They are not in the file-scope precedence table and
the only documented control is `permissions.deny` (disable, not cap); a same-name
`~/.claude/agents/` shadow is undocumented and, for `general-purpose` (the most-
used agent), would replace Claude's internal prompt fleet-wide. Left uncapped
pending a separate, explicit decision.

## Verification

- `uv run pytest` — 165 passed (full claude/cursor/opencode renderer suites + new test).
- End-to-end: rendered the `global` profile from this branch into a temp target;
  all 15 agents carry the expected `maxTurns` line (coder 100, rest 50), placed
  between `color` and `skills`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
