### PR TITLE
docs(harness-doctor): document heal for settings gate halt on removed hook keys

### DIFF
--- a/.hallouminate/wiki/architecture/config-drift.md
+++ b/.hallouminate/wiki/architecture/config-drift.md
@@ -265,6 +265,31 @@ is present.
 [^claude-user-scope-render]: agent-profile/agent_profile/renderers/claude.py:488-495,517-538
 [^staged-global-fix]: agent-profile/agent_profile/cli.py:272-307; agent-profile/tests/test_mcp_reconcile.py:test_explicit_target_user_scope_stages_plugin_mcp_without_claude_cli
 
+## Known drift pattern: registry hook-event removal halts the chezmoi settings gate
+
+**Symptom**: `dots sync` fails in the chezmoi leg with `Claude settings.json has
+key-path(s) the repo does not know about` naming hook event keys (e.g.
+`hooks.PermissionRequest`, `hooks.PostToolUse`) right after a commit *removed*
+those hooks from `chezmoi/.chezmoidata/claude.yaml`.
+
+**Why it happens**: `chezmoi/dot_claude/modify_settings.json` composes the
+desired settings.json wholesale and halts on any live key-path absent from the
+desired document. The gate cannot distinguish "Claude Code introduced a new
+key" (fold it in) from "the repo deliberately removed a key" (live is stale) —
+both look like live-only key-paths. Removing a hook *entry* under a surviving
+event key is fine (array indices are dropped from signatures); removing the
+last hook under an event key — or the last hook carrying a field like
+`timeout` — strands that key-path live and bricks every subsequent sync until
+the live file is pruned by hand.
+
+**Fix**: one-time prune of the removed key-paths from `~/.claude/settings.json`
+(e.g. `jq 'del(.hooks.<Event>)'` to a temp file, then move into place), then
+`dots sync` — the wholesale write owns `hooks` from then on. First hit
+2026-07-02 after 1bf2f88/5f78a0f removed the moshi PermissionRequest,
+auto-format PostToolUse, and jmux-attention Stop hooks. The ignore-file
+proposal in [#355](https://github.com/paulnsorensen/dotfiles/issues/355)
+addresses the adjacent app-churned-key case, not this removal case.
+
 ## Gotcha: index drift is its own drift class
 
 The hallouminate wiki index (LanceDB) is derived from the markdown on disk. If

--- a/skills/harness-doctor/SKILL.md
+++ b/skills/harness-doctor/SKILL.md
@@ -155,6 +155,26 @@ the renderers don't auto-heal. For those, propose the precise edit and confirm
 before applying — never hand-roll a jq/toml rewrite of a user-owned file when a
 renderer (or a `dots sync`) does it deterministically.
 
+**Known exception — chezmoi settings gate halts on removed hook keys.** Since
+claude went chezmoi-authoritative, `chezmoi/dot_claude/modify_settings.json`
+halts `dots sync` on any live `settings.json` key-path absent from the desired
+document. When a commit *removes* a hook event key (or the last hook carrying a
+field like `timeout`) from `chezmoi/.chezmoidata/claude.yaml`, the stranded live
+key-path trips that gate and no renderer or sync can clear it — this is the one
+case where a manual live prune IS the heal:
+
+```bash
+jq 'del(.hooks.<RemovedEvent>)' ~/.claude/settings.json > /tmp/s.json \
+  && jq -e 'type=="object"' /tmp/s.json >/dev/null \
+  && mv /tmp/s.json ~/.claude/settings.json
+dots sync   # wholesale write owns hooks from here
+```
+
+Confirm each pruned key-path against the removing commit first (`git log -p --
+chezmoi/.chezmoidata/claude.yaml`) — a live-only key with *no* removal commit is
+app-introduced and must be folded in, not pruned. Details:
+`.hallouminate/wiki/architecture/config-drift.md` § registry hook-event removal.
+
 ### 6. File dotfiles bugs as gh issues (deduped)
 
 For each confirmed **dotfiles bug**, open a GitHub issue — but dedup first:


### PR DESCRIPTION
## Why

Last night's hook removals (1bf2f88, 5f78a0f) left live `~/.claude/settings.json` carrying `hooks.PermissionRequest`, `hooks.PostToolUse`, and a `hooks.Stop.hooks.timeout` key-path that no longer exist in the registry. The `modify_settings.json` unknown-key gate halts `dots sync` on any live key-path absent from the desired document — and it cannot distinguish "Claude Code introduced a new key" (fold it in) from "the repo removed a key" (live is stale), so registry hook-event removals brick every sync until the stranded key-paths are pruned by hand. The gate's error message ("Claude Code likely introduced these") is actively misleading for this direction of drift.

## What

- **`skills/harness-doctor/SKILL.md`** — add a "Known exception" note under §5 Heal: the settings-gate halt on removed hook keys is the one case where a manual live prune IS the heal (no renderer or sync can clear it). Includes the `jq del` → validate → `mv` → `dots sync` sequence and the safety check that each pruned key-path must trace to a removal commit — a live-only key with no removal commit is app-introduced and must be folded in instead.
- **`.hallouminate/wiki/architecture/config-drift.md`** — record the drift pattern (symptom / why / fix), first hit 2026-07-02, and note that #355's ignore-file proposal covers the adjacent app-churned-key case, not this removal case.

## Verification

- `just check` exits 0
- `dots sync` green after the documented prune; `dots claude diff` reports in sync
- Wiki reindexed via `hallouminate index`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
