### PR TITLE
feat(tmux): swap jmux for tmux-claude-session-manager

### DIFF
--- a/agent-profile/tests/test_claude_legacy_hook_cleanup.py
+++ b/agent-profile/tests/test_claude_legacy_hook_cleanup.py
@@ -157,9 +157,9 @@ def test_moshi_duplicate_stripped_across_events(tmp_path: Path) -> None:
 
 def test_tmux_stop_hook_preserved(tmp_path: Path) -> None:
     # A user-authored Stop hook the registry does NOT manage (@claude-stopped)
-    # must survive self-heal. NB: the @jmux-attention Stop hook IS registry-
-    # managed now (agents/hooks/registry.yaml), so it is deliberately not used
-    # as the example here — using it would model a managed hook as user-owned.
+    # must survive self-heal. NB: `moshi-stop` IS the registry-managed Stop hook
+    # (agents/hooks/registry.yaml), so it is deliberately not used as the
+    # example here — using it would model a managed hook as user-owned.
     settings = _render(tmp_path)
     data = json.loads(settings.read_text())
     assert len(data["hooks"]["Stop"]) == 1

--- a/bin/linux-install
+++ b/bin/linux-install
@@ -259,8 +259,6 @@ NPM_GLOBALS=(
     ccusage
     "@vtsls/language-server"
     "@govcraft/agent-skills"
-    "@jx0/jmux"
-    hunkdiff
 )
 
 if command -v npm &>/dev/null; then

