### PR TITLE
fix(rectangle): auto-reload keymap and warn on missing Accessibility

### DIFF
--- a/rectangle/lib.sh
+++ b/rectangle/lib.sh
@@ -71,7 +71,8 @@ rectangle_write_shortcuts() {
 # No-op when the app is not running (nothing to reload) or not installed.
 rectangle_restart() {
     pkill -9 -f "Rectangle Pro" 2>/dev/null || return 0
-    open -a "Rectangle Pro" 2>/dev/null || true
+    open "$RECTANGLE_APP" 2>/dev/null || \
+        echo "rectangle/.sync: killed Rectangle Pro but relaunch failed - launch it manually to load the keymap" >&2
 }
 
 rectangle_sync() {
@@ -80,7 +81,7 @@ rectangle_sync() {
         return 0
     fi
     if ! [[ -d "$RECTANGLE_APP" ]]; then
-        echo "rectangle/.sync: Rectangle Pro not installed at /Applications - skipping" >&2
+        echo "rectangle/.sync: Rectangle Pro not installed at $RECTANGLE_APP - skipping" >&2
         echo "                install via: brew install --cask rectangle-pro" >&2
         return 0
     fi

--- a/rectangle/lib.sh
+++ b/rectangle/lib.sh
@@ -12,6 +12,7 @@
 # Key codes are macOS virtual key codes (NSEvent keyCode).
 
 : "${RECTANGLE_BUNDLE:=com.knollsoft.Hookshot}"
+: "${RECTANGLE_APP:=/Applications/Rectangle Pro.app}"
 
 # Emit the shortcut table, one "command|keyCode|modifierFlags" per line.
 rectangle_shortcuts() {
@@ -64,20 +65,33 @@ rectangle_write_shortcuts() {
     killall cfprefsd 2>/dev/null || true
 }
 
+# Hard-restart Rectangle Pro so it loads the freshly-written keymap. A graceful
+# `osascript quit` lets the running app flush its in-memory prefs over our
+# external writes on exit, so kill it outright (pkill -9) instead, then relaunch.
+# No-op when the app is not running (nothing to reload) or not installed.
+rectangle_restart() {
+    pkill -9 -f "Rectangle Pro" 2>/dev/null || return 0
+    open -a "Rectangle Pro" 2>/dev/null || true
+}
+
 rectangle_sync() {
     if [[ "$(uname -s)" != "Darwin" ]]; then
         echo "rectangle/.sync: skipping (not macOS)" >&2
         return 0
     fi
-    if ! [[ -d "/Applications/Rectangle Pro.app" ]]; then
+    if ! [[ -d "$RECTANGLE_APP" ]]; then
         echo "rectangle/.sync: Rectangle Pro not installed at /Applications - skipping" >&2
         echo "                install via: brew install --cask rectangle-pro" >&2
         return 0
     fi
 
     rectangle_write_shortcuts "$RECTANGLE_BUNDLE"
+    rectangle_restart
 
-    echo "rectangle/.sync: wrote SizeUp keymap to $RECTANGLE_BUNDLE - restart Rectangle Pro to load"
-    echo "rectangle/.sync: VERIFY manually - 'defaults read $RECTANGLE_BUNDLE leftHalf', then confirm" >&2
-    echo "                 Rectangle Pro honors it (plist-dict string schema is unverified off-macOS)" >&2
+    echo "rectangle/.sync: wrote SizeUp keymap to $RECTANGLE_BUNDLE and reloaded Rectangle Pro"
+    # Accessibility is macOS-gated and cannot be granted from a script. If snapping
+    # does nothing, the grant is missing (fresh install, app/OS update, or a
+    # tccutil reset can drop the app from the list) - make that loud, not silent.
+    echo "rectangle/.sync: shortcuts need Accessibility permission - if snapping does nothing, grant it:" >&2
+    echo "                 System Settings > Privacy & Security > Accessibility > enable Rectangle Pro" >&2
 }

--- a/tests/rectangle.bats
+++ b/tests/rectangle.bats
@@ -64,7 +64,8 @@ EOF
     run rectangle_restart
     [ "$status" -eq 0 ]
     grep -q 'pkill -9 -f Rectangle Pro' "$MOCK_LOG"
-    grep -q 'open -a Rectangle Pro' "$MOCK_LOG"
+    # relaunch honors $RECTANGLE_APP (not a hardcoded app name)
+    grep -qF "open $RECTANGLE_APP" "$MOCK_LOG"
 }
 
 @test "rectangle_restart is a no-op (no relaunch) when app is not running" {
@@ -74,6 +75,19 @@ EOF
     [ "$status" -eq 0 ]
     # pkill found nothing -> we must NOT open (would spawn an unwanted instance)
     ! grep -q '^open ' "$MOCK_LOG"
+}
+
+@test "rectangle_restart warns loudly when relaunch fails after a kill" {
+    # open exits non-zero (e.g. bundle missing at $RECTANGLE_APP) -> must be loud, not swallowed
+    cat > "$MOCK_BIN/open" <<EOF
+#!/usr/bin/env bash
+printf 'open %s\n' "\$*" >> "$MOCK_LOG"
+exit 1
+EOF
+    chmod +x "$MOCK_BIN/open"
+    source "$LIB"
+    run rectangle_restart
+    [[ "$output" == *"relaunch failed"* ]]
 }
 
 # ── rectangle_sync guards ──
@@ -106,7 +120,7 @@ EOF
     grep -q 'defaults write com.knollsoft.Hookshot leftHalf' "$MOCK_LOG"
     # reloaded so the keymap actually takes effect
     grep -q 'pkill -9 -f Rectangle Pro' "$MOCK_LOG"
-    grep -q 'open -a Rectangle Pro' "$MOCK_LOG"
+    grep -qF "open $RECTANGLE_APP" "$MOCK_LOG"
     # the silent-failure guidance the whole fix exists for
     [[ "$output" == *"Accessibility"* ]]
     [[ "$output" == *"enable Rectangle Pro"* ]]

--- a/tests/rectangle.bats
+++ b/tests/rectangle.bats
@@ -1,0 +1,119 @@
+#!/usr/bin/env bats
+# shellcheck disable=SC1090  # `source "$LIB"` is a runtime path, not a const
+# Tests for rectangle/lib.sh — Rectangle Pro shortcut sync.
+#
+# The sync writes the SizeUp keymap via `defaults`, then hard-restarts the app
+# so the keymap actually loads, and prints an Accessibility notice (the grant is
+# macOS-gated and cannot be scripted). Externals (defaults / pkill / open /
+# killall / uname) are mocked on $PATH; the app-install check is redirected via
+# $RECTANGLE_APP so the Darwin path runs without Rectangle Pro installed.
+
+load test_helper
+
+LIB="$REAL_DOTFILES_DIR/rectangle/lib.sh"
+
+setup() {
+    MOCK_BIN="$(mktemp -d)"
+    export PATH="$MOCK_BIN:$PATH"
+    export MOCK_LOG="$MOCK_BIN/calls.log"
+    : > "$MOCK_LOG"
+
+    # Record-only mocks for every external the sync shells out to.
+    for tool in defaults pkill open killall; do
+        cat > "$MOCK_BIN/$tool" <<EOF
+#!/usr/bin/env bash
+printf '%s %s\n' "$tool" "\$*" >> "$MOCK_LOG"
+exit 0
+EOF
+        chmod +x "$MOCK_BIN/$tool"
+    done
+
+    # Default: pretend we are on macOS with the app installed.
+    _mock_uname Darwin
+    APP_DIR="$(mktemp -d)/Rectangle Pro.app"
+    mkdir -p "$APP_DIR"
+    export RECTANGLE_APP="$APP_DIR"
+}
+
+teardown() {
+    rm -rf "$MOCK_BIN" "${APP_DIR%/*}"
+}
+
+_mock_uname() {
+    cat > "$MOCK_BIN/uname" <<EOF
+#!/usr/bin/env bash
+echo "$1"
+EOF
+    chmod +x "$MOCK_BIN/uname"
+}
+
+# pkill exits non-zero when no process matches; make restart's no-op path testable.
+_mock_pkill_nomatch() {
+    cat > "$MOCK_BIN/pkill" <<EOF
+#!/usr/bin/env bash
+printf 'pkill %s\n' "\$*" >> "$MOCK_LOG"
+exit 1
+EOF
+    chmod +x "$MOCK_BIN/pkill"
+}
+
+# ── rectangle_restart ──
+
+@test "rectangle_restart hard-kills with pkill -9 then relaunches" {
+    source "$LIB"
+    run rectangle_restart
+    [ "$status" -eq 0 ]
+    grep -q 'pkill -9 -f Rectangle Pro' "$MOCK_LOG"
+    grep -q 'open -a Rectangle Pro' "$MOCK_LOG"
+}
+
+@test "rectangle_restart is a no-op (no relaunch) when app is not running" {
+    _mock_pkill_nomatch
+    source "$LIB"
+    run rectangle_restart
+    [ "$status" -eq 0 ]
+    # pkill found nothing -> we must NOT open (would spawn an unwanted instance)
+    ! grep -q '^open ' "$MOCK_LOG"
+}
+
+# ── rectangle_sync guards ──
+
+@test "rectangle_sync skips on non-macOS and writes nothing" {
+    _mock_uname Linux
+    source "$LIB"
+    run rectangle_sync
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"skipping (not macOS)"* ]]
+    ! grep -q '^defaults ' "$MOCK_LOG"
+}
+
+@test "rectangle_sync skips when Rectangle Pro is not installed" {
+    export RECTANGLE_APP="/nonexistent/Rectangle Pro.app"
+    source "$LIB"
+    run rectangle_sync
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"not installed"* ]]
+    ! grep -q '^defaults ' "$MOCK_LOG"
+}
+
+# ── rectangle_sync happy path ──
+
+@test "rectangle_sync writes the keymap, restarts, and prints the Accessibility notice" {
+    source "$LIB"
+    run rectangle_sync
+    [ "$status" -eq 0 ]
+    # keymap written
+    grep -q 'defaults write com.knollsoft.Hookshot leftHalf' "$MOCK_LOG"
+    # reloaded so the keymap actually takes effect
+    grep -q 'pkill -9 -f Rectangle Pro' "$MOCK_LOG"
+    grep -q 'open -a Rectangle Pro' "$MOCK_LOG"
+    # the silent-failure guidance the whole fix exists for
+    [[ "$output" == *"Accessibility"* ]]
+    [[ "$output" == *"enable Rectangle Pro"* ]]
+}
+
+@test "rectangle_sync no longer tells the user to restart manually" {
+    source "$LIB"
+    run rectangle_sync
+    [[ "$output" != *"restart Rectangle Pro to load"* ]]
+}


