### PR TITLE
feat(agents): tighten sub-agent tool grants from session-analytics evidence

### DIFF
--- a/agents/registry.yaml
+++ b/agents/registry.yaml
@@ -276,7 +276,7 @@ agents:
     # is bounded. Denies native Edit/Write/Grep/Glob/NotebookEdit — all edits go
     # through cheez-write (tilth); keeps Read. Denies Agent — a dispatched coder
     # is a level-1 subagent and cannot fan out.
-    description: TDD-disciplined implementer. Takes an approved spec or unambiguous task and drives the contract → cut → implement → taste-test loop, editing through the cheez-write (tilth) skill. Runs the project's test/lint/build gates and applies review fixes. Models the easy-cheese code phase (/cook, /press, /cure). Full write surface — the one phase agent that mutates the tree. Use PROACTIVELY whenever a task requires writing or changing code — implementing a spec, fixing a bug, applying review findings — under /cook, /press, /cure, or any user-installed skill that needs a code change made.
+    description: TDD-disciplined implementer. Takes an approved spec or unambiguous task and drives the contract → cut → implement → taste-test loop, editing through the cheez-write (tilth) skill. Runs the project's test/lint/build gates and applies review fixes. Models the easy-cheese code phase (/cook, /press, /cure). Mutates the tree exclusively through cheez-write (tilth) — the one phase agent that changes code. Use PROACTIVELY whenever a task requires writing or changing code — implementing a spec, fixing a bug, applying review findings — under /cook, /press, /cure, or any user-installed skill that needs a code change made.
     models:
       claude: opus
       codex: gpt-5-codex

--- a/agents/registry.yaml
+++ b/agents/registry.yaml
@@ -20,6 +20,8 @@ agents:
     - Edit
     - Write
     - NotebookEdit
+    - Grep
+    - Glob
     color: red
     effort: medium
     skills:
@@ -39,6 +41,8 @@ agents:
     - WebSearch
     - WebFetch
     - Agent
+    - Grep
+    - Glob
     color: red
     effort: high
     skills:
@@ -56,8 +60,6 @@ agents:
     - Read
     - Write
     - Edit
-    - Grep
-    - Glob
     - Bash
     skills:
     - gh
@@ -77,6 +79,8 @@ agents:
     - Edit
     - NotebookEdit
     - AskUserQuestion
+    - Grep
+    - Glob
     color: red
     effort: medium
     skills:
@@ -97,6 +101,8 @@ agents:
     - WebFetch
     - AskUserQuestion
     - Write
+    - Grep
+    - Glob
     maxTurns: 50
     body_path: agents/agent_definitions/ghostbuster.md
   nih-scanner:
@@ -113,6 +119,8 @@ agents:
     - WebSearch
     - WebFetch
     - AskUserQuestion
+    - Grep
+    - Glob
     skills:
     - cheez-search
     maxTurns: 50
@@ -125,8 +133,6 @@ agents:
       cursor: claude-sonnet
     tools:
     - Read
-    - Grep
-    - Glob
     - Bash
     - Agent
     - mcp__serena__*
@@ -144,8 +150,6 @@ agents:
     tools:
     - Read
     - Write
-    - Grep
-    - Glob
     - Bash
     - mcp__serena__*
     skills:
@@ -168,6 +172,8 @@ agents:
     - Agent
     - WebSearch
     - WebFetch
+    - Grep
+    - Glob
     skills:
     - session-analytics
     maxTurns: 50
@@ -181,8 +187,6 @@ agents:
     tools:
     - Bash
     - Read
-    - Glob
-    - Grep
     skills:
     - cheez-search
     maxTurns: 50
@@ -219,6 +223,8 @@ agents:
     - Write
     - NotebookEdit
     - Agent
+    - Grep
+    - Glob
     color: cyan
     skills:
     - cheez-search
@@ -235,6 +241,8 @@ agents:
     - Edit
     - NotebookEdit
     - Agent
+    - Grep
+    - Glob
     color: blue
     skills:
     - briesearch
