### PR TITLE
feat(sync): wire tilth cwd-injection hook durably on dots sync (#389)

### DIFF
--- a/.sync
+++ b/.sync
@@ -59,6 +59,7 @@ run_sync() {
 
     install_tpm
     install_prek_hooks
+    install_tilth_claude_code
 
     unset DOTFILES_DEV
 

--- a/.sync-lib.sh
+++ b/.sync-lib.sh
@@ -417,3 +417,16 @@ install_prek_hooks() {
       log_info "  $line"
     done
 }
+
+# Wire tilth's cwd-injection PreToolUse hook (drops the current inject-cwd.js
+# script; the hook wiring itself is registry-authored in claude.yaml)
+install_tilth_claude_code() {
+    if ! command -v tilth &>/dev/null; then
+        log_warning "tilth not installed, skipping claude-code hook wiring"
+        return 0
+    fi
+    log_info "Wiring tilth cwd-injection hook (tilth install claude-code)..."
+    tilth install claude-code 2>&1 | while read -r line; do
+        log_info "  $line"
+    done
+}

--- a/chezmoi/.chezmoidata/claude.yaml
+++ b/chezmoi/.chezmoidata/claude.yaml
@@ -37,6 +37,8 @@ claude:
     tilth:
       command: tilth
       args: ["--mcp", "--edit"]
+      env:
+        TILTH_MCP_CWD_HOOK_INJECTED: "1"
     context7:
       command: npx
       args: ["-y", "@upstash/context7-mcp"]
@@ -87,6 +89,10 @@ claude:
           - type: command
             command: '"$HOME/.claude/hooks/deep-think-nudge.sh"'
             timeout: 5
+      - matcher: "mcp__tilth__.*"
+        hooks:
+          - type: command
+            command: node "${HOME}/.claude/tilth/inject-cwd.js"
     SessionStart:
       - hooks:
           - type: command

--- a/tests/chezmoi-wiring.bats
+++ b/tests/chezmoi-wiring.bats
@@ -441,13 +441,18 @@ EOF
         [[ "$(yq -r ".claude | has(\"$key\")" "$reg")" == "true" ]] \
             || { echo "claude.yaml missing section: $key" >&2; return 1; }
     done
-    # No plaintext secrets: every mcp env value must be a ${VAR} passthrough.
-    run yq -r '.claude.mcps[].env // {} | .[]' "$reg"
+    # No plaintext secrets: every mcp env value must be a ${VAR} passthrough,
+    # except the named marker key TILTH_MCP_CWD_HOOK_INJECTED (tilth's "1"
+    # flag, which can never carry a secret) -- mirrors the named-allowlist
+    # exemption used for inject-cwd.js below.
+    run yq -r '.claude.mcps[].env // {} | to_entries[] | .["key"] + "=" + (.["value"]|tostring)' "$reg"
     local line
     while IFS= read -r line; do
         [[ -z "$line" ]] && continue
+        [[ "$line" == "TILTH_MCP_CWD_HOOK_INJECTED=1" ]] && continue
+        local val="${line#*=}"
         # shellcheck disable=SC2016  # literal ${ } passthrough form, not expansion
-        [[ "$line" == '${'*'}' ]] || { echo "non-passthrough mcp env value: $line" >&2; return 1; }
+        [[ "$val" == '${'*'}' ]] || { echo "non-passthrough mcp env value: $line" >&2; return 1; }
     done <<<"$output"
 }
 
@@ -477,14 +482,22 @@ EOF
     # claude/hooks + agents/hooks — a wired script missing from both would
     # break every session after apply. Check both the $HOME-pathed script and
     # relative *.js runner args.
+    #
+    # inject-cwd.js is exempt: it's dropped into ~/.claude/tilth/ by
+    # `tilth install claude-code` (a post-chezmoi sync step, not exact_hooks),
+    # so it never lives in claude/hooks or agents/hooks.
     command -v yq >/dev/null 2>&1 || skip "yq not installed"
     local reg="$REAL_DOTFILES_DIR/chezmoi/.chezmoidata/claude.yaml"
-    local tok script found
+    local -a exempt_scripts=("inject-cwd.js")
+    local tok script found ex
     while IFS= read -r tok; do
         [[ -z "$tok" ]] && continue
         # shellcheck disable=SC2013,SC2016  # word-split is intended; regex is a literal
         for script in $(grep -oE '(\$HOME/\.claude/hooks/)?[A-Za-z0-9_-]+\.(js|sh)' <<<"$tok"); do
             script="${script##*/}"
+            for ex in "${exempt_scripts[@]}"; do
+                [[ "$script" == "$ex" ]] && continue 2
+            done
             found=false
             [[ -f "$REAL_DOTFILES_DIR/claude/hooks/$script" ]] && found=true
             [[ -f "$REAL_DOTFILES_DIR/agents/hooks/$script" ]] && found=true

--- a/tests/chezmoi-wiring.bats
+++ b/tests/chezmoi-wiring.bats
@@ -456,6 +456,29 @@ EOF
     done <<<"$output"
 }
 
+@test "claude registry: tilth cwd-inject hook uses \${HOME} braces, not \$HOME" {
+    # The authored command must byte-match what `tilth install claude-code`
+    # writes (an absolute expanded path), which modify_settings.json produces
+    # only from ${HOME} (braces, author-time expansion). A regression to
+    # $HOME (matching sibling hooks) would silently reintroduce oscillation.
+    command -v yq >/dev/null 2>&1 || skip "yq not installed"
+    local reg="$REAL_DOTFILES_DIR/chezmoi/.chezmoidata/claude.yaml"
+    local cmd
+    cmd=$(yq -r '.claude.hooks.PreToolUse[] | select(.matcher == "mcp__tilth__.*") | .hooks[0].command' "$reg")
+    [[ -n "$cmd" && "$cmd" != "null" ]] \
+        || { echo "no PreToolUse entry with matcher mcp__tilth__.*" >&2; return 1; }
+    # shellcheck disable=SC2016  # literal ${HOME} form, byte-matched not expanded
+    [[ "$cmd" == 'node "${HOME}/.claude/tilth/inject-cwd.js"' ]] \
+        || { echo "tilth cwd hook command drifted: $cmd" >&2; return 1; }
+}
+
+@test "claude registry: tilth MCP env carries the cwd-hook-injected marker" {
+    command -v yq >/dev/null 2>&1 || skip "yq not installed"
+    local reg="$REAL_DOTFILES_DIR/chezmoi/.chezmoidata/claude.yaml"
+    [[ "$(yq -r '.claude.mcps.tilth.env.TILTH_MCP_CWD_HOOK_INJECTED' "$reg")" == "1" ]] \
+        || { echo "claude.yaml mcps.tilth.env.TILTH_MCP_CWD_HOOK_INJECTED missing or not \"1\"" >&2; return 1; }
+}
+
 @test "claude registry: selected skills and agents resolve to real repo sources" {
     # A registry entry naming a skill/agent that no longer exists in the repo
     # would fail every `dots sync` at assembly time. Catch it in CI first.

--- a/tests/tilth-claude-code-hook.bats
+++ b/tests/tilth-claude-code-hook.bats
@@ -1,0 +1,43 @@
+#!/usr/bin/env bats
+# Tests for install_tilth_claude_code (.sync-lib.sh) — the post-chezmoi sync
+# step that drops the always-current ~/.claude/tilth/inject-cwd.js script via
+# `tilth install claude-code` (issue #389: hook wiring itself is
+# registry-authored in chezmoi/.chezmoidata/claude.yaml).
+
+load test_helper
+
+setup() {
+    setup_test_env
+    export MOCK_BIN="$TEST_HOME/bin"
+    mkdir -p "$MOCK_BIN"
+}
+
+teardown() { teardown_test_env; }
+
+run_install_tilth() {
+    PATH="$MOCK_BIN:/usr/bin:/bin" run bash -c "source '$REAL_DOTFILES_DIR/.sync-lib.sh' && install_tilth_claude_code"
+}
+
+@test "install_tilth_claude_code invokes tilth install claude-code when tilth is present" {
+    export TILTH_CALLS="$TEST_HOME/tilth-calls.log"
+    cat > "$MOCK_BIN/tilth" <<SH
+#!/bin/bash
+printf '%s\n' "\$*" >> "$TILTH_CALLS"
+exit 0
+SH
+    chmod +x "$MOCK_BIN/tilth"
+
+    run_install_tilth
+    assert_success
+    assert_file_exists "$TILTH_CALLS"
+    grep -qx "install claude-code" "$TILTH_CALLS"
+}
+
+@test "install_tilth_claude_code skips and warns when tilth is absent" {
+    export TILTH_CALLS="$TEST_HOME/tilth-calls.log"
+
+    run_install_tilth
+    assert_success
+    assert_output_contains "tilth not installed, skipping claude-code hook wiring"
+    [[ ! -f "$TILTH_CALLS" ]]
+}


### PR DESCRIPTION
Closes #389.

## What

`tilth install claude-code` (tilth PR #118) writes three surfaces, but two of them collide with this repo's chezmoi-authoritative model: `~/.claude/settings.json` and the `~/.claude.json` MCP entry are authored **wholesale** from `chezmoi/.chezmoidata/claude.yaml` on every `dots sync`, so an out-of-band `tilth install` write gets clobbered on the next sync.

So the hook wiring + MCP env are **registry-authored** (durable, survive bare `chezmoi apply`), and `tilth install claude-code` runs post-apply on sync purely to drop the always-current `~/.claude/tilth/inject-cwd.js` script (an unmanaged subtree — survives apply, tracks the binary, no vendoring drift).

## Changes

- **`chezmoi/.chezmoidata/claude.yaml`** — `mcps.tilth` gains `env: { TILTH_MCP_CWD_HOOK_INJECTED: "1" }`; new `hooks.PreToolUse` entry for `mcp__tilth__.*` → `node "${HOME}/.claude/tilth/inject-cwd.js"`. The `${HOME}` **braces** are deliberate: `modify_settings.json` expands them at author time so the authored path byte-matches what `tilth install` writes, preventing settings.json oscillation between the two writers.
- **`.sync-lib.sh`** — new `install_tilth_claude_code()`, guarded + best-effort (mirrors `install_prek_hooks`).
- **`.sync`** — invokes it after `install_prek_hooks` (post chezmoi apply, so the script lands after the registry hook that references it).
- **Tests** — new `tests/tilth-claude-code-hook.bats` (present/absent coverage); `tests/chezmoi-wiring.bats` gains narrowly-scoped named exemptions (`inject-cwd.js`, `TILTH_MCP_CWD_HOOK_INJECTED`) plus two locking invariants (the `${HOME}`-brace command form, verified to fail on a `$HOME` regression; and the MCP env marker presence).

## Not done (per the issue)

The marketplace-plugin hook path is left untouched — enabling both would wire the hook twice.

## Verification

- `dots sync` ran clean end-to-end on a live machine; `install_tilth_claude_code` fired and `~/.claude/settings.json` PreToolUse carries the expanded entry byte-matching `tilth install`'s own write.
- `just check`: exit 0 — `tests/run-tests.sh` 1071/1071, shellcheck/ruff/eslint/markdownlint clean.

## Residual note

On this host the MCP-reconcile `run_onchange` script did not visibly re-fire inside the first `dots sync` after the registry hash changed (manual `claude_mcp_reconcile` confirmed `~/.claude.json` picks up the new `env`). Looks like a chezmoi apply-state quirk, not a defect in this diff — worth a sanity check on the next post-registry-change sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)