### PR DESCRIPTION
Closes #394.

## Problem

`rectangle/.sync` wrote the SizeUp keymap to `com.knollsoft.Hookshot` but two gaps made shortcuts silently not work:

1. **Keymap never loaded** — the sync wrote the plist and flushed `cfprefsd` but only *told* the user to restart Rectangle Pro. A running instance kept its stale/empty bindings until a manual relaunch.
2. **No Accessibility signal** — Rectangle Pro needs macOS Accessibility permission to move windows. When the grant is missing (fresh install, app/OS update, or a `tccutil reset` can drop the app from the list), every shortcut does nothing and the sync said nothing about it.

## Fix

- `rectangle_restart` — hard-restart via `pkill -9 -f "Rectangle Pro"` + `open -a` after writing the keymap, so it loads automatically. A hard kill (not a graceful `osascript quit`) prevents the running app from clobbering the just-written plist on exit. No-op when the app isn't running.
- `rectangle_sync` — calls `rectangle_restart` and prints a clear Accessibility notice pointing at `System Settings → Privacy & Security → Accessibility → enable Rectangle Pro`. The grant is macOS-gated and can't be scripted, so the fix makes the requirement loud instead of silent.
- Parameterized the install check via `$RECTANGLE_APP` so the Darwin path is testable off a real install.

## Tests

New `tests/rectangle.bats` (6 tests, externals mocked on `$PATH`): restart hard-kills then relaunches; restart is a no-op when not running; sync skips on non-macOS and when uninstalled; sync writes the keymap + restarts + prints the Accessibility notice; sync no longer tells the user to restart manually.

`just check` green (the one flaky failure was a pre-existing load-sensitive timing assertion in `local-llm.bats`, unrelated to this diff — passes 3/3 in isolation).