### PR TITLE
feat(ap): compiled profile pipeline (2/4 of #340)

### DIFF
--- a/agent-profile/agent_profile/apply_compiled.py
+++ b/agent-profile/agent_profile/apply_compiled.py
@@ -1,0 +1,271 @@
+"""Apply a compiled manifest to live target roots and reconcile removals.
+
+``ap compile`` writes ``<cache>/manifest.json`` plus harness-scoped fragment
+directories. This module copies each managed *generated* fragment to its
+target's resolved root and deletes generated files recorded in the prior apply
+state that are absent from the new manifest.
+
+Deletion is strictly bounded: only paths recorded in the prior
+:class:`~agent_profile.compiled_types.ApplyState` are ever removed. Files the
+apply state does not track — including user-owned merged settings — are never
+touched here. Whole-file merge preservation is a separate concern.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from agent_profile.compiled_types import ApplyState
+from agent_profile.merged_settings_preservation import is_user_owned_merged
+
+DEFAULT_STATE_FILENAME = "apply-state.json"
+
+
+class ApplyError(Exception):
+    """A handled ``ap apply-compiled`` failure."""
+
+
+@dataclass(frozen=True)
+class ApplyResult:
+    """Outcome of one ``apply_compiled`` run."""
+
+    copied: tuple[str, ...]
+    deleted: tuple[str, ...]
+    state_path: Path
+    state: ApplyState
+    registered_mcps: tuple[str, ...] = ()
+
+
+def read_apply_state(state_path: Path) -> ApplyState:
+    """Read prior apply state; an absent file means nothing was managed yet."""
+    state_path = Path(state_path)
+    if not state_path.exists():
+        return ApplyState()
+    try:
+        raw = json.loads(state_path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ApplyError(
+            f"ap apply-compiled: cannot read apply state {state_path}: {exc}"
+        ) from exc
+    managed = raw.get("managed_files", []) if isinstance(raw, dict) else None
+    if not isinstance(managed, list) or not all(isinstance(p, str) for p in managed):
+        raise ApplyError(
+            f"ap apply-compiled: apply state {state_path} has invalid managed_files"
+        )
+    return ApplyState(managed_files=tuple(managed))
+
+
+def write_apply_state(state_path: Path, state: ApplyState) -> None:
+    state_path = Path(state_path)
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(json.dumps(state.to_dict(), indent=2, sort_keys=True) + "\n")
+
+
+def _read_manifest(manifest_path: Path) -> dict[str, Any]:
+    if not manifest_path.is_file():
+        raise ApplyError(f"ap apply-compiled: manifest '{manifest_path}' not found")
+    try:
+        data = json.loads(manifest_path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ApplyError(
+            f"ap apply-compiled: cannot read manifest {manifest_path}: {exc}"
+        ) from exc
+    if not isinstance(data, dict):
+        raise ApplyError(f"ap apply-compiled: manifest {manifest_path} is not an object")
+    return data
+
+
+def _target_roots(data: dict[str, Any]) -> dict[str, Path]:
+    targets = data.get("compile_targets")
+    if not isinstance(targets, list):
+        raise ApplyError("ap apply-compiled: manifest compile_targets must be a list")
+    roots: dict[str, Path] = {}
+    for target in targets:
+        if not isinstance(target, dict):
+            raise ApplyError("ap apply-compiled: each compile target must be an object")
+        name = target.get("name")
+        resolved = target.get("resolved_root")
+        if not isinstance(name, str) or not name:
+            raise ApplyError("ap apply-compiled: compile target missing name")
+        if not isinstance(resolved, str) or not resolved:
+            raise ApplyError(
+                f"ap apply-compiled: compile target '{name}' missing resolved_root"
+            )
+        roots[name] = Path(resolved)
+    return roots
+
+
+def _managed_pairs(
+    data: dict[str, Any], roots: dict[str, Path]
+) -> list[tuple[Path, Path]]:
+    """Return ``(fragment_path, dest_path)`` for each managed generated file.
+
+    Non-generated entries (whole merged files) are skipped — merging and
+    preservation of user-owned settings is owned elsewhere.
+    """
+    files = data.get("files")
+    if not isinstance(files, list):
+        raise ApplyError("ap apply-compiled: manifest files must be a list")
+    pairs: list[tuple[Path, Path]] = []
+    for entry in files:
+        if not isinstance(entry, dict):
+            raise ApplyError("ap apply-compiled: each manifest file must be an object")
+        if not entry.get("generated", True):
+            continue
+        target = entry.get("target")
+        fragment = entry.get("fragment_path")
+        relative = entry.get("relative_path")
+        if target not in roots:
+            raise ApplyError(
+                f"ap apply-compiled: file references unknown target '{target}'"
+            )
+        if not isinstance(fragment, str) or not fragment:
+            raise ApplyError("ap apply-compiled: manifest file missing fragment_path")
+        if not isinstance(relative, str) or not relative:
+            raise ApplyError("ap apply-compiled: manifest file missing relative_path")
+        pairs.append((Path(fragment), roots[target] / relative))
+    return pairs
+
+
+def _preserved_dests(data: dict[str, Any], roots: dict[str, Path]) -> set[str]:
+    """Resolved destination paths of user-owned merged settings to never delete.
+
+    A merged settings file previously applied as generated (clobber-copy) but
+    now marked ``generated=False`` would otherwise be reconciled out of the
+    prior apply state and deleted — destroying user content (ADR-001/spec 92).
+    """
+    preserved: set[str] = set()
+    for entry in data.get("files", []):
+        if not isinstance(entry, dict) or not is_user_owned_merged(entry):
+            continue
+        target = entry.get("target")
+        relative = entry.get("relative_path")
+        if target in roots and isinstance(relative, str):
+            preserved.add(str(roots[target] / relative))
+    return preserved
+
+
+def _user_mcps(data: dict[str, Any]) -> list[dict[str, Any]]:
+    raw = data.get("user_mcps", [])
+    if not isinstance(raw, list) or not all(isinstance(m, dict) for m in raw):
+        raise ApplyError("ap apply-compiled: manifest user_mcps must be a list of objects")
+    for mcp in raw:
+        if "name" not in mcp or "command" not in mcp:
+            raise ApplyError(
+                "ap apply-compiled: each user_mcps entry must have 'name' and 'command'"
+            )
+    return raw
+
+
+def _register_user_mcps(mcps: list[dict[str, Any]]) -> list[str]:
+    """Register each user-scope MCP via ``claude mcp add --scope user``.
+
+    The live ``~/.claude.json`` write ``ap compile`` deferred (compile stays
+    side-effect-free; the registration runs here, post-gate). ``remove`` then
+    ``add`` per server keeps re-runs idempotent. ``${VAR}`` env refs are passed
+    literally — Claude expands them at launch, so secrets never land on disk.
+    A non-zero ``add`` raises a handled :class:`ApplyError` (not an uncaught
+    ``CalledProcessError``)."""
+    if not mcps:
+        return []
+    cli = shutil.which("claude")
+    if cli is None:
+        raise ApplyError(
+            "ap apply-compiled: registering user-scope MCP servers needs the "
+            "`claude` CLI on PATH, but it was not found."
+        )
+    registered: list[str] = []
+    for mcp in mcps:
+        name = mcp["name"]
+        subprocess.run(
+            [cli, "mcp", "remove", name, "--scope", "user"],
+            capture_output=True,
+            check=False,
+        )
+        cmd = [cli, "mcp", "add", name, "--scope", "user"]
+        for key, val in (mcp.get("env") or {}).items():
+            cmd += ["-e", f"{key}={val}"]
+        cmd += ["--", mcp["command"], *mcp.get("args", [])]
+        result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+        if result.returncode != 0:
+            detail = (result.stderr or result.stdout or "").strip()
+            raise ApplyError(
+                f"ap apply-compiled: `claude mcp add {name}` exited "
+                f"{result.returncode}: {detail}"
+            )
+        registered.append(name)
+    return registered
+
+
+def apply_compiled(
+    manifest_path: Path, *, state_path: Path | None = None
+) -> ApplyResult:
+    """Copy managed fragments to resolved roots and reconcile removals.
+
+    ``state_path`` defaults to ``apply-state.json`` beside the manifest, the
+    stable per-source/profile cache location ``dots sync`` reuses each run.
+    """
+    manifest_path = Path(manifest_path)
+    state_path = (
+        manifest_path.parent / DEFAULT_STATE_FILENAME
+        if state_path is None
+        else Path(state_path)
+    )
+
+    data = _read_manifest(manifest_path)
+    roots = _target_roots(data)
+    pairs = _managed_pairs(data, roots)
+    preserved = _preserved_dests(data, roots)
+    prior = read_apply_state(state_path)
+
+    copied: list[str] = []
+    managed: set[str] = set()
+    for fragment, dest in pairs:
+        if not fragment.is_file():
+            raise ApplyError(f"ap apply-compiled: fragment '{fragment}' is missing")
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(fragment, dest)
+        copied.append(str(dest))
+        managed.add(str(dest))
+
+    deleted: list[str] = []
+    for prior_path in prior.managed_files:
+        if prior_path in managed or prior_path in preserved:
+            continue
+        path = Path(prior_path)
+        if path.is_file():
+            path.unlink()
+            deleted.append(prior_path)
+
+    # Persist state after the copy/delete reconcile and before MCP registration
+    # so moved files are always tracked even if `claude mcp add` later raises.
+    new_state = ApplyState(managed_files=tuple(sorted(managed)))
+    write_apply_state(state_path, new_state)
+
+    registered = _register_user_mcps(_user_mcps(data))
+
+    return ApplyResult(
+        copied=tuple(copied),
+        deleted=tuple(deleted),
+        state_path=state_path,
+        state=new_state,
+        registered_mcps=tuple(registered),
+    )
+
+
+def cmd_apply_compiled(args: list[str], out_stream: Any) -> int:
+    if not args:
+        raise ApplyError("Usage: ap apply-compiled <manifest>")
+    if len(args) > 1:
+        raise ApplyError(f"ap apply-compiled: unexpected argument '{args[1]}'")
+    result = apply_compiled(Path(args[0]))
+    line = f"applied {len(result.copied)} file(s), removed {len(result.deleted)}"
+    if result.registered_mcps:
+        line += f", registered {len(result.registered_mcps)} user MCP(s)"
+    print(line, file=out_stream)
+    return 0

--- a/agent-profile/agent_profile/apply_compiled.py
+++ b/agent-profile/agent_profile/apply_compiled.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import json
 import shutil
 import subprocess
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -100,6 +101,21 @@ def _target_roots(data: dict[str, Any]) -> dict[str, Path]:
     return roots
 
 
+def _safe_dest(root: Path, relative: str) -> Path:
+    """Join ``relative`` under ``root``, rejecting absolute or ``..``-escaping paths."""
+    rel = Path(relative)
+    if rel.is_absolute() or ".." in rel.parts:
+        raise ApplyError(
+            f"ap apply-compiled: relative_path '{relative}' must be relative and stay under its target root"
+        )
+    dest = (root / rel).resolve()
+    if dest != root.resolve() and root.resolve() not in dest.parents:
+        raise ApplyError(
+            f"ap apply-compiled: relative_path '{relative}' escapes its target root"
+        )
+    return dest
+
+
 def _managed_pairs(
     data: dict[str, Any], roots: dict[str, Path]
 ) -> list[tuple[Path, Path]]:
@@ -128,7 +144,7 @@ def _managed_pairs(
             raise ApplyError("ap apply-compiled: manifest file missing fragment_path")
         if not isinstance(relative, str) or not relative:
             raise ApplyError("ap apply-compiled: manifest file missing relative_path")
-        pairs.append((Path(fragment), roots[target] / relative))
+        pairs.append((Path(fragment), _safe_dest(roots[target], relative)))
     return pairs
 
 
@@ -159,6 +175,14 @@ def _user_mcps(data: dict[str, Any]) -> list[dict[str, Any]]:
             raise ApplyError(
                 "ap apply-compiled: each user_mcps entry must have 'name' and 'command'"
             )
+        if not isinstance(mcp["name"], str) or not mcp["name"]:
+            raise ApplyError(
+                "ap apply-compiled: user_mcps entry 'name' must be a non-empty string"
+            )
+        if not isinstance(mcp["command"], str) or not mcp["command"]:
+            raise ApplyError(
+                "ap apply-compiled: user_mcps entry 'command' must be a non-empty string"
+            )
     return raw
 
 
@@ -182,11 +206,22 @@ def _register_user_mcps(mcps: list[dict[str, Any]]) -> list[str]:
     registered: list[str] = []
     for mcp in mcps:
         name = mcp["name"]
-        subprocess.run(
+        removed = subprocess.run(
             [cli, "mcp", "remove", name, "--scope", "user"],
             capture_output=True,
+            text=True,
             check=False,
         )
+        if removed.returncode != 0:
+            detail = (removed.stderr or removed.stdout or "").strip()
+            # A "not found"/absent server is the expected idempotent case; any
+            # other non-zero exit is unexpected and is surfaced (non-fatal).
+            if "not found" not in detail.lower() and "no mcp server" not in detail.lower():
+                print(
+                    f"ap apply-compiled: warning: `claude mcp remove {name}` exited "
+                    f"{removed.returncode}: {detail}",
+                    file=sys.stderr,
+                )
         cmd = [cli, "mcp", "add", name, "--scope", "user"]
         for key, val in (mcp.get("env") or {}).items():
             cmd += ["-e", f"{key}={val}"]

--- a/agent-profile/agent_profile/cli.py
+++ b/agent-profile/agent_profile/cli.py
@@ -25,7 +25,14 @@ from typing import Any, NoReturn
 
 import yaml
 
-from agent_profile import discover, manifest as manifest_mod
+from agent_profile import (
+    apply_compiled,
+    compile_command,
+    discover,
+    fetch_sources_command,
+    manifest as manifest_mod,
+)
+from agent_profile.install_command import install_deprecation_message
 from agent_profile.manifest import ManifestCorrupt
 from agent_profile.parse import ParseError, parse_manifest
 from agent_profile.renderers.base import (
@@ -71,7 +78,9 @@ Commands:
   list                          List available profiles
   describe <name>               Show resolved manifest for a profile
   path <name>                   Print profile source dir
-  install <name> [opts]         Render profile into current dir
+  compile <name> --baseline <dir> --out <dir>
+                                Compile live profile fragments
+  install <name> [opts]         Deprecated; use dots sync or ap compile
   uninstall <name> [opts]       Remove a previously-installed profile
   launch <harness> [name] [..]  Install + exec the named harness CLI
   perms [opts]                  Write repo-level permission overlay (Claude + Codex)
@@ -901,11 +910,13 @@ def main(argv: list[str] | None = None) -> int:
                     )
             perms_harnesses = [h for h in harnesses if h in ("claude", "codex")]
             return cmd_perms(local, target, perms_harnesses, colors, sys.stdout)
-        if sub == "install":
+        if sub == "_install-internal":
             harnesses, target, remaining, _passthrough = _parse_common_opts(rest)
             _validate_harnesses(harnesses, colors)
             name = remaining[0] if remaining else ""
             return cmd_install(name, harnesses, target, colors, sys.stdout)
+        if sub == "install":
+            raise CliError(install_deprecation_message())
         if sub in ("uninstall", "rm"):
             harnesses, target, remaining, _passthrough = _parse_common_opts(rest)
             _validate_harnesses(harnesses, colors)
@@ -914,6 +925,32 @@ def main(argv: list[str] | None = None) -> int:
         if sub == "launch":
             _harnesses, target, remaining, passthrough = _parse_common_opts(rest)
             cmd_launch(remaining, passthrough, target, colors, sys.stdout)
+        if sub == "compile":
+            if not rest:
+                raise CliError("profile name required")
+            profile_name = compile_command.profile_arg(rest)
+            if not profile_name:
+                raise CliError("profile name required")
+            profile_dir = discover.find_profile_dir(profile_name)
+            if profile_dir is None:
+                raise CliError(f"ap compile: profile '{profile_name}' not found")
+            from agent_profile.compile_target_presence import (
+                CompileTargetPresenceError,
+                require_compile_targets,
+            )
+
+            # Early-exit gate: fail loud on missing/invalid compile_targets before
+            # compile_profile's tempdir setup. parse_manifest re-validates for its
+            # other callers; the re-check on the compile path is intentional.
+            try:
+                require_compile_targets(profile_dir)
+            except CompileTargetPresenceError as exc:
+                raise CliError(str(exc)) from exc
+            return compile_command.cmd_compile(rest, RENDERERS, sys.stdout)
+        if sub == "fetch-sources":
+            return fetch_sources_command.cmd_fetch_sources(rest, sys.stdout)
+        if sub == "apply-compiled":
+            return apply_compiled.cmd_apply_compiled(rest, sys.stdout)
         if sub in ("help", "-h", "--help"):
             sys.stdout.write(USAGE)
             return 0
@@ -923,7 +960,15 @@ def main(argv: list[str] | None = None) -> int:
         )
         sys.stderr.write(USAGE)
         return 1
-    except (CliError, ParseError, ManifestCorrupt, MergedConfigError) as exc:
+    except (
+        CliError,
+        compile_command.CompileError,
+        fetch_sources_command.FetchSourcesError,
+        apply_compiled.ApplyError,
+        ParseError,
+        ManifestCorrupt,
+        MergedConfigError,
+    ) as exc:
         print(str(exc), file=sys.stderr)
         return 1
 

--- a/agent-profile/agent_profile/compile_command.py
+++ b/agent-profile/agent_profile/compile_command.py
@@ -58,6 +58,8 @@ def profile_arg(args: list[str]) -> str:
             i += 2
         elif arg.startswith(("--baseline=", "--out=")):
             i += 1
+        elif arg.startswith("-"):
+            raise CompileError(f"ap compile: unknown option '{arg}'")
         else:
             return arg
     return ""
@@ -81,6 +83,8 @@ def _parse_args(args: list[str]) -> tuple[str, Path, Path]:
         elif arg.startswith("--out="):
             out = Path(arg.split("=", 1)[1]).resolve()
             i += 1
+        elif arg.startswith("-"):
+            raise CompileError(f"ap compile: unknown option '{arg}'")
         elif not profile:
             profile = arg
             i += 1

--- a/agent-profile/agent_profile/compile_command.py
+++ b/agent-profile/agent_profile/compile_command.py
@@ -1,0 +1,256 @@
+"""Compile live profiles into harness-scoped fragment directories."""
+
+from __future__ import annotations
+
+import filecmp
+import json
+import os
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Any, Protocol
+
+from agent_profile import discover
+from agent_profile.compiled_types import (
+    CompiledFile,
+    CompiledManifest,
+    CompileTarget,
+    MERGED_SETTINGS_BY_HARNESS,
+)
+from agent_profile.drift import FileComparison, compute_drift
+from agent_profile.parse import parse_manifest
+
+
+class CompileError(Exception):
+    """A handled ``ap compile`` failure."""
+
+
+class _Renderer(Protocol):
+    name: str
+
+    def render(
+        self, manifest: Any, target: Path, logical_root: Path | None = None
+    ) -> list[str]:
+        raise NotImplementedError
+
+
+def _usage() -> str:
+    return "Usage: ap compile <profile> --baseline <dir> --out <dir>"
+
+
+def _require_value(args: list[str], i: int, flag: str) -> str:
+    if i + 1 >= len(args):
+        raise CompileError(f"ap compile: option '{flag}' requires a value")
+    return args[i + 1]
+
+
+def profile_arg(args: list[str]) -> str:
+    """Return the profile positional from ``args``, ignoring flags in any order.
+
+    Mirrors the positional handling in ``_parse_args`` so a caller can pre-check
+    the profile before full argument parsing, regardless of flag/positional order.
+    Returns "" when no positional is present.
+    """
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg in ("--baseline", "--out"):
+            i += 2
+        elif arg.startswith(("--baseline=", "--out=")):
+            i += 1
+        else:
+            return arg
+    return ""
+
+def _parse_args(args: list[str]) -> tuple[str, Path, Path]:
+    profile = ""
+    baseline: Path | None = None
+    out: Path | None = None
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg == "--baseline":
+            baseline = Path(_require_value(args, i, "--baseline")).resolve()
+            i += 2
+        elif arg.startswith("--baseline="):
+            baseline = Path(arg.split("=", 1)[1]).resolve()
+            i += 1
+        elif arg == "--out":
+            out = Path(_require_value(args, i, "--out")).resolve()
+            i += 2
+        elif arg.startswith("--out="):
+            out = Path(arg.split("=", 1)[1]).resolve()
+            i += 1
+        elif not profile:
+            profile = arg
+            i += 1
+        else:
+            raise CompileError(f"ap compile: unexpected argument '{arg}'")
+    if not profile:
+        raise CompileError(_usage())
+    if baseline is None:
+        raise CompileError("ap compile: --baseline is required")
+    if out is None:
+        raise CompileError("ap compile: --out is required")
+    return profile, baseline, out
+
+
+def _baseline_root(baseline: Path, target: CompileTarget) -> Path:
+    home = os.environ.get("HOME")
+    if home:
+        try:
+            rel = target.resolved_root.relative_to(Path(home).resolve())
+            return baseline / rel
+        except ValueError:
+            pass
+    named = baseline / target.name
+    return named if named.exists() else baseline
+
+
+def _copy_tree(src: Path, dst: Path) -> None:
+    if src.exists():
+        shutil.copytree(src, dst, dirs_exist_ok=True)
+    else:
+        dst.mkdir(parents=True, exist_ok=True)
+
+
+def _is_merged_settings(harness: str, rel: str) -> bool:
+    """True when ``rel`` is a user-owned merged settings file for ``harness``."""
+    return rel in MERGED_SETTINGS_BY_HARNESS.get(harness, ())
+
+
+def _existing(path: Path) -> Path | None:
+    return path if path.is_file() else None
+
+
+def _merged_comparisons(
+    target: CompileTarget, harness: str, target_baseline: Path, work: Path
+) -> list[FileComparison]:
+    """Drift inputs for ``harness``'s merged settings under ``target``.
+
+    Compares the scratch chezmoi baseline, the live target file, and the
+    compiled (rendered) result for every merged settings file the harness owns.
+    """
+    return [
+        FileComparison(
+            target=target.name,
+            relative_path=rel,
+            baseline=_existing(target_baseline / rel),
+            live=_existing(target.resolved_root / rel),
+            compiled=_existing(work / rel),
+        )
+        for rel in MERGED_SETTINGS_BY_HARNESS.get(harness, ())
+    ]
+
+
+def _changed_files(before: Path, after: Path) -> list[Path]:
+    changed: list[Path] = []
+    for path in sorted(p for p in after.rglob("*") if p.is_file()):
+        rel = path.relative_to(after)
+        prior = before / rel
+        if not prior.is_file() or not filecmp.cmp(path, prior, shallow=False):
+            changed.append(rel)
+    return changed
+
+
+def compile_profile(
+    profile: str,
+    baseline: Path,
+    out: Path,
+    renderers: dict[str, _Renderer],
+) -> CompiledManifest:
+    profile_dir = discover.find_profile_dir(profile)
+    if profile_dir is None:
+        raise CompileError(f"ap compile: profile '{profile}' not found")
+
+    # parse_manifest already attaches strictly-validated compile_targets
+    # (absolute-root, env-resolution, cross-target duplicate-harness, and
+    # harness-field coverage all enforced in validate_compile_targets). Consume
+    # that single validated path rather than re-parsing the raw YAML weakly.
+    manifest = parse_manifest(profile_dir)
+    targets = manifest.compile_targets
+    if not targets:
+        raise CompileError(
+            f"ap compile: profile '{profile}' must define compile_targets"
+        )
+    fragments = out / "fragments"
+    shutil.rmtree(fragments, ignore_errors=True)
+    fragments.mkdir(parents=True, exist_ok=True)
+
+    files: list[CompiledFile] = []
+    comparisons: list[FileComparison] = []
+    user_mcps: list[dict[str, Any]] = []
+    seen_user_mcps: set[str] = set()
+    with tempfile.TemporaryDirectory(prefix="ap-compile-") as tmp:
+        tmp_root = Path(tmp)
+        for target in targets:
+            target_baseline = _baseline_root(baseline, target)
+            before = tmp_root / "before" / target.name
+            _copy_tree(target_baseline, before)
+            for harness in target.harnesses:
+                renderer = renderers.get(harness)
+                if renderer is None:
+                    raise CompileError(
+                        f"ap compile: no renderer registered for harness '{harness}'"
+                    )
+                work = tmp_root / "work" / target.name / harness
+                _copy_tree(target_baseline, work)
+                # Files render into the scratch `work` dir, but absolute deploy
+                # paths a renderer bakes into content (codex hooks.json) must
+                # point at where the fragment will be applied — the target's
+                # resolved root — not this ephemeral tempdir.
+                renderer.render(manifest, work, logical_root=target.resolved_root)
+                # User-scope MCP registrations are a live ~/.claude.json write
+                # the renderer defers during compile (logical_root is set).
+                # Collect the spec here so apply performs it post-gate.
+                collect = getattr(renderer, "user_mcp_registrations", None)
+                if collect is not None:
+                    for reg in collect(manifest):
+                        if reg["name"] not in seen_user_mcps:
+                            seen_user_mcps.add(reg["name"])
+                            user_mcps.append(reg)
+                fragment_dir = fragments / target.name / harness
+                for rel in _changed_files(before, work):
+                    src = work / rel
+                    dst = fragment_dir / rel
+                    dst.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copy2(src, dst)
+                    posix = rel.as_posix()
+                    files.append(
+                        CompiledFile(
+                            target=target.name,
+                            harness=harness,
+                            fragment_path=dst,
+                            relative_path=posix,
+                            # Merged settings carry user content: mark them
+                            # not-generated so apply preserves the live file
+                            # instead of overwriting it (ADR-001).
+                            generated=not _is_merged_settings(harness, posix),
+                        )
+                    )
+                comparisons.extend(
+                    _merged_comparisons(target, harness, target_baseline, work)
+                )
+        # Drift reads the scratch work/baseline files, so compute it before the
+        # tempdir is torn down (ADR-003): baseline vs live vs compiled.
+        drift = compute_drift(comparisons)
+
+    manifest_path = out / "manifest.json"
+    compiled = CompiledManifest(
+        profile=manifest.name,
+        source_id=str(profile_dir),
+        manifest_path=manifest_path,
+        targets=targets,
+        files=tuple(files),
+        drift=tuple(drift),
+        user_mcps=tuple(user_mcps),
+    )
+    manifest_path.write_text(json.dumps(compiled.to_dict(), indent=2) + "\n")
+    return compiled
+
+
+def cmd_compile(args: list[str], renderers: dict[str, _Renderer], out_stream: Any) -> int:
+    profile, baseline, out = _parse_args(args)
+    compiled = compile_profile(profile, baseline, out, renderers)
+    print(compiled.manifest_path, file=out_stream)
+    return 0

--- a/agent-profile/agent_profile/compile_target_presence.py
+++ b/agent-profile/agent_profile/compile_target_presence.py
@@ -1,0 +1,43 @@
+"""Validation for compiled profile deployment targets."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from agent_profile.compile_target_validation import (
+    CompileTargetValidationError,
+    validate_compile_targets,
+)
+from agent_profile.harness_field_coverage import (
+    HarnessFieldCoverageError,
+    validate_harness_field_coverage,
+)
+
+
+class CompileTargetPresenceError(Exception):
+    """Raised when a profile cannot be compiled because targets are missing."""
+
+
+def require_compile_targets(profile_dir: Path) -> dict[str, Any]:
+    """Return compile_targets, failing loud when the profile omits them."""
+
+    profile_path = profile_dir / "profile.yaml"
+    data = yaml.safe_load(profile_path.read_text()) or {}
+    if "compile_targets" not in data or not data["compile_targets"]:
+        name = data.get("name") or profile_dir.name
+        raise CompileTargetPresenceError(
+            f"ap compile: profile '{name}' must define compile_targets"
+        )
+    try:
+        compile_targets = validate_compile_targets(
+            data["compile_targets"], manifest_path=profile_path
+        )
+        validate_harness_field_coverage(
+            data, compile_targets, manifest_path=profile_path
+        )
+    except (CompileTargetValidationError, HarnessFieldCoverageError) as exc:
+        raise CompileTargetPresenceError(str(exc)) from exc
+    return data["compile_targets"]

