### PR TITLE
fix(claude): drop macOS-only SSL_CERT_FILE pin on Linux

### DIFF
--- a/chezmoi/dot_claude/modify_settings.json
+++ b/chezmoi/dot_claude/modify_settings.json
@@ -215,6 +215,15 @@ desired=$(
     '
 )
 
+# env.SSL_CERT_FILE is a macOS-only pin (dc42ae5): the Seatbelt sandbox blocks
+# Keychain access, so OpenSSL-linked tools need /etc/ssl/cert.pem spelled out.
+# That path does not exist on Linux and poisons TLS for anything honoring the
+# var (npx, curl, Go) — drop the key on non-Darwin. The unknown-key gate below
+# still treats a live copy as known so the transition sync wipes it, not halts.
+if [ "$(uname -s)" != "Darwin" ]; then
+    desired=$(printf '%s' "$desired" | jq 'del(.env.SSL_CERT_FILE)')
+fi
+
 # Fresh machine (empty stdin): emit the desired document.
 if [ -z "$live" ]; then
     printf '%s\n' "$desired"
@@ -240,7 +249,7 @@ unknown=$(
     printf '%s' "$live" | jq -r --argjson desired "$desired" '
         def sig: [ .[] | strings ];
         [ ["enabledPlugins"], ["extraKnownMarketplaces"] ] as $dyn
-        | ([ $desired | paths | sig ] | unique) as $known
+        | (([ $desired | paths | sig ] + [["env","SSL_CERT_FILE"]]) | unique) as $known
         | [ paths | sig ]
         | map(select(
               . as $p

--- a/tests/claude-settings.bats
+++ b/tests/claude-settings.bats
@@ -478,3 +478,18 @@ run_native() {
     # The literal \${HOME} token is expanded to the real HOME by the expand walk.
     [ "$(jq -r '.extraKnownMarketplaces["tok"].source.path' "$OUT")" = "$HOME/tok" ]
 }
+
+@test "modify_settings: SSL_CERT_FILE dropped from desired on Linux; live copy wiped without halting" {
+    [ "$(uname -s)" = "Darwin" ] && skip "macOS keeps the pin"
+    # Live file carrying the old pin must not trip the unknown-key gate.
+    run_modify '{"env":{"ENABLE_TOOL_SEARCH":"true","SSL_CERT_FILE":"/etc/ssl/cert.pem"}}'
+    [ "$status" -eq 0 ]
+    jq -e '.env | has("SSL_CERT_FILE") | not' "$OUT" >/dev/null
+}
+
+@test "modify_settings: SSL_CERT_FILE kept on macOS" {
+    [ "$(uname -s)" != "Darwin" ] && skip "Linux drops the pin"
+    run bash -c "CHEZMOI_SOURCE_DIR='$CZ_SRC' sh '$SCRIPT' </dev/null >'$OUT'"
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.env.SSL_CERT_FILE' "$OUT")" = "/etc/ssl/cert.pem" ]
+}


### PR DESCRIPTION
## Why

`/mcp` on the Linux box: tavily MCP timed out after 30s. Root cause: settings.json pins `SSL_CERT_FILE` (under `env`) to the macOS cert bundle path (added in dc42ae5 for the Seatbelt sandbox, where Keychain access is blocked). That path does not exist on Linux, and Go/curl/npx all honor the var there — `npx -y tavily-mcp@latest` hung on TLS to registry.npmjs.org and blew Claude's connect timeout.

## What

- `modify_settings.json`: deletes the key from the desired doc's `env` on non-Darwin; the unknown-key gate treats a live copy as known so the transition sync wipes it instead of halting. macOS keeps the pin.
- 2 bats tests: Linux drops the key without halting on a live copy; macOS keeps it (skipped cross-OS).

## Verification

- `tests/claude-settings.bats`: 29/29 pass
- `dots sync` applied on the Linux box: key gone from live settings; tavily-mcp initialize handshake completes in ~2s (was hanging 45s+)
- Full `just check` has one pre-existing failure unrelated to this diff (`chezmoi-wiring.bats:71`, fails identically with this diff stashed)

## Note

Upstream Go ignores `SSL_CERT_FILE` on darwin (golang/go#77865 still open), so the pin may never have been what fixed `gh` on the Mac — worth a Mac-side retest someday; if nothing breaks without it, the pin and this conditional can both be deleted. Research: `.cheese/research/ssl-cert-file-pin/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)