### PR TITLE
fix(chezmoi): surface drift delta instead of misleading gh-auth hint on sync failure

### DIFF
--- a/chezmoi/.sync
+++ b/chezmoi/.sync
@@ -175,7 +175,9 @@ if command -v chezmoi &>/dev/null; then
     else
         chezmoi_status=$?
         echo "  ERROR: chezmoi apply failed (exit $chezmoi_status) — alphabetically-later run_onchange installers were skipped" >&2
-        echo "         Common cause: 'gh auth status' failing → run 'gh auth login' and re-run 'dots sync'." >&2
+        echo "         See the specific error above for the cause. Common ones:" >&2
+        echo "           • agent-config drift halted the base-profile render → re-run: dots sync --accept-agent-drift" >&2
+        echo "           • 'gh auth status' failing → run 'gh auth login', then re-run 'dots sync'." >&2
     fi
 else
     echo "  Skipping chezmoi apply (chezmoi not installed); chezmoi-managed files will not sync"

--- a/chezmoi/lib/agent-profile-sync.sh
+++ b/chezmoi/lib/agent-profile-sync.sh
@@ -170,9 +170,11 @@ from pathlib import Path
 manifest = Path(sys.argv[1])
 try:
     records = json.loads(manifest.read_text()).get("drift", [])
-except Exception:
+except Exception as exc:
+    print(f"agent-profile-sync: cannot read drift records from {manifest}: {exc}", file=sys.stderr)
     sys.exit(0)
 if not isinstance(records, list):
+    print(f"agent-profile-sync: manifest {manifest} has invalid drift records", file=sys.stderr)
     sys.exit(0)
 
 

--- a/chezmoi/lib/agent-profile-sync.sh
+++ b/chezmoi/lib/agent-profile-sync.sh
@@ -152,6 +152,72 @@ sys.exit(0 if drift else 1)
 PY
 }
 