--- a/agent-profile/agent_profile/compile_target_validation.py
+++ b/agent-profile/agent_profile/compile_target_validation.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import os
+import re
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from agent_profile.compiled_types import CompileTarget, VALID_COMPILE_HARNESSES
+
+_ENV_REF_RE = re.compile(r"\$(?:\{[A-Za-z_][A-Za-z0-9_]*\}|[A-Za-z_][A-Za-z0-9_]*)")
+
+
+class CompileTargetValidationError(ValueError):
+    pass
+
+
+def validate_compile_targets(
+    raw: Any,
+    *,
+    manifest_path: Path,
+    env: Mapping[str, str] | None = None,
+) -> tuple[CompileTarget, ...]:
+    if raw in (None, {}):
+        return ()
+    if not isinstance(raw, Mapping):
+        raise CompileTargetValidationError(
+            f"ap_parse_one: {manifest_path} compile_targets must be a mapping"
+        )
+
+    targets: list[CompileTarget] = []
+    harness_owners: dict[str, str] = {}
+    env_map = os.environ if env is None else env
+
+    for name, config in raw.items():
+        target_name = str(name)
+        if not isinstance(config, Mapping):
+            raise _target_error(manifest_path, target_name, "must be a mapping")
+
+        symbolic_root = config.get("target_root")
+        if not symbolic_root:
+            raise _target_error(
+                manifest_path, target_name, "is missing required field 'target_root'"
+            )
+
+        harnesses = config.get("harnesses")
+        if not harnesses:
+            raise _target_error(
+                manifest_path, target_name, "is missing required field 'harnesses'"
+            )
+
+        resolved_root = _resolve_root(
+            str(symbolic_root), manifest_path=manifest_path, target_name=target_name, env=env_map
+        )
+        normalized_harnesses = _validate_harnesses(
+            harnesses,
+            manifest_path=manifest_path,
+            target_name=target_name,
+            harness_owners=harness_owners,
+        )
+        targets.append(
+            CompileTarget(
+                target_name,
+                str(symbolic_root),
+                resolved_root,
+                tuple(normalized_harnesses),
+            )
+        )
+
+    return tuple(targets)
+
+
+def _resolve_root(
+    symbolic_root: str,
+    *,
+    manifest_path: Path,
+    target_name: str,
+    env: Mapping[str, str],
+) -> Path:
+    expanded = os.path.expanduser(_expand_env(symbolic_root, env))
+    unresolved = _ENV_REF_RE.search(expanded)
+    if unresolved:
+        raise _target_error(
+            manifest_path,
+            target_name,
+            f"has unresolved env var {unresolved.group(0)!r} in target_root",
+        )
+
+    root = Path(expanded)
+    if not root.is_absolute():
+        raise _target_error(manifest_path, target_name, "target_root must resolve absolute")
+    return root.resolve()
+
+
+def _expand_env(value: str, env: Mapping[str, str]) -> str:
+    def replace(match: re.Match[str]) -> str:
+        token = match.group(0)
+        key = token[2:-1] if token.startswith("${") else token[1:]
+        return env.get(key, token)
+
+    return _ENV_REF_RE.sub(replace, value)
+
+
+def _validate_harnesses(
+    harnesses: Any,
+    *,
+    manifest_path: Path,
+    target_name: str,
+    harness_owners: dict[str, str],
+) -> list[str]:
+    if isinstance(harnesses, str) or not isinstance(harnesses, list | tuple):
+        raise _target_error(manifest_path, target_name, "harnesses must be a list")
+
+    normalized: list[str] = []
+    for harness in harnesses:
+        harness_name = str(harness)
+        if harness_name not in VALID_COMPILE_HARNESSES:
+            valid = "|".join(VALID_COMPILE_HARNESSES)
+            raise _target_error(
+                manifest_path,
+                target_name,
+                f"has unknown harness '{harness_name}' (valid: {valid})",
+            )
+        owner = harness_owners.get(harness_name)
+        if owner is not None:
+            raise _target_error(
+                manifest_path,
+                target_name,
+                f"duplicates harness '{harness_name}' already assigned to target '{owner}'",
+            )
+        harness_owners[harness_name] = target_name
+        normalized.append(harness_name)
+
+    return normalized
+
+
+def _target_error(
+    manifest_path: Path, target_name: str, message: str
+) -> CompileTargetValidationError:
+    return CompileTargetValidationError(
+        f"ap_parse_one: {manifest_path} compile target '{target_name}' {message}"
+    )

--- a/agent-profile/agent_profile/compiled_types.py
+++ b/agent-profile/agent_profile/compiled_types.py
@@ -1,0 +1,125 @@
+"""Shared data shapes for compiled profile deployment."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+VALID_COMPILE_HARNESSES = (
+    "claude",
+    "codex",
+    "opencode",
+    "cursor",
+    "copilot",
+)
+
+# User-editable "merged" config files: each renderer reads, merges its managed
+# keys into, and rewrites these in place, so they carry hand-written user
+# content alongside generated config. They must be drift-checked against the
+# live file and never overwritten or deleted by ``ap apply-compiled``.
+MERGED_SETTINGS_BY_HARNESS: dict[str, tuple[str, ...]] = {
+    "claude": (".claude/settings.json",),
+    "codex": (".codex/config.toml",),
+    "opencode": ("opencode.json",),
+    "cursor": (".cursor/mcp.json",),
+    "copilot": (".copilot/mcp-config.json",),
+}
+
+
+@dataclass(frozen=True)
+class CompileTarget:
+    """One named live deployment target from ``compile_targets``."""
+
+    name: str
+    symbolic_root: str
+    resolved_root: Path
+    harnesses: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "symbolic_root": self.symbolic_root,
+            "resolved_root": str(self.resolved_root),
+            "harnesses": list(self.harnesses),
+        }
+
+
+@dataclass(frozen=True)
+class CompiledFile:
+    """A generated fragment that should be applied under a target root."""
+
+    target: str
+    harness: str
+    fragment_path: Path
+    relative_path: str
+    generated: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "target": self.target,
+            "harness": self.harness,
+            "fragment_path": str(self.fragment_path),
+            "relative_path": self.relative_path,
+            "generated": self.generated,
+        }
+
+
+@dataclass(frozen=True)
+class DriftRecord:
+    """One reported difference between baseline, live, and compiled config."""
+
+    target: str
+    relative_path: str
+    path: str
+    baseline: Any
+    live: Any
+    compiled: Any
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "target": self.target,
+            "relative_path": self.relative_path,
+            "path": self.path,
+            "baseline": self.baseline,
+            "live": self.live,
+            "compiled": self.compiled,
+        }
+
+
+@dataclass(frozen=True)
+class CompiledManifest:
+    """Manifest written by ``ap compile`` and consumed by apply/drift steps."""
+
+    profile: str
+    source_id: str
+    manifest_path: Path
+    targets: tuple[CompileTarget, ...]
+    files: tuple[CompiledFile, ...] = ()
+    drift: tuple[DriftRecord, ...] = ()
+    # User-scope MCP servers (``mcp_scope: user``) to register live via the
+    # ``claude`` CLI at apply time. Recorded by ``ap compile`` instead of
+    # registered during render, so compile stays side-effect-free and the live
+    # ``~/.claude.json`` write happens post-gate in ``ap apply-compiled``.
+    user_mcps: tuple[dict[str, Any], ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "profile": self.profile,
+            "source_id": self.source_id,
+            "manifest_path": str(self.manifest_path),
+            "compile_targets": [target.to_dict() for target in self.targets],
+            "files": [file.to_dict() for file in self.files],
+            "drift": [record.to_dict() for record in self.drift],
+            "user_mcps": [dict(mcp) for mcp in self.user_mcps],
+        }
+
+
+@dataclass(frozen=True)
+class ApplyState:
+    """Previously managed generated files for compiled-manifest apply."""
+
+    managed_files: tuple[str, ...] = field(default_factory=tuple)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"managed_files": list(self.managed_files)}

--- a/agent-profile/agent_profile/drift.py
+++ b/agent-profile/agent_profile/drift.py
@@ -1,0 +1,160 @@
+"""Compute grouped drift between baseline, live, and compiled config.
+
+Pure module: given per-file comparisons (the scratch chezmoi baseline file,
+the live target file, and the compiled fragment), report every key/path where
+the three sources disagree. The caller (``dots sync`` / ``ap compile`` wiring)
+supplies the resolved paths and decides whether reported drift blocks apply.
+
+``DriftRecord.baseline``/``.live``/``.compiled`` use ``None`` for "not present"
+— an absent file, an absent key, or an explicit JSON ``null`` all collapse to
+``None``. These settings files do not use explicit nulls, so the conflation is
+harmless and keeps records JSON-serializable for the ``--json`` caller.
+
+A wholly-absent *live* file is a clean create, not drift, so it yields no
+records; baseline/compiled absence is reported (the live file diverges from a
+source that has nothing, or everything, to say).
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from agent_profile.compiled_types import DriftRecord
+
+
+class DriftError(Exception):
+    """A handled drift-computation failure (e.g. unparseable JSON)."""
+
+
+# Sentinel distinguishing "file absent on disk" from "file present, value null".
+_ABSENT_FILE = object()
+
+
+@dataclass(frozen=True)
+class FileComparison:
+    """One settings/merged file to drift-check across three sources.
+
+    ``relative_path`` is the file's path under its target root (e.g.
+    ``.claude/settings.json``); a ``.json`` suffix selects key-level diffing,
+    anything else is compared as whole-file text.
+    """
+
+    target: str
+    relative_path: str
+    baseline: Path | None
+    live: Path | None
+    compiled: Path | None
+
+
+def compute_drift(comparisons: Iterable[FileComparison]) -> list[DriftRecord]:
+    """Return drift records for every key/path the three sources disagree on.
+
+    Records are sorted by ``(target, relative_path, path)`` for deterministic
+    output and stable grouping.
+    """
+    records: list[DriftRecord] = []
+    for comparison in comparisons:
+        records.extend(_diff_file(comparison))
+    records.sort(key=lambda r: (r.target, r.relative_path, r.path))
+    return records
+
+
+def format_drift(records: Sequence[DriftRecord]) -> str:
+    """Render drift records as a grouped human diff: target → file → key/path.
+
+    Returns an empty string when there is no drift, so callers can branch on
+    truthiness.
+    """
+    if not records:
+        return ""
+    ordered = sorted(records, key=lambda r: (r.target, r.relative_path, r.path))
+    lines: list[str] = []
+    current: tuple[str, str] | None = None
+    for record in ordered:
+        group = (record.target, record.relative_path)
+        if group != current:
+            if current is not None:
+                lines.append("")
+            lines.append(f"{record.target}  {record.relative_path}")
+            current = group
+        lines.append(f"  {record.path or '(whole file)'}")
+        lines.append(f"    baseline: {_render(record.baseline)}")
+        lines.append(f"    live:     {_render(record.live)}")
+        lines.append(f"    compiled: {_render(record.compiled)}")
+    return "\n".join(lines) + "\n"
+
+
+def _diff_file(comparison: FileComparison) -> list[DriftRecord]:
+    is_json = comparison.relative_path.endswith(".json")
+    live = _read(comparison.live, is_json)
+    if live is _ABSENT_FILE:
+        return []
+    baseline = _read(comparison.baseline, is_json)
+    compiled = _read(comparison.compiled, is_json)
+
+    base_leaves = _leaves(baseline)
+    live_leaves = _leaves(live)
+    comp_leaves = _leaves(compiled)
+
+    keys = set(base_leaves) | set(live_leaves) | set(comp_leaves)
+    records: list[DriftRecord] = []
+    for key in sorted(keys):
+        base_leaf = base_leaves.get(key)
+        live_leaf = live_leaves.get(key)
+        comp_leaf = comp_leaves.get(key)
+        if base_leaf == live_leaf == comp_leaf:
+            continue
+        records.append(
+            DriftRecord(
+                target=comparison.target,
+                relative_path=comparison.relative_path,
+                path=key,
+                baseline=base_leaf,
+                live=live_leaf,
+                compiled=comp_leaf,
+            )
+        )
+    return records
+
+
+def _read(path: Path | None, is_json: bool) -> Any:
+    if path is None or not path.exists():
+        return _ABSENT_FILE
+    text = path.read_text()
+    if not is_json:
+        return text
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise DriftError(f"{path}: invalid JSON ({exc.msg})") from exc
+
+
+def _leaves(value: Any) -> dict[str, Any]:
+    """Flatten a value into ``{dotted_path: leaf}``.
+
+    Non-empty dicts recurse; lists, scalars, and empty dicts are leaves. An
+    absent file contributes nothing. A non-dict root (or text content) becomes
+    a single leaf at the empty path.
+    """
+    if value is _ABSENT_FILE:
+        return {}
+    out: dict[str, Any] = {}
+    _walk(value, "", out)
+    return out
+
+
+def _walk(value: Any, prefix: str, out: dict[str, Any]) -> None:
+    if isinstance(value, dict) and value:
+        for key, child in value.items():
+            child_prefix = f"{prefix}.{key}" if prefix else str(key)
+            _walk(child, child_prefix, out)
+    else:
+        out[prefix] = value
+
+
+def _render(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, ensure_ascii=False)

--- a/agent-profile/agent_profile/drift.py
+++ b/agent-profile/agent_profile/drift.py
@@ -148,6 +148,10 @@ def _leaves(value: Any) -> dict[str, Any]:
 
 
 def _walk(value: Any, prefix: str, out: dict[str, Any]) -> None:
+    # The empty path "" is reserved for a whole-file leaf (non-dict / text
+    # root). A literal "" key at the top level of a dict would alias that
+    # slot; in-scope settings files are non-empty dicts with non-empty keys,
+    # so the collision stays latent.
     if isinstance(value, dict) and value:
         for key, child in value.items():
             child_prefix = f"{prefix}.{key}" if prefix else str(key)

