### PR TITLE
chore(lint): ignore vendored cursor/extensions in markdownlint

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -22,3 +22,4 @@ ignores:
   # Cursor IDE runtime output (gitignored via /cursor/*); the only intentional
   # markdown under cursor/ is plugins/. Not ours to lint.
   - cursor/skills-cursor/**
+  - cursor/extensions/**


### PR DESCRIPTION
## Summary

- `just check` was failing markdown lint on `cursor/extensions/vscodevim.vim-1.32.4-universal/README.md` — a vendored Cursor IDE extension README that is gitignored but still matched by `markdownlint-cli2 '**/*.md'`.
- Add `cursor/extensions/**` to `.markdownlint-cli2.yaml` `ignores:`, next to the existing `cursor/skills-cursor/**` entry (same category: Cursor runtime output, not ours to lint).

## Verification

- `just lint-markdown` → 0 errors (was 3).
- File count linted drops 429 → 423 (the vendored extension docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)