### PR TITLE
fix(ap): inherit native_plugins through profile includes (#356)

### DIFF
--- a/agent-profile/agent_profile/parse.py
+++ b/agent-profile/agent_profile/parse.py
@@ -284,6 +284,7 @@ def _merge_two(a: dict[str, Any], b: dict[str, Any]) -> dict[str, Any]:
         "skills": a.get("skills", []) + b.get("skills", []),
         "commands": a.get("commands", []) + b.get("commands", []),
         "hooks": a.get("hooks", []) + b.get("hooks", []),
+        "native_plugins": a.get("native_plugins", []) + b.get("native_plugins", []),
         "settings": settings,
     }
 
@@ -343,7 +344,6 @@ def _parse_with_includes(
         "target_default",
         "marketplaces",
         "mcp_scope",
-        "native_plugins",
         "compile_targets",
     ):
         merged[key] = self_[key]

--- a/agent-profile/agent_profile/renderers/claude.py
+++ b/agent-profile/agent_profile/renderers/claude.py
@@ -110,7 +110,7 @@ class ClaudeRenderer:
         self._write_settings(manifest, plugin_dir, base, out)
         self._write_local_marketplace(manifest, base, profile, desc)
         self._merge_root_settings(manifest, base)
-        self._render_native_plugins(manifest, base)
+        self._render_native_plugins(manifest, base, logical_root)
 
         # Track the plugin dir root so uninstall removes the whole tree
         # (including empty sub-dirs we mkdir'd above). Matches the bash
@@ -118,7 +118,9 @@ class ClaudeRenderer:
         self._track(out, base, plugin_dir)
         return out
 