--- a/agent-profile/agent_profile/fetch_sources_command.py
+++ b/agent-profile/agent_profile/fetch_sources_command.py
@@ -1,0 +1,113 @@
+"""fetch_sources_command.py — fetch external ``source:`` skills for a profile.
+
+Spec decision: external ``source:`` fetching is split into its own
+``ap fetch-sources <profile>`` command. It is the explicit network/package
+step that runs BEFORE ``ap compile`` in the C-lite pipeline
+(``ap fetch-sources live`` -> ``ap compile live`` -> drift gate ->
+``ap apply-compiled``).
+
+The command parses the profile manifest, selects its ``source:``
+(GitHub-fetched) skills, and installs them at global scope via
+``npx skills add`` (one shallow clone per source repo, all skill-supporting
+harnesses in a single invocation) through the shared helpers in
+:mod:`agent_profile.fetch`. It renders, compiles, and applies nothing — that
+is the job of ``ap compile`` / ``ap apply-compiled``.
+
+``path:`` (local-tree) skills never reach this command: the renderers copy
+them at compile time.
+
+The CLI route is wired separately; this module only exposes
+:func:`cmd_fetch_sources` and :func:`fetch_sources`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agent_profile import discover
+from agent_profile.parse import parse_manifest
+
+
+class FetchSourcesError(Exception):
+    """A handled ``ap fetch-sources`` failure (unknown profile, bad args, or a
+    skill-fetch error). The CLI converts it to a stderr line + exit 1."""
+
+
+def _usage() -> str:
+    return "Usage: ap fetch-sources <profile>"
+
+
+def _fetch_runner(argv: list[str]) -> int:
+    """Default ``npx skills add`` runner. Indirected through a module-level
+    name so tests can stub the fetch without spawning ``npx``."""
+    from agent_profile.fetch import _default_runner
+
+    return _default_runner(argv)
+
+
+def fetch_sources(profile: str, out: Any = None) -> int:
+    """Fetch every ``source:`` skill declared by ``profile`` into the
+    skill-supporting harnesses via ``npx skills add`` (global scope).
+
+    Returns ``0`` on success, including the no-op case where the profile
+    declares no ``source:`` skills (the runner is never invoked). Raises
+    :class:`FetchSourcesError` on an unknown profile or a fetch failure.
+    Performs no compile or apply step.
+    """
+    from agent_profile.fetch import (
+        SKILL_AGENT,
+        SkillFetchError,
+        external_skills,
+        fetch_external_source,
+        group_external_sources,
+    )
+
+    profile_dir = discover.find_profile_dir(profile)
+    if profile_dir is None:
+        raise FetchSourcesError(
+            f"ap fetch-sources: profile '{profile}' not found"
+        )
+
+    manifest = parse_manifest(profile_dir)
+
+    if not external_skills(manifest.skills):
+        return 0
+
+    # All skill-supporting harnesses (the canonical map in skill_agents.txt).
+    # `npx skills add -g` installs globally regardless of harness, so a bare
+    # `ap fetch-sources <profile>` populates every harness's skill store in one
+    # shallow clone per source — the same default the retired install path used.
+    harnesses = list(SKILL_AGENT)
+
+    try:
+        for source, names, pin in group_external_sources(manifest.skills):
+            label = "*" if names is None else ", ".join(names)
+            print(
+                f"  fetching skills {source} ({label}) -> "
+                f"{', '.join(harnesses)}",
+                file=out,
+            )
+            fetch_external_source(source, names, pin, harnesses, _fetch_runner)
+    except SkillFetchError as exc:
+        raise FetchSourcesError(str(exc)) from exc
+    except OSError as exc:
+        raise FetchSourcesError(
+            f"ap: cannot run npx ({exc}); is Node/npx installed?"
+        ) from exc
+    return 0
+
+
+def cmd_fetch_sources(args: list[str], out_stream: Any) -> int:
+    """CLI entry for ``ap fetch-sources <profile>``. Parses the profile name and
+    delegates to :func:`fetch_sources`. Raises :class:`FetchSourcesError` on a
+    missing or extra argument."""
+    if not args:
+        raise FetchSourcesError(_usage())
+    profile = args[0]
+    if not profile or profile.startswith("-"):
+        raise FetchSourcesError(_usage())
+    if len(args) > 1:
+        raise FetchSourcesError(
+            f"ap fetch-sources: unexpected argument '{args[1]}'"
+        )
+    return fetch_sources(profile, out=out_stream)

--- a/agent-profile/agent_profile/harness_field_coverage.py
+++ b/agent-profile/agent_profile/harness_field_coverage.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from agent_profile.compiled_types import CompileTarget
+
+_CLAUDE_FIELDS = ("enabled_plugins", "marketplaces")
+
+
+class HarnessFieldCoverageError(ValueError):
+    pass
+
+
+def validate_harness_field_coverage(
+    raw_profile: dict[str, Any],
+    compile_targets: tuple[CompileTarget, ...],
+    *,
+    manifest_path: Path,
+) -> None:
+    target_harnesses = {
+        harness for target in compile_targets for harness in target.harnesses
+    }
+    if "claude" in target_harnesses:
+        return
+
+    for field in _CLAUDE_FIELDS:
+        if raw_profile.get(field):
+            name = raw_profile.get("name") or manifest_path.parent.name
+            raise HarnessFieldCoverageError(
+                f"ap compile: profile '{name}' field '{field}' "
+                "requires compile target harness 'claude'"
+            )

--- a/agent-profile/agent_profile/install_command.py
+++ b/agent-profile/agent_profile/install_command.py
@@ -1,0 +1,11 @@
+"""Command policy for the deprecated ``ap install`` path."""
+
+INSTALL_MIGRATION_GUIDANCE = (
+    "ap install is deprecated and no longer performs deployment.\n"
+    "Use `dots sync` for live deployment.\n"
+    "Use `ap compile <profile> --baseline <dir> --out <dir>` for staging."
+)
+
+
+def install_deprecation_message() -> str:
+    return INSTALL_MIGRATION_GUIDANCE

--- a/agent-profile/agent_profile/merged_settings_preservation.py
+++ b/agent-profile/agent_profile/merged_settings_preservation.py
@@ -1,0 +1,84 @@
+"""Guard user-owned merged settings files during compiled-manifest apply.
+
+``ap apply-compiled`` reconciles live target roots against a compiled
+manifest: it copies fragment files into place and deletes previously managed
+*generated* files that the new manifest no longer lists. Merged settings files
+(e.g. ``settings.json`` that mixes generated keys with hand-written user keys)
+are different -- they carry user-owned content and must never be deleted, only
+drift-checked. This module is the single source of truth for "is this manifest
+file a user-owned merged settings file -> preserve it".
+
+Ownership is recorded on each manifest file record (the seed model): generated
+fragments carry ``generated=True`` (the compiler owns them; normal reconcile
+applies), while user-owned merged settings carry ``generated=False`` (preserve).
+
+Records and manifests may arrive as the :mod:`agent_profile.compiled_types`
+dataclasses or as the JSON mappings ``ap apply-compiled`` reads off disk; both
+forms are accepted. Paths are matched on the manifest's ``relative_path``
+identity -- callers must express deletion candidates the same way.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from agent_profile.compiled_types import CompiledFile, CompiledManifest
+
+FileRecord = CompiledFile | Mapping[str, Any]
+ManifestLike = CompiledManifest | Mapping[str, Any]
+
+
+def _generated(record: FileRecord) -> bool:
+    if isinstance(record, CompiledFile):
+        return record.generated
+    if isinstance(record, Mapping):
+        return bool(record.get("generated", True))
+    raise TypeError(f"unsupported manifest file record: {record!r}")
+
+
+def _relative_path(record: FileRecord) -> str:
+    if isinstance(record, CompiledFile):
+        return record.relative_path
+    if isinstance(record, Mapping):
+        return str(record["relative_path"])
+    raise TypeError(f"unsupported manifest file record: {record!r}")
+
+
+def _files(manifest: ManifestLike) -> tuple[FileRecord, ...]:
+    if isinstance(manifest, CompiledManifest):
+        return manifest.files
+    if isinstance(manifest, Mapping):
+        return tuple(manifest.get("files", ()))
+    raise TypeError(f"unsupported manifest: {manifest!r}")
+
+
+def is_user_owned_merged(record: FileRecord) -> bool:
+    """Return True when a manifest file record is a user-owned merged setting.
+
+    Generated fragments are owned by the compiler and may be reconciled or
+    deleted; merged settings carry user keys and must be preserved.
+    """
+
+    return not _generated(record)
+
+
+def preserved_paths(manifest: ManifestLike) -> frozenset[str]:
+    """Relative paths the apply step must never delete."""
+
+    return frozenset(
+        _relative_path(record)
+        for record in _files(manifest)
+        if is_user_owned_merged(record)
+    )
+
+
+def filter_preserved(candidates: Iterable[str], manifest: ManifestLike) -> list[str]:
+    """Drop user-owned merged settings from deletion ``candidates``.
+
+    Returns the candidate paths that are safe to delete -- the input with the
+    manifest's user-owned merged settings removed. Input order is preserved.
+    """
+
+    preserved = preserved_paths(manifest)
+    return [path for path in candidates if path not in preserved]

