### PR TITLE
feat(skills): add routine-scaffold for Claude Code cloud routines

### DIFF
--- a/chezmoi/.chezmoidata/claude.yaml
+++ b/chezmoi/.chezmoidata/claude.yaml
@@ -226,6 +226,7 @@ claude:
     - nih-audit
     - prompt-analytics
     - rennet
+    - routine-scaffold
     - serena-project-config
     - session-analytics
     - settings-clean

--- a/skills/routine-scaffold/SKILL.md
+++ b/skills/routine-scaffold/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: routine-scaffold
+model: sonnet
+effort: medium
+allowed-tools: Task, Skill, Bash(gh:*), Bash(git:*), mcp__tilth__*
+description: >
+  Author, review, land, and register a Claude Code cloud routine end-to-end —
+  a scheduled or event-triggered cloud agent that opens PRs/issues a human
+  disposes. Use when the user says "make a routine", "schedule a cloud agent",
+  "scaffold a watcher", "set up a recurring automation", "/routine-scaffold", or
+  points at a recipe (drift-watcher, stale-docs, changelog-draft, repo-brief,
+  flaky-test-triage, pr-review-nag). Drives the `coder` and `reviewer` phase
+  agents and hands registration to the cloud-routine registrar (`RemoteTrigger`).
+  Do NOT use for local scheduled tasks (the `create_scheduled_task` /
+  plugin-`schedule` kind) or for one-off code changes (that is `/cook`).
+---
+
+# /routine-scaffold — scaffold a Claude Code cloud routine
+
+Turns "I want a recurring cloud automation" into a landed PR plus a registered
+routine. A **cloud routine** is a scheduled or event-triggered Claude Code agent
+that runs in a hosted environment, reads a version-controlled prompt, and opens
+PRs/issues for a human to dispose — it never merges its own work.
+
+The live `agents/doc-drift/` watcher is the reference pattern this skill
+generalizes. Read [`references/routine-authoring.md`](references/routine-authoring.md),
+[`references/safety.md`](references/safety.md),
+[`references/triggers.md`](references/triggers.md), and
+[`references/schedule-mechanics.md`](references/schedule-mechanics.md) as the
+taught payload; the same rules are baked into the flow's invariants below.
+
+## Args
+
+```text
+/routine-scaffold [<repo>] [--recipe <name>] [--trigger cron <expr> | api | github-event <event>]
+```
+
+- `<repo>` — target repo (path or `owner/name`). Default: the git repo of the
+  current directory. Must be a repo the user owns; artifacts land in its tree.
+- `--recipe <name>` — start from a vetted recipe under
+  [`recipes/`](recipes/): `drift-watcher`, `stale-docs`, `flaky-test-triage`,
+  `changelog-draft`, `repo-brief`, `pr-review-nag`. Omit to author from a blank
+  interview.
+- `--trigger` — trigger type. `cron <expr>` (min interval 1 hour, UTC),
+  `api` (on-demand `RemoteTrigger.run`), or `github-event <event>` (reactive,
+  e.g. `pull_request`). If omitted, the recipe's suggested trigger is offered
+  and the user confirms. See `references/triggers.md`.
+
+## When to use
+
+Use for any recurring or event-driven **cloud** automation that should produce
+reviewable artifacts: dependency/doc drift, stale-doc sweeps, changelog drafts,
+PR-review nags, flaky-test triage, repo briefs.
+
+Do NOT use for:
+
+- **Local scheduled tasks** (`create_scheduled_task`) — that is the plugin
+  `schedule` skill's local-cron kind; this skill is cloud routines only.
+- **A one-off code change** — that is `/cook`.
+- **Registering a hand-written routine with no repo artifacts** — drive the
+  `RemoteTrigger` cloud registrar directly.
+
+## Ambient assumptions
+
+The hosted environment provides (confirm per target, do not hardcode):
+
+- **`gh` GitHub OAuth** — the environment's native auth; no PAT. Cross-repo
+  reach is unconfirmed — verify write access to the target before promising a
+  PR (see Frame, step 3).
+- **Account connectors auto-attach** to any routine created in the environment
+  — Tavily and Context7 are the defaults this skill assumes. Their exact
+  `mcp__<Server>__<tool>` casing is confirmed off the first live run, never
+  guessed (see Register + Verify).
+- **Setup scripts and env vars are supported; custom base images are not.**
+
+## Flow
+
+Six phases. Code writing goes to the `coder` agent, review to `reviewer`,
+registration to the `RemoteTrigger` cloud registrar, landing to `/pr-stack` or
+`gh`.
+
+### 1. Frame
+
+1. **Resolve the target repo.** Default to the cwd git repo
+   (`git rev-parse --show-toplevel`). Confirm it with the user before writing
+   anything. If `<repo>` names another repo, resolve it and confirm.
+2. **Confirm ownership.** The repo must be one the user owns
+   (`gh repo view <owner/name> --json viewerCanAdminister,nameWithOwner`).
+3. **Verify write reach.** Confirm the environment's `gh` OAuth can push a
+   branch and open a PR against the target. If reach is unconfirmed, say so and
+   stop before promising a PR — cross-repo OAuth is a known risk.
+4. **Pick the trigger type** (`cron` / `api` / `github-event`) — see
+   `references/triggers.md`.
+5. **Pick or skip a recipe.** With `--recipe`, load its skeleton from
+   `recipes/<name>.md` and adopt its objective + prompt shape + suggested
+   trigger. Without, interview from scratch.
+6. **Interview for the contract:** the objective, the explicit
+   **success condition**, and the explicit **stop condition** (what "nothing to
+   do" looks like — the routine must exit quietly when it finds nothing).
+
+### 2. Author
+
+Dispatch the **`coder`** phase agent to draft artifacts in the target repo's
+tree, applying `references/routine-authoring.md`:
+
+- `agents/<name>/routine.md` — the committed prompt (single source of truth).
+- When the task is a **scan-and-triage watcher** shape (the doc-drift triad):
+  also scaffold `agents/<name>/sources.yaml` (the data manifest) and
+  `bin/<name>-scan` (a deterministic scanner) **with bats tests** that join the
+  target repo's test suite. The scanner holds all the version/diff math so the
+  routine's judgment stays deterministic and testable.
+
+`coder` returns the file list and confirms the scanner's tests pass locally
+(where the target repo has a runnable suite).
+
+### 3. Review
+
+Dispatch the **`reviewer`** phase agent to check the artifacts against the
+safety + authoring checklist (`references/safety.md`,
+`references/routine-authoring.md`). Reviewer must confirm:
+
+- the never-auto-merge invariant is present in the routine's prompt,
+- stop/idempotency/dedup conditions are explicit,
+- the prompt is self-contained (no reference to an authoring session),
+- evidence-not-inference: the routine acts on scanner/tool output, not guesses.
+
+Loop back to Author on any blocker before landing.
+
+### 4. Land
+
+Open the authoring PR into the target repo — **never a direct push to a default
+branch**. Prefer `/pr-stack` when a stacking tool is present in the target;
+otherwise `gh`. The PR carries the routine.md (+ manifest + scanner + tests when
+present). Do not configure auto-merge.
+
+### 5. Register
+
+Hand off to the **cloud-routine registrar** — the `RemoteTrigger` tool (actions
+`list`/`get`/`create`/`update`/`run`; **no delete**) — to create the routine. Do
+**not** route this to the local-task skill also named `schedule` (the
+`create_scheduled_task` kind): that is the spec non-goal, evaluates cron in local
+time, and cannot register a cloud routine. See `references/schedule-mechanics.md`
+for the disambiguation. Payload:
+
+- **env** — the environment id.
+- **trigger** — the chosen `cron` / `api` / `github-event` config
+  (`references/triggers.md`).
+- **`allowed_tools`** — the connector allowlist as `mcp__<Server>__<tool>`
+  (server segment literal; default connectors Tavily + Context7).
+- **message** — a short **bootstrap**:
+  `read agents/<name>/routine.md and follow it exactly`. The real prompt lives
+  in the committed file; the scheduled message only points at it.
+
+If the `RemoteTrigger` API exposes only cron creation, register cron here and
+note the api/github-event wiring as a manual follow-up (spec open question —
+verify against the `RemoteTrigger` tool before asserting otherwise).
+
+### 6. Verify
+
+Surface to the user:
+
+- the routine link and next-run time,
+- the **connector-casing caveat**: the `mcp__<Server>__<tool>` casing is
+  confirmed off the first live run's granted-tools list; if the run is blocked
+  with `host_not_allowed` / a tool refusal, adjust the allowlist strings and
+  update the routine (see `references/safety.md`).
+
+## Invariants (baked in)
+
+These hold for every routine this skill produces, regardless of recipe:
+
+- **Never auto-merge.** Every routine opens a PR/issue a human disposes. Merge
+  and any follow-on sync stay with the human.
+- **No direct push to a default branch.** Reconciling state advances only inside
+  a PR.
+- **Exit quietly on nothing-to-do.** When the routine finds nothing to act on it
+  produces no output and no artifacts.
+- **One artifact per item; honor dedup.** Watchers check open PRs/issues (and the
+  work branch) before acting.
+- **Evidence, not inference.** The routine acts on scanner/tool output, not on
+  guessed state.
+- **Bootstrap indirection.** The scheduled message is a pointer to the committed
+  `routine.md`; the prompt is version-controlled and edited by normal PRs.
+
+## Agent dispatch contracts
+
+| Phase | Agent / skill | In | Out |
+|---|---|---|---|
+| Author | `coder` | contract + recipe + target tree | file list, scanner tests green |
+| Review | `reviewer` | artifact diff + safety/authoring checklist | severity-grouped findings |
+| Land | `/pr-stack` (or `gh`) | branch + PR body | PR URL |
+| Register | `RemoteTrigger` (cloud registrar — not the local `create_scheduled_task` skill) | env, trigger, allowlist, bootstrap message | routine id + next-run |
+
+Reuse `coder` and `reviewer` — do not define new agent types.
+
+## What you don't do
+
+- No local scheduled tasks — cloud routines only.
+- No auto-merge, ever — human disposes (v1 non-goal).
+- No direct push to a default branch.
+- No owning `RemoteTrigger` registration logic — that stays with the
+  cloud-routine registrar (the `RemoteTrigger` tool / cloud `schedule` skill),
+  never the local `create_scheduled_task` one.
+- No hardcoded connector casing — confirm off the first live run.
+- No `security-advisory-sweep` recipe — research found no vetted source.

--- a/skills/routine-scaffold/SKILL.md
+++ b/skills/routine-scaffold/SKILL.md
@@ -2,7 +2,7 @@
 name: routine-scaffold
 model: sonnet
 effort: medium
-allowed-tools: Task, Skill, Bash(gh:*), Bash(git:*), mcp__tilth__*
+allowed-tools: Task, Skill, RemoteTrigger, Bash(gh:*), Bash(git:*), mcp__tilth__*
 description: >
   Author, review, land, and register a Claude Code cloud routine end-to-end —
   a scheduled or event-triggered cloud agent that opens PRs/issues a human

--- a/skills/routine-scaffold/recipes/changelog-draft.md
+++ b/skills/routine-scaffold/recipes/changelog-draft.md
@@ -1,0 +1,38 @@
+# Recipe: changelog-draft
+
+Draft (never publish) release notes from the Conventional Commits since the last
+tag, and open a PR that adds the draft to `CHANGELOG.md` for a human to edit and
+ship.
+
+- **Shape:** prompt-only (no scanner/manifest — reads git history directly).
+- **Suggested trigger:** `cron` — weekly or pre-release cadence, e.g.
+  `0 16 * * 5` (Fri 16:00 UTC); or `api` to run before cutting a release.
+- **Connectors:** `gh` / `git`; Context7 only if external references need docs.
+
+## Objective
+
+Turn the commits since the last release tag into a grouped changelog draft and
+open a PR — the human edits and releases; the routine never tags or publishes.
+
+## Prompt skeleton
+
+```text
+You are the changelog-draft routine for <repo>. Draft release notes since the
+last tag and open a PR.
+
+1. Find the last release tag (git describe --tags --abbrev=0) and the commits
+   since it. If there are no releasable commits, exit quietly.
+2. Group commits by Conventional Commit type (feat / fix / perf / ... ); flag
+   breaking changes. Draft a grouped changelog section with a proposed version
+   (do not decide the final version authoritatively — propose it).
+3. Open a PR that prepends the draft to CHANGELOG.md (create the file if absent).
+   Title: `docs(changelog): draft notes since <last-tag>`.
+   Never tag, never publish a release, never push to a default branch directly.
+4. Report the proposed version and PR link.
+```
+
+## Review checklist
+
+- Draft only — no tag, no release publish.
+- Version is proposed, not asserted final.
+- Exit-quiet when there are no releasable commits.

--- a/skills/routine-scaffold/recipes/drift-watcher.md
+++ b/skills/routine-scaffold/recipes/drift-watcher.md
@@ -30,7 +30,8 @@ exactly one artifact per drifted item.
 You are the orchestrator for <repo>'s drift routine. Detect drift between
 watched upstreams and our config, then triage and act on each drift.
 
-1. Ensure the tracking label exists (idempotent): gh label create <name> ... || true
+1. Ensure the tracking label exists (idempotent, but surface real failures):
+   gh label list --search <name> | grep -q <name> || gh label create <name> ...
 2. Run bin/<name>-scan; parse its JSON. Take items where .drifted == true.
    If none, exit quietly — no output, no artifacts.
 3. Dispatch one subagent per drifted item (parallel; file-disjoint). Each:

--- a/skills/routine-scaffold/recipes/drift-watcher.md
+++ b/skills/routine-scaffold/recipes/drift-watcher.md
@@ -1,0 +1,54 @@
+# Recipe: drift-watcher
+
+The reference pattern — watch external upstreams whose docs/releases govern your
+config, detect drift, and triage each into a PR or an issue. Generalizes the live
+`agents/doc-drift/` watcher.
+
+- **Shape:** scan-and-triage watcher (the full triad).
+- **Suggested trigger:** `cron` — e.g. `0 8 * * 1,4` (Mon + Thu 08:00 UTC).
+- **Connectors:** Tavily (release notes / changelogs) + Context7 (config / API
+  docs).
+
+## Artifacts to scaffold
+
+1. `agents/<name>/sources.yaml` — the watched sources: each with an `id`, a
+   `signal` (how to resolve current state, e.g. `npm view` / `gh release`), the
+   files it `governs`, and a `reconciled` marker (last version a human folded in).
+2. `bin/<name>-scan` — resolves each source's current version, compares to
+   `reconciled`, emits JSON per source (`{id, current, drifted, status}`).
+   Deterministic; fails loud on an unknown signal type. Ship bats tests.
+3. `agents/<name>/routine.md` — the orchestrator prompt below.
+
+## Objective
+
+Detect drift between watched upstreams and our config; triage each drift and open
+exactly one artifact per drifted item.
+
+## Prompt skeleton
+
+```text
+You are the orchestrator for <repo>'s drift routine. Detect drift between
+watched upstreams and our config, then triage and act on each drift.
+
+1. Ensure the tracking label exists (idempotent): gh label create <name> ... || true
+2. Run bin/<name>-scan; parse its JSON. Take items where .drifted == true.
+   If none, exit quietly — no output, no artifacts.
+3. Dispatch one subagent per drifted item (parallel; file-disjoint). Each:
+   - Dedup: if an open PR/issue or branch <name>/<id>-<current> covers it, report `dup`.
+   - Read the change via Tavily (release notes) + Context7 (docs); read the
+     governs files directly.
+   - Classify: no-op | small | large/idea.
+   - Act: no-op/small -> PR (bump the reconciled marker; small also edits governs);
+     large/idea -> GH issue (no bump). Never a direct push to a default branch.
+4. Print a one-line summary per item.
+
+Invariants: never auto-merge; reconciled advances only inside a PR; one artifact
+per item; subagents are file-disjoint.
+```
+
+## Review checklist
+
+- Scanner has tests and fails loud on unknown signals.
+- `reconciled` bumped only inside a PR.
+- Dedup checks open PRs/issues and the branch.
+- Never-auto-merge invariant present.

--- a/skills/routine-scaffold/recipes/flaky-test-triage.md
+++ b/skills/routine-scaffold/recipes/flaky-test-triage.md
@@ -1,0 +1,38 @@
+# Recipe: flaky-test-triage
+
+Watch recent CI runs for tests that fail intermittently, cluster them by test,
+and open an issue per flaky test (never a silent skip or auto-quarantine).
+
+- **Shape:** scan-and-triage watcher over CI history.
+- **Suggested trigger:** `cron` — daily, e.g. `0 7 * * *` (07:00 UTC), or
+  `github-event` on `workflow_run` completion for reactive triage.
+- **Connectors:** `gh` (CI runs / logs); Context7 for test-framework docs.
+
+## Objective
+
+Identify tests that pass and fail without a code change (flaky), and file one
+tracked issue per flaky test with the failure evidence — never quarantine or skip
+a test automatically.
+
+## Prompt skeleton
+
+```text
+You are the flaky-test-triage routine for <repo>. Find intermittently failing
+tests and file a tracked issue per flaky test.
+
+1. Ensure label `flaky-test` exists (idempotent).
+2. Pull recent CI runs (gh run list / gh run view --log). Identify tests that
+   both passed and failed across runs on the same commit range (flaky signal).
+   If none, exit quietly.
+3. Cluster failures by test id. Dedup against open `flaky-test` issues.
+4. For each new flaky test, open an issue: the test id, the failing runs, the
+   error signature, and how often it flaked. Do NOT edit tests, skip, or
+   quarantine — a human decides the fix.
+5. Print a one-line summary per test.
+```
+
+## Review checklist
+
+- Flaky classification rests on observed pass+fail on the same code, not a guess.
+- Issues only — no test edits, skips, or quarantines.
+- Dedup against existing issues; exit-quiet on clean.

--- a/skills/routine-scaffold/recipes/pr-review-nag.md
+++ b/skills/routine-scaffold/recipes/pr-review-nag.md
@@ -1,0 +1,38 @@
+# Recipe: pr-review-nag
+
+Watch open PRs and nag on the ones that have stalled — no review, failing CI, or
+sitting past an age threshold — with a single idempotent comment per PR. The
+reactive recipe: `github-event` shines here.
+
+- **Shape:** scan-and-triage over open PRs (lightweight; no manifest/scanner
+  needed — `gh` is the data source).
+- **Suggested trigger:** `github-event` on `pull_request` for react-on-open, or
+  `cron` (e.g. `0 */6 * * *`, every 6h — respects the 1h floor) for a sweep.
+- **Connectors:** `gh`.
+
+## Objective
+
+Surface stalled PRs (no review, red CI, or aged past a threshold) with one
+idempotent nudge comment each — never merge, never close, never change code.
+
+## Prompt skeleton
+
+```text
+You are the pr-review-nag routine for <repo>. Nudge stalled open PRs.
+
+1. List open PRs (gh pr list --json number,title,reviews,statusCheckRollup,
+   updatedAt). Classify each: awaiting-review | ci-red | stale (aged past
+   <threshold>). If none qualify, exit quietly.
+2. For each qualifying PR, check for an existing nag comment (a marker string in
+   the PR's comments). If already nagged for this state, skip — one nudge per
+   state, not per run.
+3. Post a single comment: what's blocking it and the suggested next step.
+   Never merge, close, approve, request changes, or edit code.
+4. Report a one-line summary per PR.
+```
+
+## Review checklist
+
+- Idempotent: one comment per PR per state (marker-checked), not per run.
+- Comment-only — no merge / close / approve / code change.
+- Exit-quiet when nothing qualifies.

--- a/skills/routine-scaffold/recipes/repo-brief.md
+++ b/skills/routine-scaffold/recipes/repo-brief.md
@@ -1,0 +1,37 @@
+# Recipe: repo-brief
+
+Produce a periodic digest of what changed in the repo — merged PRs, new issues,
+notable diffs, dependency moves — and open an issue (or update a pinned tracking
+issue) with the brief. Read-only against code; the only artifact is the brief.
+
+- **Shape:** prompt-only (reads git/gh history; no scanner/manifest).
+- **Suggested trigger:** `cron` — weekly, e.g. `0 15 * * 1` (Mon 15:00 UTC).
+- **Connectors:** `gh` / `git`; Tavily/Context7 only if the brief cites external
+  context.
+
+## Objective
+
+Summarize the repo's recent activity into a readable brief and post it as an
+issue, so the maintainer gets a standing digest without auto-changing anything.
+
+## Prompt skeleton
+
+```text
+You are the repo-brief routine for <repo>. Produce a weekly activity digest.
+
+1. Ensure label `repo-brief` exists (idempotent).
+2. Collect the last window's activity: merged PRs, opened/closed issues, notable
+   commits, dependency changes (gh pr list --state merged, gh issue list, git
+   log). If nothing meaningful happened, exit quietly.
+3. Write a concise brief: what shipped, what's open and stalling, notable diffs,
+   anything that needs attention. Evidence-linked (PR/issue/commit refs).
+4. Post it as a new issue, or update the pinned `repo-brief` tracking issue.
+   Never change code, never open a PR, never auto-merge anything.
+5. Report the issue link.
+```
+
+## Review checklist
+
+- Read-only against code — the brief is the only artifact.
+- Every claim links to a PR/issue/commit (evidence, not inference).
+- Exit-quiet on a dead week.

--- a/skills/routine-scaffold/recipes/stale-docs.md
+++ b/skills/routine-scaffold/recipes/stale-docs.md
@@ -1,0 +1,42 @@
+# Recipe: stale-docs
+
+Scan the repo's docs for staleness — references to renamed/removed files,
+commands, or symbols that no longer exist — and open a PR (small fixes) or issue
+(judgment calls) per cluster.
+
+- **Shape:** scan-and-triage watcher (lightweight — a scanner helps but the
+  manifest can be a glob set).
+- **Suggested trigger:** `cron` — weekly, e.g. `0 9 * * 1` (Mon 09:00 UTC).
+- **Connectors:** Context7 (for external tool/API references) + repo file reads.
+
+## Objective
+
+Find docs that reference things that no longer exist (moved files, removed
+flags/commands, renamed symbols) and reconcile each with a PR or flag it with an
+issue.
+
+## Prompt skeleton
+
+```text
+You are the stale-docs routine for <repo>. Find docs whose references have gone
+stale and reconcile them.
+
+1. Ensure label `stale-docs` exists (idempotent).
+2. Scan docs (README, docs/, wiki, *.md) for references to repo paths, commands,
+   or symbols. For each referenced path/command/symbol, verify it still exists
+   (git ls-files, --help output, code search). Collect broken references.
+   If none, exit quietly.
+3. Group broken references by doc. Dedup against open PRs/issues.
+4. Act per group:
+   - Mechanical fix (path/name update) -> PR.
+   - Ambiguous (needs a human's intent) -> issue with the evidence.
+   Never a direct push to a default branch; never auto-merge.
+5. Print a one-line summary per doc.
+```
+
+## Review checklist
+
+- Verification is evidence-based (the reference actually resolves or not), not a
+  guess.
+- Ambiguous rewrites become issues, not silent edits.
+- Dedup present; exit-quiet on clean.

--- a/skills/routine-scaffold/references/routine-authoring.md
+++ b/skills/routine-scaffold/references/routine-authoring.md
@@ -1,0 +1,76 @@
+# Routine authoring — how to write a routine prompt that behaves
+
+The routine prompt (`agents/<name>/routine.md` in the target repo) is the single
+source of truth. The scheduled message only says "read it and follow it
+exactly," so everything the routine needs lives here. It runs cold in a hosted
+environment with no memory of the authoring session.
+
+## Self-contained prompt
+
+The prompt must stand alone:
+
+- Never reference "this session," "the above," or any ephemeral context — a
+  future run has none of it.
+- State the objective, the exact steps, every file path / URL / tool name, the
+  success criteria, and the stop condition inline.
+- Write in second-person imperative: "Run the scanner…", "Open a PR…".
+
+## Explicit stop conditions
+
+A routine that cannot decide when to do nothing will manufacture busywork.
+
+- Name what "nothing to do" looks like (empty scanner result, no matching PRs,
+  no drift).
+- On that condition, **exit quietly** — no output, no artifacts, no PR.
+- The Acceptance case is literal: when a routine finds nothing to act on, its
+  authored prompt makes it exit silently.
+
+## Evidence, not inference
+
+Act on observed tool output, never on a guess about repo state.
+
+- Push deterministic math (version diffs, counts, date windows) into a
+  committed, tested scanner — not the model's head. The routine parses the
+  scanner's JSON; it does not eyeball versions.
+- Research via connectors (Tavily for web/release notes, Context7 for library /
+  API / config docs) to *judge impact*, then read the governed files directly
+  before acting.
+
+## Idempotency and dedup
+
+Runs overlap and repeat; the routine must not stack duplicate artifacts.
+
+- Before acting on an item, search open PRs/issues **and** the work branch
+  (`<name>/<item>-<current>`) for existing coverage; if found, report `dup` and
+  stop for that item.
+- Store the last-reconciled marker as a committed field that advances **only
+  inside a merged PR**, so drift keeps surfacing until a human disposes it.
+
+## File-disjoint fan-out
+
+When a routine processes several independent items, fan one subagent per item so
+each item's reading and reasoning stays in its own context window:
+
+- Give each subagent exactly one item plus the data it needs.
+- Keep subagents **file-disjoint** — each touches only its own governed files and
+  its own line in the manifest (git merges the per-line updates); never another
+  item's files or branch.
+- If subagent dispatch is unavailable in the environment, process items
+  sequentially in the same context — the per-item logic is identical.
+
+## The scan-and-triage triad (watcher shape)
+
+The doc-drift watcher is the worked example. When the task is a watcher, scaffold
+all three:
+
+1. **Data manifest** (`agents/<name>/sources.yaml`) — what to watch, the signal
+   to resolve it, the files each item governs, and the reconciled marker.
+2. **Deterministic scanner** (`bin/<name>-scan`) — resolves current state,
+   compares to the marker, emits JSON (`{id, current, drifted, status}`), with
+   bats tests in the target's suite. Fail loud on an unknown signal type.
+3. **Routine prompt** (`agents/<name>/routine.md`) — runs the scanner, triages
+   each drifted item (no-op / small / large-idea → PR / PR / issue), fans out
+   per item, honors the invariants.
+
+Not every routine is a watcher — a changelog-draft or repo-brief needs only the
+prompt. Scaffold the manifest + scanner only for scan-and-triage shapes.

--- a/skills/routine-scaffold/references/safety.md
+++ b/skills/routine-scaffold/references/safety.md
@@ -61,6 +61,9 @@ allowlist did not admit that tool:
 
 ## Label / track
 
-Give each routine a tracking label (e.g. `gh label create <name>`) so its
-artifacts are filterable and dedup can find prior work. Create it idempotently
-(`|| true`) at the top of the routine.
+Give each routine a tracking label so its artifacts are filterable and dedup can
+find prior work. Create it idempotently at the top of the routine, but ignore
+*only* the already-exists case so real auth/permission failures still surface —
+e.g. `gh label list --search <name> | grep -q <name> || gh label create <name>`.
+A blanket `|| true` would swallow those failures silently, violating the
+fail-fast posture this document exists to enforce.

--- a/skills/routine-scaffold/references/safety.md
+++ b/skills/routine-scaffold/references/safety.md
@@ -1,0 +1,66 @@
+# Routine safety — the invariants and how to hold them
+
+A cloud routine runs unattended with write access. These are the safety rules the
+skill bakes into every routine and the `reviewer` phase checks before landing.
+
+## Never auto-merge; the human disposes
+
+The converging safety default across every independent source reviewed
+(matplotlib, ITK, camel-ai, Voyfai, and Chainguard's own gate): the routine
+opens a PR or issue; a human reviews, merges, and runs any follow-on sync.
+
+- Auto-merge is an explicit **v1 non-goal**. Do not configure it, even opt-in.
+- The documented Chainguard exception (auto-merge behind a separate,
+  deterministic non-LLM approver + green CI) needs infra most repos lack and is
+  single-source-cited — out of scope for v1, revisitable later.
+
+## No direct push to a default branch
+
+Any state the routine advances (a reconciled marker, a version bump, a changelog
+entry) advances **only inside a PR**. The routine never pushes to `main` /
+`master` directly.
+
+## Scoped write access
+
+The routine writes only what its task needs:
+
+- Its own artifact files and its own branch (`<name>/<item>-<ref>`).
+- In fan-out, each subagent is file-disjoint — never another item's files.
+- Confirm the environment's `gh` OAuth actually reaches the target repo before
+  promising a PR. Cross-repo OAuth reach is unconfirmed; verify per target with
+  `gh repo view <owner/name> --json viewerCanAdminister`.
+
+## Allowlist gating
+
+Connectors are gated by the routine's `allowed_tools` list. A tool the routine
+needs but the allowlist omits is refused at run time.
+
+- Reference MCP tools as `mcp__<Server>__<tool>` — the server segment is a
+  literal connector name (e.g. `mcp__Tavily__*`, `mcp__Context7__*`; casing
+  illustrative only — confirm off the first live run, below).
+- Grant only the connectors the routine actually uses.
+
+## Connector-casing verification
+
+The exact casing of `mcp__<Server>__<tool>` is **not confirmed by docs** — it is
+confirmed off the first live run's granted-tools list.
+
+- Do not hardcode a casing guess as final.
+- After the first run, read the granted-tools list; if the run was blocked, the
+  allowlist casing is the first suspect.
+
+## 403 `host_not_allowed` troubleshooting
+
+A connector call blocked with `host_not_allowed` (or a tool refusal) means the
+allowlist did not admit that tool:
+
+1. Check the `allowed_tools` casing against the run's granted-tools list.
+2. Confirm the connector is actually attached to the environment.
+3. Update the routine's allowlist and re-run; the committed `routine.md` is
+   unchanged — only the registration's allowlist moves.
+
+## Label / track
+
+Give each routine a tracking label (e.g. `gh label create <name>`) so its
+artifacts are filterable and dedup can find prior work. Create it idempotently
+(`|| true`) at the top of the routine.

--- a/skills/routine-scaffold/references/schedule-mechanics.md
+++ b/skills/routine-scaffold/references/schedule-mechanics.md
@@ -1,8 +1,9 @@
 # Schedule mechanics — the RemoteTrigger / environment model
 
 How a cloud routine is registered and what the hosted environment gives it. This
-is the knowledge the Register phase hands to `/schedule`; the source of truth for
-registration logic is the `/schedule` skill itself.
+is the knowledge the Register phase hands to the cloud-routine registrar — the
+`RemoteTrigger` tool (equivalently the cloud `schedule` skill that wraps it), not
+a bare `/schedule`; see the disambiguation below.
 
 Reference: <https://code.claude.com/docs/en/routines>,
 <https://code.claude.com/docs/en/settings> (allowlist prefix).

--- a/skills/routine-scaffold/references/schedule-mechanics.md
+++ b/skills/routine-scaffold/references/schedule-mechanics.md
@@ -1,0 +1,90 @@
+# Schedule mechanics — the RemoteTrigger / environment model
+
+How a cloud routine is registered and what the hosted environment gives it. This
+is the knowledge the Register phase hands to `/schedule`; the source of truth for
+registration logic is the `/schedule` skill itself.
+
+Reference: <https://code.claude.com/docs/en/routines>,
+<https://code.claude.com/docs/en/settings> (allowlist prefix).
+
+## Routines are RemoteTrigger cloud agents
+
+- A **routine** is a scheduled/event-triggered cloud agent registered against the
+  claude.ai remote-trigger API, driven by the **`RemoteTrigger`** tool. Its
+  actions are `list` / `get` / `create` / `update` / `run` — there is genuinely
+  **no delete** action (verified against the tool's own schema, not inferred).
+- This skill owns authoring + review + landing the PR; the **cloud-routine**
+  registrar owns creating and updating the RemoteTrigger. Do not duplicate
+  registration logic here.
+
+### Disambiguate the registrar — two skills are both named `schedule`
+
+The Register hand-off MUST land on the **cloud-routine** registrar, not the
+similarly-named local-task skill:
+
+- **Cloud routines (this skill's target):** the `RemoteTrigger` tool (equivalently
+  the built-in *cloud* `schedule` skill that drives it). Runs in a hosted
+  **environment** (`env_…`), evaluates cron in **UTC**, and takes an
+  `allowed_tools` allowlist plus trigger config.
+- **Local scheduled tasks (the spec non-goal — do NOT use):** the plugin skill
+  *also* named `schedule`, which calls the **`create_scheduled_task`** tool. It
+  runs locally, evaluates cron in **local time**, and has no environment /
+  `allowed_tools` / `github-event`. Registering a cloud routine through it is
+  wrong.
+
+Because a bare `/schedule` is ambiguous between the two, Register drives cloud
+registration via the `RemoteTrigger` tool explicitly — never the local
+`create_scheduled_task` skill. (The session-only `CronCreate` / `CronList` /
+`CronDelete` tools are in-memory job timers for *this* session, not cloud
+routines — do not confuse them with registration either.)
+
+## Environment model
+
+- **Environment id** — the routine runs in a named hosted environment (`env_…`).
+- **`gh` auth** — the environment's native GitHub OAuth; no PAT. Cross-repo reach
+  is unconfirmed — verify per target.
+- **Supported extension points:** cached **setup scripts** and **env vars**.
+- **Not supported:** custom base images / devcontainers for cloud routines.
+
+## Connector auto-attach
+
+Account connectors auto-attach to any routine created in the environment (Tavily,
+Context7, and others). The skill assumes Tavily + Context7 are present as the
+default research connectors.
+
+- The routine still only gets the connectors named in its `allowed_tools`.
+- Reference each as `mcp__<Server>__<tool>` — the `<Server>` segment is a literal
+  connector name. Casing is confirmed off the first live run (see
+  `safety.md`), not guessed.
+
+## The bootstrap-message pattern
+
+The routine's scheduled message is **not** the prompt — it is a short bootstrap
+that points at the committed prompt:
+
+```text
+read agents/<name>/routine.md and follow it exactly
+```
+
+- The real prompt lives in `agents/<name>/routine.md`, version-controlled and
+  edited by normal PRs — one source of truth.
+- Updating the routine's behavior is a PR to that file, not a registration edit.
+- The registration changes only when the trigger, env, or allowlist changes.
+
+## Registration payload (handed to `/schedule`)
+
+```yaml
+trigger: cron | api | github-event   # see triggers.md
+env: <environment id>
+allowed_tools: [mcp__<Server>__<tool>, ...]   # default: Tavily + Context7
+message: "read agents/<name>/routine.md and follow it exactly"
+```
+
+## Known unknowns
+
+- **Numeric limits** (daily cap / concurrency / per-run timeout) — the docs'
+  "Usage and limits" section did not render in research; do not assert a number
+  until confirmed.
+- **api / github-event creation via `RemoteTrigger`** — confirm the
+  cloud-routine registrar exposes these trigger kinds before wiring them; it may
+  support only cron creation today.

--- a/skills/routine-scaffold/references/triggers.md
+++ b/skills/routine-scaffold/references/triggers.md
@@ -33,8 +33,8 @@ structurally cannot express.
 
 - Use for: review-every-PR nags, label-on-open, react-to-release.
 - Example event: `pull_request` (opened / synchronized).
-- `<speculative>` on our end-to-end wiring — validate against `/schedule` and the
-  first live event before asserting it works.
+- `<speculative>` on our end-to-end wiring — validate against the `RemoteTrigger`
+  registrar and the first live event before asserting it works.
 
 ## Choosing
 
@@ -45,6 +45,6 @@ structurally cannot express.
 | "every time a PR opens", "on release" | `github-event` |
 
 Combine when a routine needs both a cadence and a reaction (e.g. a nightly sweep
-plus an on-PR check). Confirm `/schedule` exposes creation for the api and
-github-event kinds before wiring them — it may support only cron creation today
-(spec open question).
+plus an on-PR check). Confirm the `RemoteTrigger` registrar exposes creation for
+the api and github-event kinds before wiring them — it may support only cron
+creation today (spec open question).

--- a/skills/routine-scaffold/references/triggers.md
+++ b/skills/routine-scaffold/references/triggers.md
@@ -1,0 +1,50 @@
+# Triggers — cron, api, github-event
+
+Claude Code routines take three combinable trigger types. All three are
+first-class in this skill; only `cron` is battle-tested by us, so the api and
+github-event wiring rests on Claude Code docs, not our own live run — flag that
+uncertainty when you use them.
+
+Reference: <https://code.claude.com/docs/en/routines>
+
+## cron — scheduled, time-driven
+
+The battle-tested path. Fires on a schedule.
+
+- **Minimum interval: 1 hour.** Sub-hourly cron is rejected.
+- **Timezone: UTC** for the routine cron expression (distinct from `/schedule`'s
+  local-cron kind, which evaluates in local time).
+- Use for: doc/dependency drift sweeps, weekly repo briefs, changelog drafts on a
+  cadence, stale-doc scans.
+- Example: `0 8 * * 1,4` — Mon + Thu 08:00 UTC.
+
+## api — on-demand
+
+No schedule; the routine runs when `RemoteTrigger.run` invokes it.
+
+- Use for: automations you want to fire manually or from an external caller, not
+  on a clock.
+- No cron expression; register with an api trigger and invoke on demand.
+
+## github-event — reactive
+
+Fires in response to a GitHub event, unlocking reactive routines that cron
+structurally cannot express.
+
+- Use for: review-every-PR nags, label-on-open, react-to-release.
+- Example event: `pull_request` (opened / synchronized).
+- `<speculative>` on our end-to-end wiring — validate against `/schedule` and the
+  first live event before asserting it works.
+
+## Choosing
+
+| Want | Trigger |
+|---|---|
+| "every Monday", "hourly", "nightly" | `cron` |
+| "when I ask", "from a script" | `api` |
+| "every time a PR opens", "on release" | `github-event` |
+
+Combine when a routine needs both a cadence and a reaction (e.g. a nightly sweep
+plus an on-PR check). Confirm `/schedule` exposes creation for the api and
+github-event kinds before wiring them — it may support only cron creation today
+(spec open question).


### PR DESCRIPTION
## What

A local dotfiles skill `/routine-scaffold` that authors, reviews, PRs, and registers a Claude Code **cloud** routine end-to-end — codifying the routine best-practices knowledge that was previously re-derived from scratch each time (env/connector model, `allowed_tools` allowlist prefix, cron floor, committed-prompt + bootstrap indirection, never-auto-merge safety).

Spec: `routine-scaffold` (durable corpus).

## Shape

- **Six-phase flow** — Frame → Author → Review → Land → Register → Verify. Delegates code writing to the `coder` agent, checks to `reviewer`, registration to the `RemoteTrigger` cloud registrar (via `/schedule`), landing to `/pr-stack` or `gh`.
- **Taught payload** (`references/`) — `routine-authoring.md`, `safety.md`, `triggers.md`, `schedule-mechanics.md`.
- **Recipe library** (`recipes/`) — drift-watcher, stale-docs, flaky-test-triage, changelog-draft, repo-brief, pr-review-nag.
- **All three trigger types** first-class: `cron`, `api`, `github-event`.
- **Never auto-merges** — human disposes every generated PR (converging safety default).
- Listed in `chezmoi/.chezmoidata/claude.yaml` selected skills.

## Verification

- `just check` exits 0 (lint + 1067-test suite; `agent-skill-model-effort.bats` now covers `routine-scaffold` 7/7).
- `dots sync` applies cleanly; markdownlint clean on all 11 new files; internal doc links resolve.
- Reviewed via the ultracook chain (cook → press → age → cure → age); one medium correctness finding fixed (disambiguated the cloud `RemoteTrigger` registrar from the local `create_scheduled_task` `/schedule` skill), re-confirmed clean at the medium+ floor.

## Known caveats

- api/github-event trigger mechanics are docs-only, untested by us — the skill flags this rather than asserting it.
- Connector-name casing (`mcp__<Server>__<tool>`) is illustrative; the skill instructs reading it off the first live run's granted-tools list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)