-    def _render_native_plugins(self, manifest: Manifest, base: Path) -> None:
+    def _render_native_plugins(
+        self, manifest: Manifest, base: Path, logical_root: Path | None = None
+    ) -> None:
         """Register each claude_native plugin as a directory marketplace entry
         and prime Claude's CLI resolution cache via `claude plugin marketplace add`.
 
@@ -129,6 +131,14 @@ class ClaudeRenderer:
         - Calls ``claude plugin marketplace add <marketplace_root>`` to prime the
           CLI's resolution cache (writing extraKnownMarketplaces alone is not
           enough: the CLI must also index the marketplace directory).
+
+        The ``claude plugin marketplace add`` call is a live ``~/.claude`` write,
+        so it is deferred during compile (``logical_root`` set) to keep compile
+        side-effect-free — mirroring how user-scope MCP registrations defer. The
+        settings.json fragment (extraKnownMarketplaces + enabledPlugins) is still
+        written to the scratch ``base`` either way; apply / ``dots sync`` primes
+        the CLI cache post-gate. The legacy direct render (logical_root None)
+        still primes inline.
 
         Native skills (marked _from_native_plugin) are skipped by _write_skills;
         native MCPs (with claude removed from harnesses by DEDUP) are not written
@@ -153,7 +163,10 @@ class ClaudeRenderer:
             expanded = os.path.expandvars(os.path.expanduser(str(marketplace_root)))
             markets[marketplace_name] = {"source": {"source": "directory", "path": expanded}}
             enabled[f"{name}@{marketplace_name}"] = True
-            # Prime CLI resolution cache.
+            # Prime CLI resolution cache — a live ~/.claude write, deferred
+            # during compile (logical_root set) so compile stays side-effect-free.
+            if logical_root is not None:
+                continue
             try:
                 result = subprocess.run(
                     ["claude", "plugin", "marketplace", "add", expanded],

--- a/agent-profile/tests/test_claude_native_plugins.py
+++ b/agent-profile/tests/test_claude_native_plugins.py
@@ -987,3 +987,57 @@ def test_claude_renderer_rewrites_skill_allowed_tools(tmp_path):
     assert "mcp__hallouminate__*" not in text, text
     assert "mcp__tilth__*" in text
     assert "Task, Skill, Bash(gh:*)" in text  # non-MCP entries preserved in order
+
+
+# ── Regression: native_plugins must inherit through includes ───────────────
+
+def test_native_plugins_inherit_through_includes(tmp_path, monkeypatch):
+    """An outer profile that ``include``s a base carrying native plugins must
+    inherit them.
+
+    Regression for the silent-disable bug (issue #356): ``native_plugins`` was
+    in the outermost-profile-only override list, so ``parse_manifest(global)``
+    — ``global`` includes ``base`` but declares no own ``native_plugins`` —
+    clobbered base's inherited [milknado, hallouminate] back to ``[]``. The
+    live installer runs ``ap install global``, so every native plugin silently
+    vanished from the rendered settings. native_plugins must merge across
+    includes like mcps/agents/skills/hooks, not get overridden like name.
+    """
+    from agent_profile.parse import parse_manifest
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    market_root = _make_marketplace(
+        tmp_path, "milknado",
+        [{"name": "milknado", "source": "./plugins/milknado"}],
+    )
+    _make_payload(market_root, "./plugins/milknado", "milknado")
+    _make_plugins_registry(repo, {"milknado": {
+        "path": str(market_root),
+        "harnesses": ["claude"],
+        "claude_native": True,
+    }})
+    monkeypatch.setenv("DOTFILES_DIR", str(repo))
+
+    profiles = repo / "profiles"
+    base = profiles / "base"
+    base.mkdir(parents=True)
+    (base / "profile.yaml").write_text(
+        "name: base\nregistries:\n  plugins: agents/plugins/registry.yaml\n"
+    )
+    outer = profiles / "outer"
+    outer.mkdir()
+    (outer / "profile.yaml").write_text("name: outer\ninclude: [base]\n")
+
+    def resolver(name):
+        d = profiles / name
+        return d if d.is_dir() else None
+
+    base_names = [p["name"] for p in parse_manifest(base, resolver).native_plugins]
+    outer_names = [p["name"] for p in parse_manifest(outer, resolver).native_plugins]
+
+    assert base_names == ["milknado"]
+    assert outer_names == ["milknado"], (
+        "outer profile including base must inherit base's native_plugins; "
+        f"got {outer_names} (outermost-override clobbered the inherited value)"
+    )


### PR DESCRIPTION
Fixes #356 — native Claude plugins (hallouminate, milknado) silently disabled after `dots sync`.

### Root cause
`native_plugins` sat in `parse.py`'s outermost-profile-only override list, so a profile that `include`s a base carrying native plugins (`global → base`) clobbered the inherited `[milknado, hallouminate]` back to `[]`. The live installer runs `ap install global`, so `_render_native_plugins` iterated nothing — every native plugin vanished from the rendered Claude settings.

### Fix
- **`parse.py`** — `_merge_two` now concatenates `native_plugins` across includes (like `mcps`/`agents`/`skills`/`hooks`); dropped from the outermost-override list so the inherited value survives.
- **`renderers/claude.py`** — defer the `claude plugin marketplace add` CLI priming (a live `~/.claude` write) when `logical_root` is set, so `ap compile` stays side-effect-free now that native plugins flow into the compiled settings fragment. The legacy direct render (`logical_root=None`) still primes inline. Mirrors the existing user-scope-MCP deferral.
- regression test asserting an outer profile inherits its base's `native_plugins`.

### Why the renderer change is here
This was first scoped as a legacy-renderer-only hotfix, but #358 (the compile pipeline) merged to `main` mid-flight. With the parse fix on the new main, `ap compile live` renders native plugins into the compiled settings.json, and the compile path's marketplace-add side-effect polluted live settings during compile — breaking `test_compile_apply_preservation` and `test_compile_generated_discriminator`. Deferring the side-effect restores side-effect-free compile and makes both pass **without weakening either** (the user-key-survives test passes correctly because compile no longer mutates live).

### Verification
- `parse_manifest(global).native_plugins` resolves `[milknado, hallouminate]` (was `[]`).
- New `test_native_plugins_inherit_through_includes` fails pre-fix, passes post-fix.
- Full `agent-profile/tests/`: **893 passed**, 2 skipped; only the 4 pre-existing `test_canonical_permissions` failures remain — identical on plain `main` (local RTK-hook environment artifact; green in CI).

### Follow-up (not blocking, out of scope)
The compile→apply path computes native-plugin entries into the merged settings *fragment*, but apply preserves the live merged-settings file (generated=False), so it does not yet merge native plugins into live, and the deferred CLI marketplace priming is not yet performed at apply. Wiring apply / `dots sync` to perform the deferred registration belongs with the #359 apply-gate work. The live machine is already hand-fixed, so no urgency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
