### PR TITLE
feat(claude): profile-scope official plugins, purge wozcode, sibling-wiki corpora

### DIFF
--- a/.hallouminate/wiki/architecture/config-drift.md
+++ b/.hallouminate/wiki/architecture/config-drift.md
@@ -235,6 +235,53 @@ auto-format PostToolUse, and jmux-attention Stop hooks. The ignore-file
 proposal in [#355](https://github.com/paulnsorensen/dotfiles/issues/355)
 addresses the adjacent app-churned-key case, not this removal case.
 
+## Known drift pattern: third-party plugin daemons re-write settings.json after "removal"
+
+**Symptom**: The unknown-key halt names a key you already pruned from live
+`~/.claude/settings.json` (it "comes back"), possibly with a *different value*
+than before — e.g. `agent: "woz:code"` reappearing after `agent: "woz:code-free"`
+was deleted. The plugin behind it shows as disabled or uninstalled.
+
+**Why it happens**: Some marketplace plugins (first hit: `woz@wozcode-marketplace`,
+2026-07-04) run persistent node daemons out of the plugin cache
+(`~/.claude/plugins/cache/<mp>/<plugin>/<ver>/servers/*.js`). Uninstalling the
+plugin or removing its marketplace does NOT kill an already-running daemon, and
+the daemon keeps rewriting its settings keys (`agent`, `attribution.*`,
+`statusLine`) — and can rewrite `enabledPlugins` — between your prune and the
+next `chezmoi apply`. The woz case also hijacked commit/PR `attribution` to
+advertise itself.
+
+**Fix**: `pgrep -af <plugin-cache-path>` → kill the daemons → move the cache
+payload out of `~/.claude/plugins/cache/` → THEN prune the keys and `dots sync`.
+Order matters: prune-first loses the race.
+
+**Detection**: A pruned key that resurrects, or any process whose command line
+points into `~/.claude/plugins/cache/`.
+
+## Gotcha: official plugins are enabled by `claude/plugins/registry.yaml`, not the claude.yaml base
+
+`enabledPlugins` in `chezmoi/.chezmoidata/claude.yaml` is only the BASE layer;
+`claude/plugins/registry.yaml`'s `load:` values overlay it (registry wins).
+Removing a plugin from the base while its registry entry still says `load: true`
+changes nothing — the classic "I cleaned it out but it's still in my sessions"
+trap. As of 2026-07-04 the official plugins (playwright, frontend-design,
+plugin-dev, skill-creator) are `load: false` (installed but globally disabled;
+the `fe` and `plugin` ap profiles enable them per-session), and
+claude-md-management is removed entirely. `load: false` ≠ absent: absent means
+sync.sh uninstalls the payload, which would break the profiles that enable it.
+
+## Gotcha: hallouminate daemon caches corpus config — restart after config.toml changes
+
+The hallouminate **daemon** is the single owner of the LanceDB ground dir and
+the corpus registry; CLI and MCP clients talk to it over a Unix socket. It
+reads `~/.config/hallouminate/config.toml` at startup only. After chezmoi
+deploys a config change (new `[[corpus]]` entries, path edits), a still-running
+daemon silently serves the OLD corpus set — `hallouminate index` reports only
+the stale corpora, with no error. Fix: `hallouminate daemon restart`, then
+re-index. First hit 2026-07-04: four new sibling-wiki `[[corpus]]` entries
+(milknado/easy-cheese/tilth/hallouminate) rendered correctly but were invisible
+until the daemon restarted.
+
 ## Gotcha: index drift is its own drift class
 
 The hallouminate wiki index (LanceDB) is derived from the markdown on disk. If

--- a/chezmoi/.chezmoidata/claude.yaml
+++ b/chezmoi/.chezmoidata/claude.yaml
@@ -109,12 +109,9 @@ claude:
   # agents/plugins/registry.yaml (native: ∋ claude entries — milknado, hallouminate
   # — keyed by each marketplace.json .name) at apply time. sync.sh does not write
   # settings.json. Native marketplaces are NOT listed here: the overlay owns them.
-  enabledPlugins:
-    claude-md-management@claude-plugins-official: true
-    playwright@claude-plugins-official: true
-    frontend-design@claude-plugins-official: true
-    plugin-dev@claude-plugins-official: true
-    skill-creator@claude-plugins-official: true
+  # Official-marketplace plugins are profile-scoped, not global: fe enables
+  # playwright + frontend-design; plugin enables plugin-dev + skill-creator.
+  enabledPlugins: {}
 
   # Base layer for extraKnownMarketplaces (empty): the gate-filtered
   # claude/plugins/registry.yaml overlay and the native-claude

--- a/chezmoi/.chezmoidata/omp.yaml
+++ b/chezmoi/.chezmoidata/omp.yaml
@@ -55,6 +55,11 @@ omp:
       enabled: true
     task:
       eager: default
+    # Consent answer omp recorded live (autoqa prompt) — promoted to survive
+    # the wholesale re-author.
+    dev:
+      autoqa:
+        consent: granted
     # Reasoning goes to the interactive session (default) and the reasoning
     # roles (plan/slow). Delegation/dispatch roles that "just do work" —
     # smol/tiny/task/commit — stay on cheap/no-reasoning models so subagent

--- a/chezmoi/dot_config/hallouminate/config.toml.tmpl
+++ b/chezmoi/dot_config/hallouminate/config.toml.tmpl
@@ -22,6 +22,21 @@ globs = ["**/*.md"]
 exclude = ["**/.git/**"]
 
 {{ end -}}
+# Sibling-repo wikis, exposed to the cheez-wiki command center (and every other
+# workspace) so cross-repo grounding — roadmaps/, architecture pages — works
+# from one session. Same rules as the cheez-wiki block above: stat-guarded per
+# machine, and flat [[corpus]] (NOT [[repository]]) so these never collide with
+# each repo's own repo-layer config deriving `repo:<name>:wiki`.
+{{ range $repo := list "milknado" "easy-cheese" "tilth" "hallouminate" -}}
+{{ if stat (joinPath $.chezmoi.homeDir "Dev" $repo ".hallouminate" "wiki") -}}
+[[corpus]]
+name = "{{ $repo }}-wiki"
+paths = ["~/Dev/{{ $repo }}/.hallouminate/wiki"]
+globs = ["**/*.md"]
+exclude = ["**/.git/**"]
+
+{{ end -}}
+{{ end -}}
 # Top-level embeddings default for all repos (per-repo config can override).
 # snowflake-arctic-embed-s: 384-dim, English, retrieval-tuned. Full precision
 # (quantized=false) — corpora are small, so keep max quality.

--- a/claude/plugins/registry.yaml
+++ b/claude/plugins/registry.yaml
@@ -22,30 +22,27 @@
 
 plugins:
   # --- Workflow plugins ---
-  claude-md-management@claude-plugins-official:
-    description: Audit, maintain, and improve CLAUDE.md files with session learnings
-    scope: user
-    load: true
-
+  # load: false → payload stays installed but globally disabled; the fe and
+  # plugin ap profiles flip these on per-session via enabled_plugins.
   playwright@claude-plugins-official:
     description: Browser testing and automation with Playwright
     scope: user
-    load: true
+    load: false
 
   frontend-design@claude-plugins-official:
     description: Frontend design skill for UI/UX implementation
     scope: user
-    load: true
+    load: false
 
   plugin-dev@claude-plugins-official:
     description: Plugin development toolkit for building and testing Claude Code plugins
     scope: user
-    load: true
+    load: false
 
   skill-creator@claude-plugins-official:
     description: Guided skill creation workflow with component design, implementation, and validation
     scope: user
-    load: true
+    load: false
 
   # --- Local plugins (dotfiles) ---
   # Gated entries are skipped unless the named env var is "true" (see .env.example).

--- a/profiles/fe/profile.yaml
+++ b/profiles/fe/profile.yaml
@@ -16,7 +16,6 @@ permissions_allow:
   - "mcp__shadcn__*"
 # Per-profile plugin set (ccp settings-merge parity).
 enabled_plugins:
-  "claude-md-management@claude-plugins-official": true
   "playwright@claude-plugins-official": true
   "frontend-design@claude-plugins-official": true
   "plugin-dev@claude-plugins-official": false

--- a/profiles/plugin/profile.yaml
+++ b/profiles/plugin/profile.yaml
@@ -10,7 +10,6 @@ isolated: true
 system_prompt: CLAUDE.md
 # Per-profile plugin set (ccp settings-merge parity).
 enabled_plugins:
-  "claude-md-management@claude-plugins-official": true
   "plugin-dev@claude-plugins-official": true
   "skill-creator@claude-plugins-official": true
   "playwright@claude-plugins-official": false

--- a/profiles/spec/profile.yaml
+++ b/profiles/spec/profile.yaml
@@ -13,7 +13,6 @@ permissions_deny:
   - NotebookEdit
 # Per-profile plugin set (ccp settings-merge parity).
 enabled_plugins:
-  "claude-md-management@claude-plugins-official": true
   "plugin-dev@claude-plugins-official": false
   "skill-creator@claude-plugins-official": false
   "frontend-design@claude-plugins-official": false

--- a/tests/claude-settings.bats
+++ b/tests/claude-settings.bats
@@ -40,7 +40,7 @@ STDIN"
     [ "$(jq -r '.model' "$OUT")" = "opus" ]
     [ "$(jq -r '.effortLevel' "$OUT")" = "medium" ]
     # Registry-authored keys composed in.
-    jq -e '.enabledPlugins["claude-md-management@claude-plugins-official"]' "$OUT" >/dev/null
+    jq -e '.enabledPlugins | has("plugin-dev@claude-plugins-official")' "$OUT" >/dev/null
     jq -e '.hooks.PreToolUse | length > 0' "$OUT" >/dev/null
     jq -e '.permissions.allow | length > 0' "$OUT" >/dev/null
     jq -e '.permissions.deny | index("Bash(sudo:*)")' "$OUT" >/dev/null
@@ -87,7 +87,7 @@ STDIN"
     # registry values authored in
     [ "$(jq -r '.permissions.defaultMode' "$OUT")" = "auto" ]
     [ "$(jq -r '.model' "$OUT")" = "opus" ]
-    jq -e '.enabledPlugins["claude-md-management@claude-plugins-official"]' "$OUT" >/dev/null
+    jq -e '.enabledPlugins | has("plugin-dev@claude-plugins-official")' "$OUT" >/dev/null
     jq -e '.permissions.deny | length > 0' "$OUT" >/dev/null
 }
 