--- a/bin/tmux-cheatsheet
+++ b/bin/tmux-cheatsheet
@@ -77,7 +77,9 @@ print_cheatsheet() {
     row "tsip"                   "tailscale ip -4"
 
     hdr "Popups & misc"
-    row "prefix G"               "popup: lazygit"
+    row "prefix g"               "popup: lazygit"
+    row "prefix y"               "launch/attach Claude session here"
+    row "prefix u"               "Claude session picker (working/waiting/idle)"
     row "prefix o"               "popup: yazi (file manager)"
     row "prefix t"               "popup: scratch terminal"
     row "prefix ?"               "general dotfiles cheatsheet"

--- a/chezmoi/.chezmoidata/claude.yaml
+++ b/chezmoi/.chezmoidata/claude.yaml
@@ -93,6 +93,17 @@ claude:
         hooks:
           - type: command
             command: node "${HOME}/.claude/tilth/inject-cwd.js"
+      - matcher: "AskUserQuestion"
+        hooks:
+          - type: command
+            command: '[ -x "$HOME/.tmux/plugins/tmux-claude-session-manager/scripts/state.sh" ] && "$HOME/.tmux/plugins/tmux-claude-session-manager/scripts/state.sh" waiting || true'
+            timeout: 5
+    Notification:
+      - matcher: "permission_prompt"
+        hooks:
+          - type: command
+            command: '[ -x "$HOME/.tmux/plugins/tmux-claude-session-manager/scripts/state.sh" ] && "$HOME/.tmux/plugins/tmux-claude-session-manager/scripts/state.sh" waiting || true'
+            timeout: 5
     SessionStart:
       - hooks:
           - type: command
@@ -107,11 +118,19 @@ claude:
           - type: command
             command: moshi-hook claude-hook
             async: true
+      - hooks:
+          - type: command
+            command: '[ -x "$HOME/.tmux/plugins/tmux-claude-session-manager/scripts/state.sh" ] && "$HOME/.tmux/plugins/tmux-claude-session-manager/scripts/state.sh" working || true'
+            timeout: 5
     Stop:
       - hooks:
           - type: command
             command: moshi-hook claude-hook
             async: true
+      - hooks:
+          - type: command
+            command: '[ -x "$HOME/.tmux/plugins/tmux-claude-session-manager/scripts/state.sh" ] && "$HOME/.tmux/plugins/tmux-claude-session-manager/scripts/state.sh" idle || true'
+            timeout: 5
 
   # ── settings.json plugin keys ───────────────────────────────────────────────
   # Base layer for enabledPlugins / extraKnownMarketplaces. modify_settings.json

--- a/chezmoi/.chezmoidata/claude.yaml
+++ b/chezmoi/.chezmoidata/claude.yaml
@@ -96,13 +96,13 @@ claude:
       - matcher: "AskUserQuestion"
         hooks:
           - type: command
-            command: '[ -x "$HOME/.tmux/plugins/tmux-claude-session-manager/scripts/state.sh" ] && "$HOME/.tmux/plugins/tmux-claude-session-manager/scripts/state.sh" waiting || true'
+            command: 'if [ -x "$HOME/.tmux/plugins/tmux-claude-session-manager/scripts/state.sh" ]; then "$HOME/.tmux/plugins/tmux-claude-session-manager/scripts/state.sh" waiting; fi'
             timeout: 5
     Notification:
       - matcher: "permission_prompt"
         hooks:
           - type: command
-            command: '[ -x "$HOME/.tmux/plugins/tmux-claude-session-manager/scripts/state.sh" ] && "$HOME/.tmux/plugins/tmux-claude-session-manager/scripts/state.sh" waiting || true'
+            command: 'if [ -x "$HOME/.tmux/plugins/tmux-claude-session-manager/scripts/state.sh" ]; then "$HOME/.tmux/plugins/tmux-claude-session-manager/scripts/state.sh" waiting; fi'
             timeout: 5
     SessionStart:
       - hooks:
@@ -120,7 +120,7 @@ claude:
             async: true
       - hooks:
           - type: command
-            command: '[ -x "$HOME/.tmux/plugins/tmux-claude-session-manager/scripts/state.sh" ] && "$HOME/.tmux/plugins/tmux-claude-session-manager/scripts/state.sh" working || true'
+            command: 'if [ -x "$HOME/.tmux/plugins/tmux-claude-session-manager/scripts/state.sh" ]; then "$HOME/.tmux/plugins/tmux-claude-session-manager/scripts/state.sh" working; fi'
             timeout: 5
     Stop:
       - hooks:
@@ -129,7 +129,7 @@ claude:
             async: true
       - hooks:
           - type: command
-            command: '[ -x "$HOME/.tmux/plugins/tmux-claude-session-manager/scripts/state.sh" ] && "$HOME/.tmux/plugins/tmux-claude-session-manager/scripts/state.sh" idle || true'
+            command: 'if [ -x "$HOME/.tmux/plugins/tmux-claude-session-manager/scripts/state.sh" ]; then "$HOME/.tmux/plugins/tmux-claude-session-manager/scripts/state.sh" idle; fi'
             timeout: 5
 
   # ── settings.json plugin keys ───────────────────────────────────────────────

--- a/packages/packages.yaml
+++ b/packages/packages.yaml
@@ -52,7 +52,7 @@ packages:
   - watch
   - parallel                                  # GNU parallel — run shell jobs concurrently
   - node                                      # bundles npm on mac + linux
-  - bun                                       # JS/TS runtime required by jmux
+  - bun                                       # JS/TS runtime
   - sd
   - vhs
   - gettext
@@ -112,8 +112,6 @@ packages:
   - markdownlint-cli2: { source: npm }
   - ccusage: { source: npm }
   - agent-skills: { source: npm, pkg: "@govcraft/agent-skills" }
-  - jmux: { source: npm, pkg: "@jx0/jmux" }   # tmux workspace for running coding agents in parallel
-  - hunkdiff: { source: npm }                 # diff viewer used by jmux's Ctrl-a g info panel
   - graphite: { source: npm, pkg: "@withgraphite/graphite-cli", platform: linux } # `gt` — stacked-diff PR workflow (mac uses the withgraphite/tap brew formula)
 
   # uv tools (Python)

--- a/tests/chezmoi-wiring.bats
+++ b/tests/chezmoi-wiring.bats
@@ -508,10 +508,12 @@ EOF
     #
     # inject-cwd.js is exempt: it's dropped into ~/.claude/tilth/ by
     # `tilth install claude-code` (a post-chezmoi sync step, not exact_hooks),
-    # so it never lives in claude/hooks or agents/hooks.
+    # so it never lives in claude/hooks or agents/hooks. state.sh is exempt
+    # for the same reason: it ships inside the tmux-claude-session-manager
+    # TPM plugin (~/.tmux/plugins/...), installed by `prefix+I`, not by dots sync.
     command -v yq >/dev/null 2>&1 || skip "yq not installed"
     local reg="$REAL_DOTFILES_DIR/chezmoi/.chezmoidata/claude.yaml"
-    local -a exempt_scripts=("inject-cwd.js")
+    local -a exempt_scripts=("inject-cwd.js" "state.sh")
     local tok script found ex
     while IFS= read -r tok; do
         [[ -z "$tok" ]] && continue

--- a/tmux.conf
+++ b/tmux.conf
@@ -133,8 +133,7 @@ bind / display-popup -E -xC -yC -w 80% -h 90% -d "#{pane_current_path}" "$HOME/D
 # ---------------------------------------------------------------------------
 # Floating popups
 # ---------------------------------------------------------------------------
-# `g` is intercepted by jmux's input router (toggles diff panel); use `G` instead
-bind G display-popup -E -xC -yC -w 80% -h 80% -d "#{pane_current_path}" "lazygit"
+bind g display-popup -E -xC -yC -w 80% -h 80% -d "#{pane_current_path}" "lazygit"
 bind o display-popup -E -xC -yC -w 80% -h 80% -d "#{pane_current_path}" "yazi"
 bind t display-popup -E -xC -yC -w 60% -h 60% -d "#{pane_current_path}"
 
@@ -164,6 +163,7 @@ set -g @plugin 'tmux-plugins/tmux-resurrect'
 set -g @plugin 'tmux-plugins/tmux-continuum'
 set -g @plugin 'tmux-plugins/tmux-yank'
 set -g @plugin 'laktak/extrakto'
+set -g @plugin 'craftzdog/tmux-claude-session-manager'
 
 # Auto-restore off: a fresh server (e.g. from `cc` outside tmux) would otherwise
 # restore a stale saved session ("Tmux restore complete!"). Auto-SAVE still runs;


### PR DESCRIPTION
Retires the immature `jmux` tool and adopts `craftzdog/tmux-claude-session-manager` as the switcher over multiple concurrent Claude Code sessions, layered on the existing `ccw`/`sesh`/tmux stack. Removes `jmux` + its `hunkdiff` dependency from the package registry (`packages/packages.yaml`) and linux installer (`bin/linux-install`), keeping general-purpose `bun`. Adds the plugin's TPM entry to `tmux.conf` (`prefix+y` launch/attach, `prefix+u` status picker) and wires four guarded Claude status hooks in `chezmoi/.chezmoidata/claude.yaml` so the picker shows live working/waiting/idle state per session — the guard no-ops until the plugin is TPM-installed. Reclaims `prefix+g` for the lazygit popup (jmux no longer intercepts `g`) and updates the tmux cheatsheet plus the hooks-wiring test exemption. Gates green: `just check` (1076 bats + lint + workflows), `agent-profile` pytest (905 passed), and a plugin-verified taste-test.

Post-merge activation (not done here — this was a worktree): `dots sync` then `prefix+I` in tmux to install the plugin, and `npm uninstall -g @jx0/jmux hunkdiff` if they were installed globally.
