### PR TITLE
fix(omp): avoid plugin MCP duplicates

### DIFF
--- a/chezmoi/.chezmoidata/omp.yaml
+++ b/chezmoi/.chezmoidata/omp.yaml
@@ -17,11 +17,14 @@
 # `setupVersion` is machine state, not config: the modify_ script preserves it
 # from the live file and never authors it here.
 #
-# Keep OMP discovery native-only. Each id below is a non-OMP discovery
-# provider that can otherwise import external agent config, MCP servers,
-# commands, skills, hooks, prompts, tools, or settings from another harness.
-# `github` here is the GitHub/Copilot discovery source; it is separate from
-# the OMP `github.enabled` integration flag below.
+# Keep external discovery shut off while leaving OMP-native sources on. Each
+# id below is a non-OMP discovery provider that can import another harness'
+# agent config, MCP servers, commands, skills, hooks, prompts, tools, or
+# settings. Native OMP plugin discovery stays enabled; plugin-owned MCPs
+# therefore must NOT also be listed in dot_omp/private_agent/mcp.json, or OMP
+# exposes both `server` and `plugin:server` namespaces. `github` here is the
+# GitHub/Copilot discovery source; it is separate from the OMP `github.enabled`
+# integration flag below.
 #
 # Gotcha — array settings REPLACE, they don't merge across omp config layers.
 # A project-level .omp/config.yml that sets its own `disabledProviders` list

--- a/chezmoi/dot_omp/private_agent/mcp.json
+++ b/chezmoi/dot_omp/private_agent/mcp.json
@@ -10,20 +10,6 @@
       "env": {
         "CONTEXT7_API_KEY": "${CONTEXT7_API_KEY}"
       }
-    },
-    "hallouminate": {
-      "command": "hallouminate",
-      "args": [
-        "serve"
-      ]
-    },
-    "milknado": {
-      "command": "uvx",
-      "args": [
-        "--from",
-        "git+https://github.com/paulnsorensen/milknado@main",
-        "milknado-mcp"
-      ]
     }
   }
 }

--- a/tests/omp-config.bats
+++ b/tests/omp-config.bats
@@ -119,15 +119,29 @@ STDIN"
     [[ "$output" == *".chezmoidata/omp.yaml"* ]]      # registry path named
 }
 
-@test "omp-mcp: native user config defines requested MCP servers" {
+@test "omp-mcp: native user config keeps only direct MCP servers" {
     local cfg="$REAL_DOTFILES_DIR/chezmoi/dot_omp/private_agent/mcp.json"
-    jq -e '.mcpServers.hallouminate.command == "hallouminate"' "$cfg"
-    jq -e '.mcpServers.hallouminate.args == ["serve"]' "$cfg"
-    jq -e '.mcpServers.milknado.command == "uvx"' "$cfg"
-    jq -e '.mcpServers.milknado.args == ["--from", "git+https://github.com/paulnsorensen/milknado@main", "milknado-mcp"]' "$cfg"
+    local plugin_registry="$REAL_DOTFILES_DIR/agents/plugins/registry.yaml"
     jq -e '.mcpServers.context7.command == "npx"' "$cfg"
     jq -e '.mcpServers.context7.args == ["-y", "@upstash/context7-mcp"]' "$cfg"
     jq -e '.mcpServers.context7.env.CONTEXT7_API_KEY == "${CONTEXT7_API_KEY}"' "$cfg"
+    jq -e '.mcpServers | has("hallouminate") | not' "$cfg"
+    jq -e '.mcpServers | has("milknado") | not' "$cfg"
+
+    # Plugin-owned MCPs arrive through OMP's native plugin discovery as
+    # plugin:server namespaces. Listing the same server here creates duplicate
+    # bare + plugin-prefixed MCP instances.
+    local duplicates
+    duplicates=$(
+        comm -12 \
+            <(jq -r '.mcpServers | keys[]' "$cfg" | sort) \
+            <(yq -r '.plugins | keys | .[]' "$plugin_registry" | sort)
+    )
+    if [ -n "$duplicates" ]; then
+        echo "dot_omp/private_agent/mcp.json duplicates plugin-owned MCP server(s):"
+        printf '%s\n' "$duplicates"
+        return 1
+    fi
 }
 # --- models.yml template↔registry seam -------------------------------------
 # dot_omp/private_agent/models.yml.tmpl authors ~/.omp/agent/models.yml WHOLESALE


### PR DESCRIPTION
## Summary
- remove plugin-owned hallouminate and milknado MCPs from direct OMP mcp.json
- document that OMP native plugin discovery remains enabled beside disabled external providers
- add a regression guard preventing direct MCP server keys from duplicating plugin registry keys

## Verification
- `rtk bash tests/run-tests.sh omp-config.bats`
- targeted `chezmoi apply --source chezmoi ~/.omp/agent/mcp.json`