+# Print a human-readable summary of the drift between the live install and the
+# compiled output, reading the `drift` records from the manifest. Records whose
+# `live` and `compiled` values are present and equal are no-ops (the file just
+# isn't in the chezmoi scratch baseline) and are omitted; everything else is a
+# pending change shown as `live → compiled`. Long/multiline values are
+# truncated so the codex/copilot whole-file merge records stay readable.
+agent_profile_print_drift_delta() {
+    local cache_dir manifest
+    cache_dir=$1
+    manifest="$cache_dir/manifest.json"
+    python3 - "$manifest" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+manifest = Path(sys.argv[1])
+try:
+    records = json.loads(manifest.read_text()).get("drift", [])
+except Exception:
+    sys.exit(0)
+if not isinstance(records, list):
+    sys.exit(0)
+
+
+def fmt(value, absent):
+    if value is None:
+        return absent
+    text = value if isinstance(value, str) else json.dumps(value, sort_keys=True)
+    text = " ".join(text.split())
+    return text if len(text) <= 60 else text[:57] + "..."
+
+
+def is_noop(rec):
+    return "live" in rec and "compiled" in rec and rec["live"] == rec["compiled"]
+
+
+changes = [r for r in records if isinstance(r, dict) and not is_noop(r)]
+print("agent-profile-sync: compiled agent config differs from your live install", file=sys.stderr)
+if not changes:
+    print("    (re-tracking only — no value changes)", file=sys.stderr)
+    sys.exit(0)
+
+cap = 50
+shown = 0
+last_file = None
+for rec in changes:
+    if shown >= cap:
+        break
+    rel = rec.get("relative_path") or "(unknown)"
+    if rel != last_file:
+        print(f"  {rel}", file=sys.stderr)
+        last_file = rel
+    path = rec.get("path") or "(whole file)"
+    if "live" in rec or "compiled" in rec:
+        delta = f"{fmt(rec.get('live'), '(none)')} → {fmt(rec.get('compiled'), '(removed)')}"
+        print(f"    {path}: {delta}", file=sys.stderr)
+    else:
+        print(f"    {path}", file=sys.stderr)
+    shown += 1
+
+remaining = len(changes) - shown
+if remaining > 0:
+    print(f"    … and {remaining} more change(s)", file=sys.stderr)
+PY
+}
+
 agent_profile_drift_gate() {
     local cache_dir accept_drift drift_status
     cache_dir=$1
@@ -165,18 +231,20 @@ agent_profile_drift_gate() {
         *) return 1 ;;
     esac
 
+    agent_profile_print_drift_delta "$cache_dir"
+
     if [[ "$accept_drift" == true ]]; then
-        echo "agent-profile-sync: continuing because --accept-agent-drift was passed"
+        echo "agent-profile-sync: continuing because --accept-agent-drift was passed" >&2
         return 0
     fi
 
     if ! _apsync_interactive; then
-        echo "agent-profile-sync: drift detected during noninteractive dots sync" >&2
-        echo "agent-profile-sync: rerun with --accept-agent-drift to accept it for this run" >&2
+        echo "agent-profile-sync: drift NOT applied during noninteractive dots sync." >&2
+        echo "agent-profile-sync: to apply the changes above, re-run: dots sync --accept-agent-drift" >&2
         return 1
     fi
 
-    if _apsync_confirm "Continue and apply generated agent config? [y/N] "; then
+    if _apsync_confirm "Continue and apply the changes above? [y/N] "; then
         return 0
     fi
 

--- a/tests/agent-profile-sync.bats
+++ b/tests/agent-profile-sync.bats
@@ -117,9 +117,53 @@ _force_interactive_yes() {
     run agent_profile_sync live
 
     assert_failure
-    assert_output_contains "--accept-agent-drift"
+    assert_output_contains "dots sync --accept-agent-drift"
     grep -qF "compile live" "$AP_LOG"
     ! grep -qF "apply-compiled" "$AP_LOG"
+}
+
+@test "noninteractive drift prints the delta, not a gh-auth hint" {
+    MOCK_AP_DRIFT=1
+    source "$LIB"
+    _force_noninteractive
+
+    run agent_profile_sync live
+
+    assert_failure
+    assert_output_contains "differs from your live install"
+    assert_output_contains ".claude/settings.json"
+    assert_output_not_contains "gh auth"
+}
+
+@test "drift delta shows live→compiled changes and hides no-op records" {
+    source "$LIB"
+    mkdir -p "$AGENT_PROFILE_CACHE_DIR"
+    cat >"$AGENT_PROFILE_CACHE_DIR/manifest.json" <<'JSON'
+{"drift":[
+  {"relative_path":".claude/settings.json","path":"enabledPlugins.todoist-flow","live":true,"compiled":null},
+  {"relative_path":".claude/settings.json","path":"enabledPlugins.milknado","live":null,"compiled":true},
+  {"relative_path":"opencode.json","path":"permission.bash.rg *","live":"allow","compiled":"allow"}
+]}
+JSON
+
+    run agent_profile_print_drift_delta "$AGENT_PROFILE_CACHE_DIR"
+
+    assert_success
+    assert_output_contains "enabledPlugins.todoist-flow: true → (removed)"
+    assert_output_contains "enabledPlugins.milknado: (none) → true"
+    assert_output_not_contains "permission.bash.rg"
+}
+
+@test "drift delta reports re-tracking only when all records are no-ops" {
+    source "$LIB"
+    mkdir -p "$AGENT_PROFILE_CACHE_DIR"
+    printf '%s\n' '{"drift":[{"relative_path":"opencode.json","path":"permission.bash.rg *","live":"allow","compiled":"allow"}]}' \
+        >"$AGENT_PROFILE_CACHE_DIR/manifest.json"
+
+    run agent_profile_print_drift_delta "$AGENT_PROFILE_CACHE_DIR"
+
+    assert_success
+    assert_output_contains "re-tracking only"
 }
 
 @test "noninteractive drift with override shows drift and applies" {


### PR DESCRIPTION
## Problem

`dots sync` reported `FAILURES in: chezmoi`, and the only on-screen cause was a hard-coded hint blaming `gh auth status`. The real cause is the **agent drift gate** halting the base-profile render during a noninteractive sync — its own message was buried in the streamed output, and the actual delta (what would change) was never shown. The gh-auth hint actively misdirected debugging.

## Fix

- **`chezmoi/lib/agent-profile-sync.sh`** — new `agent_profile_print_drift_delta` reads the manifest `drift` records and prints the pending `live → compiled` changes grouped by file. No-op records (`live == compiled` — files merely absent from the chezmoi scratch baseline) are hidden; long/multiline values truncate to 60 chars; output caps at 50 lines with a `… and N more` tail. The gate prints the delta in all three paths (accept / noninteractive / interactive) and ends the noninteractive halt with the exact remedy:
  ```
  agent-profile-sync: to apply the changes above, re-run: dots sync --accept-agent-drift
  ```
- **`chezmoi/.sync`** — the trailing hint no longer asserts gh-auth as *the* cause. It points at the specific error above and lists drift-accept first, gh-login second.

## Tests

- `tests/agent-profile-sync.bats`: 3 new tests — delta prints `live→compiled`, hides no-ops, `re-tracking only` fallback, and asserts `gh auth` is **absent** from the noninteractive drift output.
- Full `just check` green (shellcheck + ruff + bats + serena smoke).

🤖 Generated with [Claude Code](https://claude.com/claude-code)