### PR TITLE
fix(packages): guard rustup PATH when brew prefix is unset

### DIFF
--- a/packages/sync.sh
+++ b/packages/sync.sh
@@ -332,9 +332,10 @@ sync_cargo() {
                 return 0
             fi
             # Brew-installed rustup keeps cargo proxies in opt/rustup/bin
-            local rustup_bin
-            rustup_bin="$(brew --prefix rustup 2>/dev/null)/bin"
-            if [[ -d "$rustup_bin" ]]; then
+            local rustup_prefix rustup_bin
+            rustup_prefix="$(brew --prefix rustup 2>/dev/null || true)"
+            rustup_bin="$rustup_prefix/bin"
+            if [[ -n "$rustup_prefix" && -d "$rustup_bin" ]]; then
                 export PATH="$rustup_bin:$PATH"
             elif [[ -f "$HOME/.cargo/env" ]]; then
                 # shellcheck disable=SC1091


### PR DESCRIPTION
Guard the rustup PATH export when the Homebrew prefix is unset, so `packages/sync.sh` does not emit a broken `PATH` entry on machines without brew.

Split out of #340 (independent one-line fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
