### PR TITLE
fix(sync): re-reconcile claude MCPs after tilth install to preserve --edit

### DIFF
--- a/.sync
+++ b/.sync
@@ -60,6 +60,7 @@ run_sync() {
     install_tpm
     install_prek_hooks
     install_tilth_claude_code
+    reconcile_claude_mcps
 
     unset DOTFILES_DEV
 

--- a/.sync-lib.sh
+++ b/.sync-lib.sh
@@ -425,8 +425,40 @@ install_tilth_claude_code() {
         log_warning "tilth not installed, skipping claude-code hook wiring"
         return 0
     fi
-    log_info "Wiring tilth cwd-injection hook (tilth install claude-code)..."
-    tilth install claude-code 2>&1 | while read -r line; do
+    log_info "Wiring tilth cwd-injection hook (tilth install claude-code --edit)..."
+    tilth install claude-code --edit 2>&1 | while read -r line; do
+        log_info "  $line"
+    done
+}
+
+# Re-reconcile user-scope claude MCPs as the FINAL write of every sync.
+#
+# WHY unconditional (unlike the hash-gated run_onchange reconcile):
+# install_tilth_claude_code runs `tilth install claude-code`, which rewrites the
+# tilth entry in ~/.claude.json with tilth's OWN defaults (no --edit, no env,
+# absolute command path) — clobbering the registry-authoritative shape. The
+# chezmoi run_onchange reconcile only fires when the registry `mcps` hash
+# changes, so it can't heal this. Running the reconcile here restores the
+# registry shape after every tilth install. It's idempotent, so already-correct
+# entries are no-ops.
+reconcile_claude_mcps() {
+    local lib="$dir/chezmoi/lib/claude-mcp-reconcile.sh"
+    if ! command -v claude &>/dev/null || ! command -v yq &>/dev/null || [[ ! -f "$lib" ]]; then
+        log_warning "Skipping claude MCP reconcile (claude, yq, or reconcile lib missing)"
+        return 0
+    fi
+
+    log_info "Reconciling claude MCPs (restore registry shape after tilth install)..."
+    # shellcheck source=chezmoi/lib/claude-mcp-reconcile.sh
+    source "$lib"
+
+    local mcps_json
+    mcps_json=$(yq -o=json '.claude.mcps' "$dir/chezmoi/.chezmoidata/claude.yaml")
+
+    claude_mcp_reconcile \
+        "$mcps_json" \
+        "$HOME/.claude.json" \
+        "$HOME/.claude/.chezmoi-mcp-manifest" 2>&1 | while read -r line; do
         log_info "  $line"
     done
 }

--- a/tests/reconcile-claude-mcps.bats
+++ b/tests/reconcile-claude-mcps.bats
@@ -1,0 +1,106 @@
+#!/usr/bin/env bats
+# Behavioural test for reconcile_claude_mcps() in .sync-lib.sh — the
+# unconditional MCP reconcile that runs as the FINAL write of every `dots sync`,
+# healing the tilth ~/.claude.json entry after `tilth install claude-code`
+# clobbers it (drops the registry-authored --edit / env). Because the chezmoi
+# run_onchange reconcile is hash-gated (only fires when the registry mcps block
+# changes), it cannot undo that clobber; this function does, every sync.
+#
+# The `claude` CLI is mocked with a recorder that also applies add-json / remove
+# mutations to the fixture ~/.claude.json, so the reconcile flow behaves like
+# the real CLI (same pattern as tests/claude-mcp-reconcile.bats).
+
+load test_helper
+
+setup() {
+    setup_test_env
+    command -v jq >/dev/null 2>&1 || skip "jq not installed"
+    command -v yq >/dev/null 2>&1 || skip "yq not installed"
+
+    export LIB="$REAL_DOTFILES_DIR/.sync-lib.sh"
+    export CJ="$TEST_HOME/.claude.json"
+    export MANIFEST="$TEST_HOME/.claude/.chezmoi-mcp-manifest"
+    export CALLS="$TEST_HOME/claude-calls.log"
+
+    # Mock claude CLI: records argv; applies add-json/remove to $CJ.
+    local fake_bin="$TEST_HOME/fake-bin"
+    mkdir -p "$fake_bin"
+    cat > "$fake_bin/claude" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$CALLS"
+case "$1 $2" in
+    "mcp add-json")
+        name="$3"; json="$4"
+        jq --arg n "$name" --argjson v "$json" '.mcpServers[$n] = $v' "$CJ" > "$CJ.tmp" \
+            && mv "$CJ.tmp" "$CJ"
+        ;;
+    "mcp remove")
+        name="$3"
+        jq --arg n "$name" 'del(.mcpServers[$n])' "$CJ" > "$CJ.tmp" && mv "$CJ.tmp" "$CJ"
+        ;;
+esac
+exit 0
+SH
+    chmod +x "$fake_bin/claude"
+    export PATH="$fake_bin:$PATH"
+
+    # Fixture dotfiles root the function reads via $dir: the real reconcile lib
+    # plus a minimal claude registry whose tilth entry carries --edit.
+    export FIX="$TEST_HOME/fixture-dotfiles"
+    mkdir -p "$FIX/chezmoi/lib" "$FIX/chezmoi/.chezmoidata"
+    cp "$REAL_DOTFILES_DIR/chezmoi/lib/claude-mcp-reconcile.sh" "$FIX/chezmoi/lib/"
+    cat > "$FIX/chezmoi/.chezmoidata/claude.yaml" <<'YAML'
+claude:
+  mcps:
+    tilth:
+      command: tilth
+      args: ["--mcp", "--edit"]
+      env:
+        TILTH_MCP_CWD_HOOK_INJECTED: "1"
+YAML
+}
+
+teardown() { teardown_test_env; }
+
+@test "reconcile_claude_mcps: restores --edit after a tilth install clobber" {
+    # Clobbered shape: tilth entry as `tilth install claude-code` rewrites it —
+    # no --edit, no env, absolute command path.
+    jq -n '{mcpServers: {tilth: {type:"stdio", command:"/usr/local/bin/tilth", args:["--mcp"], env:{}}}}' > "$CJ"
+    mkdir -p "${MANIFEST%/*}"
+    printf 'tilth\n' > "$MANIFEST"
+
+    run bash -c "dir='$FIX'; source '$LIB'; reconcile_claude_mcps"
+    [ "$status" -eq 0 ]
+
+    # Drift detected → registry shape re-applied: --edit is back.
+    jq -e '.mcpServers.tilth.args | index("--edit")' "$CJ" >/dev/null
+    [ "$(jq -r '.mcpServers.tilth.command' "$CJ")" = "tilth" ]
+    [ "$(jq -r '.mcpServers.tilth.env.TILTH_MCP_CWD_HOOK_INJECTED' "$CJ")" = "1" ]
+    grep -q "mcp add-json tilth" "$CALLS"
+}
+
+@test "reconcile_claude_mcps: no-ops when the tilth entry already matches the registry" {
+    # Already-correct shape (env keys sorted as jq stores them): reconcile must
+    # not remove/re-add — idempotent final write.
+    jq -n '{mcpServers: {tilth: {type:"stdio", command:"tilth", args:["--mcp","--edit"], env:{TILTH_MCP_CWD_HOOK_INJECTED:"1"}}}}' > "$CJ"
+    mkdir -p "${MANIFEST%/*}"
+    printf 'tilth\n' > "$MANIFEST"
+
+    run bash -c "dir='$FIX'; source '$LIB'; reconcile_claude_mcps"
+    [ "$status" -eq 0 ]
+    ! grep -q "mcp add-json tilth" "$CALLS"
+    ! grep -q "mcp remove tilth" "$CALLS"
+}
+
+@test "reconcile_claude_mcps: skips (returns 0) when claude CLI is missing" {
+    jq -n '{mcpServers: {tilth: {type:"stdio", command:"/usr/local/bin/tilth", args:["--mcp"], env:{}}}}' > "$CJ"
+    # PATH with the tools the function needs EXCEPT claude, so its guard trips.
+    local minimal="$TEST_HOME/minimal-bin"
+    mkdir -p "$minimal"
+    for t in bash yq jq sed; do
+        ln -s "$(command -v $t)" "$minimal/$t" 2>/dev/null || true
+    done
+    run bash -c "PATH='$minimal' bash -c \"dir='$FIX'; source '$LIB'; reconcile_claude_mcps\""
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Skipping claude MCP reconcile"* ]]
+}

