### PR TITLE
fix(codex): backfill config safety defaults

### DIFF
--- a/chezmoi/lib/install-codex.sh
+++ b/chezmoi/lib/install-codex.sh
@@ -1,15 +1,80 @@
 #!/bin/bash
 # install-codex.sh — scaffold ~/.codex/ from the dotfiles codex/ source.
 #
-# config.toml is copied only when ~/.codex/config.toml does not exist yet, so
-# user edits in $HOME survive — and `codex mcp add` (driven by
-# agents/mcp/sync.sh) can mutate that same file without chezmoi clobbering its
-# changes on the next sync. Re-bootstrap with `rm ~/.codex/config.toml && dots sync`.
+# config.toml is copied only when ~/.codex/config.toml does not exist yet.
+# Existing files stay user-owned, but this installer backfills missing safety
+# defaults so older configs keep the repo's Codex baseline without clobbering
+# user edits or MCP entries.
 #
 # Usage:
 #   install-codex.sh <source_dir>
 
 set -euo pipefail
+
+codex_config_has() {
+    local expr="$1" file="$2"
+
+    command -v yq >/dev/null 2>&1 || return 1
+    [[ "$(yq -p=toml "$expr // \"\"" "$file" 2>/dev/null)" != "" ]]
+}
+
+codex_prepend_root_defaults() {
+    local file="$1"
+    local defaults=()
+
+    codex_config_has '.approval_policy' "$file" || defaults+=('approval_policy = "on-request"')
+    codex_config_has '.sandbox_mode' "$file" || defaults+=('sandbox_mode = "workspace-write"')
+    ((${#defaults[@]})) || return 0
+
+    local tmp
+    tmp="$(mktemp)"
+    printf '%s\n' "${defaults[@]}" >"$tmp"
+    printf '\n' >>"$tmp"
+    cat "$file" >>"$tmp"
+    mv "$tmp" "$file"
+}
+
+codex_set_table_default() {
+    local file="$1" section="$2" key="$3" value="$4" expr="$5"
+
+    codex_config_has "$expr" "$file" && return 0
+
+    local tmp
+    tmp="$(mktemp)"
+    if grep -q "^[[:space:]]*\\[$section\\][[:space:]]*$" "$file"; then
+        awk -v section="$section" -v line="$key = $value" '
+            $0 ~ "^[[:space:]]*\\[" section "\\][[:space:]]*$" && !done {
+                print
+                print line
+                done = 1
+                next
+            }
+            { print }
+        ' "$file" >"$tmp"
+    else
+        cat "$file" >"$tmp"
+        printf '\n[%s]\n%s = %s\n' "$section" "$key" "$value" >>"$tmp"
+    fi
+    mv "$tmp" "$file"
+}
+
+codex_backfill_config_defaults() {
+    local file="$1"
+
+    command -v yq >/dev/null 2>&1 || {
+        echo "  Skipped Codex defaults backfill (yq not installed)"
+        return 0
+    }
+
+    yq -p=toml -o=toml '.' "$file" >/dev/null || {
+        echo "install-codex.sh: existing config.toml is not parseable TOML" >&2
+        return 1
+    }
+
+    codex_prepend_root_defaults "$file"
+    codex_set_table_default "$file" sandbox_workspace_write network_access true '.sandbox_workspace_write.network_access'
+    codex_set_table_default "$file" tui input_mode '"vim"' '.tui.input_mode'
+}
 
 if (( $# != 1 )); then
     echo "Usage: $0 <source_dir>" >&2
@@ -34,6 +99,7 @@ if [[ -f "$src_config" ]]; then
         cp "$src_config" "$dst_config"
         echo "  Scaffolded ~/.codex/config.toml"
     else
-        echo "  Skipped ~/.codex/config.toml (already exists; user-owned)"
+        echo "  Skipped ~/.codex/config.toml scaffold (already exists; backfilled missing defaults)"
     fi
+    codex_backfill_config_defaults "$dst_config"
 fi

--- a/tests/install-codex.bats
+++ b/tests/install-codex.bats
@@ -1,8 +1,8 @@
 #!/usr/bin/env bats
-# shellcheck disable=SC1090,SC2034,SC2317
-# Tests for chezmoi/lib/install-codex.sh — first-time-only scaffold of
-# ~/.codex/config.toml. Once the user's config exists, the installer leaves
-# it alone so `codex mcp add` (and any user edits) survive subsequent syncs.
+# shellcheck disable=SC1090,SC2030,SC2031,SC2034,SC2317
+# Tests for chezmoi/lib/install-codex.sh — first-time scaffold plus
+# non-destructive default backfill for older user-owned ~/.codex/config.toml
+# files.
 
 load test_helper
 
@@ -37,11 +37,14 @@ teardown() { teardown_test_env; }
     run bash "$INSTALLER" "$SRC_DIR"
     assert_success
     assert_output_contains "Scaffolded"
-    assert_file_exists "$CODEX_HOME/config.toml"
-    grep -q 'model = "gpt-5"' "$CODEX_HOME/config.toml"
+    [[ "$(yq -p=toml '.model' "$CODEX_HOME/config.toml")" == "gpt-5" ]]
+    [[ "$(yq -p=toml '.approval_policy' "$CODEX_HOME/config.toml")" == "on-request" ]]
+    [[ "$(yq -p=toml '.sandbox_mode' "$CODEX_HOME/config.toml")" == "workspace-write" ]]
+    [[ "$(yq -p=toml '.sandbox_workspace_write.network_access' "$CODEX_HOME/config.toml")" == "true" ]]
+    [[ "$(yq -p=toml '.tui.input_mode' "$CODEX_HOME/config.toml")" == "vim" ]]
 }
 
-@test "install-codex.sh preserves an existing user-owned config.toml" {
+@test "install-codex.sh backfills defaults without clobbering existing user config" {
     export CODEX_HOME="$TEST_HOME/.codex"
     mkdir -p "$CODEX_HOME"
     cat > "$CODEX_HOME/config.toml" <<'USER'
@@ -50,14 +53,15 @@ model = "gpt-codex-user"
 [mcp_servers.custom]
 command = "my-tool"
 USER
-    local before; before=$(shasum -a 256 "$CODEX_HOME/config.toml" | awk '{print $1}')
     run bash "$INSTALLER" "$SRC_DIR"
     assert_success
-    assert_output_contains "Skipped"
-    local after; after=$(shasum -a 256 "$CODEX_HOME/config.toml" | awk '{print $1}')
-    [[ "$before" == "$after" ]]
-    grep -q 'gpt-codex-user' "$CODEX_HOME/config.toml"
-    grep -q 'my-tool'        "$CODEX_HOME/config.toml"
+    assert_output_contains "backfilled missing defaults"
+    [[ "$(yq -p=toml '.model' "$CODEX_HOME/config.toml")" == "gpt-codex-user" ]]
+    [[ "$(yq -p=toml '.mcp_servers.custom.command' "$CODEX_HOME/config.toml")" == "my-tool" ]]
+    [[ "$(yq -p=toml '.approval_policy' "$CODEX_HOME/config.toml")" == "on-request" ]]
+    [[ "$(yq -p=toml '.sandbox_mode' "$CODEX_HOME/config.toml")" == "workspace-write" ]]
+    [[ "$(yq -p=toml '.sandbox_workspace_write.network_access' "$CODEX_HOME/config.toml")" == "true" ]]
+    [[ "$(yq -p=toml '.tui.input_mode' "$CODEX_HOME/config.toml")" == "vim" ]]
 }
 
 @test "install-codex.sh honors CODEX_HOME override" {


### PR DESCRIPTION
## Summary
- Backfill missing Codex CLI safety defaults into existing user-owned `~/.codex/config.toml` files.
- Preserve existing user settings and MCP entries while adding missing sandbox/approval defaults.
- Update installer tests to cover the non-destructive backfill path.

## Verification
- `rtk bash -n chezmoi/lib/install-codex.sh`
- `rtk shellcheck chezmoi/lib/install-codex.sh tests/install-codex.bats`
- `rtk bats tests/install-codex.bats tests/install-agents-doc.bats tests/agents-hooks-sync.bats`
- Applied installer locally and verified live `~/.codex/config.toml` now has `approval_policy=on-request`, `sandbox_mode=workspace-write`, `sandbox_workspace_write.network_access=true`, and `tui.input_mode=vim`.