@@ -253,6 +261,8 @@ agents:
     - Write
     - NotebookEdit
     - Agent
+    - Grep
+    - Glob
     color: red
     effort: high
     skills:
@@ -263,8 +273,9 @@ agents:
     body_path: agents/agent_definitions/reviewer.md
   coder:
     # Runs on opus at low effort: the write surface needs judgment but the loop
-    # is bounded. Keeps Edit/Write (it mutates the tree) but denies Agent — a
-    # dispatched coder is a level-1 subagent and cannot fan out.
+    # is bounded. Denies native Edit/Write/Grep/Glob/NotebookEdit — all edits go
+    # through cheez-write (tilth); keeps Read. Denies Agent — a dispatched coder
+    # is a level-1 subagent and cannot fan out.
     description: TDD-disciplined implementer. Takes an approved spec or unambiguous task and drives the contract → cut → implement → taste-test loop, editing through the cheez-write (tilth) skill. Runs the project's test/lint/build gates and applies review fixes. Models the easy-cheese code phase (/cook, /press, /cure). Full write surface — the one phase agent that mutates the tree. Use PROACTIVELY whenever a task requires writing or changing code — implementing a spec, fixing a bug, applying review findings — under /cook, /press, /cure, or any user-installed skill that needs a code change made.
     models:
       claude: opus
@@ -272,6 +283,11 @@ agents:
       opencode: inherit
     disallowedTools:
     - Agent
+    - Grep
+    - Glob
+    - Edit
+    - Write
+    - NotebookEdit
     color: green
     effort: low
     skills:
@@ -303,6 +319,9 @@ agents:
       opencode: inherit
     disallowedTools:
     - Agent
+    - Grep
+    - Glob
+    - NotebookEdit
     color: yellow
     skills:
     - cheez-search

--- a/tests/phase-agent-handoff.bats
+++ b/tests/phase-agent-handoff.bats
@@ -72,7 +72,7 @@ block_sha() {
 }
 
 # The descriptions promise read-only phase agents that cannot recurse, and a
