### PR TITLE
fix(session-analytics): handle DuckDB tmp spill left as directory

### DIFF
--- a/skills/session-analytics/scripts/ingest.py
+++ b/skills/session-analytics/scripts/ingest.py
@@ -389,7 +389,10 @@ def main():
         sys.exit(1)
 
     if os.path.exists(DB_TMP_PATH):
-        os.remove(DB_TMP_PATH)
+        if os.path.isdir(DB_TMP_PATH):
+            shutil.rmtree(DB_TMP_PATH)
+        else:
+            os.remove(DB_TMP_PATH)
 
     print("Loading canonical rows into DuckDB...")
     t0 = time.time()


### PR DESCRIPTION
## What

`ingest.py`'s pre-run cleanup of `sessions.duckdb.tmp` called `os.remove()`, which raises `IsADirectoryError` when a DuckDB spill left the tmp path as a **directory** instead of a file. This crashed `python3 ingest.py` live.

## Fix

Handle both cases at the cleanup site (`shutil` was already imported):

```python
if os.path.exists(DB_TMP_PATH):
    if os.path.isdir(DB_TMP_PATH):
        shutil.rmtree(DB_TMP_PATH)
    else:
        os.remove(DB_TMP_PATH)
```

Single file, +4 −1. The success-path `os.replace(DB_TMP_PATH, DB_PATH)` is unchanged and out of scope.

## Verify

Reproduced both branches: a directory at the tmp path is removed via `shutil.rmtree` without raising; the file case still goes through `os.remove`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)