@@ -280,8 +280,8 @@ run_modify_gated() {
     [ "$(jq -r '.extraKnownMarketplaces["todoist-flow"].source.source' "$OUT")" = "directory" ]
     run jq -r '.extraKnownMarketplaces["todoist-flow"].source.path' "$OUT"
     [[ "$output" == */claude/plugins/local/todoist-flow ]]
-    # claude.yaml base entries survive alongside the overlay.
-    [ "$(jq -r '.enabledPlugins["skill-creator@claude-plugins-official"]' "$OUT")" = "true" ]
+    # Official plugins are registry-overlaid with load: false (profile-scoped).
+    [ "$(jq -r '.enabledPlugins["skill-creator@claude-plugins-official"]' "$OUT")" = "false" ]
     # (native marketplaces — milknado, hallouminate — are covered by the native
     # overlay tests below; they warn+skip here since no cache exists in the sandbox.)
 }
@@ -293,8 +293,8 @@ run_modify_gated() {
     [ "$status" -ne 0 ]
     run jq -e '.extraKnownMarketplaces["todoist-flow"]' "$OUT"
     [ "$status" -ne 0 ]
-    # Base official plugins remain.
-    [ "$(jq -r '.enabledPlugins["skill-creator@claude-plugins-official"]' "$OUT")" = "true" ]
+    # Official plugins remain, disabled (load: false — profile-scoped).
+    [ "$(jq -r '.enabledPlugins["skill-creator@claude-plugins-official"]' "$OUT")" = "false" ]
 }
 
 # Build a custom CHEZMOI_SOURCE_DIR at $TEST_HOME/root/chezmoi with a sibling
