### PR TITLE
fix(agent-profile): gate codex live config.toml touches (follow-up cure to #366)

### DIFF
--- a/.hallouminate/wiki/operations/claude-dotfiles-ownership.md
+++ b/.hallouminate/wiki/operations/claude-dotfiles-ownership.md
@@ -57,7 +57,7 @@ Destructive changes must be provenance-aware, not wholesale deletes:
 - Use `claude /status` or `claude doctor` to inspect active setting sources and validation errors.[^claude-settings]
 - Use `/hooks`, `/mcp`, and `/plugin list` / plugin UI after destructive changes to confirm runtime state, because deleting declarative settings alone is not documented as equivalent to uninstalling plugins or removing manual MCPs.[^claude-plugins][^claude-mcp]
 
-_Source: Claude dotfiles / OMP isolation research plus Claude+chezmoi destructive-management briesearch · Updated: 2026-07-01 · Supersedes: seeded-once-only descriptions in older wiki rows._
+*Source: Claude dotfiles / OMP isolation research plus Claude+chezmoi destructive-management briesearch · Updated: 2026-07-01 · Supersedes: seeded-once-only descriptions in older wiki rows.*
 
 [^claude-settings]: Claude Code settings docs, retrieved 2026-07-01: <https://docs.anthropic.com/en/docs/claude-code/settings>
 [^claude-memory]: Claude Code memory docs, retrieved 2026-07-01: <https://docs.anthropic.com/en/docs/claude-code/memory>

--- a/.hallouminate/wiki/operations/claude-dotfiles-ownership.md
+++ b/.hallouminate/wiki/operations/claude-dotfiles-ownership.md
@@ -11,7 +11,7 @@ Claude Code's official settings scopes are user (`~/.claude/settings.json`), pro
 ## This repo's ownership split
 
 - **Repo-owned sources**: `chezmoi/lib/claude-settings-authoritative.json`, `chezmoi/dot_claude/modify_settings.json`, `claude/{commands,hooks,reference,workflows}`, agent/skill/MCP registries, profile YAML, and plugin payloads.
-- **Rendered/copied targets**: `~/.claude/{commands,hooks,reference,workflows}` are one-way copied; `agents/`, MCP servers, and skills are rendered through `ap`; the live `~/.claude/settings.json` is produced by chezmoi and then profile-aware renderer merges.
+- **Rendered/copied targets**: `~/.claude/{commands,hooks,reference,workflows}` are one-way copied; `agents/`, MCP servers, and skills are rendered through `ap`; the live `~/.claude/settings.json` is produced by chezmoi's `modify_settings.json`. The profile-aware renderer merge (`_merge_root_settings`) runs only for an isolated `ap launch`, not on the live `dots sync` path.
 - **Live/runtime state**: `~/.claude.json`, `~/.claude/projects/*/memory`, `~/.claude/settings.local.json`, repo-local `.claude/`, sessions, worktrees, plugin cache/data, marketplace cache, approvals/trust state, OAuth/session state, and app-created sticky state.
 
 `claude/README.md:13-17` records why this matters: the repo stopped symlinking into `~/.claude/` because Claude runtime writes leaked back into the checkout. `.gitignore:49-50` ignores repo-local `.claude/` for the same reason.
@@ -21,7 +21,7 @@ Claude Code's official settings scopes are user (`~/.claude/settings.json`), pro
 `chezmoi/dot_claude/modify_settings.json` owns the live settings boundary:
 
 - Repo-owned keys (`model`, `effortLevel`, `env`, hooks, sandbox, theme, `editorMode`, `permissions.defaultMode`, spinner verbs, etc.) are overwritten from `chezmoi/lib/claude-settings-authoritative.json` on each apply (`chezmoi/dot_claude/modify_settings.json:7-11`).
-- `ap`-managed keys (`permissions.allow`, `permissions.deny`, `permissions.ask`, `permissions.additionalDirectories`, `enabledPlugins`, `extraKnownMarketplaces`) are preserved from the live file and reasserted by `ap` (`chezmoi/dot_claude/modify_settings.json:12-17`, `agent-profile/agent_profile/renderers/claude.py:640-655`).
+- `permissions.allow`, `permissions.deny`, `permissions.ask`, `permissions.additionalDirectories`, `enabledPlugins`, and `extraKnownMarketplaces` are preserved from the live file and reasserted by chezmoi's `modify_settings.json` on each apply (`chezmoi/dot_claude/modify_settings.json:12-17`) — chezmoi is the single writer for the live install. `ap`'s `_merge_root_settings` also reasserts these, but only for an *isolated* `ap launch` (gated on `manifest.isolated`, `agent-profile/agent_profile/renderers/claude.py:613-687`); it does not run on the live `dots sync` path.
 - Unknown live key paths fail the apply instead of being silently clobbered, forcing a classification decision when Claude Code introduces a sticky setting (`chezmoi/dot_claude/modify_settings.json:18-22`, `chezmoi/dot_claude/modify_settings.json:91-100`).
 
 This is intentionally stricter than `create_` seed-once behavior: new settings either become repo-owned, become renderer-owned, or are explicitly left live-only.

--- a/agent-profile/agent_profile/renderers/claude.py
+++ b/agent-profile/agent_profile/renderers/claude.py
@@ -621,12 +621,15 @@ class ClaudeRenderer:
         install manifest. :meth:`clean` un-merges by removing exactly the
         keys this method added.
 
-        The canonical allow/deny lists are the SSOT root render (mechanism A):
-        ``create_settings.json`` no longer carries a ``permissions`` block, so
-        this method re-asserts the canonical set into root settings.json on
-        every ``dots sync``. It owns only the ``allow`` and ``deny`` subkeys —
-        any other ``permissions.*`` key (``defaultMode`` etc.) is left intact,
-        and the lists are written verbatim from the resolved manifest (already
+        This runs only for isolated launches (gated ``if manifest.isolated``
+        in :meth:`render`). The canonical allow/deny lists are the SSOT root
+        render (mechanism A): ``create_settings.json`` no longer carries a
+        ``permissions`` block. For the live global install, chezmoi's
+        ``modify_settings.json`` owns reasserting the canonical set; this
+        method only reasserts into an isolated profile's settings.json. It
+        owns only the ``allow`` and ``deny`` subkeys — any other
+        ``permissions.*`` key (``defaultMode`` etc.) is left intact, and the
+        lists are written verbatim from the resolved manifest (already
         sorted+deduped by the parser).
 
         ``${VAR}`` / ``~`` in marketplace paths expand against the process
@@ -635,13 +638,8 @@ class ClaudeRenderer:
         ``{"source": {"source": "directory", "path": <expanded>}}`` record;
         github-source marketplaces stay user-managed in the seed.
 
-        No-op when the profile declares none of the three surfaces. When the
-        file does not exist, creates an empty ``{}`` seed first — operator
-        running ``ap install global`` standalone (no chezmoi pass) gets a
-        minimal file rather than a hard error; chezmoi's
-        ``create_settings.json`` won't overwrite it later (``create_``
-        semantics), so the operator is responsible for filling in the rest if
-        they're skipping ``dots sync``."""
+        No-op when the profile declares none of the three surfaces. Creates an
+        empty ``{}`` seed first when the file does not exist."""
         # Rewrite mcp__<server>__* → mcp__plugin_<plugin>_<server>__* for plugins
         # native on claude (their tools are re-namespaced by the native install).
         server_plugins = native_mcp_server_plugins(manifest.native_plugins, "claude")

--- a/agent-profile/agent_profile/renderers/codex.py
+++ b/agent-profile/agent_profile/renderers/codex.py
@@ -97,6 +97,9 @@ class CodexRenderer:
         self._write_hooks(manifest, target, out_files, logical_root)
         if manifest.isolated:
             self._write_mcps(manifest, target)
+        # Ungated by design: writes the Codex CLI's own plugin store, not the
+        # merged config.toml. Codex is not chezmoi-migrated yet, so ap still
+        # owns this surface for live installs — revisit when it migrates.
         self._render_native_plugins(manifest)
         self._write_rules(manifest, target, out_files)
         if manifest.isolated:
@@ -316,7 +319,14 @@ class CodexRenderer:
         # (developers.openai.com/codex/hooks: "Codex loads all matching
         # hooks"), so leaving orphan legacy blocks fires every managed hook
         # twice per session — once from each source.
-        self._clean_legacy_config_toml_hooks(codex_hooks, target)
+        #
+        # Gated on isolation to match _write_mcps/_write_mcp_tool_scopes and
+        # the claude renderer's _clean_legacy_settings_hooks: a live (non-
+        # isolated) render must not touch the shared config.toml, which is
+        # user/chezmoi territory. hooks.json below is a managed output file
+        # and is still written either way.
+        if manifest.isolated:
+            self._clean_legacy_config_toml_hooks(codex_hooks, target)
 
         # Hook scripts are written under base_dir (the physical render dir), but
         # the command Codex executes must reference where the script will be

--- a/agent-profile/agent_profile/renderers/copilot.py
+++ b/agent-profile/agent_profile/renderers/copilot.py
@@ -169,6 +169,9 @@ class CopilotRenderer:
         self._write_hooks(manifest, base, out_files)
         if manifest.isolated:
             self._write_mcp(manifest, base)
+        # Ungated by design: writes Copilot's own CLI plugin store, not a
+        # merged config file. Copilot is not chezmoi-migrated yet, so ap still
+        # owns this surface for live installs — revisit when it migrates.
         self._render_native_plugins(manifest)
         return out_files
 

--- a/agent-profile/tests/test_codex_legacy_hook_cleanup.py
+++ b/agent-profile/tests/test_codex_legacy_hook_cleanup.py
@@ -37,6 +37,9 @@ def _manifest_with_hook(src: Path, script_basename: str) -> Manifest:
     return Manifest(
         name="p1",
         description="t",
+        # isolated: the legacy config.toml sweep only runs for isolated
+        # launches now (live installs leave the shared config.toml alone).
+        isolated=True,
         hooks=[
             {
                 "name": "session-start-cheese-flair",

--- a/agent-profile/tests/test_renderer_codex.py
+++ b/agent-profile/tests/test_renderer_codex.py
@@ -424,6 +424,53 @@ def test_nonisolated_manifest_skips_config_toml_writes(renderer, src, target):
     assert cfg.read_text() == seeded
 
 
+def test_nonisolated_render_preserves_legacy_config_toml_hooks(renderer, src, target):
+    """A non-isolated (live) render with a codex hook still writes hooks.json,
+    but must NOT sweep legacy [[hooks.*]] blocks from the shared config.toml —
+    that file is user/chezmoi territory now. The seeded legacy block points at
+    a managed basename (exactly what the migration sweep strips in an isolated
+    launch), so its byte-identical survival proves the sweep is gated off for
+    live installs. Mirrors the _write_mcps/_write_mcp_tool_scopes gating."""
+    hooks_dir = src / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    (hooks_dir / "session-start-cheese-flair.sh").write_text("#!/bin/bash\n: flair\n")
+
+    cfg = target / ".codex" / "config.toml"
+    cfg.parent.mkdir(parents=True)
+    seeded = (
+        "[[hooks.SessionStart]]\n"
+        'matcher = "startup|resume"\n'
+        "\n"
+        "[[hooks.SessionStart.hooks]]\n"
+        'type = "command"\n'
+        'command = "bash $HOME/.codex/hooks/session-start-cheese-flair.sh"\n'
+        "timeout = 5\n"
+    )
+    cfg.write_text(seeded)
+
+    manifest = Manifest(
+        name="live",
+        hooks=[
+            {
+                "name": "session-start-cheese-flair",
+                "event": "SessionStart",
+                "script": "hooks/session-start-cheese-flair.sh",
+                "matcher": "startup|resume",
+                "timeout": 5,
+                "harnesses": ["claude", "codex"],
+                "_source_dir": str(src),
+            }
+        ],
+    )
+    renderer.render(manifest, target)
+
+    assert cfg.read_text() == seeded, (
+        "non-isolated render swept a legacy config.toml hook block; the live "
+        "config.toml must stay untouched"
+    )
+    # hooks.json is a managed output file, written regardless of isolation.
+    assert (target / ".codex" / "hooks.json").is_file()
+
 def test_mcp_merge_preserves_user_keys_and_comments(renderer, src, target):
     """The bash golden proves yq dropped the user's comments; tomlkit keeps
     them. Assert both data parity (keys/values match the bash golden) AND


### PR DESCRIPTION
Follow-up cure to #366 (merged as a366c19). Fresh-context review of the merged diff surfaced four findings; this PR resolves all four.

## Findings addressed

1. **[Medium, correctness]** `renderers/codex.py` — the legacy `[[hooks.<event>]]` sweep (`_clean_legacy_config_toml_hooks`) ran unconditionally inside `_write_hooks`, read-modify-writing the live `.codex/config.toml` even for non-isolated renders. This diverged from the gated `_write_mcps`/`_write_mcp_tool_scopes` and the claude renderer's `_clean_legacy_settings_hooks` (gated on `manifest.isolated`). Fix: gate the sweep call on `manifest.isolated`, mirroring the claude treatment — only the sweep is gated, not the whole `_write_hooks`, so `hooks.json` (a managed output file) is still written for live installs.

2. **[Medium, spec/docs]** `operations/claude-dotfiles-ownership.md` — the doc credited `ap` (`claude.py:640-655`) with reasserting `enabledPlugins`/`extraKnownMarketplaces`, but that code (`_merge_root_settings`) is gated behind `manifest.isolated` and does not run on the live install. Reattributed reassertion to chezmoi's `modify_settings.json`, scoping the `ap` citation to isolated launches (lines 14 and 24).

3. **[Low, assertions]** `tests/test_renderer_codex.py` — added `test_nonisolated_render_preserves_legacy_config_toml_hooks`, which seeds a legacy `[[hooks.SessionStart]]` block pointing at a managed basename plus a codex hook in a non-isolated manifest, and asserts the block survives byte-identical. This test failed before finding 1's fix (sweep wiped the block) and passes after. The sibling suite `test_codex_legacy_hook_cleanup.py` now builds isolated manifests, since the sweep is isolated-only.

4. **[Low, docs]** `renderers/codex.py` + `renderers/copilot.py` — added one-line comments at each `_render_native_plugins` call noting the CLI plugin-store write is intentionally ungated pending those harnesses' chezmoi migration.

## Verification

- `uv run pytest tests/test_renderer_codex.py tests/test_codex_legacy_hook_cleanup.py` — 83 passed.
- Full `agent-profile` suite: 901 passed, 2 skipped, 4 pre-existing failures (`EnvResolutionError` in compile/apply preservation tests) confirmed failing identically on the unmodified base — unrelated to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)