### PR TITLE
fix(codex): seed tilth --edit in the codex config so it reproduces

### DIFF
--- a/codex/config.toml
+++ b/codex/config.toml
@@ -1,7 +1,8 @@
 # Codex CLI base configuration. chezmoi installs this to ~/.codex/config.toml
-# only on first run — subsequent edits in $HOME survive, and `codex mcp add`
-# (driven by agents/mcp/sync.sh) writes server entries directly into this
-# file without going through chezmoi.
+# on first run only; subsequent edits in $HOME survive. MCP servers are seeded
+# directly from this file — the old agents/mcp/sync.sh path is retired and no
+# longer runs under `dots sync`, so install-codex.sh copies this seed once and
+# preserves existing MCP entries thereafter.
 #
 # Reference: https://developers.openai.com/codex/config-reference
 
@@ -14,6 +15,13 @@ sandbox_mode = "workspace-write"
 # an absolute path — TOML does not expand `~`, so we cannot bake it into this
 # seed file. The same script keeps ~/.codex/preamble.md in sync with
 # agents/preamble.md.
+
+# tilth code-intelligence MCP. `--edit` enables the tilth_write tool (edit
+# mode); without it tilth is read-only and cheez-write breaks. Seeded here
+# directly since the agents/mcp registry sync that once populated it is retired.
+[mcp_servers.tilth]
+command = "tilth"
+args = ["--mcp", "--edit"]
 
 [sandbox_workspace_write]
 network_access = true

--- a/tests/config-validation.bats
+++ b/tests/config-validation.bats
@@ -23,6 +23,25 @@ DOTFILES_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME}")/.." && pwd)"
     [[ $status -eq 0 ]]
 }
 
+# ── Codex ───────────────────────────────────────────────────────────────────
+
+@test "codex config seed is valid TOML" {
+    local config="$DOTFILES_DIR/codex/config.toml"
+    [[ -f "$config" ]] || skip "codex config seed not found"
+    run yq '.' "$config" -p toml -o json
+    [[ $status -eq 0 ]]
+}
+
+@test "codex config seed registers tilth in edit mode (--edit)" {
+    # Reproducibility guard: the agents/mcp sync that once populated
+    # ~/.codex/config.toml is retired, so this seed is the only source of tilth
+    # on a fresh setup. Without --edit tilth is read-only and cheez-write breaks.
+    local config="$DOTFILES_DIR/codex/config.toml"
+    [[ -f "$config" ]] || skip "codex config seed not found"
+    [[ "$(yq -p=toml '.mcp_servers.tilth.command' "$config")" == "tilth" ]]
+    yq -p=toml '.mcp_servers.tilth.args[]' "$config" | grep -qx -- '--edit'
+}
+
 # ── Shell scripts ─────────────────────────────────────────────────────────────
 
 @test "all zsh config files have valid syntax" {


### PR DESCRIPTION
## Problem

On a fresh machine, codex would get **no tilth MCP at all** (hence no `tilth_write` / `cheez-write`). The seed `codex/config.toml` had no `[mcp_servers.*]` entry, and the `agents/mcp` registry sync that once populated `~/.codex/config.toml` is **retired** (no longer runs under `dots sync`). So the live tilth entry on existing machines is an orphan with no source-of-truth backing — not reproducible.

Unlike Claude (fixed in #393), codex has **no live-clobber bug** — nothing rewrites `~/.codex/config.toml`'s MCP table after first scaffold. This is purely the reproducibility gap.

## Fix

- Add `[mcp_servers.tilth]` with `args = ["--mcp", "--edit"]` to the seed `codex/config.toml`, so a fresh `install-codex.sh` scaffold gets tilth in edit mode.
- Correct the stale comment that still claims `agents/mcp/sync.sh` populates this file.
- Two `config-validation.bats` guards: the seed is valid TOML, and it registers tilth with `--edit`.

## Note

The seed is copied only on first run, so existing machines are unaffected (their live tilth `--edit` already works). Codex's other orphaned live MCPs (`context7`, `tavily`, `serena`, `milknado`) have the same source-of-truth gap — out of scope here, flagged for a follow-up.

`just check`: exit 0 — 0 lint errors, 1073 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)