@@ -348,8 +348,9 @@ setup_custom_registry() {
     run bash -c "env -u TODOIST CHEZMOI_SOURCE_DIR='$src' sh '$SCRIPT' </dev/null >'$OUT'"
     [ "$status" -eq 0 ]
     [[ "$output" == *"plugin registry not found"* ]]
-    # Base claude.yaml plugins present; no gated overlay entries.
-    [ "$(jq -r '.enabledPlugins["skill-creator@claude-plugins-official"]' "$OUT")" = "true" ]
+    # claude.yaml base is empty — no official plugins without the registry.
+    run jq -e '.enabledPlugins["skill-creator@claude-plugins-official"]' "$OUT"
+    [ "$status" -ne 0 ]
     run jq -e '.enabledPlugins["todoist-flow@todoist-flow"]' "$OUT"
     [ "$status" -ne 0 ]
 }


### PR DESCRIPTION
## Summary

- **Profile-scope the official plugins**: `enabledPlugins` base in `claude.yaml` emptied; `claude/plugins/registry.yaml` now carries `load: false` for playwright / frontend-design / plugin-dev / skill-creator (installed, globally disabled — the `fe` and `plugin` ap profiles enable them per-session). `claude-md-management` removed entirely.
- **Root cause writeup**: the plugin registry overlay *wins* over the claude.yaml base, so past "cleanouts" of the base changed nothing — documented in the wiki config-drift page.
- **wozcode purge fallout**: the disabled woz plugin left persistent node daemons running from the plugin cache that kept rewriting `settings.json` (`agent`, WOZCODE commit `attribution`, `statusLine`) and bricking the chezmoi unknown-key gate. Killed + purged; pattern documented.
- **omp**: promote live `dev.autoqa.consent` into `omp.yaml` so the wholesale re-author stops halting.
- **hallouminate**: expose milknado / easy-cheese / tilth / hallouminate repo wikis as stat-guarded flat `[[corpus]]` entries for cross-repo grounding; daemon config-caching gotcha documented.

## Verification

- `just check` green (bats assertions updated to the new registry semantics)
- `dots sync` applies cleanly; live `enabledPlugins` = 4 officials `false` + milknado/hallouminate `true`
- All four new corpora index after `hallouminate daemon restart` (32/9/2/13 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)