### PR TITLE
feat(omp): isolate native config

### DIFF
--- a/bin/cheatsheet
+++ b/bin/cheatsheet
@@ -135,6 +135,7 @@ print_cheatsheet() {
     hdr "AI agents"
     row "copilot"             "GitHub Copilot (allow/deny floor)"
     row "oc"                  "opencode"
+    row "omp [args]"          "Oh My Pi + managed prompt addendum"
     row "ompt"                "Oh My Pi tight profile"
     row "ocp <name>"          "opencode with a named profile"
     row "octight [args]"      "opencode tight profile"

--- a/chezmoi/.chezmoidata/omp.yaml
+++ b/chezmoi/.chezmoidata/omp.yaml
@@ -17,15 +17,16 @@
 # `setupVersion` is machine state, not config: the modify_ script preserves it
 # from the live file and never authors it here.
 #
-# `disabledProviders: [claude]` is why omp no longer reads ~/.claude. omp's
-# `claude` discovery provider (discovery/claude.ts, provider id "claude") pulls
-# CLAUDE.md, settings.json, skills/, hooks, MCP config, commands, tools, and
-# SYSTEM.md from ~/.claude; disabling the whole provider drops all of it.
+# Keep OMP discovery native-only. Each id below is a non-OMP discovery
+# provider that can otherwise import external agent config, MCP servers,
+# commands, skills, hooks, prompts, tools, or settings from another harness.
+# `github` here is the GitHub/Copilot discovery source; it is separate from
+# the OMP `github.enabled` integration flag below.
 #
 # Gotcha — array settings REPLACE, they don't merge across omp config layers.
 # A project-level .omp/config.yml that sets its own `disabledProviders` list
-# replaces this global one wholesale and can silently re-enable `claude`.
-# Check every active layer if claude discovery reappears.
+# replaces this global one wholesale and can silently re-enable external
+# discovery. Check every active layer if non-native discovery reappears.
 
 omp:
   config:
@@ -34,6 +35,12 @@ omp:
     defaultThinkingLevel: auto
     disabledProviders:
       - claude
+      - codex
+      - cursor
+      - gemini
+      - github
+      - opencode
+      - agents-md
     display:
       showTokenUsage: true
       cacheMissMarker: true

--- a/chezmoi/.chezmoiignore
+++ b/chezmoi/.chezmoiignore
@@ -26,6 +26,8 @@ lib/
 # removal semantics). Patterns are target-relative, hence .claude not
 # dot_claude.
 !.claude/**
+# Global *.md ignore would otherwise skip the managed OMP prompt addendum.
+!.omp/agent/APPEND_SYSTEM.md
 {{- /*
 Local LLM stack is per-machine, opt-in. When the localLLM flag is false,
 ignore the whole stack tree + its systemd units so non-LLM machines stay

--- a/chezmoi/dot_omp/private_agent/APPEND_SYSTEM.md
+++ b/chezmoi/dot_omp/private_agent/APPEND_SYSTEM.md
@@ -1,9 +1,34 @@
 # OMP system prompt addendum
 
-- Follow repository instructions over generic defaults.
-- Code changes: read before editing, keep scope exact, avoid speculative features, avoid needless abstractions, and skip unrelated cleanup.
-- Prefer existing patterns and match local style. Delete only code made obsolete by the current change.
-- Dotfiles specifics: shell scripts fail fast, quote variable expansions, source new zsh config from `zshrc` in load order, and manage Claude skills, agents, and MCP servers through their registries.
-- Tool routing: use OMP-native file, search, edit, and code-intelligence tools before shell. Use shell for tests, builds, and non-file operations.
-- Verify significant changes before claiming completion. Cite the command or scenario and result.
-- Communication: concise, calibrated (`<certain>`, `<speculative>`, `<don't know>`), evidence first.
+Repository instructions override generic defaults. Match local style and existing patterns even when you'd do it differently; flag a convention you think is harmful rather than forking silently.
+
+## Before coding
+
+- Think first: state assumptions, name tradeoffs, and ask when the request is ambiguous or has multiple readings — don't guess and don't hide confusion.
+- Read before you write: exports, immediate callers, shared utilities. "Looks orthogonal" is dangerous.
+- Define success as a verifiable goal before starting. Turn a fuzzy ask into a test or runnable check, then loop until it passes.
+
+## Scope
+
+- Code is a liability — every changed line must trace to the request. Prefer a supported library over reinventing; prefer three clear lines over a premature abstraction.
+- Be surgical but finish the whole surgery: do the full ask, nothing more. No extra features, flexibility, error handling for impossible cases, or unrelated cleanup. Don't silently drop or defer the hard or tedious parts — if something genuinely can't be done as asked, stop and say so.
+- Fail fast and loud: validate external input, handle errors where they occur, no silent fallback that returns corrupted data.
+- Name things after real-world concepts, not their container types. Minimize mutable state.
+
+## Tests
+
+- Tests encode WHY the behavior matters, not just what it does. A test that can't fail when the logic changes is wrong.
+- Assert specific values and specific error types, not existence or "didn't crash". Never weaken an assertion to make a test pass.
+
+## Verify and communicate
+
+- Don't eyeball what code can compute — run it for counts, arithmetic, diffs, regex, date math.
+- Don't fake completion: "tests pass" is false if any were skipped. Flag uncertainty instead of hiding it.
+- Checkpoint after each significant step: what's done, what's verified, what's left.
+- Be concise: lead with the answer, add minimal support, stop. No preamble, no closing recap. One sentence beats a paragraph.
+- Calibrate every claim: `<certain>` (verified), `<speculative>` (informed guess), `<don't know>`. An absence claim ("X has no Y", "not possible") needs evidence ruling out each candidate — "didn't find it" is not "doesn't exist". When pointed at evidence, re-read the source and re-derive; don't defend a challenged claim.
+
+## Tooling
+
+- Prefer OMP-native file, search, edit, and code-intelligence tools over shell; use shell for tests, builds, and non-file operations.
+- Prefix shell commands with `rtk` (e.g. `rtk git status`, `rtk cargo test`) — it compacts output when a filter exists and passes through unchanged otherwise, so it is always safe to use.

--- a/chezmoi/dot_omp/private_agent/APPEND_SYSTEM.md
+++ b/chezmoi/dot_omp/private_agent/APPEND_SYSTEM.md
@@ -1,0 +1,9 @@
+# OMP system prompt addendum
+
+- Follow repository instructions over generic defaults.
+- Code changes: read before editing, keep scope exact, avoid speculative features, avoid needless abstractions, and skip unrelated cleanup.
+- Prefer existing patterns and match local style. Delete only code made obsolete by the current change.
+- Dotfiles specifics: shell scripts fail fast, quote variable expansions, source new zsh config from `zshrc` in load order, and manage Claude skills, agents, and MCP servers through their registries.
+- Tool routing: use OMP-native file, search, edit, and code-intelligence tools before shell. Use shell for tests, builds, and non-file operations.
+- Verify significant changes before claiming completion. Cite the command or scenario and result.
+- Communication: concise, calibrated (`<certain>`, `<speculative>`, `<don't know>`), evidence first.

--- a/chezmoi/dot_omp/private_agent/extensions/cheese-flair.ts
+++ b/chezmoi/dot_omp/private_agent/extensions/cheese-flair.ts
@@ -1,0 +1,41 @@
+// Cheese-flair extension — injects a rotating cheese-flair sample once per
+// session by running the shared deployed hook script and adding its stdout as
+// injected context (persisted + TUI-visible). This reuses the same script the
+// Claude SessionStart hook runs, so both harnesses draw from one flair bank.
+//
+// Fails open: a missing or failing script is a no-op, never blocks startup.
+// Modeled on the vendored rtk.ts extension structure.
+//
+// `session_start` cannot return an injected message (notification-only), so we
+// use `before_agent_start` — the only lifecycle event that returns a persisted
+// message — guarded to fire once, mirroring Claude's session-start injection.
+
+import type { ExtensionAPI } from "@oh-my-pi/pi-coding-agent"
+
+const FLAIR_SCRIPT = `${process.env.HOME}/.claude/hooks/session-start-cheese-flair.sh`
+const FLAIR_TIMEOUT_MS = 3_000
+
+export default function (pi: ExtensionAPI) {
+  let injected = false
+
+  pi.on("before_agent_start", async () => {
+    if (injected) return
+    injected = true // set before exec so a failure never retries every turn
+
+    try {
+      const result = await pi.exec("bash", [FLAIR_SCRIPT], { timeout: FLAIR_TIMEOUT_MS })
+      const text = result.stdout.trim()
+      if (result.killed || result.code !== 0 || text === "") return
+      return {
+        message: {
+          customType: "cheese-flair",
+          content: text,
+          display: true,
+        },
+      }
+    } catch (err) {
+      console.warn("[cheese-flair] flair script failed; skipping injection", err)
+      return
+    }
+  })
+}

--- a/chezmoi/dot_omp/private_agent/extensions/cheese-flair.ts
+++ b/chezmoi/dot_omp/private_agent/extensions/cheese-flair.ts
@@ -10,7 +10,7 @@
 // use `before_agent_start` — the only lifecycle event that returns a persisted
 // message — guarded to fire once, mirroring Claude's session-start injection.
 
-import type { ExtensionAPI } from "@oh-my-pi/pi-coding-agent"
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
 
 const FLAIR_SCRIPT = `${process.env.HOME}/.claude/hooks/session-start-cheese-flair.sh`
 const FLAIR_TIMEOUT_MS = 3_000

--- a/chezmoi/dot_omp/private_agent/extensions/rtk.ts
+++ b/chezmoi/dot_omp/private_agent/extensions/rtk.ts
@@ -1,0 +1,84 @@
+// Vendored from rtk-ai/rtk `hooks/pi/rtk.ts` @develop (local rtk 0.43.0).
+// Deploys to ~/.omp/agent/extensions/rtk.ts. To change rewrite rules, edit
+// rtk's Rust registry (src/discover/registry.rs), not this file.
+//
+// RTK Pi extension — rewrites bash commands to use rtk for token savings.
+// Requires: rtk >= 0.23.0 in PATH.
+//
+// This is a thin delegating extension: all rewrite logic lives in `rtk rewrite`,
+// which is the single source of truth (src/discover/registry.rs).
+// To add or change rewrite rules, edit the Rust registry — not this file.
+//
+// Exit code contract for `rtk rewrite`:
+//   0 + stdout  Rewrite found → mutate command
+//   1           No RTK equivalent → pass through unchanged
+//   3 + stdout  Rewrite (advisory) → mutate command
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+import { isToolCallEventType } from "@earendil-works/pi-coding-agent"
+
+const REWRITE_TIMEOUT_MS = 2_000
+const MIN_SUPPORTED_RTK_MINOR = 23
+
+// Parse "X.Y.Z" semver, return [major, minor, patch] or null.
+function parseSemver(raw: string): [number, number, number] | null {
+  const m = raw.trim().match(/(\d+)\.(\d+)\.(\d+)/)
+  if (!m) return null
+  return [parseInt(m[1], 10), parseInt(m[2], 10), parseInt(m[3], 10)]
+}
+
+// Calls `rtk rewrite`; returns the rewritten command or null (pass through).
+async function rewriteCommand(
+  pi: ExtensionAPI,
+  cmd: string,
+  signal?: AbortSignal
+): Promise<string | null> {
+  const result = await pi.exec("rtk", ["rewrite", cmd], {
+    timeout: REWRITE_TIMEOUT_MS,
+    signal,
+  })
+  if (result.killed) return null
+  if (result.code !== 0 && result.code !== 3) return null
+  return result.stdout.trim() || null
+}
+
+export default async function (pi: ExtensionAPI) {
+  // Probe rtk version at load time; disables extension if missing or too old.
+  const ver = await pi.exec("rtk", ["--version"], { timeout: REWRITE_TIMEOUT_MS })
+  if (ver.code !== 0) {
+    console.warn("[rtk] rtk binary not found in PATH — extension disabled")
+    return
+  }
+
+  // Warn and bail if rtk predates 0.23.0 (when `rtk rewrite` was introduced).
+  const parsed = parseSemver(ver.stdout.replace(/^rtk\s+/, ""))
+  if (parsed) {
+    const [major, minor] = parsed
+    if (major === 0 && minor < MIN_SUPPORTED_RTK_MINOR) {
+      console.warn(`[rtk] rtk ${ver.stdout.trim()} is too old (need >= 0.23.0) — extension disabled`)
+      return
+    }
+  }
+
+  pi.on("tool_call", async (event, ctx) => {
+    try {
+      if (!isToolCallEventType("bash", event)) return
+
+      const cmd = event.input.command
+      if (typeof cmd !== "string" || cmd.trim() === "") return
+
+      if (cmd.startsWith("rtk ")) return
+      if (process.env.RTK_DISABLED === "1") return
+
+      // Delegate to RTK.
+      const rewritten = await rewriteCommand(pi, cmd, ctx.signal)
+      if (rewritten && rewritten !== cmd) {
+        event.input.command = rewritten
+      }
+    } catch (err) {
+      // Fail open: never block execution on an unexpected error.
+      console.warn("[rtk] unexpected error in tool_call handler; passing through command", err)
+      return
+    }
+  })
+}

--- a/chezmoi/dot_omp/private_agent/mcp.json
+++ b/chezmoi/dot_omp/private_agent/mcp.json
@@ -6,7 +6,10 @@
       "args": [
         "-y",
         "@upstash/context7-mcp"
-      ]
+      ],
+      "env": {
+        "CONTEXT7_API_KEY": "${CONTEXT7_API_KEY}"
+      }
     },
     "hallouminate": {
       "command": "hallouminate",

--- a/chezmoi/dot_omp/private_agent/mcp.json
+++ b/chezmoi/dot_omp/private_agent/mcp.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://raw.githubusercontent.com/can1357/oh-my-pi/main/packages/coding-agent/src/config/mcp-schema.json",
+  "mcpServers": {
+    "context7": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@upstash/context7-mcp"
+      ]
+    },
+    "hallouminate": {
+      "command": "hallouminate",
+      "args": [
+        "serve"
+      ]
+    },
+    "milknado": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "git+https://github.com/paulnsorensen/milknado@main",
+        "milknado-mcp"
+      ]
+    }
+  }
+}

--- a/tests/omp-config.bats
+++ b/tests/omp-config.bats
@@ -127,6 +127,7 @@ STDIN"
     jq -e '.mcpServers.milknado.args == ["--from", "git+https://github.com/paulnsorensen/milknado@main", "milknado-mcp"]' "$cfg"
     jq -e '.mcpServers.context7.command == "npx"' "$cfg"
     jq -e '.mcpServers.context7.args == ["-y", "@upstash/context7-mcp"]' "$cfg"
+    jq -e '.mcpServers.context7.env.CONTEXT7_API_KEY == "${CONTEXT7_API_KEY}"' "$cfg"
 }
 # --- models.yml template↔registry seam -------------------------------------
 # dot_omp/private_agent/models.yml.tmpl authors ~/.omp/agent/models.yml WHOLESALE
@@ -235,4 +236,5 @@ TOML
     [ "$status" -eq 0 ]
     [[ "$output" == *".omp/agent/extensions/rtk.ts"* ]]
     [[ "$output" == *".omp/agent/extensions/cheese-flair.ts"* ]]
+    [[ "$output" == *".omp/agent/APPEND_SYSTEM.md"* ]]
 }

--- a/tests/omp-config.bats
+++ b/tests/omp-config.bats
@@ -38,22 +38,20 @@ STDIN"
     [ "$(yq '.colorBlindMode' "$OUT")" = "true" ]
     [ "$(yq '.defaultThinkingLevel' "$OUT")" = "auto" ]
     [ "$(yq '.modelRoles.vision' "$OUT")" = "openai-codex/gpt-5.4" ]
-    [ "$(yq '.disabledProviders | length' "$OUT")" = "1" ]
-    [ "$(yq '.disabledProviders | .[0]' "$OUT")" = "claude" ]
+    [ "$(yq '.disabledProviders | join(",")' "$OUT")" = "claude,codex,cursor,gemini,github,opencode,agents-md" ]
     # setupVersion is machine state — never authored on a fresh machine.
     [ "$(yq 'has("setupVersion")' "$OUT")" = "false" ]
 }
 
 @test "omp-config: managed-key drift is wiped, setupVersion preserved" {
     # In-app symbolPreset change + a hand-edited (emptied) disabledProviders
-    # list must be driven back to the registry values; setupVersion survives.
+    # list must be driven back to the native-only registry values; setupVersion survives.
     run_modify 'symbolPreset: ascii
 disabledProviders: []
 setupVersion: 1'
     [ "$status" -eq 0 ]
     [ "$(yq '.symbolPreset' "$OUT")" = "nerd" ]
-    [ "$(yq '.disabledProviders | length' "$OUT")" = "1" ]
-    [ "$(yq '.disabledProviders | .[0]' "$OUT")" = "claude" ]
+    [ "$(yq '.disabledProviders | join(",")' "$OUT")" = "claude,codex,cursor,gemini,github,opencode,agents-md" ]
     [ "$(yq '.setupVersion' "$OUT")" = "1" ]
 }
 
@@ -121,6 +119,15 @@ STDIN"
     [[ "$output" == *".chezmoidata/omp.yaml"* ]]      # registry path named
 }
 
+@test "omp-mcp: native user config defines requested MCP servers" {
+    local cfg="$REAL_DOTFILES_DIR/chezmoi/dot_omp/private_agent/mcp.json"
+    jq -e '.mcpServers.hallouminate.command == "hallouminate"' "$cfg"
+    jq -e '.mcpServers.hallouminate.args == ["serve"]' "$cfg"
+    jq -e '.mcpServers.milknado.command == "uvx"' "$cfg"
+    jq -e '.mcpServers.milknado.args == ["--from", "git+https://github.com/paulnsorensen/milknado@main", "milknado-mcp"]' "$cfg"
+    jq -e '.mcpServers.context7.command == "npx"' "$cfg"
+    jq -e '.mcpServers.context7.args == ["-y", "@upstash/context7-mcp"]' "$cfg"
+}
 # --- models.yml template↔registry seam -------------------------------------
 # dot_omp/private_agent/models.yml.tmpl authors ~/.omp/agent/models.yml WHOLESALE
 # from the `omp.models` subtree via `{{ .omp.models | toYaml }}`. These lock the

--- a/tests/omp-config.bats
+++ b/tests/omp-config.bats
@@ -201,3 +201,38 @@ TOML
     # target is NOT in the ignore list (chezmoi applies it).
     [[ "$output" != *".omp/agent/models.yml"* ]]
 }
+
+# --- .chezmoiignore negation ordering -------------------------------------
+# .chezmoiignore is last-match-wins: the !.omp/agent/APPEND_SYSTEM.md re-include
+# only survives the global *.md ignore because it is positioned AFTER it. A
+# reorder that moves the negation above *.md would silently stop deploying the
+# managed prompt addendum. Pin the ordering.
+@test "omp-ignore: APPEND_SYSTEM.md re-include stays after the *.md ignore" {
+    local ignore="$REAL_DOTFILES_DIR/chezmoi/.chezmoiignore"
+    local md_line neg_line
+    md_line=$(grep -n '^\*\.md$' "$ignore" | head -1 | cut -d: -f1)
+    neg_line=$(grep -n '^!\.omp/agent/APPEND_SYSTEM\.md$' "$ignore" | head -1 | cut -d: -f1)
+    [ -n "$md_line" ]
+    [ -n "$neg_line" ]
+    # Negation must come strictly after the glob ignore (last match wins).
+    [ "$neg_line" -gt "$md_line" ]
+}
+
+# --- omp extension modules are chezmoi-managed -----------------------------
+# rtk.ts and cheese-flair.ts under dot_omp/private_agent/extensions/ deploy to
+# ~/.omp/agent/extensions/ (auto-discovered by omp's extension loader). Nothing
+# in .chezmoiignore may exclude them, or the extensions silently never deploy.
+@test "omp-ext: rtk.ts and cheese-flair.ts are chezmoi-managed" {
+    command -v chezmoi >/dev/null 2>&1 || skip "chezmoi not installed"
+    local cfg="$TEST_HOME/cz-ext.toml"
+    cat > "$cfg" <<TOML
+sourceDir = "$REAL_DOTFILES_DIR/chezmoi"
+
+[data]
+email = "test@example.com"
+TOML
+    run chezmoi --config "$cfg" --source "$REAL_DOTFILES_DIR/chezmoi" managed
+    [ "$status" -eq 0 ]
+    [[ "$output" == *".omp/agent/extensions/rtk.ts"* ]]
+    [[ "$output" == *".omp/agent/extensions/cheese-flair.ts"* ]]
+}

--- a/tests/zsh-config.bats
+++ b/tests/zsh-config.bats
@@ -85,7 +85,7 @@ teardown() {
     [[ "$output" == $'profile launch codex codex-plan --sandbox workspace\nprofile launch codex codex-code --model gpt-5' ]]
 }
 
-@test "omp wrapper appends managed system prompt" {
+@test "omp wrapper appends the default-profile system prompt" {
     command -v zsh &>/dev/null || skip "zsh not installed"
     local fakebin="$TEST_HOME/bin"
     mkdir -p "$fakebin"
@@ -94,6 +94,9 @@ teardown() {
 printf '%s\n' "$@"
 SH
     chmod +x "$fakebin/omp"
+    # The wrapper only passes --append-system-prompt when the addendum exists.
+    mkdir -p "$TEST_HOME/.omp/agent"
+    printf 'addendum\n' > "$TEST_HOME/.omp/agent/APPEND_SYSTEM.md"
 
     run zsh -c "PATH='$fakebin':\$PATH; HOME='$TEST_HOME'; source '$REAL_DOTFILES_DIR/zsh/aliases.zsh'; omp --model gpt-5"
 
@@ -102,6 +105,50 @@ SH
     [ "${lines[1]}" = "$TEST_HOME/.omp/agent/APPEND_SYSTEM.md" ]
     [ "${lines[2]}" = "--model" ]
     [ "${lines[3]}" = "gpt-5" ]
+}
+
+@test "ompt wrapper appends the tight-profile system prompt, not the default" {
+    command -v zsh &>/dev/null || skip "zsh not installed"
+    local fakebin="$TEST_HOME/bin"
+    mkdir -p "$fakebin"
+    cat > "$fakebin/omp" <<'SH'
+#!/bin/sh
+printf '%s\n' "$@"
+SH
+    chmod +x "$fakebin/omp"
+    # Both addenda exist; the derivation must pick the PI_CONFIG_DIR one.
+    mkdir -p "$TEST_HOME/.omp/agent" "$TEST_HOME/.omp-tight/agent"
+    printf 'default\n' > "$TEST_HOME/.omp/agent/APPEND_SYSTEM.md"
+    printf 'tight\n'   > "$TEST_HOME/.omp-tight/agent/APPEND_SYSTEM.md"
+
+    run zsh -c "PATH='$fakebin':\$PATH; HOME='$TEST_HOME'; source '$REAL_DOTFILES_DIR/zsh/aliases.zsh'; ompt --model gpt-5"
+
+    assert_success
+    [ "${lines[0]}" = "--append-system-prompt" ]
+    # Derives from PI_CONFIG_DIR=.omp-tight — NOT the default .omp path.
+    [ "${lines[1]}" = "$TEST_HOME/.omp-tight/agent/APPEND_SYSTEM.md" ]
+    [ "${lines[1]}" != "$TEST_HOME/.omp/agent/APPEND_SYSTEM.md" ]
+    [ "${lines[2]}" = "--model" ]
+    [ "${lines[3]}" = "gpt-5" ]
+}
+
+@test "omp wrapper omits --append-system-prompt when the addendum is absent" {
+    command -v zsh &>/dev/null || skip "zsh not installed"
+    local fakebin="$TEST_HOME/bin"
+    mkdir -p "$fakebin"
+    cat > "$fakebin/omp" <<'SH'
+#!/bin/sh
+printf '%s\n' "$@"
+SH
+    chmod +x "$fakebin/omp"
+    # No addendum on disk (e.g. tight profile with no APPEND_SYSTEM.md): the
+    # wrapper must not pass a nonexistent path to omp.
+    run zsh -c "PATH='$fakebin':\$PATH; HOME='$TEST_HOME'; source '$REAL_DOTFILES_DIR/zsh/aliases.zsh'; ompt --model gpt-5"
+
+    assert_success
+    [ "${lines[0]}" = "--model" ]
+    [ "${lines[1]}" = "gpt-5" ]
+    [ "${#lines[@]}" -eq 2 ]
 }
 
 @test "completion.zsh has cdd completion" {

--- a/tests/zsh-config.bats
+++ b/tests/zsh-config.bats
@@ -84,6 +84,26 @@ teardown() {
     assert_success
     [[ "$output" == $'profile launch codex codex-plan --sandbox workspace\nprofile launch codex codex-code --model gpt-5' ]]
 }
+
+@test "omp wrapper appends managed system prompt" {
+    command -v zsh &>/dev/null || skip "zsh not installed"
+    local fakebin="$TEST_HOME/bin"
+    mkdir -p "$fakebin"
+    cat > "$fakebin/omp" <<'SH'
+#!/bin/sh
+printf '%s\n' "$@"
+SH
+    chmod +x "$fakebin/omp"
+
+    run zsh -c "PATH='$fakebin':\$PATH; HOME='$TEST_HOME'; source '$REAL_DOTFILES_DIR/zsh/aliases.zsh'; omp --model gpt-5"
+
+    assert_success
+    [ "${lines[0]}" = "--append-system-prompt" ]
+    [ "${lines[1]}" = "$TEST_HOME/.omp/agent/APPEND_SYSTEM.md" ]
+    [ "${lines[2]}" = "--model" ]
+    [ "${lines[3]}" = "gpt-5" ]
+}
+
 @test "completion.zsh has cdd completion" {
     local completion_file="$REAL_DOTFILES_DIR/zsh/completion.zsh"
 

--- a/zsh/aliases.zsh
+++ b/zsh/aliases.zsh
@@ -169,8 +169,12 @@ if command -v opencode &> /dev/null; then
   alias oc='opencode'
 fi
 
-# Oh My Pi tight profile - isolated agent dir at ~/.omp-tight/agent
+# Oh My Pi - isolated native config with managed prompt addendum
 if command -v omp &> /dev/null; then
+  omp() {
+    command omp --append-system-prompt "$HOME/.omp/agent/APPEND_SYSTEM.md" "$@"
+  }
+
   ompt() {
     PI_CONFIG_DIR=.omp-tight omp "$@"
   }

--- a/zsh/aliases.zsh
+++ b/zsh/aliases.zsh
@@ -173,7 +173,7 @@ fi
 if command -v omp &> /dev/null; then
   omp() {
     # Derive the addendum from the active config dir so `ompt` (PI_CONFIG_DIR
-    # =.omp-tight) gets its own tight-profile prompt, not the default one.
+    # =.omp-tight) does not inherit the default prompt (it picks up a tight-profile prompt if one is ever added).
     local addendum="$HOME/${PI_CONFIG_DIR:-.omp}/agent/APPEND_SYSTEM.md"
     if [[ -f "$addendum" ]]; then
       command omp --append-system-prompt "$addendum" "$@"

--- a/zsh/aliases.zsh
+++ b/zsh/aliases.zsh
@@ -172,7 +172,14 @@ fi
 # Oh My Pi - isolated native config with managed prompt addendum
 if command -v omp &> /dev/null; then
   omp() {
-    command omp --append-system-prompt "$HOME/.omp/agent/APPEND_SYSTEM.md" "$@"
+    # Derive the addendum from the active config dir so `ompt` (PI_CONFIG_DIR
+    # =.omp-tight) gets its own tight-profile prompt, not the default one.
+    local addendum="$HOME/${PI_CONFIG_DIR:-.omp}/agent/APPEND_SYSTEM.md"
+    if [[ -f "$addendum" ]]; then
+      command omp --append-system-prompt "$addendum" "$@"
+    else
+      command omp "$@"
+    fi
   }
 
   ompt() {


### PR DESCRIPTION
## Summary
- Disable non-native OMP discovery providers so OMP stops importing Claude, Codex, OpenCode, Cursor, Gemini, GitHub/Copilot, and agents-md config.
- Add OMP-native `mcp.json` for context7, hallouminate, and milknado.
- Add a managed OMP prompt addendum and wrap `omp` to append it at launch.

## Test plan
- [x] `bats tests/omp-config.bats tests/zsh-config.bats`
- [x] `chezmoi --source chezmoi managed | sort | grep '^\.omp/agent/'`
- [x] `chezmoi --source chezmoi apply ~/.omp/agent/config.yml ~/.omp/agent/mcp.json ~/.omp/agent/APPEND_SYSTEM.md`
- [x] `omp config get disabledProviders`
- [x] `jq -r '.mcpServers | keys | join(",")' ~/.omp/agent/mcp.json`
- [x] `wc -l ~/.omp/agent/APPEND_SYSTEM.md`

Note: `omp mcp list` was attempted twice and timed out after 60s and 180s while resolving/listing MCP servers, so the PR verifies the native MCP config file rather than a live OMP MCP inventory.