### PR TITLE
fix(chezmoi): parenthesize case patterns for macOS bash 3.2

### DIFF
--- a/.hallouminate/wiki/operations/sync-and-chezmoi.md
+++ b/.hallouminate/wiki/operations/sync-and-chezmoi.md
@@ -56,6 +56,14 @@ Drop a templated source under `chezmoi/` using the [source-state attributes](htt
 
 **Inspect/debug:** `chezmoi --source $DOTFILES/chezmoi diff` (what would change) · `data` (rendered namespace) · `execute-template < FILE.tmpl` · `chezmoi doctor`.
 
+
+
+### Gotcha: `case` inside `$(…)` breaks macOS `/bin/bash` (3.2.57)
+
+A `run_onchange`/`.chezmoiscripts` shell script (or any repo `.sh`) that nests a `case … esac` **inside a `$(…)` command substitution** must parenthesize every pattern — `(git) … ;;`, not `git) … ;;`. macOS ships GNU bash 3.2.57 (the GPLv2 freeze), whose parser naively counts parens while scanning for the end of `$(…)` and treats the pattern's closing `)` as closing the substitution → `syntax error near unexpected token ';;'` **at parse time** (so it fails even on machines where the code path never executes). Linux/Homebrew bash 5.x parses both forms fine, which is why it survives CI/review and only bites on a real macOS `dots sync`.
+
+Two safe forms: parenthesize the patterns (`(git)`), or define the `case` in a named function and call it via `$(fn)` — the `case` is then not textually inside the substitution. `chezmoi/dot_claude/modify_settings.json` uses the function form deliberately; `run_onchange_after_sync-claude-plugins.sh.tmpl` (added #378) hit the bug and was fixed to the parenthesized form.
+
 ## Shell functions need tests
 
 Every shell function that does real work needs a bats test. `.sync` (and any orchestrator) forks to tested functions instead of nesting untestable logic inline — `.sync` runs on every `dots sync`, so a regression there breaks the whole environment, and inline logic can't be exercised without running the full destructive sync against a real `$HOME`.

--- a/.hallouminate/wiki/operations/sync-and-chezmoi.md
+++ b/.hallouminate/wiki/operations/sync-and-chezmoi.md
@@ -56,8 +56,6 @@ Drop a templated source under `chezmoi/` using the [source-state attributes](htt
 
 **Inspect/debug:** `chezmoi --source $DOTFILES/chezmoi diff` (what would change) · `data` (rendered namespace) · `execute-template < FILE.tmpl` · `chezmoi doctor`.
 
-
-
 ### Gotcha: `case` inside `$(…)` breaks macOS `/bin/bash` (3.2.57)
 
 A `run_onchange`/`.chezmoiscripts` shell script (or any repo `.sh`) that nests a `case … esac` **inside a `$(…)` command substitution** must parenthesize every pattern — `(git) … ;;`, not `git) … ;;`. macOS ships GNU bash 3.2.57 (the GPLv2 freeze), whose parser naively counts parens while scanning for the end of `$(…)` and treats the pattern's closing `)` as closing the substitution → `syntax error near unexpected token ';;'` **at parse time** (so it fails even on machines where the code path never executes). Linux/Homebrew bash 5.x parses both forms fine, which is why it survives CI/review and only bites on a real macOS `dots sync`.

--- a/chezmoi/.chezmoiscripts/run_onchange_after_sync-claude-plugins.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/run_onchange_after_sync-claude-plugins.sh.tmpl
@@ -60,14 +60,18 @@ desired_json=$(
             | @tsv' \
         | while IFS="$(printf '\t')" read -r key kind rawpath; do
             [[ -z "$key" ]] && continue
+            # Patterns are parenthesized ("(git)" not "git)") — macOS's stock
+            # /bin/bash (3.2.57) mis-parses an unparenthesized case pattern
+            # inside a $(...) command substitution (its naive paren-counting
+            # sees the pattern's closing ")" as closing the substitution).
             case "$kind" in
-                git) root="$HOME/.cache/ap/plugins/$key" ;;
-                path)
+                (git) root="$HOME/.cache/ap/plugins/$key" ;;
+                (path)
                     # shellcheck disable=SC2088  # literal "~/" expanded below
                     case "$rawpath" in
-                        "~/"*) root="$HOME/${rawpath#"~/"}" ;;
-                        /*)    root="$rawpath" ;;
-                        *)     root="$repo_root/$rawpath" ;;
+                        ("~/"*) root="$HOME/${rawpath#"~/"}" ;;
+                        (/*)    root="$rawpath" ;;
+                        (*)     root="$repo_root/$rawpath" ;;
                     esac
                     ;;
             esac


### PR DESCRIPTION
## Problem

`dots sync` fails on macOS with:

```
sync-claude-plugins.sh: line 65: syntax error near unexpected token `;;'
chezmoi: .chezmoiscripts/sync-claude-plugins.sh: exit status 2
```

`chezmoi apply` exits 2, halting the sync and skipping alphabetically-later `run_onchange` installers.

## Root cause

`chezmoi/.chezmoiscripts/run_onchange_after_sync-claude-plugins.sh.tmpl` (added in #378, first exercised on this sync) nests a `case…esac` **inside a `$(…)` command substitution** with **unparenthesized** patterns (`git) … ;;`). macOS ships GNU bash 3.2.57 (the GPLv2 freeze), whose parser naively counts parens while scanning for the end of `$(…)` and treats the pattern's closing `)` as closing the substitution — a **parse-time** error, so it fails even though the machine reaches the code path. Linux/Homebrew bash 5.x parses both forms, which is why it passed review/CI and only bit on a real macOS `dots sync`.

## Fix

- Parenthesize every case pattern (`(git)`, `(path)`, `("~/"*)`, `(/*)`, `(*)`) in both the outer and nested `case`, with an inline comment explaining the bash-3.2 reason.
- Document the gotcha in `operations/sync-and-chezmoi.md` § Adding a chezmoi file (the repo already dodges it in `modify_settings.json` via the function-call form; this records why).

## Verification

- `bash -n` on the `chezmoi execute-template` output: clean (was `exit 2`).
- `dots sync`: green on two consecutive runs (idempotent); chezmoi + claude sections both clean.
- Repo-wide scan for the same pattern: no other real instances (10 other `case` blocks are top-level; `modify_settings.json` uses the deliberate function-call workaround).
- `just check`: passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)