### PR TITLE
fix(sync): scope plain brew upgrade to formulae so docker-desktop skips sudo

### DIFF
--- a/packages/sync.sh
+++ b/packages/sync.sh
@@ -237,7 +237,14 @@ sync_brew() {
     if [[ "${UPGRADE_MODE:-false}" == "true" ]]; then
         log_info "Upgrading brew packages..."
         brew update </dev/null || log_warning "brew update failed"
-        brew upgrade </dev/null || log_warning "brew upgrade failed"
+        # Formulae only. A bare `brew upgrade` also upgrades any genuinely
+        # outdated cask (no exclude flag), so a `greedy: false` cask like
+        # docker-desktop would be reinstalled here — prompting for sudo/admin —
+        # whenever its installed version lags the cask. Route *all* cask
+        # upgrades through upgrade_casks_greedy instead, which honors the
+        # exclusion list. `brew outdated --cask --greedy-auto-updates` is a
+        # superset of the plain outdated set, so nothing is missed.
+        brew upgrade --formula </dev/null || log_warning "brew upgrade failed"
         # Casks flagged `auto_updates true` (e.g. Cursor) are skipped by a plain
         # `brew upgrade`; --greedy-auto-updates version-checks them and reinstalls
         # only on a diff. Excludes `version :latest` casks (no version to compare,

--- a/tests/packages.bats
+++ b/tests/packages.bats
@@ -668,6 +668,18 @@ MOCKRUSTUP
     grep -q "brew upgrade" "$BREW_LOG"
 }
 
+@test "UPGRADE_MODE plain upgrade is formula-scoped (never touches casks/docker)" {
+    # A bare \`brew upgrade\` also upgrades outdated casks, reinstalling a
+    # greedy:false cask like docker-desktop and prompting for sudo. The plain
+    # pass must be --formula only; all cask upgrades route through the
+    # exclusion-aware greedy pass.
+    write_test_yaml
+    UPGRADE_MODE=true run bash "$SYNC_SCRIPT"
+    assert_success
+    grep -q "brew upgrade --formula" "$BREW_LOG"
+    ! grep -qE "^brew upgrade\$" "$BREW_LOG"
+}
+
 @test "UPGRADE_MODE excludes greedy:false casks (docker-desktop) from greedy upgrade" {
     [[ "$(uname)" == "Darwin" ]] || skip "macOS only (sync_brew not invoked on Linux)"
 


### PR DESCRIPTION
## Problem

Running `dots up` (upgrade mode) intermittently prompted for an admin password to upgrade Docker Desktop, despite docker-desktop being flagged `greedy: false` to avoid exactly that.

## Root cause

The `greedy: false` exclusion only guarded the *greedy* cask pass (`upgrade_casks_greedy`). But the plain `brew upgrade` on the line above upgrades formulae **and any genuinely-outdated cask**. docker-desktop has `auto_updates`, so brew skips it *unless* the installed Caskroom version lags the cask — which happens whenever the app hasn't self-updated. In that state the plain pass reinstalled the cask and triggered the sudo prompt. There is no exclude flag for `brew upgrade`.

## Fix

- Scope the plain pass to `brew upgrade --formula`.
- Route **all** cask upgrades through `upgrade_casks_greedy`, which already honors the exclusion list. `brew outdated --cask --greedy-auto-updates` is a superset of the plain outdated set, so no other cask is missed.

## Test

Added `UPGRADE_MODE plain upgrade is formula-scoped` asserting the plain pass emits `brew upgrade --formula` and never a bare `brew upgrade`. Full `just check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)