### PR TITLE
chore(claude): disable experimental agent teams

### DIFF
--- a/chezmoi/lib/claude-settings-authoritative.json
+++ b/chezmoi/lib/claude-settings-authoritative.json
@@ -2,7 +2,6 @@
   "model": "opus",
   "effortLevel": "medium",
   "env": {
-    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
     "ENABLE_TOOL_SEARCH": "true"
   },
   "permissions": {


### PR DESCRIPTION
## What

Removes the `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` opt-in from the repo-authoritative Claude settings source (`chezmoi/lib/claude-settings-authoritative.json`).

## Why

Turning the experimental multi-agent teammate feature back off. The flag is an opt-in, so its absence is the pre-opt-in default (off). The `modify_settings.json` merge takes `.env` from the authoritative source, so on the next `dots sync` it drops from live `~/.claude/settings.json`. `ENABLE_TOOL_SEARCH` is unaffected.

Note: agent teams (the `SendMessage` teammate feature) are independent from Workflows (the `Workflow` orchestration tool) — this touches only teams.

## Verification

- `dots sync` succeeds; live `settings.json` env now carries only `ENABLE_TOOL_SEARCH`.
- `tests/claude-settings.bats` 17/17, `tests/chezmoi-wiring.bats` 60/60, shellcheck ok.
- JSON-only change (no Python/shell touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)