-# coder that keeps the write surface. Lock those tool-surface contracts in the
+# coder that edits only through tilth (cheez-write). Lock those tool-surface contracts in the
 # registry so they can't silently drift. The same metadata renders to Claude,
 # Codex, opencode, and Copilot CLI; Copilot ignores model overrides.
 @test "phase agents declare model intent for model-aware harnesses" {

--- a/tests/phase-agent-handoff.bats
+++ b/tests/phase-agent-handoff.bats
@@ -117,20 +117,22 @@ block_sha() {
     # must still deny code edits and fan-out.
     run yq '.agents.researcher.disallowedTools' "$registry"
     assert_success
-    [[ "$output" == *Edit* ]] || { echo "researcher must deny Edit" >&2; return 1; }
     [[ "$output" == *Agent* ]] || { echo "researcher must deny Agent (no subagent fan-out)" >&2; return 1; }
+    # Exact membership: a substring check for Edit would match NotebookEdit.
+    run yq -e '.agents.researcher.disallowedTools[] | select(. == "Edit")' "$registry"
+    [[ "$status" -eq 0 ]] || { echo "researcher must deny Edit" >&2; return 1; }
 }
 
 @test "coder denies native edit tools and subagent fan-out in the registry" {
     local registry="$AGENTS_DIR/registry.yaml"
-    run yq '.agents.coder.disallowedTools' "$registry"
-    assert_success
     # Aggressive lockdown (session-analytics evidence): coder mutates the tree
     # exclusively through cheez-write (tilth), so native edit/search tools are denied.
-    for tool in Edit Write NotebookEdit Grep Glob; do
-        [[ "$output" == *"$tool"* ]] || { echo "coder must deny $tool (edits go through cheez-write)" >&2; return 1; }
+    # Exact membership per tool: a substring check for Edit would match NotebookEdit.
+    for tool in Edit Write NotebookEdit Grep Glob Agent; do
+        run yq -e ".agents.coder.disallowedTools[] | select(. == \"$tool\")" "$registry"
+        [[ "$status" -eq 0 ]] || { echo "coder must deny $tool (edits go through cheez-write)" >&2; return 1; }
     done
-    # Read is kept (see decision 5), and Agent denied (level-1 subagent, no fan-out).
-    [[ "$output" != *Read* ]] || { echo "coder must keep native Read" >&2; return 1; }
-    [[ "$output" == *Agent* ]] || { echo "coder must deny Agent (no subagent fan-out)" >&2; return 1; }
+    # Read is kept (see decision 5).
+    run yq -e '.agents.coder.disallowedTools[] | select(. == "Read")' "$registry"
+    [[ "$status" -ne 0 ]] || { echo "coder must keep native Read" >&2; return 1; }
 }

--- a/tests/phase-agent-handoff.bats
+++ b/tests/phase-agent-handoff.bats
@@ -121,10 +121,16 @@ block_sha() {
     [[ "$output" == *Agent* ]] || { echo "researcher must deny Agent (no subagent fan-out)" >&2; return 1; }
 }
 
-@test "coder keeps the write surface but cannot spawn subagents" {
+@test "coder denies native edit tools and subagent fan-out in the registry" {
     local registry="$AGENTS_DIR/registry.yaml"
     run yq '.agents.coder.disallowedTools' "$registry"
     assert_success
-    [[ "$output" != *Write* ]] || { echo "coder must keep Write (it mutates the tree)" >&2; return 1; }
+    # Aggressive lockdown (session-analytics evidence): coder mutates the tree
+    # exclusively through cheez-write (tilth), so native edit/search tools are denied.
+    for tool in Edit Write NotebookEdit Grep Glob; do
+        [[ "$output" == *"$tool"* ]] || { echo "coder must deny $tool (edits go through cheez-write)" >&2; return 1; }
+    done
+    # Read is kept (see decision 5), and Agent denied (level-1 subagent, no fan-out).
+    [[ "$output" != *Read* ]] || { echo "coder must keep native Read" >&2; return 1; }
     [[ "$output" == *Agent* ]] || { echo "coder must deny Agent (no subagent fan-out)" >&2; return 1; }
 }


### PR DESCRIPTION
## Summary

Locks down sub-agent tool grants in `agents/registry.yaml`, driven by session-analytics evidence (1,053 spawns, ~36k sub-agent tool calls) and research against the Claude Code sub-agent docs (`.cheese/research/claude-subagent-lockdown/`):

- **All 16 custom agents** now deny `Grep`, `Glob`, `NotebookEdit` — zero observed uses across all spawns; tilth_search/cheez-* fully displaced them. Explicit-allowlist agents (fromage-fort, ricotta-reducer, roquefort-wrecker, whey-drainer) had Grep/Glob stripped from their `tools:` lists.
- **researcher** additionally denies `Edit` (0 observed calls; keeps `Write` for `.cheese/research/` slugs).
- **coder** aggressively denies `Edit`/`Write` — its 265 native workspace Edit calls were drift from the cheez-write mandate; all edits now go through tilth. Keeps native `Read`.
- Native `Read` retained everywhere (15–100% of each agent's reads target `/tmp`, outside-workspace files, or binaries that tilth doesn't cover).
- Contract tests rewritten with exact-membership `yq` assertions (a substring check for `Edit` is tautological once every agent denies `NotebookEdit`).
- coder description reworded to match the tilth-only write surface.

## Verification

- `bats tests/phase-agent-handoff.bats`: 9/9 pass
- `just check`: lint green; only failure is `chezmoi-wiring.bats` test 183, which also fails on a clean `origin/main` worktree (environmental, unrelated)
- `dots sync` applied; rendered `~/.claude/agents/coder.md` shows `disallowedTools: [Agent, Grep, Glob, Edit, Write, NotebookEdit]`
- Fresh-context taste-test + ten-dimension `/age` review passed; both findings (test tautology, stale description) fixed in follow-up commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)