### PR TITLE
build: add can1357/tap/omp brew formula

### DIFF
--- a/packages/packages.yaml
+++ b/packages/packages.yaml
@@ -65,6 +65,7 @@ packages:
   # which wires the systemd daemon. Then `tailscale up`. See operations/remote-access wiki.
   - anomalyco/tap/opencode                    # open-source AI coding agent (fresher than homebrew-core)
   - charmbracelet/tap/crush                   # Charm terminal AI coding agent (MCP via crush.json)
+  - can1357/tap/omp
 
   # Rust build acceleration
   - sccache                                   # rustc wrapper for compile caching


### PR DESCRIPTION
Adds the `can1357/tap/omp` Homebrew tap formula to `packages/packages.yaml` so it installs via `dots sync`. Placed alongside the other tap-sourced tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)