--- a/agent-profile/agent_profile/overlay.py
+++ b/agent-profile/agent_profile/overlay.py
@@ -422,6 +422,7 @@ def _write_codex_config(
         sections.append(
             f"model_instructions_file = {_codex_toml_value(str(sp))}\n"
         )
+    sections.append('\n[tui]\ninput_mode = "vim"\n')
     tables = _codex_mcp_tables(manifest)
     if tables:
         sections.append(tables)

--- a/agent-profile/agent_profile/parse.py
+++ b/agent-profile/agent_profile/parse.py
@@ -34,6 +34,11 @@ from agent_profile._validate import (
     _validate_name,
     _validate_relpath,
 )
+from agent_profile.compile_target_validation import (
+    CompileTargetValidationError,
+    validate_compile_targets,
+)
+from agent_profile.compiled_types import CompileTarget
 from agent_profile.env import load_dotenv
 from agent_profile.ingest import expand_registries
 
@@ -68,9 +73,10 @@ class Manifest:
     enabled_plugins: dict[str, bool] = field(default_factory=dict)
     env: dict[str, str] = field(default_factory=dict)
     extra_args: list[str] = field(default_factory=list)
-    # Install-time fields (curd: global profile). Outer-profile only, like
-    # the launch-overlay fields above. ``target_default`` is consulted by
-    # the CLI when ``--target`` is not passed; ``marketplaces`` is read by
+    # Legacy install fields. Outer-profile only, like the launch-overlay
+    # fields above. ``target_default`` is still consulted by the internal
+    # install path used by old profile stubs; live deployment now uses
+    # ``compile_targets`` on the live profile. ``marketplaces`` is read by
     # the claude renderer to register entries in ``extraKnownMarketplaces``
     # under the live settings.json (matching how ``enabled_plugins`` lands
     # in ``enabledPlugins``). ``${VAR}`` refs (``$HOME``, ``${DOTFILES_DIR}``)
@@ -90,6 +96,7 @@ class Manifest:
     # marketplace_root, marketplace_name, and description so the renderer can
     # register the marketplace.
     native_plugins: list[dict[str, Any]] = field(default_factory=list)
+    compile_targets: tuple[CompileTarget, ...] = ()
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize to the same JSON shape parse.sh emits (used for the
@@ -104,6 +111,7 @@ class Manifest:
             "name": self.name,
             "description": self.description,
             "mcp_scope": self.mcp_scope,
+            "compile_targets": [target.to_dict() for target in self.compile_targets],
         }
 
 
@@ -181,6 +189,13 @@ def parse_one(profile_dir: Path) -> dict[str, Any]:
 
     reg = _expand_registries_directive(raw.get("registries"))
 
+    try:
+        compile_targets = validate_compile_targets(
+            raw.get("compile_targets"), manifest_path=manifest_path
+        )
+    except CompileTargetValidationError as exc:
+        raise ParseError(str(exc)) from exc
+
     return {
         "name": name,
         "description": raw.get("description") or "",
@@ -198,6 +213,7 @@ def parse_one(profile_dir: Path) -> dict[str, Any]:
         "target_default": raw.get("target_default") or None,
         "marketplaces": dict(raw.get("marketplaces") or {}),
         "mcp_scope": raw.get("mcp_scope") or "plugin",
+        "compile_targets": compile_targets,
         # Registry-derived items come first; inline items append (matching
         # the include "outer last" convention so an inline override on a
         # name-collision wins on scalar/object merges downstream).
@@ -328,6 +344,7 @@ def _parse_with_includes(
         "marketplaces",
         "mcp_scope",
         "native_plugins",
+        "compile_targets",
     ):
         merged[key] = self_[key]
     return merged
@@ -368,4 +385,5 @@ def parse_manifest(profile_dir: Path, find_profile_dir: Any = None) -> Manifest:
         marketplaces=merged["marketplaces"],
         mcp_scope=merged["mcp_scope"],
         native_plugins=merged.get("native_plugins", []),
+        compile_targets=merged["compile_targets"],
     )

--- a/agent-profile/agent_profile/renderers/base.py
+++ b/agent-profile/agent_profile/renderers/base.py
@@ -11,7 +11,7 @@ Renderer protocol contract
 A renderer is an object exposing:
 
   - ``name: str`` — the harness name (``"claude"``, ``"codex"``, …).
-  - ``render(manifest, target) -> list[str]`` — write this harness's
+  - ``render(manifest, target, logical_root=None) -> list[str]`` — write this harness's
     artefacts under ``target`` and return the list of relative paths
     written (whole-file artefacts only; merged files such as
     ``opencode.json`` are *not* listed — they are surgically undone in
@@ -76,8 +76,18 @@ class Renderer(Protocol):
     name: str
     mcp_default: tuple[str, ...]
 
-    def render(self, manifest: Manifest, target: Path) -> list[str]:
-        """Write artefacts under ``target``; return relative paths written."""
+    def render(
+        self, manifest: Manifest, target: Path, logical_root: Path | None = None
+    ) -> list[str]:
+        """Write artefacts under ``target``; return relative paths written.
+
+        ``logical_root`` is the directory the artefacts will ultimately be
+        DEPLOYED to, when that differs from the physical ``target`` they are
+        written to. ``ap compile`` renders into a scratch dir but the files
+        will live under the target's resolved root, so a renderer that bakes an
+        absolute deploy path into file content (only codex's ``hooks.json``
+        today) must root it at ``logical_root`` when set. ``None`` (the
+        live-install default) means deploy root == ``target``."""
         ...
 
     def clean(self, manifest: Manifest, target: Path) -> None:

--- a/agent-profile/agent_profile/renderers/claude.py
+++ b/agent-profile/agent_profile/renderers/claude.py
@@ -91,7 +91,7 @@ class ClaudeRenderer:
     name = "claude"
     mcp_default = _MCP_DEFAULT
 
-    def render(self, manifest: Manifest, target: Path) -> list[str]:
+    def render(self, manifest: Manifest, target: Path, logical_root: Path | None = None) -> list[str]:
         out: list[str] = []
         base = Path(str(target).rstrip("/"))
         profile = manifest.name
@@ -106,7 +106,7 @@ class ClaudeRenderer:
         self._write_skills(manifest, target, out)
         self._write_commands(manifest, plugin_dir, base, out)
         self._write_hooks(manifest, plugin_dir, base, profile, out)
-        self._write_mcp_json(manifest, plugin_dir, base, out)
+        self._write_mcp_json(manifest, plugin_dir, base, out, logical_root)
         self._write_settings(manifest, plugin_dir, base, out)
         self._write_local_marketplace(manifest, base, profile, desc)
         self._merge_root_settings(manifest, base)
@@ -509,6 +509,7 @@ class ClaudeRenderer:
         plugin_dir: Path,
         base: Path,
         out: list[str],
+        logical_root: Path | None = None,
     ) -> None:
         mine = mcps_for(manifest, "claude", _MCP_DEFAULT)
         if not mine:
@@ -519,12 +520,36 @@ class ClaudeRenderer:
             # (`mcp__<server>__*`) and land in ~/.claude.json. No plugin
             # .mcp.json is written, so its file is dropped from the install
             # manifest and swept on the next render.
-            self._register_user_mcps(mine)
+            #
+            # `claude mcp add` writes the LIVE ~/.claude.json regardless of the
+            # scratch render dir, so it is a live side-effect. During compile
+            # (rendering into a scratch dir for deferred apply — signalled by a
+            # non-None `logical_root`) we must NOT touch live state before the
+            # drift gate: `ap compile` records the registrations via
+            # `user_mcp_registrations()` and `ap apply-compiled` performs the
+            # live write post-gate. The install/launch path (logical_root None)
+            # writes directly to the live target, so it registers immediately.
+            if logical_root is None:
+                self._register_user_mcps(mine)
             return
         servers = {mcp["name"]: mcp_server_entry(mcp) for mcp in mine}
         out_path = plugin_dir / ".mcp.json"
         _dump_json(out_path, {"mcpServers": servers})
         self._track(out, base, out_path)
+
+    def user_mcp_registrations(self, manifest: Manifest) -> list[dict]:
+        """User-scope MCP registrations for ``ap compile`` to defer to apply.
+
+        Pure read of the resolved manifest — no CLI, no live write. Returns
+        ``{name, command, args?, env?}`` per server (``${VAR}`` env refs stay
+        literal, matching the plugin-scope ``.mcp.json``), or ``[]`` when the
+        profile is not user-scope or projects no MCP to claude."""
+        if manifest.mcp_scope != "user":
+            return []
+        return [
+            {"name": mcp["name"], **mcp_server_entry(mcp)}
+            for mcp in mcps_for(manifest, "claude", _MCP_DEFAULT)
+        ]
 
     @staticmethod
     def _claude_cli() -> str:

--- a/agent-profile/agent_profile/renderers/codex.py
+++ b/agent-profile/agent_profile/renderers/codex.py
@@ -87,12 +87,14 @@ class CodexRenderer:
     name = "codex"
     mcp_default = _CODEX_MCP_DEFAULT
 
-    def render(self, manifest: Manifest, target: Path) -> list[str]:
+    def render(
+        self, manifest: Manifest, target: Path, logical_root: Path | None = None
+    ) -> list[str]:
         out_files: list[str] = []
         target = Path(target)
         self._write_agents(manifest, target, out_files)
         self._write_skills(manifest, target, out_files)
-        self._write_hooks(manifest, target, out_files)
+        self._write_hooks(manifest, target, out_files, logical_root)
         self._write_mcps(manifest, target)
         self._render_native_plugins(manifest)
         self._write_rules(manifest, target, out_files)
@@ -294,7 +296,11 @@ class CodexRenderer:
     # absolute copied path because Codex runs hook commands from the session cwd,
     # not from ~/.codex.
     def _write_hooks(
-        self, manifest: Manifest, target: Path, out_files: list[str]
+        self,
+        manifest: Manifest,
+        target: Path,
+        out_files: list[str],
+        logical_root: Path | None = None,
     ) -> None:
         codex_hooks = base.hooks_for(manifest, "codex")
         if not codex_hooks:
@@ -308,7 +314,18 @@ class CodexRenderer:
         # twice per session — once from each source.
         self._clean_legacy_config_toml_hooks(codex_hooks, target)
 
+        # Hook scripts are written under base_dir (the physical render dir), but
+        # the command Codex executes must reference where the script will be
+        # DEPLOYED. For a live install the two are the same ($HOME). For `ap
+        # compile`, base_dir is an ephemeral tempdir while the deploy root is
+        # the target's resolved root, supplied as logical_root — baking the
+        # tempdir would emit a dangling, non-deterministic command path.
         base_dir = Path(str(target).rstrip("/"))
+        deploy_dir = (
+            Path(str(logical_root).rstrip("/"))
+            if logical_root is not None
+            else base_dir
+        )
         hook_groups: dict[str, list[dict]] = {}
         for item in codex_hooks:
             event = item.get("event")
@@ -344,7 +361,7 @@ class CodexRenderer:
                 base.copy_hook_shared_assets(
                     item, base_dir / ".codex", base_dir, out_files
                 )
-                command = f"bash {shlex.quote(str(abs_script))}"
+                command = f"bash {shlex.quote(str(deploy_dir / rel_script))}"
             elif not command:
                 raise ValueError(
                     f"codex_render: hook event '{event}' has neither 'script' "

--- a/agent-profile/agent_profile/renderers/copilot.py
+++ b/agent-profile/agent_profile/renderers/copilot.py
@@ -159,7 +159,7 @@ class CopilotRenderer:
     name = "copilot"
     mcp_default = _COPILOT_MCP_DEFAULT
 
-    def render(self, manifest: Manifest, target: Path) -> list[str]:
+    def render(self, manifest: Manifest, target: Path, logical_root: Path | None = None) -> list[str]:
         out_files: list[str] = []
         base = Path(str(target).rstrip("/"))
 

--- a/agent-profile/agent_profile/renderers/crush.py
+++ b/agent-profile/agent_profile/renderers/crush.py
@@ -51,7 +51,7 @@ class CrushRenderer:
     name = "crush"
     mcp_default = _CRUSH_MCP_DEFAULT
 
-    def render(self, manifest: Manifest, target: Path) -> list[str]:
+    def render(self, manifest: Manifest, target: Path, logical_root: Path | None = None) -> list[str]:
         base = Path(str(target).rstrip("/"))
         config_path = base / _CRUSH_CONFIG_REL
         data = (

--- a/agent-profile/agent_profile/renderers/cursor.py
+++ b/agent-profile/agent_profile/renderers/cursor.py
@@ -75,7 +75,7 @@ class CursorRenderer:
     name = "cursor"
     mcp_default = _CURSOR_MCP_DEFAULT
 
-    def render(self, manifest: Manifest, target: Path) -> list[str]:
+    def render(self, manifest: Manifest, target: Path, logical_root: Path | None = None) -> list[str]:
         out: list[str] = []
         self._warn_unsupported(manifest)
         self._write_agents(manifest, target, out)

--- a/agent-profile/agent_profile/renderers/opencode.py
+++ b/agent-profile/agent_profile/renderers/opencode.py
@@ -179,7 +179,7 @@ class OpencodeRenderer:
     name = "opencode"
     mcp_default = _OPENCODE_MCP_DEFAULT
 
-    def render(self, manifest: Manifest, target: Path) -> list[str]:
+    def render(self, manifest: Manifest, target: Path, logical_root: Path | None = None) -> list[str]:
         """Render opencode's native subagent files (``<target>/agents/``),
         copy local skills into ``<target>/skills/``, then merge this
         profile's opencode MCPs + translated permissions into

--- a/agent-profile/tests/compile_fixtures.py
+++ b/agent-profile/tests/compile_fixtures.py
@@ -1,0 +1,71 @@
+"""Shared fixtures for compiled profile tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+
+from agent_profile.compiled_types import CompileTarget
+
+
+def live_profile_yaml(*, compile_targets: dict | None = None, **overrides: object) -> str:
+    profile = {
+        "name": "live",
+        "description": "Live agent deployment profile",
+        "include": ["base", "_permissions"],
+        "compile_targets": compile_targets
+        or {
+            "home": {
+                "target_root": "$HOME",
+                "harnesses": ["claude", "codex", "cursor", "copilot"],
+            },
+            "opencode": {
+                "target_root": "$HOME/.config/opencode",
+                "harnesses": ["opencode"],
+            },
+        },
+        "enabled_plugins": {"global@local": True},
+        "marketplaces": {"local": "$HOME/.claude/plugins/local"},
+    }
+    profile.update(overrides)
+    return yaml.safe_dump(profile, sort_keys=False)
+
+
+def write_live_profile(root: Path, **overrides: object) -> Path:
+    profile_dir = root / "live"
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    (profile_dir / "profile.yaml").write_text(live_profile_yaml(**overrides))
+    return profile_dir
+
+
+def write_minimal_includes(root: Path) -> None:
+    for name in ("base", "_permissions"):
+        profile_dir = root / name
+        profile_dir.mkdir(parents=True, exist_ok=True)
+        (profile_dir / "profile.yaml").write_text(f"name: {name}\n")
+
+
+def compiled_target(
+    tmp_path: Path,
+    *,
+    name: str = "home",
+    symbolic_root: str = "$HOME",
+    harnesses: tuple[str, ...] = ("claude", "codex"),
+) -> CompileTarget:
+    resolved_root = tmp_path / "targets" / name
+    resolved_root.mkdir(parents=True, exist_ok=True)
+    return CompileTarget(name, symbolic_root, resolved_root, harnesses)
+
+
+def write_json(path: Path, data: object) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n")
+    return path
+
+
+def write_text(path: Path, content: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+    return path

--- a/agent-profile/tests/conftest.py
+++ b/agent-profile/tests/conftest.py
@@ -12,17 +12,38 @@ without pulling in a production renderer module.
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 
 import pytest
 
-from agent_profile import shared
-from agent_profile.parse import Manifest
-from agent_profile.renderers.base import mcps_for
-from agent_profile.cli import ALL_HARNESSES
+from agent_profile import cli, compile_command, shared
+from agent_profile.manifest import ManifestCorrupt
+from agent_profile.parse import Manifest, ParseError
+from agent_profile.renderers.base import MergedConfigError, mcps_for
+from agent_profile.cli import ALL_HARNESSES, CliError
 
 GOLDEN = Path(__file__).parent / "fixtures" / "golden"
 
+
+def install_profile(argv: list[str]) -> int:
+    """Drive the internal render/install seam after public `ap install` deprecation."""
+    args = argv[1:] if argv and argv[0] == "install" else argv
+    colors = cli._Colors(False)
+    try:
+        harnesses, target, remaining, _passthrough = cli._parse_common_opts(args)
+        cli._validate_harnesses(harnesses, colors)
+        name = remaining[0] if remaining else ""
+        return cli.cmd_install(name, harnesses, target, colors, sys.stdout)
+    except (
+        CliError,
+        compile_command.CompileError,
+        ParseError,
+        ManifestCorrupt,
+        MergedConfigError,
+    ) as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
 
 @pytest.fixture
 def golden():
@@ -92,7 +113,7 @@ class StubRenderer:
     def _merged_path(self, target: Path) -> Path:
         return Path(str(target).rstrip("/")) / f"{self.name}.json"
 
-    def render(self, manifest: Manifest, target: Path) -> list[str]:
+    def render(self, manifest: Manifest, target: Path, logical_root: Path | None = None) -> list[str]:
         out: list[str] = []
         base = Path(str(target).rstrip("/"))
         for agent in manifest.agents:

--- a/agent-profile/tests/fixtures/golden/strings/help.txt
+++ b/agent-profile/tests/fixtures/golden/strings/help.txt
@@ -4,7 +4,9 @@ Commands:
   list                          List available profiles
   describe <name>               Show resolved manifest for a profile
   path <name>                   Print profile source dir
-  install <name> [opts]         Render profile into current dir
+  compile <name> --baseline <dir> --out <dir>
+                                Compile live profile fragments
+  install <name> [opts]         Deprecated; use dots sync or ap compile
   uninstall <name> [opts]       Remove a previously-installed profile
   launch <harness> [name] [..]  Install + exec the named harness CLI
   perms [opts]                  Write repo-level permission overlay (Claude + Codex)

--- a/agent-profile/tests/test_apply_compiled.py
+++ b/agent-profile/tests/test_apply_compiled.py
@@ -350,6 +350,19 @@ def test_apply_file_referencing_unknown_target_raises(tmp_path):
         apply_compiled.apply_compiled(mpath)
 
 
+@pytest.mark.parametrize("escaping", ["../escape.md", "a/../../escape.md", "/abs/escape.md"])
+def test_apply_rejects_relative_path_escaping_target_root(tmp_path, escaping):
+    """Finding regression: a ``relative_path`` that is absolute or climbs out of
+    its target root via ``..`` is rejected with a handled ApplyError, so a
+    malicious manifest cannot write or unlink outside the resolved root."""
+    root = tmp_path / "live"
+    cache = tmp_path / "compiled"
+    frag = _fragment(cache, "home", "claude", "placeholder.md", "x\n")
+    frag["relative_path"] = escaping
+    mpath = _write_manifest(cache, _manifest([_target("home", root)], [frag]))
+    with pytest.raises(apply_compiled.ApplyError, match="relative_path"):
+        apply_compiled.apply_compiled(mpath)
+
 # --- CLI seam --------------------------------------------------------------
 
 
@@ -525,4 +538,27 @@ def test_apply_user_mcp_missing_required_key_is_handled(tmp_path):
         _manifest_user_mcps([_target("home", tmp_path / "live")], [bad]),
     )
     with pytest.raises(apply_compiled.ApplyError, match="'name' and 'command'"):
+        apply_compiled.apply_compiled(mpath)
+
+
+@pytest.mark.parametrize(
+    ("bad", "match"),
+    [
+        ({"name": 123, "command": "npx"}, "'name' must be a non-empty string"),
+        ({"name": "", "command": "npx"}, "'name' must be a non-empty string"),
+        ({"name": "ctx", "command": 123}, "'command' must be a non-empty string"),
+        ({"name": "ctx", "command": ""}, "'command' must be a non-empty string"),
+    ],
+)
+def test_apply_user_mcp_non_string_key_is_handled(tmp_path, bad, match):
+    """Finding regression: a user_mcps entry whose ``name``/``command`` is present
+    but not a non-empty string raises a handled ApplyError before the argv ever
+    reaches ``subprocess.run`` (which would otherwise raise an uncaught TypeError).
+    """
+    cache = tmp_path / "compiled"
+    mpath = _write_manifest(
+        cache,
+        _manifest_user_mcps([_target("home", tmp_path / "live")], [bad]),
+    )
+    with pytest.raises(apply_compiled.ApplyError, match=match):
         apply_compiled.apply_compiled(mpath)

--- a/agent-profile/tests/test_apply_compiled.py
+++ b/agent-profile/tests/test_apply_compiled.py
@@ -1,0 +1,528 @@
+"""Steel threads for ``ap apply-compiled``.
+
+These exercise the pure apply module against tmp_path fixtures only — never the
+real ``$HOME``. Every resolved target root points inside ``tmp_path``.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+import pytest
+
+from agent_profile import apply_compiled
+from agent_profile.compiled_types import ApplyState
+
+
+def _target(name, root, *, symbolic="$HOME", harnesses=("claude",)):
+    return {
+        "name": name,
+        "symbolic_root": symbolic,
+        "resolved_root": str(root),
+        "harnesses": list(harnesses),
+    }
+
+
+def _fragment(cache, target, harness, rel, content, *, generated=True):
+    frag = cache / "fragments" / target / harness / rel
+    frag.parent.mkdir(parents=True, exist_ok=True)
+    frag.write_text(content)
+    return {
+        "target": target,
+        "harness": harness,
+        "fragment_path": str(frag),
+        "relative_path": rel,
+        "generated": generated,
+    }
+
+
+def _manifest(targets, files, *, profile="live"):
+    return {
+        "profile": profile,
+        "source_id": "/src",
+        "manifest_path": "/cache/manifest.json",
+        "compile_targets": targets,
+        "files": files,
+        "drift": [],
+    }
+
+
+def _write_manifest(cache, manifest):
+    cache.mkdir(parents=True, exist_ok=True)
+    path = cache / "manifest.json"
+    path.write_text(json.dumps(manifest, indent=2) + "\n")
+    return path
+
+
+# --- copy / update ---------------------------------------------------------
+
+
+def test_apply_copies_managed_files_to_resolved_root(tmp_path):
+    root = tmp_path / "live"
+    cache = tmp_path / "compiled"
+    frag = _fragment(cache, "home", "claude", ".claude/agents/reviewer.md", "review\n")
+    mpath = _write_manifest(cache, _manifest([_target("home", root)], [frag]))
+
+    result = apply_compiled.apply_compiled(mpath)
+
+    dest = root / ".claude/agents/reviewer.md"
+    assert dest.read_text() == "review\n"
+    assert result.copied == (str(dest),)
+    assert result.state.managed_files == (str(dest),)
+
+
+def test_apply_updates_existing_file_in_place(tmp_path):
+    root = tmp_path / "live"
+    dest = root / ".claude/agents/reviewer.md"
+    dest.parent.mkdir(parents=True)
+    dest.write_text("old body\n")
+    cache = tmp_path / "compiled"
+    frag = _fragment(cache, "home", "claude", ".claude/agents/reviewer.md", "new body\n")
+    mpath = _write_manifest(cache, _manifest([_target("home", root)], [frag]))
+
+    apply_compiled.apply_compiled(mpath)
+
+    assert dest.read_text() == "new body\n"
+
+
+def test_apply_writes_to_each_target_resolved_root(tmp_path):
+    home = tmp_path / "home"
+    oc = tmp_path / "oc"
+    cache = tmp_path / "compiled"
+    f_home = _fragment(cache, "home", "claude", ".claude/agents/r.md", "h\n")
+    f_oc = _fragment(cache, "opencode", "opencode", ".opencode/agents/r.md", "o\n")
+    targets = [
+        _target("home", home),
+        _target(
+            "opencode",
+            oc,
+            symbolic="$HOME/.config/opencode",
+            harnesses=("opencode",),
+        ),
+    ]
+    mpath = _write_manifest(cache, _manifest(targets, [f_home, f_oc]))
+
+    apply_compiled.apply_compiled(mpath)
+
+    assert (home / ".claude/agents/r.md").read_text() == "h\n"
+    assert (oc / ".opencode/agents/r.md").read_text() == "o\n"
+
+
+def test_apply_writes_state_beside_manifest_by_default(tmp_path):
+    root = tmp_path / "live"
+    cache = tmp_path / "compiled"
+    frag = _fragment(cache, "home", "claude", ".claude/agents/r.md", "x\n")
+    mpath = _write_manifest(cache, _manifest([_target("home", root)], [frag]))
+
+    result = apply_compiled.apply_compiled(mpath)
+
+    state_path = cache / apply_compiled.DEFAULT_STATE_FILENAME
+    assert result.state_path == state_path
+    assert apply_compiled.read_apply_state(state_path) == result.state
+
+
+# --- delete previously-managed, absent from new manifest -------------------
+
+
+def test_apply_deletes_previously_managed_file_absent_from_manifest(tmp_path):
+    root = tmp_path / "live"
+    stale = root / ".claude/agents/old.md"
+    stale.parent.mkdir(parents=True)
+    stale.write_text("stale\n")
+    cache = tmp_path / "compiled"
+    cache.mkdir()
+    apply_compiled.write_apply_state(
+        cache / apply_compiled.DEFAULT_STATE_FILENAME,
+        ApplyState(managed_files=(str(stale),)),
+    )
+    frag = _fragment(cache, "home", "claude", ".claude/agents/new.md", "new\n")
+    mpath = _write_manifest(cache, _manifest([_target("home", root)], [frag]))
+
+    result = apply_compiled.apply_compiled(mpath)
+
+    assert not stale.exists()
+    assert str(stale) in result.deleted
+    assert str(stale) not in result.state.managed_files
+    assert (root / ".claude/agents/new.md").read_text() == "new\n"
+
+
+def test_apply_keeps_file_present_in_new_manifest(tmp_path):
+    root = tmp_path / "live"
+    dest = root / ".claude/agents/reviewer.md"
+    dest.parent.mkdir(parents=True)
+    dest.write_text("old\n")
+    cache = tmp_path / "compiled"
+    cache.mkdir()
+    apply_compiled.write_apply_state(
+        cache / apply_compiled.DEFAULT_STATE_FILENAME,
+        ApplyState(managed_files=(str(dest),)),
+    )
+    frag = _fragment(cache, "home", "claude", ".claude/agents/reviewer.md", "fresh\n")
+    mpath = _write_manifest(cache, _manifest([_target("home", root)], [frag]))
+
+    result = apply_compiled.apply_compiled(mpath)
+
+    assert dest.read_text() == "fresh\n"
+    assert str(dest) not in result.deleted
+    assert str(dest) in result.state.managed_files
+
+
+def test_reconcile_removes_dropped_file_across_applies(tmp_path):
+    """End-to-end: a file present in compile #1 but dropped in compile #2 is
+    removed on the second apply, driven entirely by the persisted apply state."""
+    root = tmp_path / "live"
+    cache = tmp_path / "cache"  # stable per-source/profile cache reused each run
+    a1 = _fragment(cache, "home", "claude", ".claude/agents/a.md", "a\n")
+    b1 = _fragment(cache, "home", "claude", ".claude/agents/b.md", "b\n")
+    mpath = _write_manifest(cache, _manifest([_target("home", root)], [a1, b1]))
+
+    apply_compiled.apply_compiled(mpath)
+    assert (root / ".claude/agents/b.md").exists()
+
+    a2 = _fragment(cache, "home", "claude", ".claude/agents/a.md", "a\n")
+    mpath = _write_manifest(cache, _manifest([_target("home", root)], [a2]))
+    result = apply_compiled.apply_compiled(mpath)
+
+    assert not (root / ".claude/agents/b.md").exists()
+    assert (root / ".claude/agents/a.md").read_text() == "a\n"
+    assert str(root / ".claude/agents/b.md") in result.deleted
+
+
+# --- CRITICAL boundary: never touch files not in prior apply state ---------
+
+
+def test_apply_never_deletes_file_not_in_prior_state(tmp_path):
+    root = tmp_path / "live"
+    user_file = root / ".claude/settings.json"
+    user_file.parent.mkdir(parents=True)
+    user_file.write_text('{"user":"owned"}\n')
+    cache = tmp_path / "compiled"
+    frag = _fragment(cache, "home", "claude", ".claude/agents/reviewer.md", "body\n")
+    mpath = _write_manifest(cache, _manifest([_target("home", root)], [frag]))
+
+    result = apply_compiled.apply_compiled(mpath)
+
+    assert user_file.read_text() == '{"user":"owned"}\n'
+    assert str(user_file) not in result.deleted
+
+
+def test_apply_deletes_dropped_managed_but_preserves_untracked_neighbor(tmp_path):
+    """The reconcile and safety guarantees together: a dropped managed file is
+    removed while an untracked user file in the same target survives."""
+    root = tmp_path / "live"
+    stale = root / ".claude/agents/old.md"
+    stale.parent.mkdir(parents=True)
+    stale.write_text("stale\n")
+    user_file = root / ".claude/settings.json"
+    user_file.write_text('{"user":"owned"}\n')
+    cache = tmp_path / "compiled"
+    cache.mkdir()
+    apply_compiled.write_apply_state(
+        cache / apply_compiled.DEFAULT_STATE_FILENAME,
+        ApplyState(managed_files=(str(stale),)),  # user_file deliberately untracked
+    )
+    frag = _fragment(cache, "home", "claude", ".claude/agents/new.md", "new\n")
+    mpath = _write_manifest(cache, _manifest([_target("home", root)], [frag]))
+
+    result = apply_compiled.apply_compiled(mpath)
+
+    assert not stale.exists()
+    assert str(stale) in result.deleted
+    assert user_file.read_text() == '{"user":"owned"}\n'
+    assert str(user_file) not in result.deleted
+
+
+def test_apply_skips_non_generated_files(tmp_path):
+    """Whole merged files (generated=False) are owned by the merge module: this
+    apply neither copies nor tracks them."""
+    root = tmp_path / "live"
+    cache = tmp_path / "compiled"
+    merged = _fragment(
+        cache, "home", "claude", ".claude/settings.json", '{"m":1}\n', generated=False
+    )
+    mpath = _write_manifest(cache, _manifest([_target("home", root)], [merged]))
+
+    result = apply_compiled.apply_compiled(mpath)
+
+    assert not (root / ".claude/settings.json").exists()
+    assert result.state.managed_files == ()
+    assert result.copied == ()
+
+
+def test_apply_skips_prior_managed_path_already_gone(tmp_path):
+    """A prior-managed file the user already deleted is reconciled out of state
+    without error and is not reported as deleted."""
+    root = tmp_path / "live"
+    gone = root / ".claude/agents/gone.md"  # never created on disk
+    cache = tmp_path / "compiled"
+    cache.mkdir()
+    apply_compiled.write_apply_state(
+        cache / apply_compiled.DEFAULT_STATE_FILENAME,
+        ApplyState(managed_files=(str(gone),)),
+    )
+    frag = _fragment(cache, "home", "claude", ".claude/agents/r.md", "r\n")
+    mpath = _write_manifest(cache, _manifest([_target("home", root)], [frag]))
+
+    result = apply_compiled.apply_compiled(mpath)
+
+    assert result.deleted == ()
+    assert str(gone) not in result.state.managed_files
+
+
+# --- idempotency -----------------------------------------------------------
+
+
+def test_second_apply_same_manifest_is_idempotent(tmp_path):
+    root = tmp_path / "live"
+    cache = tmp_path / "compiled"
+    frag = _fragment(cache, "home", "claude", ".claude/agents/r.md", "body\n")
+    mpath = _write_manifest(cache, _manifest([_target("home", root)], [frag]))
+
+    apply_compiled.apply_compiled(mpath)
+    result = apply_compiled.apply_compiled(mpath)
+
+    dest = root / ".claude/agents/r.md"
+    assert result.deleted == ()
+    assert dest.read_text() == "body\n"
+    assert result.state.managed_files == (str(dest),)
+
+
+# --- apply state read/write ------------------------------------------------
+
+
+def test_read_apply_state_missing_returns_empty(tmp_path):
+    assert apply_compiled.read_apply_state(tmp_path / "nope.json") == ApplyState()
+
+
+def test_apply_state_round_trip(tmp_path):
+    path = tmp_path / "state.json"
+    state = ApplyState(managed_files=("/a/x", "/b/y"))
+    apply_compiled.write_apply_state(path, state)
+    assert apply_compiled.read_apply_state(path) == state
+
+
+def test_read_apply_state_rejects_malformed(tmp_path):
+    path = tmp_path / "state.json"
+    path.write_text('{"managed_files": "not-a-list"}')
+    with pytest.raises(apply_compiled.ApplyError):
+        apply_compiled.read_apply_state(path)
+
+
+# --- input validation ------------------------------------------------------
+
+
+def test_apply_missing_manifest_raises(tmp_path):
+    with pytest.raises(apply_compiled.ApplyError):
+        apply_compiled.apply_compiled(tmp_path / "missing.json")
+
+
+def test_apply_malformed_manifest_raises(tmp_path):
+    path = tmp_path / "manifest.json"
+    path.write_text("{ not json")
+    with pytest.raises(apply_compiled.ApplyError):
+        apply_compiled.apply_compiled(path)
+
+
+def test_apply_missing_fragment_raises(tmp_path):
+    root = tmp_path / "live"
+    cache = tmp_path / "compiled"
+    cache.mkdir()
+    entry = {
+        "target": "home",
+        "harness": "claude",
+        "fragment_path": str(cache / "fragments/home/claude/x.md"),
+        "relative_path": "x.md",
+        "generated": True,
+    }
+    mpath = _write_manifest(cache, _manifest([_target("home", root)], [entry]))
+    with pytest.raises(apply_compiled.ApplyError):
+        apply_compiled.apply_compiled(mpath)
+
+
+def test_apply_file_referencing_unknown_target_raises(tmp_path):
+    cache = tmp_path / "compiled"
+    frag = _fragment(cache, "ghost", "claude", "x.md", "x\n")
+    mpath = _write_manifest(
+        cache, _manifest([_target("home", tmp_path / "live")], [frag])
+    )
+    with pytest.raises(apply_compiled.ApplyError):
+        apply_compiled.apply_compiled(mpath)
+
+
+# --- CLI seam --------------------------------------------------------------
+
+
+def test_cmd_apply_compiled_applies_and_returns_zero(tmp_path, capsys):
+    root = tmp_path / "live"
+    cache = tmp_path / "compiled"
+    frag = _fragment(cache, "home", "claude", ".claude/agents/r.md", "body\n")
+    mpath = _write_manifest(cache, _manifest([_target("home", root)], [frag]))
+
+    rc = apply_compiled.cmd_apply_compiled([str(mpath)], sys.stdout)
+
+    assert rc == 0
+    assert (root / ".claude/agents/r.md").read_text() == "body\n"
+    assert "applied 1 file(s)" in capsys.readouterr().out
+
+
+def test_cmd_apply_compiled_requires_manifest_arg():
+    with pytest.raises(apply_compiled.ApplyError):
+        apply_compiled.cmd_apply_compiled([], sys.stdout)
+
+
+# --- user-scope MCP registration (deferred from compile) -------------------
+
+
+def _fake_claude(tmp_path, monkeypatch):
+    """A fake ``claude`` first on PATH logging each call's args; returns the log."""
+    bindir = tmp_path / "fakebin"
+    bindir.mkdir()
+    log = tmp_path / "claude-calls.log"
+    shim = bindir / "claude"
+    shim.write_text('#!/bin/sh\nprintf "%s\\n" "$*" >> "$AP_TEST_CLAUDE_LOG"\nexit 0\n')
+    shim.chmod(0o755)
+    monkeypatch.setenv("AP_TEST_CLAUDE_LOG", str(log))
+    monkeypatch.setenv("PATH", f"{bindir}:/usr/bin")
+    return log
+
+
+_USER_MCP = {
+    "name": "context7",
+    "command": "npx",
+    "args": ["-y", "@upstash/context7-mcp"],
+    "env": {"CONTEXT7_API_KEY": "${CONTEXT7_API_KEY}"},
+}
+
+
+def _manifest_user_mcps(targets, user_mcps):
+    m = _manifest(targets, [])
+    m["user_mcps"] = user_mcps
+    return m
+
+
+def test_apply_registers_user_mcps_via_cli(tmp_path, monkeypatch):
+    """apply performs the live ``claude mcp add`` the compile deferred —
+    remove-then-add per server, idempotent."""
+    log = _fake_claude(tmp_path, monkeypatch)
+    cache = tmp_path / "compiled"
+    mpath = _write_manifest(
+        cache,
+        _manifest_user_mcps([_target("home", tmp_path / "live")], [_USER_MCP]),
+    )
+
+    result = apply_compiled.apply_compiled(mpath)
+
+    assert result.registered_mcps == ("context7",)
+    assert log.read_text().splitlines() == [
+        "mcp remove context7 --scope user",
+        "mcp add context7 --scope user -e CONTEXT7_API_KEY=${CONTEXT7_API_KEY} "
+        "-- npx -y @upstash/context7-mcp",
+    ]
+
+
+def test_apply_user_mcp_passes_literal_var_not_secret(tmp_path, monkeypatch):
+    """The ``claude mcp add`` argv carries the literal ``${VAR}``; a real
+    process-env value never leaks into the stored registration."""
+    monkeypatch.setenv("CONTEXT7_API_KEY", "sk-real-secret-123")
+    log = _fake_claude(tmp_path, monkeypatch)
+    cache = tmp_path / "compiled"
+    mpath = _write_manifest(
+        cache,
+        _manifest_user_mcps([_target("home", tmp_path / "live")], [_USER_MCP]),
+    )
+
+    apply_compiled.apply_compiled(mpath)
+
+    text = log.read_text()
+    assert "-e CONTEXT7_API_KEY=${CONTEXT7_API_KEY}" in text
+    assert "sk-real-secret-123" not in text
+
+
+def test_apply_user_mcp_missing_cli_fails_loud(tmp_path, monkeypatch):
+    """No ``claude`` on PATH but user_mcps present → handled ApplyError."""
+    emptybin = tmp_path / "emptybin"
+    emptybin.mkdir()
+    monkeypatch.setenv("PATH", str(emptybin))
+    cache = tmp_path / "compiled"
+    mpath = _write_manifest(
+        cache,
+        _manifest_user_mcps([_target("home", tmp_path / "live")], [_USER_MCP]),
+    )
+    with pytest.raises(apply_compiled.ApplyError, match="claude` CLI"):
+        apply_compiled.apply_compiled(mpath)
+
+
+def test_apply_user_mcp_add_failure_is_handled(tmp_path, monkeypatch):
+    """A non-zero ``claude mcp add`` raises a handled ApplyError, not an
+    uncaught CalledProcessError."""
+    bindir = tmp_path / "fakebin"
+    bindir.mkdir()
+    shim = bindir / "claude"
+    # `remove` succeeds (exit 0); `add` fails (exit 1).
+    shim.write_text('#!/bin/sh\ncase "$1 $2" in "mcp add") exit 1;; esac\nexit 0\n')
+    shim.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{bindir}:/usr/bin")
+    cache = tmp_path / "compiled"
+    mpath = _write_manifest(
+        cache,
+        _manifest_user_mcps([_target("home", tmp_path / "live")], [_USER_MCP]),
+    )
+    with pytest.raises(apply_compiled.ApplyError, match="claude mcp add context7"):
+        apply_compiled.apply_compiled(mpath)
+
+
+def test_apply_no_user_mcps_makes_no_claude_call(tmp_path, monkeypatch):
+    """A manifest without user_mcps never touches the claude CLI."""
+    log = _fake_claude(tmp_path, monkeypatch)
+    root = tmp_path / "live"
+    cache = tmp_path / "compiled"
+    frag = _fragment(cache, "home", "claude", ".claude/agents/r.md", "r\n")
+    mpath = _write_manifest(cache, _manifest([_target("home", root)], [frag]))
+
+    result = apply_compiled.apply_compiled(mpath)
+
+    assert result.registered_mcps == ()
+    assert not log.exists()
+
+
+def test_apply_persists_state_when_mcp_registration_fails(tmp_path, monkeypatch):
+    """Finding regression: disk copy/delete is committed before MCP registration,
+    so when ``claude mcp add`` raises, the apply state must still record the
+    already-moved files — otherwise the next reconcile uses stale managed_files
+    and orphans them."""
+    bindir = tmp_path / "fakebin"
+    bindir.mkdir()
+    shim = bindir / "claude"
+    shim.write_text('#!/bin/sh\ncase "$1 $2" in "mcp add") exit 1;; esac\nexit 0\n')
+    shim.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{bindir}:/usr/bin")
+    root = tmp_path / "live"
+    cache = tmp_path / "compiled"
+    frag = _fragment(cache, "home", "claude", ".claude/agents/r.md", "r\n")
+    manifest = _manifest_user_mcps([_target("home", root)], [_USER_MCP])
+    manifest["files"] = [frag]
+    mpath = _write_manifest(cache, manifest)
+
+    with pytest.raises(apply_compiled.ApplyError, match="claude mcp add context7"):
+        apply_compiled.apply_compiled(mpath)
+
+    dest = root / ".claude/agents/r.md"
+    assert dest.read_text() == "r\n"  # file was moved before the failure
+    state = apply_compiled.read_apply_state(
+        cache / apply_compiled.DEFAULT_STATE_FILENAME
+    )
+    assert state.managed_files == (str(dest),)
+
+
+def test_apply_user_mcp_missing_required_key_is_handled(tmp_path):
+    """Finding regression: a user_mcps entry missing ``name``/``command`` raises a
+    handled ApplyError, not an uncaught KeyError."""
+    cache = tmp_path / "compiled"
+    bad = {"command": "npx", "args": ["-y", "x"]}  # no 'name'
+    mpath = _write_manifest(
+        cache,
+        _manifest_user_mcps([_target("home", tmp_path / "live")], [bad]),
+    )
+    with pytest.raises(apply_compiled.ApplyError, match="'name' and 'command'"):
+        apply_compiled.apply_compiled(mpath)

--- a/agent-profile/tests/test_cli.py
+++ b/agent-profile/tests/test_cli.py
@@ -11,7 +11,7 @@ import json
 import pytest
 
 from agent_profile import cli
-from tests.conftest import write_profile
+from tests.conftest import install_profile, write_profile
 
 REVIEWER_BODY = "Reviewer body for foo\n"
 HOOK_BODY = "#!/bin/bash\nexit 0\n"
@@ -43,6 +43,8 @@ def make_basic_profile(root, name):
 
 
 def run(argv) -> int:
+    if argv and argv[0] == "install":
+        return install_profile(argv)
     return cli.main(argv)
 
 

--- a/agent-profile/tests/test_compile_apply_preservation.py
+++ b/agent-profile/tests/test_compile_apply_preservation.py
@@ -1,0 +1,108 @@
+"""End-to-end: user-owned merged settings survive compile -> apply-compiled.
+
+Spec line 92 / ADR-001: ``ap apply-compiled`` must never overwrite or delete a
+user-owned merged settings file. The data-loss regression these pin is compile
+emitting ``.claude/settings.json`` as ``generated=True`` (apply clobber-copies
+it) or apply reconciling it out of a stale apply state (apply deletes it).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from agent_profile import apply_compiled, compile_command
+from agent_profile.compiled_types import ApplyState
+from agent_profile.renderers.registry import build_registry
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_live_user_key_survives_compile_then_apply(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    (home / ".claude").mkdir(parents=True)
+    settings = home / ".claude" / "settings.json"
+    settings.write_text(json.dumps({"userOwnedKey": "keep-me"}) + "\n")
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("DOTFILES_DIR", str(REPO_ROOT))
+
+    baseline = tmp_path / "baseline"
+    baseline.mkdir()
+    out = tmp_path / "out"
+
+    compile_command.compile_profile("live", baseline, out, build_registry())
+    manifest = out / "manifest.json"
+
+    data = json.loads(manifest.read_text())
+    settings_entries = [
+        f for f in data["files"] if f["relative_path"] == ".claude/settings.json"
+    ]
+    assert settings_entries, "compile should emit a .claude/settings.json fragment"
+    # The merged settings fragment is marked user-owned so apply preserves it.
+    assert all(f["generated"] is False for f in settings_entries)
+
+    apply_compiled.apply_compiled(manifest)
+
+    assert json.loads(settings.read_text()) == {"userOwnedKey": "keep-me"}
+
+
+def test_apply_does_not_delete_merged_settings_tracked_by_prior_state(tmp_path):
+    """Migration safety: a settings.json left in the prior apply state (from an
+    old generated=True run) must not be deleted when the new manifest marks it
+    generated=False — that reconcile-delete would destroy user content."""
+    root = tmp_path / "home"
+    settings = root / ".claude" / "settings.json"
+    settings.parent.mkdir(parents=True)
+    settings.write_text('{"userOwnedKey": "keep-me"}\n')
+
+    cache = tmp_path / "cache"
+    cache.mkdir()
+    apply_compiled.write_apply_state(
+        cache / apply_compiled.DEFAULT_STATE_FILENAME,
+        ApplyState(managed_files=(str(settings),)),
+    )
+
+    frag = cache / "fragments/home/claude/.claude/agents/r.md"
+    frag.parent.mkdir(parents=True)
+    frag.write_text("body\n")
+    settings_frag = cache / "fragments/home/claude/.claude/settings.json"
+    settings_frag.write_text('{"permissions": {"allow": []}}\n')
+
+    manifest = {
+        "profile": "live",
+        "source_id": "/src",
+        "manifest_path": str(cache / "manifest.json"),
+        "compile_targets": [
+            {
+                "name": "home",
+                "symbolic_root": "$HOME",
+                "resolved_root": str(root),
+                "harnesses": ["claude"],
+            }
+        ],
+        "files": [
+            {
+                "target": "home",
+                "harness": "claude",
+                "fragment_path": str(frag),
+                "relative_path": ".claude/agents/r.md",
+                "generated": True,
+            },
+            {
+                "target": "home",
+                "harness": "claude",
+                "fragment_path": str(settings_frag),
+                "relative_path": ".claude/settings.json",
+                "generated": False,
+            },
+        ],
+        "drift": [],
+    }
+    mpath = cache / "manifest.json"
+    mpath.write_text(json.dumps(manifest, indent=2) + "\n")
+
+    result = apply_compiled.apply_compiled(mpath)
+
+    assert settings.exists()
+    assert json.loads(settings.read_text()) == {"userOwnedKey": "keep-me"}
+    assert str(settings) not in result.deleted

--- a/agent-profile/tests/test_compile_command.py
+++ b/agent-profile/tests/test_compile_command.py
@@ -168,6 +168,27 @@ def test_profile_arg_extracts_positional_regardless_of_flag_order():
     assert compile_command.profile_arg(["--baseline", "b", "--out", "o"]) == ""
 
 
+def test_profile_arg_rejects_unknown_flag():
+    """An unknown ``--flag`` is reported as an unknown option, not silently
+    returned as the profile positional (which misreported ``profile '--bogus'
+    not found``)."""
+    with pytest.raises(compile_command.CompileError, match="unknown option '--bogus'"):
+        compile_command.profile_arg(["--bogus"])
+
+
+def test_parse_args_rejects_unknown_flag():
+    with pytest.raises(compile_command.CompileError, match="unknown option '--bogus'"):
+        compile_command._parse_args(["live", "--bogus", "--baseline", "b", "--out", "o"])
+
+
+def test_cli_compile_unknown_flag_reports_unknown_option(capsys):
+    """``ap compile --bogus`` surfaces an unknown-option error (exit 1), not a
+    misleading ``profile '--bogus' not found``."""
+    rc = run(["compile", "--bogus"])
+    assert rc == 1
+    assert "unknown option '--bogus'" in capsys.readouterr().err
+
+
 def test_compile_accepts_flags_before_profile(env, monkeypatch, stub_renderers):
     """The CLI compile pre-check must extract the profile positionally, not
     assume it is the first arg. ``--baseline X --out Y live`` previously errored

--- a/agent-profile/tests/test_compile_command.py
+++ b/agent-profile/tests/test_compile_command.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from agent_profile import cli, compile_command
+from agent_profile.renderers.registry import build_registry
+from tests.compile_fixtures import (
+    write_live_profile,
+    write_minimal_includes,
+    write_text,
+)
+
+
+def run(argv: list[str]) -> int:
+    return cli.main(argv)
+
+
+@pytest.fixture
+def prod_renderers():
+    """Wire the production renderers for one test (compile uses cli.RENDERERS)."""
+    saved = cli.RENDERERS
+    cli.set_renderers(build_registry())
+    yield
+    cli.set_renderers(saved)
+
+
+_USER_MCP = {
+    "name": "context7",
+    "command": "npx",
+    "args": ["-y", "@upstash/context7-mcp"],
+    "env": {"CONTEXT7_API_KEY": "${CONTEXT7_API_KEY}"},
+    "harnesses": ["claude"],
+}
+
+
+def test_compile_live_writes_harness_fragments_and_target_manifest(
+    env, monkeypatch, stub_renderers
+):
+    write_minimal_includes(env.profiles)
+    profile_dir = write_live_profile(
+        env.profiles,
+        agents=[{"name": "reviewer", "body_path": "reviewer.md"}],
+    )
+    write_text(profile_dir / "reviewer.md", "review body\n")
+    home = env.tmp / "home"
+    baseline = env.tmp / "baseline"
+    out = env.tmp / "compiled"
+    baseline.mkdir()
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    assert run(["compile", "live", "--baseline", str(baseline), "--out", str(out)]) == 0
+
+    claude_agent = out / "fragments/home/claude/.claude/agents/reviewer.md"
+    codex_agent = out / "fragments/home/codex/.codex/agents/reviewer.md"
+    opencode_agent = out / "fragments/opencode/opencode/.opencode/agents/reviewer.md"
+    assert claude_agent.read_text() == "review body\n"
+    assert codex_agent.read_text() == "review body\n"
+    assert opencode_agent.read_text() == "review body\n"
+
+    data = json.loads((out / "manifest.json").read_text())
+    assert data["profile"] == "live"
+    assert data["compile_targets"] == [
+        {
+            "name": "home",
+            "symbolic_root": "$HOME",
+            "resolved_root": str(home),
+            "harnesses": ["claude", "codex", "cursor", "copilot"],
+        },
+        {
+            "name": "opencode",
+            "symbolic_root": "$HOME/.config/opencode",
+            "resolved_root": str(home / ".config/opencode"),
+            "harnesses": ["opencode"],
+        },
+    ]
+    assert {
+        (entry["target"], entry["harness"], entry["relative_path"])
+        for entry in data["files"]
+    } >= {
+        ("home", "claude", ".claude/agents/reviewer.md"),
+        ("home", "codex", ".codex/agents/reviewer.md"),
+        ("opencode", "opencode", ".opencode/agents/reviewer.md"),
+    }
+
+
+def test_compile_user_scope_does_not_mutate_live_or_require_claude(
+    env, monkeypatch, prod_renderers
+):
+    """Finding 1 regression: ``ap compile`` of a ``mcp_scope: user`` profile is
+    side-effect-free — it neither shells out to ``claude`` nor touches the live
+    ``~/.claude.json``. The user-scope registration is recorded in the manifest
+    (literal ``${VAR}``, not the resolved secret) for ``apply`` to perform
+    post-gate. Before the fix the claude renderer shelled ``claude mcp add``
+    during compile, so a host without the CLI aborted the whole sync."""
+    write_minimal_includes(env.profiles)
+    write_live_profile(env.profiles, mcp_scope="user", mcps=[_USER_MCP])
+    home = env.tmp / "home"
+    baseline = env.tmp / "baseline"
+    out = env.tmp / "compiled"
+    home.mkdir()
+    baseline.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("CONTEXT7_API_KEY", "sk-real-secret-do-not-leak")
+    # No `claude` (or anything else) on PATH — compile must not need it.
+    emptybin = env.tmp / "emptybin"
+    emptybin.mkdir()
+    monkeypatch.setenv("PATH", str(emptybin))
+
+    assert run(["compile", "live", "--baseline", str(baseline), "--out", str(out)]) == 0
+
+    # Compile touched no live state.
+    assert not (home / ".claude.json").exists()
+
+    data = json.loads((out / "manifest.json").read_text())
+    assert data["user_mcps"] == [
+        {
+            "name": "context7",
+            "command": "npx",
+            "args": ["-y", "@upstash/context7-mcp"],
+            "env": {"CONTEXT7_API_KEY": "${CONTEXT7_API_KEY}"},
+        }
+    ]
+    assert "sk-real-secret-do-not-leak" not in (out / "manifest.json").read_text()
+
+
+def test_compile_profile_requires_compile_targets(env):
+    """``compile_profile`` called directly (bypassing the CLI presence gate)
+    still fails loud when the profile declares no compile_targets — the
+    targets-presence guard is not lost with ``_load_compile_targets`` deleted."""
+    from tests.conftest import write_profile
+
+    write_profile(env.profiles, "notargets", "name: notargets\n")
+    with pytest.raises(compile_command.CompileError):
+        compile_command.compile_profile(
+            "notargets", env.tmp / "b", env.tmp / "o", build_registry()
+        )
+
+
+def test_compile_uses_strict_target_validation(env, monkeypatch):
+    """Finding 2 / spec-verify: compile consumes the strictly-validated
+    ``manifest.compile_targets``. A cross-target duplicate harness — which the
+    deleted weak ``_load_compile_targets`` parser accepted but strict
+    validation rejects — fails the compile."""
+    monkeypatch.setenv("HOME", str(env.tmp / "home"))
+    write_minimal_includes(env.profiles)
+    write_live_profile(
+        env.profiles,
+        compile_targets={
+            "a": {"target_root": "$HOME", "harnesses": ["claude"]},
+            "b": {"target_root": "$HOME/b", "harnesses": ["claude"]},
+        },
+    )
+    with pytest.raises(Exception, match="duplicates harness 'claude'"):
+        compile_command.compile_profile(
+            "live", env.tmp / "b", env.tmp / "o", build_registry()
+        )
+
+
+def test_profile_arg_extracts_positional_regardless_of_flag_order():
+    """``profile_arg`` mirrors ``_parse_args`` positional handling: the profile
+    is found whether it leads or trails the flags, and flag values are skipped."""
+    assert compile_command.profile_arg(["live", "--baseline", "b", "--out", "o"]) == "live"
+    assert compile_command.profile_arg(["--baseline", "b", "--out", "o", "live"]) == "live"
+    assert compile_command.profile_arg(["--baseline=b", "--out=o", "live"]) == "live"
+    assert compile_command.profile_arg(["--baseline", "b", "--out", "o"]) == ""
+
+
+def test_compile_accepts_flags_before_profile(env, monkeypatch, stub_renderers):
+    """The CLI compile pre-check must extract the profile positionally, not
+    assume it is the first arg. ``--baseline X --out Y live`` previously errored
+    with a misleading ``profile '--baseline' not found``."""
+    write_minimal_includes(env.profiles)
+    write_live_profile(env.profiles)
+    home = env.tmp / "home"
+    baseline = env.tmp / "baseline"
+    out = env.tmp / "compiled"
+    home.mkdir()
+    baseline.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    assert run(["compile", "--baseline", str(baseline), "--out", str(out), "live"]) == 0

--- a/agent-profile/tests/test_compile_drift_wiring.py
+++ b/agent-profile/tests/test_compile_drift_wiring.py
@@ -1,0 +1,44 @@
+"""Drift detection is wired into ``ap compile``.
+
+Spec acceptance (specs/ap-chezmoi-compiler.md) + ADR-003: WHEN live merged
+settings differ from the scratch chezmoi baseline or compiled result THE SYSTEM
+SHALL surface grouped diffs before any apply step. The deployment contract is
+that ``ap compile`` records those differences in ``manifest["drift"]`` — the
+exact field the ``dots sync`` shell gate (``agent_profile_has_drift`` in
+chezmoi/lib/agent-profile-sync.sh) reads to decide whether to prompt/block.
+
+``compile_profile`` calls ``compute_drift`` over each target's merged settings
+files (baseline vs live vs compiled), so a divergent live ``settings.json`` is
+reported under ``manifest["drift"]``. See .cheese/press/ap-chezmoi-compiler.md.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from agent_profile import compile_command
+from agent_profile.renderers.registry import build_registry
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_compile_records_drift_for_divergent_live_settings(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    (home / ".claude").mkdir(parents=True)
+    # A user-owned key the migration must surface as drift, not silently clobber.
+    (home / ".claude" / "settings.json").write_text(
+        json.dumps({"userOwnedKey": "keep-me"}) + "\n"
+    )
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("DOTFILES_DIR", str(REPO_ROOT))
+
+    baseline = tmp_path / "baseline"
+    baseline.mkdir()
+    out = tmp_path / "out"
+
+    compile_command.compile_profile("live", baseline, out, build_registry())
+
+    data = json.loads((out / "manifest.json").read_text())
+    drift_targets = {(r["target"], r["relative_path"]) for r in data["drift"]}
+    assert ("home", ".claude/settings.json") in drift_targets

--- a/agent-profile/tests/test_compile_generated_discriminator.py
+++ b/agent-profile/tests/test_compile_generated_discriminator.py
@@ -1,0 +1,77 @@
+"""Lock the ``generated`` discriminator and the absent-live drift boundary.
+
+b4d17a4 wired two coupled behaviours into ``compile_profile`` that the existing
+suite only pins from one side:
+
+* Each fragment's ``generated`` flag is ``not _is_merged_settings(...)``. The
+  preservation test (test_compile_apply_preservation) only asserts merged
+  settings are ``generated=False``. If the discriminator regressed to
+  *all*-False, apply would stop reconciling/deleting stale generated config
+  (spec line 91); if it regressed to *all*-True, apply would clobber user-owned
+  merged settings (spec line 92). These tests pin both directions.
+
+* Drift is computed over baseline/live/compiled. A fresh machine with no live
+  settings file is a clean create, not drift (drift.py contract) — the
+  migration must not spuriously block ``dots sync`` on first deploy.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from agent_profile import compile_command
+from agent_profile.compiled_types import MERGED_SETTINGS_BY_HARNESS
+from agent_profile.renderers.registry import build_registry
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_MERGED_PATHS = {rel for rels in MERGED_SETTINGS_BY_HARNESS.values() for rel in rels}
+
+
+def _compile_live(tmp_path, monkeypatch, *, with_live_settings: bool) -> dict:
+    home = tmp_path / "home"
+    home.mkdir(parents=True)
+    if with_live_settings:
+        (home / ".claude").mkdir()
+        (home / ".claude" / "settings.json").write_text(
+            json.dumps({"userOwnedKey": "keep-me"}) + "\n"
+        )
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("DOTFILES_DIR", str(REPO_ROOT))
+    baseline = tmp_path / "baseline"
+    baseline.mkdir()
+    out = tmp_path / "out"
+    compile_command.compile_profile("live", baseline, out, build_registry())
+    return json.loads((out / "manifest.json").read_text())
+
+
+def test_normal_fragments_generated_merged_settings_not(tmp_path, monkeypatch):
+    data = _compile_live(tmp_path, monkeypatch, with_live_settings=True)
+    files = data["files"]
+
+    generated = {f["relative_path"] for f in files if f["generated"] is True}
+    preserved = {f["relative_path"] for f in files if f["generated"] is False}
+
+    # Reconcilable generated config must still exist (spec 91): a regression to
+    # all-False would empty this set and silently disable apply's delete pass.
+    assert generated, "expected at least one generated=True fragment"
+
+    # Every emitted merged settings file is user-owned (spec 92): a regression to
+    # all-True would put these in `generated` and apply would clobber them.
+    emitted_merged = {f["relative_path"] for f in files} & _MERGED_PATHS
+    assert emitted_merged, "expected the live profile to emit merged settings files"
+    assert emitted_merged <= preserved
+    # And no generated=True fragment is a merged settings file.
+    assert not (generated & _MERGED_PATHS)
+
+
+def test_absent_live_settings_is_clean_create_not_drift(tmp_path, monkeypatch):
+    data = _compile_live(tmp_path, monkeypatch, with_live_settings=False)
+    settings_drift = [
+        r for r in data["drift"] if r["relative_path"] == ".claude/settings.json"
+    ]
+    assert settings_drift == [], (
+        "a fresh machine with no live settings.json is a clean create, "
+        f"not drift, but compile reported: {settings_drift}"
+    )

--- a/agent-profile/tests/test_compile_idempotency.py
+++ b/agent-profile/tests/test_compile_idempotency.py
@@ -1,0 +1,110 @@
+"""Compile must bake the *deploy* root into codex hooks.json, not the
+ephemeral render dir.
+
+``ap compile`` renders each target into a throwaway tempdir and captures the
+changed files as fragments. The codex renderer writes ``.codex/hooks.json``
+with an ABSOLUTE ``bash <root>/.codex/hooks/<hook>.sh`` command (Codex runs
+hook commands from the session cwd, so the path must be absolute). If that
+absolute path is rooted at the compile tempdir, the emitted fragment (a) points
+at a directory that is deleted the moment compile finishes, and (b) changes
+every run, so hooks.json is reported as drift on every recompile — defeating
+the baseline/live/compiled comparison ADR-003 depends on.
+
+These tests drive the REAL renderers (not the conftest stub, which writes only
+relative content and so cannot see this bug).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from agent_profile import compile_command
+from agent_profile.renderers.registry import build_registry
+from tests.conftest import write_profile
+
+_PROFILE_YAML = (
+    "name: live\n"
+    "description: live deployment\n"
+    "compile_targets:\n"
+    "  home:\n"
+    '    target_root: "$HOME"\n'
+    "    harnesses: [codex]\n"
+    "hooks:\n"
+    "  - name: guard\n"
+    "    event: PreToolUse\n"
+    "    matcher: Bash\n"
+    "    script: hooks/guard.sh\n"
+    "    harnesses: [codex]\n"
+)
+
+
+def _make_profile(root: Path) -> None:
+    write_profile(
+        root,
+        "live",
+        _PROFILE_YAML,
+        {"hooks/guard.sh": "#!/bin/sh\necho guard\n"},
+    )
+
+
+def _hook_commands(hooks_json: Path) -> list[str]:
+    data = json.loads(hooks_json.read_text())
+    return [
+        handler["command"]
+        for groups in data["hooks"].values()
+        for group in groups
+        for handler in group["hooks"]
+    ]
+
+
+def test_compiled_codex_hook_command_rooted_at_deploy_root(env, monkeypatch, tmp_path):
+    """The baked hook command must reference the target's deploy root (resolved
+    $HOME), never the ``ap-compile-*`` render tempdir."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    _make_profile(env.profiles)
+    baseline = tmp_path / "baseline"
+    baseline.mkdir()
+    out = tmp_path / "out"
+
+    compile_command.compile_profile("live", baseline, out, build_registry())
+
+    hooks_json = out / "fragments/home/codex/.codex/hooks.json"
+    commands = _hook_commands(hooks_json)
+    assert commands, "expected at least one codex hook command"
+    expected = f"bash {home}/.codex/hooks/guard.sh"
+    for command in commands:
+        assert "ap-compile" not in command, (
+            f"render tempdir leaked into compiled hooks.json: {command!r}"
+        )
+        assert command == expected, (
+            f"hook command not rooted at deploy root: {command!r} != {expected!r}"
+        )
+
+
+def test_recompile_reports_no_codex_drift(env, monkeypatch, tmp_path):
+    """Feeding a compile's own render back as the baseline must yield zero codex
+    fragments — compile is deterministic w.r.t. the deploy root, so nothing
+    changed."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    _make_profile(env.profiles)
+    baseline = tmp_path / "baseline"
+    baseline.mkdir()
+    renderers = build_registry()
+
+    first = tmp_path / "first"
+    compile_command.compile_profile("live", baseline, first, renderers)
+
+    second = tmp_path / "second"
+    recompiled = compile_command.compile_profile(
+        "live", first / "fragments/home/codex", second, renderers
+    )
+
+    codex_drift = [
+        f.relative_path for f in recompiled.files if f.harness == "codex"
+    ]
+    assert codex_drift == [], f"recompile reported codex drift: {codex_drift}"

--- a/agent-profile/tests/test_compile_target_presence.py
+++ b/agent-profile/tests/test_compile_target_presence.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from agent_profile.cli import main
+from tests.conftest import write_profile
+
+
+def test_compile_rejects_profile_without_compile_targets(
+    tmp_path, monkeypatch, capsys
+):
+    profiles = tmp_path / "profiles"
+    write_profile(
+        profiles,
+        "missing-targets",
+        "name: missing-targets\ndescription: lacks compile targets\n",
+    )
+    monkeypatch.setenv("AP_EXTRA_SEARCH_PATHS", str(profiles))
+
+    assert main(["compile", "missing-targets"]) == 1
+
+    err = capsys.readouterr().err
+    assert "ap compile:" in err
+    assert "missing-targets" in err
+    assert "compile_targets" in err
+
+
+def test_compile_rejects_empty_compile_targets(tmp_path, monkeypatch, capsys):
+    profiles = tmp_path / "profiles"
+    write_profile(
+        profiles,
+        "empty-targets",
+        "name: empty-targets\ndescription: empty compile targets\ncompile_targets: {}\n",
+    )
+    monkeypatch.setenv("AP_EXTRA_SEARCH_PATHS", str(profiles))
+
+    assert main(["compile", "empty-targets"]) == 1
+
+    err = capsys.readouterr().err
+    assert "ap compile:" in err
+    assert "empty-targets" in err
+    assert "compile_targets" in err

--- a/agent-profile/tests/test_compile_target_validation.py
+++ b/agent-profile/tests/test_compile_target_validation.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import pytest
+
+from agent_profile import cli
+from agent_profile.parse import parse_manifest
+
+from .compile_fixtures import write_live_profile, write_minimal_includes
+
+
+def _write_targets(env, compile_targets: dict) -> None:
+    write_minimal_includes(env.profiles)
+    write_live_profile(env.profiles, compile_targets=compile_targets)
+
+
+def _describe(capsys) -> str:
+    rc = cli.main(["describe", "live"])
+    captured = capsys.readouterr()
+    assert rc == 1
+    return captured.err
+
+
+def test_valid_compile_targets_resolve_to_absolute_roots(env, monkeypatch):
+    monkeypatch.setenv("HOME", str(env.tmp / "home"))
+    _write_targets(
+        env,
+        {
+            "home": {"target_root": "$HOME", "harnesses": ["claude", "codex"]},
+            "opencode": {
+                "target_root": "${HOME}/.config/opencode",
+                "harnesses": ["opencode"],
+            },
+        },
+    )
+
+    manifest = parse_manifest(env.profiles / "live")
+
+    assert [target.name for target in manifest.compile_targets] == ["home", "opencode"]
+    assert manifest.compile_targets[0].resolved_root == env.tmp / "home"
+    assert manifest.compile_targets[1].resolved_root == env.tmp / "home/.config/opencode"
+
+
+@pytest.mark.parametrize(
+    ("target_name", "compile_targets", "expected"),
+    [
+        (
+            "home",
+            {"home": {"target_root": "$HOME", "harnesses": ["claude", "whey"]}},
+            "unknown harness 'whey'",
+        ),
+        (
+            "codex",
+            {
+                "home": {"target_root": "$HOME", "harnesses": ["codex"]},
+                "codex": {"target_root": "$HOME/.codex", "harnesses": ["codex"]},
+            },
+            "duplicates harness 'codex'",
+        ),
+        (
+            "home",
+            {"home": {"harnesses": ["claude"]}},
+            "missing required field 'target_root'",
+        ),
+        (
+            "home",
+            {"home": {"target_root": "$HOME"}},
+            "missing required field 'harnesses'",
+        ),
+        (
+            "home",
+            {"home": {"target_root": "relative/path", "harnesses": ["claude"]}},
+            "target_root must resolve absolute",
+        ),
+        (
+            "home",
+            {"home": {"target_root": "$AP_TEST_MISSING/root", "harnesses": ["claude"]}},
+            "unresolved env var '$AP_TEST_MISSING'",
+        ),
+    ],
+)
+def test_invalid_compile_targets_exit_nonzero_with_target_name(
+    env, capsys, monkeypatch, target_name, compile_targets, expected
+):
+    monkeypatch.setenv("HOME", str(env.tmp / "home"))
+    monkeypatch.delenv("AP_TEST_MISSING", raising=False)
+    _write_targets(env, compile_targets)
+
+    err = _describe(capsys)
+
+    assert f"compile target '{target_name}'" in err
+    assert expected in err

--- a/agent-profile/tests/test_drift.py
+++ b/agent-profile/tests/test_drift.py
@@ -1,0 +1,422 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agent_profile.compiled_types import DriftRecord
+from agent_profile.drift import (
+    DriftError,
+    FileComparison,
+    compute_drift,
+    format_drift,
+)
+from tests.compile_fixtures import write_json, write_text
+
+
+def _comparison(
+    tmp_path: Path,
+    *,
+    target: str = "home",
+    relative_path: str = ".claude/settings.json",
+    baseline: object | None = None,
+    live: object | None = None,
+    compiled: object | None = None,
+) -> FileComparison:
+    """Materialize three settings files and pair them as one comparison.
+
+    ``None`` means the source file is absent. JSON-suffixed relative paths get
+    JSON bodies; anything else is written as raw text.
+    """
+    is_json = relative_path.endswith(".json")
+
+    def _write(slot: str, value: object | None) -> Path | None:
+        if value is None:
+            return None
+        path = tmp_path / slot / relative_path
+        return write_json(path, value) if is_json else write_text(path, value)  # type: ignore[arg-type]
+
+    return FileComparison(
+        target=target,
+        relative_path=relative_path,
+        baseline=_write("baseline", baseline),
+        live=_write("live", live),
+        compiled=_write("compiled", compiled),
+    )
+
+
+def _by_path(records: list[DriftRecord]) -> dict[str, DriftRecord]:
+    return {r.path: r for r in records}
+
+
+def test_no_drift_when_all_three_identical(tmp_path):
+    settings = {"env": {"FOO": "1"}, "permissions": {"allow": ["a"]}}
+    records = compute_drift(
+        [_comparison(tmp_path, baseline=settings, live=settings, compiled=settings)]
+    )
+    assert records == []
+    assert format_drift(records) == ""
+
+
+def test_reports_key_where_live_diverges_from_baseline_and_compiled(tmp_path):
+    records = compute_drift(
+        [
+            _comparison(
+                tmp_path,
+                baseline={"env": {"FOO": "1"}},
+                live={"env": {"FOO": "2"}},
+                compiled={"env": {"FOO": "1"}},
+            )
+        ]
+    )
+    assert len(records) == 1
+    rec = records[0]
+    assert rec.target == "home"
+    assert rec.relative_path == ".claude/settings.json"
+    assert rec.path == "env.FOO"
+    assert (rec.baseline, rec.live, rec.compiled) == ("1", "2", "1")
+
+
+def test_reports_compiled_change_against_unmodified_live(tmp_path):
+    # Live still matches baseline; compile wants to add a managed key. The
+    # three disagree, so the pending change is surfaced for conscious review.
+    records = compute_drift(
+        [
+            _comparison(
+                tmp_path,
+                baseline={"model": "opus"},
+                live={"model": "opus"},
+                compiled={"model": "opus", "hooks": {"PreToolUse": "x"}},
+            )
+        ]
+    )
+    rec = _by_path(records)["hooks.PreToolUse"]
+    assert (rec.baseline, rec.live, rec.compiled) == (None, None, "x")
+
+
+def test_lists_compared_as_whole_leaf_values(tmp_path):
+    records = compute_drift(
+        [
+            _comparison(
+                tmp_path,
+                baseline={"permissions": {"allow": ["a"]}},
+                live={"permissions": {"allow": ["a", "b"]}},
+                compiled={"permissions": {"allow": ["a"]}},
+            )
+        ]
+    )
+    assert len(records) == 1
+    rec = records[0]
+    assert rec.path == "permissions.allow"
+    assert rec.baseline == ["a"]
+    assert rec.live == ["a", "b"]
+    assert rec.compiled == ["a"]
+
+
+def test_nested_keys_flatten_to_dotted_paths(tmp_path):
+    records = compute_drift(
+        [
+            _comparison(
+                tmp_path,
+                baseline={"a": {"b": {"c": 1}}},
+                live={"a": {"b": {"c": 2}}},
+                compiled={"a": {"b": {"c": 1}}},
+            )
+        ]
+    )
+    assert [r.path for r in records] == ["a.b.c"]
+
+
+def test_absent_live_file_is_a_clean_create_not_drift(tmp_path):
+    records = compute_drift(
+        [
+            _comparison(
+                tmp_path,
+                baseline={"env": {"FOO": "1"}},
+                live=None,
+                compiled={"env": {"FOO": "1"}},
+            )
+        ]
+    )
+    assert records == []
+
+
+def test_baseline_absent_but_live_present_is_reported(tmp_path):
+    records = compute_drift(
+        [
+            _comparison(
+                tmp_path,
+                baseline=None,
+                live={"env": {"FOO": "local"}},
+                compiled={"env": {"FOO": "managed"}},
+            )
+        ]
+    )
+    rec = _by_path(records)["env.FOO"]
+    assert rec.baseline is None
+    assert rec.live == "local"
+    assert rec.compiled == "managed"
+
+
+def test_key_removed_in_compiled_is_reported(tmp_path):
+    records = compute_drift(
+        [
+            _comparison(
+                tmp_path,
+                baseline={"keep": 1, "drop": 2},
+                live={"keep": 1, "drop": 2},
+                compiled={"keep": 1},
+            )
+        ]
+    )
+    rec = _by_path(records)["drop"]
+    assert (rec.baseline, rec.live, rec.compiled) == (2, 2, None)
+
+
+def test_non_json_file_compared_as_whole_text(tmp_path):
+    records = compute_drift(
+        [
+            _comparison(
+                tmp_path,
+                relative_path="AGENTS.md",
+                baseline="seed body\n",
+                live="locally edited body\n",
+                compiled="seed body\n",
+            )
+        ]
+    )
+    assert len(records) == 1
+    rec = records[0]
+    assert rec.path == ""
+    assert rec.baseline == "seed body\n"
+    assert rec.live == "locally edited body\n"
+    assert rec.compiled == "seed body\n"
+
+
+def test_identical_non_json_file_yields_no_drift(tmp_path):
+    records = compute_drift(
+        [
+            _comparison(
+                tmp_path,
+                relative_path="AGENTS.md",
+                baseline="same\n",
+                live="same\n",
+                compiled="same\n",
+            )
+        ]
+    )
+    assert records == []
+
+
+def test_malformed_live_json_fails_loud(tmp_path):
+    path = write_text(tmp_path / "live" / ".claude" / "settings.json", "{not json")
+    comparison = FileComparison(
+        target="home",
+        relative_path=".claude/settings.json",
+        baseline=None,
+        live=path,
+        compiled=None,
+    )
+    with pytest.raises(DriftError) as excinfo:
+        compute_drift([comparison])
+    assert str(path) in str(excinfo.value)
+
+
+def test_malformed_baseline_json_fails_loud(tmp_path):
+    baseline = write_text(
+        tmp_path / "baseline" / ".claude" / "settings.json", "{not json"
+    )
+    live = write_json(tmp_path / "live" / ".claude" / "settings.json", {"k": 1})
+    comparison = FileComparison(
+        target="home",
+        relative_path=".claude/settings.json",
+        baseline=baseline,
+        live=live,
+        compiled=None,
+    )
+    with pytest.raises(DriftError) as excinfo:
+        compute_drift([comparison])
+    assert str(baseline) in str(excinfo.value)
+
+
+def test_absent_live_short_circuits_before_reading_other_sources(tmp_path):
+    # Live absent must return [] before any baseline/compiled read, so a corrupt
+    # baseline that would otherwise raise is never touched.
+    baseline = write_text(
+        tmp_path / "baseline" / ".claude" / "settings.json", "{not json"
+    )
+    comparison = FileComparison(
+        target="home",
+        relative_path=".claude/settings.json",
+        baseline=baseline,
+        live=None,
+        compiled=None,
+    )
+    assert compute_drift([comparison]) == []
+
+
+def test_compiled_absent_but_baseline_and_live_present_reported(tmp_path):
+    records = compute_drift(
+        [
+            _comparison(
+                tmp_path,
+                baseline={"k": 1},
+                live={"k": 2},
+                compiled=None,
+            )
+        ]
+    )
+    rec = _by_path(records)["k"]
+    assert (rec.baseline, rec.live, rec.compiled) == (1, 2, None)
+
+
+def test_baseline_drift_reported_when_live_matches_compiled(tmp_path):
+    # Acceptance: live differs from the baseline (even though it already equals
+    # compiled, i.e. apply is a no-op) is still surfaced for conscious review.
+    records = compute_drift(
+        [
+            _comparison(
+                tmp_path,
+                baseline={"k": "seed"},
+                live={"k": "managed"},
+                compiled={"k": "managed"},
+            )
+        ]
+    )
+    rec = _by_path(records)["k"]
+    assert (rec.baseline, rec.live, rec.compiled) == ("seed", "managed", "managed")
+
+
+def test_identical_empty_dict_values_are_no_drift(tmp_path):
+    settings = {"hooks": {}}
+    records = compute_drift(
+        [_comparison(tmp_path, baseline=settings, live=settings, compiled=settings)]
+    )
+    assert records == []
+
+
+def test_populating_an_empty_dict_reports_the_new_leaf(tmp_path):
+    records = compute_drift(
+        [
+            _comparison(
+                tmp_path,
+                baseline={"hooks": {}},
+                live={"hooks": {"PreToolUse": "x"}},
+                compiled={"hooks": {}},
+            )
+        ]
+    )
+    assert "hooks.PreToolUse" in {r.path for r in records}
+
+
+def test_records_sorted_by_target_file_then_path(tmp_path):
+    records = compute_drift(
+        [
+            _comparison(
+                tmp_path,
+                target="opencode",
+                relative_path="opencode.json",
+                baseline={"z": 1, "a": 1},
+                live={"z": 2, "a": 2},
+                compiled={"z": 1, "a": 1},
+            ),
+            _comparison(
+                tmp_path,
+                target="home",
+                relative_path=".claude/settings.json",
+                baseline={"k": 1},
+                live={"k": 2},
+                compiled={"k": 1},
+            ),
+        ]
+    )
+    keys = [(r.target, r.relative_path, r.path) for r in records]
+    assert keys == [
+        ("home", ".claude/settings.json", "k"),
+        ("opencode", "opencode.json", "a"),
+        ("opencode", "opencode.json", "z"),
+    ]
+
+
+def test_format_groups_by_target_then_file_then_key(tmp_path):
+    records = compute_drift(
+        [
+            _comparison(
+                tmp_path,
+                target="home",
+                relative_path=".claude/settings.json",
+                baseline={"env": {"FOO": "1"}, "permissions": {"allow": ["a"]}},
+                live={"env": {"FOO": "2"}, "permissions": {"allow": ["a", "b"]}},
+                compiled={"env": {"FOO": "1"}, "permissions": {"allow": ["a"]}},
+            ),
+            _comparison(
+                tmp_path,
+                target="opencode",
+                relative_path="opencode.json",
+                baseline={"theme": "dark"},
+                live={"theme": "light"},
+                compiled={"theme": "dark"},
+            ),
+        ]
+    )
+    text = format_drift(records)
+    assert text == (
+        "home  .claude/settings.json\n"
+        "  env.FOO\n"
+        '    baseline: "1"\n'
+        '    live:     "2"\n'
+        '    compiled: "1"\n'
+        "  permissions.allow\n"
+        '    baseline: ["a"]\n'
+        '    live:     ["a", "b"]\n'
+        '    compiled: ["a"]\n'
+        "\n"
+        "opencode  opencode.json\n"
+        "  theme\n"
+        '    baseline: "dark"\n'
+        '    live:     "light"\n'
+        '    compiled: "dark"\n'
+    )
+
+
+def test_format_renders_absent_value_and_whole_file_label(tmp_path):
+    records = compute_drift(
+        [
+            _comparison(
+                tmp_path,
+                relative_path="AGENTS.md",
+                baseline=None,
+                live="local\n",
+                compiled="managed\n",
+            )
+        ]
+    )
+    text = format_drift(records)
+    assert "  (whole file)\n" in text
+    assert "    baseline: null\n" in text
+
+
+def test_records_are_json_serializable_for_json_caller(tmp_path):
+    records = compute_drift(
+        [
+            _comparison(
+                tmp_path,
+                baseline={"env": {"FOO": "1"}, "list": [1, 2]},
+                live={"env": {"FOO": "2"}, "list": [1, 2, 3]},
+                compiled={"env": {"FOO": "1"}, "list": [1, 2]},
+            )
+        ]
+    )
+    payload = json.dumps([r.to_dict() for r in records])
+    restored = json.loads(payload)
+    assert {r["path"] for r in restored} == {"env.FOO", "list"}
+    foo = next(r for r in restored if r["path"] == "env.FOO")
+    assert foo == {
+        "target": "home",
+        "relative_path": ".claude/settings.json",
+        "path": "env.FOO",
+        "baseline": "1",
+        "live": "2",
+        "compiled": "1",
+    }

--- a/agent-profile/tests/test_fetch_sources_command.py
+++ b/agent-profile/tests/test_fetch_sources_command.py
@@ -1,0 +1,216 @@
+"""test_fetch_sources_command.py — ``ap fetch-sources <profile>`` fetches external
+``source:`` skills WITHOUT compiling or applying anything.
+
+Spec acceptance: WHEN external ``source:`` skills are present in the profile
+THE SYSTEM SHALL fetch them via ``ap fetch-sources <profile>`` before compile;
+the command returns non-zero / raises on fetch failure and performs NO compile
+or apply. ``npx`` is stubbed via the module-level ``_fetch_runner`` so no test
+touches the network.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from agent_profile import fetch_sources_command as fsc
+from agent_profile.fetch_sources_command import (
+    FetchSourcesError,
+    cmd_fetch_sources,
+    fetch_sources,
+)
+from tests.compile_fixtures import write_live_profile, write_minimal_includes
+from tests.conftest import write_profile
+
+
+def _stub_runner(monkeypatch, rc: int = 0):
+    """Replace the npx runner with a recorder; return the captured-call list."""
+    calls: list[list[str]] = []
+    monkeypatch.setattr(
+        fsc, "_fetch_runner", lambda argv: calls.append(argv) or rc
+    )
+    return calls
+
+
+# ─── fetches source: skills (acceptance happy path) ──────────────────────────
+
+
+def test_fetch_sources_fetches_source_skill(env, monkeypatch):
+    write_profile(
+        env.profiles,
+        "extprof",
+        "name: extprof\n"
+        "skills:\n"
+        "  - name: mold\n    source: paulnsorensen/easy-cheese\n    pin: v1\n",
+    )
+    calls = _stub_runner(monkeypatch)
+
+    assert fetch_sources("extprof") == 0
+
+    fetches = [c for c in calls if "npx" in c and "skills" in c and "add" in c]
+    assert len(fetches) == 1
+    argv = fetches[0]
+    assert argv[argv.index("add") + 1] == "paulnsorensen/easy-cheese@v1"
+    assert "mold" in argv
+
+
+def test_fetch_sources_targets_all_skill_supporting_harnesses(env, monkeypatch):
+    """A bare ``ap fetch-sources <profile>`` installs into every skill-supporting
+    harness (the canonical skill_agents.txt map) in one invocation."""
+    write_profile(
+        env.profiles,
+        "extprof",
+        "name: extprof\nskills:\n  - name: cook\n    source: o/r\n",
+    )
+    calls = _stub_runner(monkeypatch)
+
+    assert fetch_sources("extprof") == 0
+    assert len(calls) == 1
+    argv = calls[0]
+    agents = sorted(argv[i + 1] for i, t in enumerate(argv) if t == "--agent")
+    assert agents == sorted(
+        ["claude-code", "codex", "cursor", "github-copilot", "opencode"]
+    )
+
+
+def test_fetch_sources_repo_level_source_uses_skill_star(env, monkeypatch):
+    """A bare ``source:`` (no name) installs every skill via ``--skill '*'``."""
+    write_profile(
+        env.profiles,
+        "extprof",
+        "name: extprof\nskills:\n  - source: paulnsorensen/easy-cheese\n",
+    )
+    calls = _stub_runner(monkeypatch)
+
+    assert fetch_sources("extprof") == 0
+    assert len(calls) == 1
+    argv = calls[0]
+    assert argv[argv.index("add") + 1] == "paulnsorensen/easy-cheese"
+    assert argv[argv.index("--skill") + 1] == "*"
+
+
+def test_fetch_sources_live_profile_fetches_before_compile(env, monkeypatch):
+    """The acceptance shape: the live profile (with compile_targets) carrying a
+    ``source:`` skill fetches it — and writes no compile manifest."""
+    write_minimal_includes(env.profiles)
+    write_live_profile(
+        env.profiles,
+        skills=[{"name": "mold", "source": "paulnsorensen/easy-cheese"}],
+    )
+    calls = _stub_runner(monkeypatch)
+
+    assert fetch_sources("live") == 0
+    assert len(calls) == 1
+    assert "paulnsorensen/easy-cheese" in calls[0]
+    # No compile/apply: nothing rendered into the cwd target tree.
+    assert not (env.target / "manifest.json").exists()
+    assert not any(env.target.rglob("manifest.json"))
+    assert not (env.target / "fragments").exists()
+
+
+# ─── no source: skills = no-op success ───────────────────────────────────────
+
+
+def test_fetch_sources_no_source_skills_is_noop_success(env, monkeypatch):
+    write_profile(env.profiles, "noext", "name: noext\n")
+    calls = _stub_runner(monkeypatch)
+
+    assert fetch_sources("noext") == 0
+    assert calls == []
+
+
+def test_fetch_sources_only_path_skills_is_noop_success(env, monkeypatch):
+    """``path:`` skills are copied by renderers, not fetched — so a profile with
+    only local skills triggers no fetch and exits zero."""
+    write_profile(
+        env.profiles,
+        "localonly",
+        "name: localonly\nskills:\n  - name: local-skill\n    path: skills/local-skill\n",
+        {"skills/local-skill/SKILL.md": "# local\n"},
+    )
+    calls = _stub_runner(monkeypatch)
+
+    assert fetch_sources("localonly") == 0
+    assert calls == []
+
+
+# ─── fetch failure -> raises, no compile/apply ───────────────────────────────
+
+
+def test_fetch_sources_fetch_failure_raises(env, monkeypatch):
+    """A non-zero npx exit surfaces as FetchSourcesError (the CLI maps it to a
+    clean stderr line + exit 1), and no compile artifact is produced."""
+    write_profile(
+        env.profiles,
+        "extprof",
+        "name: extprof\nskills:\n  - name: mold\n    source: o/r\n",
+    )
+    _stub_runner(monkeypatch, rc=1)
+
+    with pytest.raises(FetchSourcesError) as exc:
+        fetch_sources("extprof")
+    assert "npx skills add failed" in str(exc.value)
+    assert not any(env.target.rglob("manifest.json"))
+
+
+def test_fetch_sources_missing_npx_raises_clean(env, monkeypatch):
+    """npx absent -> the runner raises FileNotFoundError (an OSError); the
+    command reports it as a clean FetchSourcesError, not a traceback."""
+
+    def boom(argv):
+        raise FileNotFoundError(2, "No such file or directory", "npx")
+
+    write_profile(
+        env.profiles,
+        "extprof",
+        "name: extprof\nskills:\n  - name: mold\n    source: o/r\n",
+    )
+    monkeypatch.setattr(fsc, "_fetch_runner", boom)
+
+    with pytest.raises(FetchSourcesError) as exc:
+        fetch_sources("extprof")
+    assert "Node/npx" in str(exc.value)
+
+
+def test_fetch_sources_unknown_profile_raises(env, monkeypatch):
+    _stub_runner(monkeypatch)
+    with pytest.raises(FetchSourcesError) as exc:
+        fetch_sources("does-not-exist")
+    assert "not found" in str(exc.value)
+
+
+# ─── cmd_fetch_sources arg handling ──────────────────────────────────────────
+
+
+def test_cmd_fetch_sources_parses_profile_and_returns_zero(env, monkeypatch):
+    write_profile(
+        env.profiles,
+        "extprof",
+        "name: extprof\nskills:\n  - name: mold\n    source: o/r\n",
+    )
+    calls = _stub_runner(monkeypatch)
+
+    assert cmd_fetch_sources(["extprof"], sys.stdout) == 0
+    assert len(calls) == 1
+
+
+def test_cmd_fetch_sources_missing_profile_raises(env):
+    with pytest.raises(FetchSourcesError) as exc:
+        cmd_fetch_sources([], sys.stdout)
+    assert "Usage:" in str(exc.value)
+
+
+def test_cmd_fetch_sources_extra_argument_raises(env, monkeypatch):
+    write_profile(env.profiles, "extprof", "name: extprof\n")
+    _stub_runner(monkeypatch)
+
+    with pytest.raises(FetchSourcesError) as exc:
+        cmd_fetch_sources(["extprof", "bogus"], sys.stdout)
+    assert "unexpected argument" in str(exc.value)
+
+
+def test_cmd_fetch_sources_flag_as_profile_raises(env):
+    with pytest.raises(FetchSourcesError) as exc:
+        cmd_fetch_sources(["--harness"], sys.stdout)
+    assert "Usage:" in str(exc.value)

--- a/agent-profile/tests/test_harness_field_coverage.py
+++ b/agent-profile/tests/test_harness_field_coverage.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from agent_profile import cli
+
+from .compile_fixtures import write_live_profile, write_minimal_includes
+
+
+def test_compile_rejects_enabled_plugins_without_claude_target(env, capsys, monkeypatch):
+    monkeypatch.setenv("HOME", str(env.tmp / "home"))
+    write_minimal_includes(env.profiles)
+    write_live_profile(
+        env.profiles,
+        compile_targets={
+            "home": {"target_root": "$HOME", "harnesses": ["codex"]},
+        },
+    )
+
+    assert cli.main(["compile", "live"]) == 1
+
+    err = capsys.readouterr().err
+    assert "enabled_plugins" in err
+    assert "requires compile target harness 'claude'" in err

--- a/agent-profile/tests/test_install_deprecation.py
+++ b/agent-profile/tests/test_install_deprecation.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from agent_profile import cli
+from agent_profile.install_command import INSTALL_MIGRATION_GUIDANCE
+
+
+def test_install_exits_nonzero_with_migration_guidance(capsys):
+    assert cli.main(["install", "base"]) == 1
+
+    err = capsys.readouterr().err
+    assert err == f"{INSTALL_MIGRATION_GUIDANCE}\n"

--- a/agent-profile/tests/test_integration.py
+++ b/agent-profile/tests/test_integration.py
@@ -13,7 +13,7 @@ import json
 
 from agent_profile import cli
 from agent_profile.manifest import manifest_path
-from tests.conftest import write_profile
+from tests.conftest import install_profile, write_profile
 
 
 def _agent_profile(name, agent="reviewer"):
@@ -37,6 +37,8 @@ def make_basic(root, name, agent="reviewer", body=None):
 
 
 def run(argv):
+    if argv and argv[0] == "install":
+        return install_profile(argv)
     return cli.main(argv)
 
 

--- a/agent-profile/tests/test_integration_production.py
+++ b/agent-profile/tests/test_integration_production.py
@@ -33,7 +33,7 @@ import tomlkit
 from agent_profile import cli
 from agent_profile.manifest import manifest_path
 from agent_profile.renderers.registry import build_registry
-from tests.conftest import write_profile
+from tests.conftest import install_profile, write_profile
 
 
 @pytest.fixture
@@ -91,7 +91,7 @@ def _make_multi(root, name):
 
 def test_production_install_touches_all_surfaces(env, capsys, prod_renderers):
     _make_multi(env.profiles, "multi")
-    assert cli.main(["install", "multi", "--target", str(env.target)]) == 0
+    assert install_profile(["install", "multi", "--target", str(env.target)]) == 0
     capsys.readouterr()
     t = env.target
 
@@ -140,7 +140,7 @@ def test_production_install_uninstall_roundtrip_clean(env, capsys, prod_renderer
     _make_multi(env.profiles, "multi")
     t = env.target
 
-    cli.main(["install", "multi", "--target", str(t)])
+    install_profile(["install", "multi", "--target", str(t)])
     capsys.readouterr()
     tracked = list(json.loads(manifest_path(t).read_text())["multi"]["files"])
     assert tracked
@@ -182,7 +182,7 @@ def test_production_codex_user_config_preserved_through_cli(
         "command = \"keep-me\"\n"
     )
 
-    cli.main(["install", "multi", "--target", str(t)])
+    install_profile(["install", "multi", "--target", str(t)])
     capsys.readouterr()
 
     after_install = cfg.read_text()
@@ -227,8 +227,8 @@ def test_production_refcount_shared_agent_full_install(env, capsys, prod_rendere
     t = env.target
     shared = t / ".claude/agents/shared.md"
 
-    cli.main(["install", "alpha", "--target", str(t)])
-    cli.main(["install", "beta", "--target", str(t)])
+    install_profile(["install", "alpha", "--target", str(t)])
+    install_profile(["install", "beta", "--target", str(t)])
     capsys.readouterr()
     assert shared.is_file()
     assert "beta body" in shared.read_text()  # beta wrote last

--- a/agent-profile/tests/test_mcp_reconcile.py
+++ b/agent-profile/tests/test_mcp_reconcile.py
@@ -25,7 +25,7 @@ import agent_profile.renderers.claude as cl
 from agent_profile import cli
 from agent_profile.parse import Manifest
 from agent_profile.renderers.registry import build_registry
-from tests.conftest import write_profile
+from tests.conftest import install_profile, write_profile
 
 
 @pytest.fixture
@@ -49,7 +49,7 @@ def _yaml(name: str, mcp_names: list[str]) -> str:
 
 
 def _install(env, name: str) -> int:
-    return cli.main(["install", name, "--target", str(env.target)])
+    return install_profile(["install", name, "--target", str(env.target)])
 
 
 # ─── integration: drop one MCP, re-install ───────────────────────────────────
@@ -187,7 +187,7 @@ def test_dropped_mcp_unregistered_from_claude_user_scope(
         "g",
         _yaml_claude_user("g", ["srv1", "srv2"], str(env.target)),
     )
-    assert cli.main(["install", "g"]) == 0
+    assert install_profile(["install", "g"]) == 0
     capsys.readouterr()
     calls.clear()  # discard first-install register churn
 
@@ -197,7 +197,7 @@ def test_dropped_mcp_unregistered_from_claude_user_scope(
         "g",
         _yaml_claude_user("g", ["srv1"], str(env.target)),
     )
-    assert cli.main(["install", "g"]) == 0
+    assert install_profile(["install", "g"]) == 0
     capsys.readouterr()
 
     # Reconcile must `claude mcp remove srv2` and never re-add it.

--- a/agent-profile/tests/test_merged_settings_preservation.py
+++ b/agent-profile/tests/test_merged_settings_preservation.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent_profile.compiled_types import (
+    CompiledFile,
+    CompiledManifest,
+    CompileTarget,
+)
+from agent_profile.merged_settings_preservation import (
+    filter_preserved,
+    is_user_owned_merged,
+    preserved_paths,
+)
+
+
+def _file(relative_path: str, *, generated: bool, target: str = "home") -> CompiledFile:
+    return CompiledFile(
+        target=target,
+        harness="claude",
+        fragment_path=Path("/fragments") / target / relative_path,
+        relative_path=relative_path,
+        generated=generated,
+    )
+
+
+def _manifest(*files: CompiledFile) -> CompiledManifest:
+    target = CompileTarget(
+        name="home",
+        symbolic_root="$HOME",
+        resolved_root=Path("/home/user"),
+        harnesses=("claude",),
+    )
+    return CompiledManifest(
+        profile="live",
+        source_id="profiles/live",
+        manifest_path=Path("/cache/manifest.json"),
+        targets=(target,),
+        files=files,
+    )
+
+
+def test_merged_settings_record_is_user_owned():
+    merged = _file(".claude/settings.json", generated=False)
+
+    assert is_user_owned_merged(merged) is True
+
+
+def test_generated_fragment_is_not_user_owned():
+    generated = _file(".claude/agents/reviewer.md", generated=True)
+
+    assert is_user_owned_merged(generated) is False
+
+
+def test_generated_defaults_true_so_records_are_reconcilable_by_default():
+    # CompiledFile.generated defaults to True; an unmarked record must not be
+    # mistaken for a preserved merged file (else reconcile would never delete).
+    default = CompiledFile(
+        target="home",
+        harness="claude",
+        fragment_path=Path("/fragments/home/.claude/x"),
+        relative_path=".claude/x",
+    )
+
+    assert is_user_owned_merged(default) is False
+
+
+def test_preserved_paths_lists_only_merged_settings():
+    manifest = _manifest(
+        _file(".claude/settings.json", generated=False),
+        _file(".claude/agents/reviewer.md", generated=True),
+        _file(".codex/config.toml", generated=False),
+    )
+
+    assert preserved_paths(manifest) == frozenset(
+        {".claude/settings.json", ".codex/config.toml"}
+    )
+
+
+def test_apply_reconcile_never_deletes_user_owned_merged_settings():
+    # Acceptance: a merged settings file present in deletion candidates must be
+    # dropped from the safe-to-delete set so apply-compiled cannot remove it,
+    # while a dropped generated fragment stays eligible for deletion.
+    manifest = _manifest(_file(".claude/settings.json", generated=False))
+    candidates = [
+        ".claude/settings.json",  # user-owned merged -> preserve
+        ".claude/agents/stale.md",  # generated, dropped from manifest -> delete
+    ]
+
+    safe_to_delete = filter_preserved(candidates, manifest)
+
+    assert ".claude/settings.json" not in safe_to_delete
+    assert safe_to_delete == [".claude/agents/stale.md"]
+
+
+def test_filter_preserved_preserves_input_order():
+    manifest = _manifest(_file(".claude/settings.json", generated=False))
+    candidates = ["b.md", ".claude/settings.json", "a.md"]
+
+    assert filter_preserved(candidates, manifest) == ["b.md", "a.md"]
+
+
+def test_works_on_json_manifest_mappings():
+    # ap apply-compiled reads the manifest as JSON; the dataclass form is not
+    # guaranteed at the call site, so mapping records must behave identically.
+    merged = {"relative_path": ".claude/settings.json", "generated": False}
+    generated = {"relative_path": ".claude/hooks.json", "generated": True}
+    unmarked = {"relative_path": ".claude/x"}
+
+    assert is_user_owned_merged(merged) is True
+    assert is_user_owned_merged(generated) is False
+    assert is_user_owned_merged(unmarked) is False
+
+    manifest = {"files": [merged, generated, unmarked]}
+    assert preserved_paths(manifest) == frozenset({".claude/settings.json"})
+    assert filter_preserved(
+        [".claude/settings.json", ".claude/hooks.json"], manifest
+    ) == [".claude/hooks.json"]
+
+
+def test_empty_manifest_preserves_nothing():
+    manifest = _manifest()
+
+    assert preserved_paths(manifest) == frozenset()
+    assert filter_preserved(["a", "b"], manifest) == ["a", "b"]
+
+
+def test_unsupported_record_fails_loud():
+    with pytest.raises(TypeError):
+        is_user_owned_merged(object())  # type: ignore[arg-type]
+
+
+def test_unsupported_manifest_fails_loud():
+    with pytest.raises(TypeError):
+        preserved_paths(object())  # type: ignore[arg-type]
+    with pytest.raises(TypeError):
+        filter_preserved(["a"], object())  # type: ignore[arg-type]

--- a/agent-profile/tests/test_overlay.py
+++ b/agent-profile/tests/test_overlay.py
@@ -774,16 +774,18 @@ def _assert_real_tight_codex_profile(name: str, prompt_phrase: str, monkeypatch,
 
     profile_text = (pdir / "profile.yaml").read_text()
     assert "registries:" not in profile_text
-    assert "skills:" not in profile_text
+    assert "skills:" in profile_text
+    assert "compile_targets:" in profile_text
     assert m.isolated is True
     assert m.system_prompt == "AGENTS.md"
     assert [mcp["name"] for mcp in m.mcps] == ["tilth"]
-    assert m.skills == []
+    assert [skill.get("source") for skill in m.skills] == ["paulnsorensen/easy-cheese"]
     assert m.agents == []
 
     _, env = overlay.build_isolated_launch(m, pdir, "codex")
     cfg = tomllib.loads((Path(env["CODEX_HOME"]) / "config.toml").read_text())
     assert cfg["model_instructions_file"] == str(pdir / "AGENTS.md")
+    assert cfg["tui"]["input_mode"] == "vim"
     assert set(cfg["mcp_servers"]) == {"tilth"}
     assert cfg["mcp_servers"]["tilth"] == {
         "command": "tilth",
@@ -792,13 +794,13 @@ def _assert_real_tight_codex_profile(name: str, prompt_phrase: str, monkeypatch,
     assert prompt_phrase in (pdir / "AGENTS.md").read_text()
 
 
-def test_real_codex_plan_profile_is_tilth_only(monkeypatch, tmp_path):
+def test_real_codex_plan_profile_is_tight_codex_world(monkeypatch, tmp_path):
     _assert_real_tight_codex_profile(
         "codex-plan", "planning and spec work", monkeypatch, tmp_path
     )
 
 
-def test_real_codex_code_profile_is_tilth_only(monkeypatch, tmp_path):
+def test_real_codex_code_profile_is_tight_codex_world(monkeypatch, tmp_path):
     _assert_real_tight_codex_profile(
         "codex-code", "focused implementation", monkeypatch, tmp_path
     )
@@ -962,6 +964,7 @@ def test_codex_isolated_config_defaults_to_auto_permissions(tmp_path, monkeypatc
     assert cfg["approval_policy"] == "on-request"
     assert cfg["approvals_reviewer"] == "auto_review"
     assert cfg["sandbox_mode"] == "workspace-write"
+    assert cfg["tui"]["input_mode"] == "vim"
 
 
 def test_codex_system_prompt_is_model_instructions_file(tmp_path, monkeypatch):

--- a/agent-profile/tests/test_renderer_agents.py
+++ b/agent-profile/tests/test_renderer_agents.py
@@ -164,12 +164,12 @@ def test_claude_agent_disallowed_tools(tmp_path: Path) -> None:
     ).read_text()
     assert "disallowedTools: [Edit, Write]" in shared_file
 
-def test_claude_shared_agent_carries_model_color_effort_skills(
+def test_claude_shared_agent_carries_model_color_effort_skills_max_turns(
     tmp_path: Path,
 ) -> None:
     # The user-scoped shared file wins over the plugin copy (priority 4 > 5),
     # so it must carry the full claude metadata — a model-neutral shared file
-    # would silently drop the agent's pinned model and its color/effort/skills.
+    # would silently drop the agent's pinned model and its color/effort/maxTurns/skills.
     ClaudeRenderer().render(
         _agent_manifest(
             tmp_path,
@@ -178,6 +178,7 @@ def test_claude_shared_agent_carries_model_color_effort_skills(
             color="red",
             effort="high",
             skills=["scout", "gh"],
+            maxTurns=20,
         ),
         tmp_path,
     )
@@ -188,6 +189,7 @@ def test_claude_shared_agent_carries_model_color_effort_skills(
     assert "color: red" in shared_file
     assert "effort: high" in shared_file
     assert "skills: [scout, gh]" in shared_file
+    assert "maxTurns: 20" in shared_file
 
 
 # ── cursor ────────────────────────────────────────────────────────────

--- a/agent-profile/tests/test_renderer_claude.py
+++ b/agent-profile/tests/test_renderer_claude.py
@@ -755,13 +755,36 @@ def test_user_scope_clean_removes_via_cli(env, monkeypatch):
 
 
 def test_user_scope_missing_cli_fails_loud(env, monkeypatch):
-    # PATH with no `claude` -> user-scope render must raise, not silently skip.
+    # PATH with no `claude` -> user-scope render (install/launch path,
+    # logical_root None) must raise, not silently skip.
     emptybin = env.tmp / "emptybin"
     emptybin.mkdir()
     monkeypatch.setenv("PATH", str(emptybin))
     profile_dir = write_profile(env.profiles, "mcpuser", _MCPTEST_USER_YAML)
     with pytest.raises(FileNotFoundError):
         ClaudeRenderer().render(parse_manifest(profile_dir), env.target)
+
+
+def test_user_scope_compile_mode_defers_registration(env, monkeypatch):
+    # Compile renders into a scratch dir (logical_root set). The live
+    # `claude mcp add` must NOT fire — even with no `claude` on PATH the render
+    # succeeds, and the registration spec is exposed for apply to perform.
+    emptybin = env.tmp / "emptybin"
+    emptybin.mkdir()
+    monkeypatch.setenv("PATH", str(emptybin))
+    profile_dir = write_profile(env.profiles, "mcpuser", _MCPTEST_USER_YAML)
+    manifest = parse_manifest(profile_dir)
+    renderer = ClaudeRenderer()
+    # No raise despite missing CLI — compile is side-effect-free.
+    renderer.render(manifest, env.target, logical_root=env.tmp / "real-home")
+    assert renderer.user_mcp_registrations(manifest) == [
+        {
+            "name": "context7",
+            "command": "npx",
+            "args": ["-y", "@upstash/context7-mcp"],
+            "env": {"KEY": "VAL"},
+        }
+    ]
 
 
 def test_user_scope_clean_missing_cli_fails_loud(env, monkeypatch):

--- a/agent-profile/tests/test_skill_fetch_wiring.py
+++ b/agent-profile/tests/test_skill_fetch_wiring.py
@@ -15,7 +15,7 @@ from agent_profile.parse import parse_manifest
 from agent_profile.renderers.claude import ClaudeRenderer
 from agent_profile.renderers.codex import CodexRenderer
 from agent_profile.renderers.copilot import CopilotRenderer
-from tests.conftest import write_profile
+from tests.conftest import install_profile, write_profile
 
 
 # ─── renderers skip source-only skills ────────────────────────────────
@@ -73,7 +73,7 @@ def test_install_fetches_source_skill(env, stub_renderers, monkeypatch, capsys):
     calls = []
     monkeypatch.setattr(cli, "_skill_fetch_runner", lambda argv: calls.append(argv) or 0)
 
-    assert cli.main(["install", "extprof", "--harness", "claude"]) == 0
+    assert install_profile(["install", "extprof", "--harness", "claude"]) == 0
     # One `npx … skills add` for the single source skill, targeting claude.
     # Anchor on the `add` keyword (not positional indices) so the assertion
     # survives future argv-prefix changes like --yes.
@@ -94,7 +94,7 @@ def test_install_fetches_all_in_scope_harnesses_in_one_call(env, stub_renderers,
     calls = []
     monkeypatch.setattr(cli, "_skill_fetch_runner", lambda argv: calls.append(argv) or 0)
 
-    assert cli.main(["install", "extprof", "--harness", "claude,codex"]) == 0
+    assert install_profile(["install", "extprof", "--harness", "claude,codex"]) == 0
     # One invocation (one clone) covering both harnesses via repeated --agent.
     assert len(calls) == 1
     argv = calls[0]
@@ -106,7 +106,7 @@ def test_install_skips_fetch_when_no_source_skills(env, stub_renderers, monkeypa
     write_profile(env.profiles, "noext", "name: noext\n")
     calls = []
     monkeypatch.setattr(cli, "_skill_fetch_runner", lambda argv: calls.append(argv) or 0)
-    assert cli.main(["install", "noext", "--harness", "claude"]) == 0
+    assert install_profile(["install", "noext", "--harness", "claude"]) == 0
     assert calls == []
 
 
@@ -124,7 +124,7 @@ def test_install_repo_level_source_uses_skill_star(env, stub_renderers, monkeypa
     calls = []
     monkeypatch.setattr(cli, "_skill_fetch_runner", lambda argv: calls.append(argv) or 0)
 
-    assert cli.main(["install", "extprof", "--harness", "claude"]) == 0
+    assert install_profile(["install", "extprof", "--harness", "claude"]) == 0
     assert len(calls) == 1
     argv = calls[0]
     assert argv[argv.index("add") + 1] == "paulnsorensen/easy-cheese"
@@ -143,7 +143,7 @@ def test_install_fetch_failure_exits_clean(env, stub_renderers, monkeypatch, cap
         "name: extprof\nskills:\n  - name: mold\n    source: o/r\n",
     )
     monkeypatch.setattr(cli, "_skill_fetch_runner", lambda argv: 1)
-    assert cli.main(["install", "extprof", "--harness", "claude"]) == 1
+    assert install_profile(["install", "extprof", "--harness", "claude"]) == 1
     err = capsys.readouterr().err
     assert "Traceback" not in err
     assert "npx skills add failed" in err
@@ -161,7 +161,7 @@ def test_install_fetch_missing_npx_exits_clean(env, stub_renderers, monkeypatch,
         "name: extprof\nskills:\n  - name: mold\n    source: o/r\n",
     )
     monkeypatch.setattr(cli, "_skill_fetch_runner", boom)
-    assert cli.main(["install", "extprof", "--harness", "claude"]) == 1
+    assert install_profile(["install", "extprof", "--harness", "claude"]) == 1
     err = capsys.readouterr().err
     assert "Traceback" not in err
     assert "Node/npx" in err

--- a/agent-profile/tests/test_staged_install_skill_fetch.py
+++ b/agent-profile/tests/test_staged_install_skill_fetch.py
@@ -9,7 +9,7 @@ existing fetch behavior.
 from __future__ import annotations
 
 from agent_profile import cli
-from tests.conftest import write_profile
+from tests.conftest import install_profile, write_profile
 
 
 # ─── staged install skips the global skill fetch ──────────────────────────────
@@ -29,7 +29,7 @@ def test_staged_install_does_not_invoke_skill_fetch(
     calls = []
     monkeypatch.setattr(cli, "_skill_fetch_runner", lambda argv: calls.append(argv) or 0)
 
-    assert cli.main(["install", "extprof", "--harness", "claude", "--target", str(env.target)]) == 0
+    assert install_profile(["install", "extprof", "--harness", "claude", "--target", str(env.target)]) == 0
     # No npx skills add should have been invoked
     assert calls == []
 
@@ -45,7 +45,7 @@ def test_staged_install_prints_skip_message(env, stub_renderers, monkeypatch, ca
     )
     monkeypatch.setattr(cli, "_skill_fetch_runner", lambda argv: 0)
 
-    assert cli.main(["install", "extprof", "--harness", "claude", "--target", str(env.target)]) == 0
+    assert install_profile(["install", "extprof", "--harness", "claude", "--target", str(env.target)]) == 0
     out = capsys.readouterr().out
     # A message about skipping external skills for staged/non-live target
     assert "external skills skipped" in out
@@ -68,7 +68,7 @@ def test_live_install_invokes_skill_fetch(env, stub_renderers, monkeypatch):
     monkeypatch.setattr(cli, "_skill_fetch_runner", lambda argv: calls.append(argv) or 0)
 
     # No --target flag: target comes from profile's target_default
-    assert cli.main(["install", "extprof", "--harness", "claude"]) == 0
+    assert install_profile(["install", "extprof", "--harness", "claude"]) == 0
     fetches = [c for c in calls if "npx" in c and "add" in c]
     assert len(fetches) == 1
 
@@ -78,5 +78,5 @@ def test_staged_no_source_skills_still_exits_zero(env, stub_renderers, monkeypat
     write_profile(env.profiles, "noext", "name: noext\n")
     calls = []
     monkeypatch.setattr(cli, "_skill_fetch_runner", lambda argv: calls.append(argv) or 0)
-    assert cli.main(["install", "noext", "--harness", "claude", "--target", str(env.target)]) == 0
+    assert install_profile(["install", "noext", "--harness", "claude", "--target", str(env.target)]) == 0
     assert calls == []

--- a/profiles/base/profile.yaml
+++ b/profiles/base/profile.yaml
@@ -14,3 +14,7 @@ registries:
   skills:  [skills/_registry.yaml, skills/]
   hooks:   agents/hooks/registry.yaml
   plugins: agents/plugins/registry.yaml
+compile_targets:
+  home:
+    target_root: "$HOME"
+    harnesses: ["codex"]

--- a/profiles/codex-code/profile.yaml
+++ b/profiles/codex-code/profile.yaml
@@ -7,3 +7,9 @@ mcps:
   - name: tilth
     command: tilth
     args: ["--mcp", "--edit"]
+skills:
+  - { source: paulnsorensen/easy-cheese }
+compile_targets:
+  home:
+    target_root: "$HOME"
+    harnesses: ["codex"]

--- a/profiles/codex-plan/profile.yaml
+++ b/profiles/codex-plan/profile.yaml
@@ -7,3 +7,9 @@ mcps:
   - name: tilth
     command: tilth
     args: ["--mcp", "--edit"]
+skills:
+  - { source: paulnsorensen/easy-cheese }
+compile_targets:
+  home:
+    target_root: "$HOME"
+    harnesses: ["codex"]

--- a/profiles/global/profile.yaml
+++ b/profiles/global/profile.yaml
@@ -1,76 +1,14 @@
-# global — the live install of `base` into the machine.
+# global — migration stub for the old live install profile.
 #
-# `base` is the registry-derived union of MCPs, skills, hooks — a render
-# primitive useful for inspection or staged builds. `global` wraps that
-# union with the operator-intent fields needed to actually deploy onto
-# this machine: target $HOME by default, register the local marketplace,
-# and enable the rendered plugin so its `plugin.json` (which carries the
-# SessionStart hook wiring etc.) is honored by Claude.
-#
-# Why split it out: `ap install base` without --target writes the plugin
-# tree into $PWD, which is correct for staging but confusing as the
-# "make my machine live" verb. `ap install global` (no flags) targets
-# $HOME via `target_default`, so the operator-intent reads cleanly.
-#
-# Chezmoi drives this on `dots sync` through
-# `chezmoi/lib/install-base-profile.sh`, which calls `ap install global`.
-# Standalone use is also fine: `dots profile install global`.
+# Live deployment moved to `profiles/live/profile.yaml` and `dots sync`. This
+# profile keeps the old name parseable for migration docs/tests, but `ap install`
+# is deprecated and no longer deploys it.
 name: global
-description: Live install — renders base into $HOME and wires it into Claude
-# _permissions carries the canonical cross-harness allow/deny lists; the
-# renderers lower them onto each harness's native surface. The live wrappers
-# (`global` here, `opencode-global` for opencode) both include it; this profile
-# is still the Claude-specific live overlay.
+description: Deprecated live install alias; use `dots sync` / profile `live`
 include: [base, _permissions]
-
-# `--target` precedence in ap is: explicit flag > profile target_default >
-# Path.cwd(). $HOME (and ~) expand at install time via os.path.expandvars
-# / expanduser; unset refs leave a literal, so the failure surfaces as
-# "path does not exist" rather than a generic KeyError.
 target_default: $HOME
-
-# Marketplaces (claude only — other renderers ignore the field). The
-# value is a directory path that ap wraps as
-# `{source: {source: "directory", path: <expanded>}}` in
-# ~/.claude/settings.json's extraKnownMarketplaces. github-source
-# marketplaces stay user-managed in the chezmoi seed.
-#
-# Must match where the renderer actually writes the plugin tree:
-# target_default above is $HOME, so the claude renderer drops the
-# global plugin at $HOME/.claude/plugins/local/global/ and emits the
-# directory `marketplace.json` alongside it. Pointing `local` at
-# $HOME/.claude/plugins/local lets Claude resolve `global@local` to
-# that on-disk tree via the marketplace.json (an explicit registration,
-# not just fallback). (Earlier this pointed at
-# ${DOTFILES_DIR}/.claude/plugins/local, which only contained a staged
-# `base/` tree and not the live `global/`.)
 marketplaces:
   local: $HOME/.claude/plugins/local
-
-# enabled_plugins (claude only — same field the launch-overlay uses for
-# isolated profiles, repurposed here for non-isolated installs). ap's
-# claude renderer merges these into settings.json's `enabledPlugins`,
-# preserving siblings (user-managed plugin toggles survive). Without
-# this, Claude wouldn't load the rendered plugin tree and its bundled
-# SessionStart hook (cheese-flair) would stay inert.
-#
-# Plugin id is `<profile_name>@<marketplace_name>` because ap's claude
-# renderer writes the tree to `.claude/plugins/local/<profile_name>/`
-# (here: `.claude/plugins/local/global/`) and we registered the
-# `local` marketplace above. The on-disk plugin name and the enabled
-# entry must match — if you rename this profile, update both.
 enabled_plugins:
   global@local: true
-
-# mcp_scope (claude only — other harnesses already write a single bare
-# user-level config and ignore this). "user" makes the claude renderer
-# register each MCP via `claude mcp add --scope user` (into ~/.claude.json,
-# bare tool names `mcp__<server>__*`) instead of writing the plugin's
-# .mcp.json (which produces plugin-scoped names
-# `mcp__plugin_global_<server>__*`). The plugin tree is still rendered +
-# enabled above — it carries the skills, commands, hooks, and agents; only
-# MCP registration moves to user scope. Bare names mean the existing
-# settings.json allowlist matches with no per-plugin namespacing. Default
-# elsewhere is "plugin" (closed-world / staged renders keep their bundled
-# .mcp.json).
 mcp_scope: user

--- a/profiles/live/profile.yaml
+++ b/profiles/live/profile.yaml
@@ -1,0 +1,29 @@
+# live — the only profile dots sync deploys to this machine.
+#
+# The profile carries the base registry union plus the live permission floor and
+# compiles into two target roots: $HOME for the dot-dir harnesses, and
+# $HOME/.config/opencode for opencode's root-relative renderer.
+name: live
+description: Live compiled agent config for dots sync
+include: [base, _permissions]
+
+compile_targets:
+  home:
+    target_root: $HOME
+    harnesses: [claude, codex, cursor, copilot]
+  opencode:
+    target_root: $HOME/.config/opencode
+    harnesses: [opencode]
+
+# Claude plugin wiring mirrors the former global live overlay. The compiled
+# apply path writes the plugin tree under ~/.claude/plugins/local/live and
+# registers that local marketplace so Claude can resolve live@local.
+marketplaces:
+  local: $HOME/.claude/plugins/local
+
+enabled_plugins:
+  live@local: true
+
+# Keep MCP registration at user scope so existing bare mcp__<server>__*
+# permission rules keep matching after the compile/apply migration.
+mcp_scope: user

--- a/profiles/opencode-global/profile.yaml
+++ b/profiles/opencode-global/profile.yaml
@@ -1,15 +1,8 @@
-# opencode-global — the live install wrapper for opencode.
+# opencode-global — migration stub for the old opencode live install profile.
 #
-# opencode shares `base`'s registry-derived union, but unlike the dot-dir
-# harnesses it writes config at the target root (`~/.config/opencode`). This
-# wrapper keeps the install on the live path without passing `--target`, so
-# `_permissions` still lowers onto opencode and external `source:` skills still
-# fetch via `npx skills add`.
+# Live deployment moved to `profiles/live/profile.yaml`; its `opencode` compile
+# target writes to $HOME/.config/opencode during `dots sync`.
 name: opencode-global
-description: Live install — renders base into $HOME/.config/opencode with _permissions
+description: Deprecated opencode live install alias; use `dots sync` / profile `live`
 include: [base, _permissions]
-
-# `--target` precedence in ap is: explicit flag > profile target_default >
-# Path.cwd(). The installer forwards HOME explicitly, so this resolves against
-# the caller's target home during `dots sync`.
 target_default: $HOME/.config/opencode


### PR DESCRIPTION
**PR 2 of 4 — split of #340** ("compile agent profiles before chezmoi apply").

The `ap` compiler engine: renders live profile fragments into harness-scoped directories with a compiled manifest, plus:
- compiled profile types and seed fixtures
- compile-target validation + presence checks
- harness-field coverage rejection
- `ap compile`, `ap fetch-sources`, `ap apply-compiled` commands
- grouped drift records
- user-owned merged-settings preservation
- deprecation of the legacy `install` command
- the `profile.yaml` inputs the compiler consumes

The new `ap` subcommands are **inert until the deploy wiring (PR 3) activates them**, so this is independently mergeable.

### Stack
- PR 2 (this) → base `main`
- PR 3 deploy wiring → base this branch
- PR 4 opencode/codex/maxTurns → base PR 3

### Test
`uv run --project agent-profile pytest agent-profile/tests/` — 882 pass (the 4 `test_canonical_permissions` failures are a local RTK-hook environment artifact, identical on #340, and pass in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