--- a/tests/tilth-claude-code-hook.bats
+++ b/tests/tilth-claude-code-hook.bats
@@ -18,7 +18,7 @@ run_install_tilth() {
     PATH="$MOCK_BIN:/usr/bin:/bin" run bash -c "source '$REAL_DOTFILES_DIR/.sync-lib.sh' && install_tilth_claude_code"
 }
 
-@test "install_tilth_claude_code invokes tilth install claude-code when tilth is present" {
+@test "install_tilth_claude_code invokes tilth install claude-code --edit when tilth is present" {
     export TILTH_CALLS="$TEST_HOME/tilth-calls.log"
     cat > "$MOCK_BIN/tilth" <<SH
 #!/bin/bash
@@ -30,7 +30,7 @@ SH
     run_install_tilth
     assert_success
     assert_file_exists "$TILTH_CALLS"
-    grep -qx "install claude-code" "$TILTH_CALLS"
+    grep -qx "install claude-code --edit" "$TILTH_CALLS"
 }
 
 @test "install_tilth_claude_code skips and warns when tilth is absent" {


### PR DESCRIPTION
## Problem

`dots sync` deploys the tilth MCP server **without `--edit`**, so `mcp__tilth__tilth_write` is unavailable and `cheez-write` breaks every session.

**Root cause:** the tilth entry in `~/.claude.json` is authored in the registry (`chezmoi/.chezmoidata/claude.yaml`) as `args: ["--mcp","--edit"]` + a cwd-injection env. The chezmoi MCP reconcile sets it correctly — but it's `run_onchange` (hash-gated: only fires when the registry `mcps` block changes). Then `install_tilth_claude_code()` runs **later** in the sync, shelling out to `tilth install claude-code`, which rewrites the entry with tilth's own defaults (no `--edit`, no env, absolute command path) — clobbering the reconcile. Every `dots sync` re-clobbers.

## Fix (two parts)

1. **`tilth install claude-code --edit`** — the installer supports `--edit` (*"Enable edit mode (whole-file-tag output + tilth_write tool)"*); request it at the source.
2. **`reconcile_claude_mcps()`** — a new step in `.sync` called immediately after the install, running the authoritative `claude_mcp_reconcile` **unconditionally** (unlike the hash-gated `run_onchange`) to restore the full registry shape (`--edit` + cwd env + canonical command) as the final write of every sync. Idempotent — already-correct entries no-op.

## Tests

- New `tests/reconcile-claude-mcps.bats` (3): restores `--edit` after a simulated clobber, no-ops when already-correct, skips when `claude` missing (red→green confirmed).
- Updated `tests/tilth-claude-code-hook.bats` assertion for the `--edit` install invocation.
- `just check`: exit 0 — 0 lint errors, 1074 tests pass.

## Note

Codex is unaffected by this clobber (nothing rewrites `~/.codex/config.toml`'s MCP table), but its tilth `--edit` is not in the checked-in seed — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)