### PR TITLE
fix: four independent tmux/cc/theme dotfiles fixes + deterministic warm-up test

### DIFF
--- a/.sync-lib.sh
+++ b/.sync-lib.sh
@@ -127,17 +127,24 @@ sync_hidden_dirs() {
     done
 }
 
-# Install TPM (tmux plugin manager) + its plugins if not present
+# Install TPM (tmux plugin manager) if not present, then run install_plugins
+# on every sync — it's idempotent (skips already-installed plugins), so this
+# also repairs machines where the plugin dir predates newly added plugins.
 install_tpm() {
     command -v tmux &>/dev/null || return 0
-    [[ -d "$HOME/.tmux/plugins/tpm" ]] && return 0
 
-    log_info "Installing TPM (tmux plugin manager)..."
-    git clone https://github.com/tmux-plugins/tpm "$HOME/.tmux/plugins/tpm" 2>&1 | while read -r line; do
-      log_info "  $line"
-    done
+    if [[ ! -d "$HOME/.tmux/plugins/tpm" ]]; then
+        log_info "Installing TPM (tmux plugin manager)..."
+        git clone https://github.com/tmux-plugins/tpm "$HOME/.tmux/plugins/tpm" 2>&1 | while read -r line; do
+          log_info "  $line"
+        done
+    fi
+
+    local install_plugins="$HOME/.tmux/plugins/tpm/bin/install_plugins"
+    [[ -x "$install_plugins" ]] || return 0
+
     log_info "Installing tmux plugins..."
-    "$HOME/.tmux/plugins/tpm/bin/install_plugins" 2>&1 | while read -r line; do
+    "$install_plugins" 2>&1 | while read -r line; do
       log_info "  $line"
     done
 }

--- a/tests/cc-session-mirror.bats
+++ b/tests/cc-session-mirror.bats
@@ -1,0 +1,97 @@
+#!/usr/bin/env bats
+# Tests for the outside-tmux attach/create branch of _cc_base (zsh/claude.zsh).
+# Bug: `tmux new-session -A -s "$session"` attaches even when a client is
+# ALREADY attached to that session, so a second terminal in the same repo
+# mirrors the first instead of getting its own session. Fix: only reattach
+# (-A) when the target session is absent or detached; when it already has a
+# client, spin up a fresh uniquely-named session instead (no -A).
+
+load test_helper
+
+CLAUDE_ZSH="$REAL_DOTFILES_DIR/zsh/claude.zsh"
+
+setup() {
+    FIXTURE_DIR="$(mktemp -d)"
+    MOCK_BIN="$(mktemp -d)"
+    export PATH="$MOCK_BIN:$PATH"
+    export MOCK_ARGS_FILE="$MOCK_BIN/args"
+    mkdir -p "$FIXTURE_DIR/bin"
+    cp "$REAL_DOTFILES_DIR/bin/cc-env-exec" "$FIXTURE_DIR/bin/cc-env-exec"
+    cp "$REAL_DOTFILES_DIR/bin/cc-session-name" "$FIXTURE_DIR/bin/cc-session-name"
+    # Not a git repo: cc-session-name falls back to the bare basename of
+    # FIXTURE_DIR, which we can compute without hardcoding a name.
+    SESSION_NAME="$("$FIXTURE_DIR/bin/cc-session-name" "$FIXTURE_DIR")"
+}
+
+teardown() {
+    rm -rf "$FIXTURE_DIR" "$MOCK_BIN"
+}
+
+# Mock tmux: list-sessions reports attachment state from $MOCK_TMUX_SESSIONS
+# (raw "name:attached" lines); has-session succeeds only for names listed in
+# $MOCK_TMUX_HAS_SESSIONS (comma-separated); new-session invocations are
+# recorded verbatim.
+_mock_tmux() {
+    cat > "$MOCK_BIN/tmux" <<'EOF'
+#!/usr/bin/env bash
+case "$1" in
+    list-sessions)
+        printf '%s\n' "${MOCK_TMUX_SESSIONS:-}"
+        exit 0
+        ;;
+    has-session)
+        target="${3#=}"
+        IFS=',' read -ra known <<< "${MOCK_TMUX_HAS_SESSIONS:-}"
+        for n in "${known[@]}"; do
+            [[ "$n" == "$target" ]] && exit 0
+        done
+        exit 1
+        ;;
+    new-session)
+        printf '%s\n' "$@" > "$MOCK_ARGS_FILE"
+        exit 0
+        ;;
+    *)
+        exit 0
+        ;;
+esac
+EOF
+    chmod +x "$MOCK_BIN/tmux"
+}
+
+@test "cc spins up a fresh uniquely-named session (no -A) when the target session already has a client attached" {
+    command -v zsh &>/dev/null || skip "zsh not installed"
+    _mock_tmux
+    export MOCK_TMUX_SESSIONS="${SESSION_NAME}:1"
+    export MOCK_TMUX_HAS_SESSIONS="$SESSION_NAME"
+    run zsh -fc "export DOTFILES_DIR='$FIXTURE_DIR'; cd '$FIXTURE_DIR'; unset TMUX; source '$CLAUDE_ZSH'; cc"
+    [ "$status" -eq 0 ]
+    [ -f "$MOCK_ARGS_FILE" ]
+    # A fresh session was created, distinct from the mirrored/attached one...
+    grep -qx -- "${SESSION_NAME}-2" "$MOCK_ARGS_FILE"
+    ! grep -qx -- "$SESSION_NAME" "$MOCK_ARGS_FILE"
+    # ...and -A (attach-if-exists, the mirroring flag) was NOT used.
+    ! grep -qx -- '-A' "$MOCK_ARGS_FILE"
+}
+
+@test "cc still reattaches (-A) when the target session is detached (orphan de-sprawl preserved)" {
+    command -v zsh &>/dev/null || skip "zsh not installed"
+    _mock_tmux
+    export MOCK_TMUX_SESSIONS="${SESSION_NAME}:0"
+    run zsh -fc "export DOTFILES_DIR='$FIXTURE_DIR'; cd '$FIXTURE_DIR'; unset TMUX; source '$CLAUDE_ZSH'; cc"
+    [ "$status" -eq 0 ]
+    [ -f "$MOCK_ARGS_FILE" ]
+    grep -qx -- '-A' "$MOCK_ARGS_FILE"
+    grep -qx -- "$SESSION_NAME" "$MOCK_ARGS_FILE"
+}
+
+@test "cc still reattaches (-A) when no session with that name exists yet" {
+    command -v zsh &>/dev/null || skip "zsh not installed"
+    _mock_tmux
+    export MOCK_TMUX_SESSIONS=""
+    run zsh -fc "export DOTFILES_DIR='$FIXTURE_DIR'; cd '$FIXTURE_DIR'; unset TMUX; source '$CLAUDE_ZSH'; cc"
+    [ "$status" -eq 0 ]
+    [ -f "$MOCK_ARGS_FILE" ]
+    grep -qx -- '-A' "$MOCK_ARGS_FILE"
+    grep -qx -- "$SESSION_NAME" "$MOCK_ARGS_FILE"
+}

--- a/tests/local-llm.bats
+++ b/tests/local-llm.bats
@@ -820,23 +820,21 @@ MOCK
 
     # chat/completions sleeps 10s; if the function blocked on it, opencode-lean
     # would take >10s. The probe stays fast so only the warm-up could stall.
-    cat > "$MOCK_BIN/curl" << 'MOCK'
+    local warm_done="$TEST_HOME/warm-done"
+    cat > "$MOCK_BIN/curl" << MOCK
 #!/bin/bash
-[[ "$*" == *chat/completions* ]] && sleep 10
+[[ "\$*" == *chat/completions* ]] && { sleep 10; echo done > "$warm_done"; }
 exit 0
 MOCK
     chmod +x "$MOCK_BIN/curl"
 
     # shellcheck disable=SC1090
     source "$ALIASES"
-    local start end
-    start=$(date +%s)
     run opencode-lean --model local-llm/local-sonnet
-    end=$(date +%s)
     assert_success
     assert_output_contains "opencode-called"
-    # Must return well under the 10s warm-up sleep — proves it is backgrounded.
-    (( end - start < 5 ))
+    # Warm-up is still mid-sleep -> it was backgrounded, not run inline.
+    [[ ! -f "$warm_done" ]]
 }
 
 @test "opencode-lean warms the lean.json default model on a bare (no --model) launch" {

--- a/tests/theme-palette.bats
+++ b/tests/theme-palette.bats
@@ -1,0 +1,41 @@
+#!/usr/bin/env bats
+# Regression for theme/generate.sh emitting @thm_* option names that match
+# catppuccin/tmux v2's declarations. The plugin loads overrides with
+# `set -ogq @thm_<name> "..."` — `-ogq` only preserves a pre-set value under
+# the EXACT option name, so a mismatched name is silently invisible and the
+# built-in mocha default wins instead. See catppuccin_options_tmux.conf for
+# the option names the plugin actually declares (@thm_fg, @thm_surface_0/1/2,
+# @thm_subtext_0/1, @thm_overlay_0/1/2).
+
+load test_helper
+
+setup() {
+    setup_test_env
+    export THEME_REPO="$TEST_HOME/theme-repo"
+    mkdir -p "$THEME_REPO/theme" "$THEME_REPO/zsh" "$THEME_REPO/bin"
+    touch "$THEME_REPO/vimrc"
+    cp "$REAL_DOTFILES_DIR/theme/generate.sh" "$THEME_REPO/theme/generate.sh"
+    cp "$REAL_DOTFILES_DIR/theme/config.yaml" "$THEME_REPO/theme/config.yaml"
+    cp -R "$REAL_DOTFILES_DIR/theme/schemes" "$THEME_REPO/theme/schemes"
+}
+
+teardown() { teardown_test_env; }
+
+@test "generate_tmux_theme emits catppuccin/tmux v2's exact @thm_* option names" {
+    run bash "$THEME_REPO/theme/generate.sh"
+    assert_success
+
+    local conf="$THEME_REPO/tmux/theme.conf"
+    assert_file_exists "$conf"
+
+    # Correct names catppuccin/tmux v2 declares via `-ogq` — must be present
+    # verbatim or the plugin's exact-name match never sees our override.
+    grep -qx 'set -g @thm_surface_0   "#3c291c"' "$conf"
+    grep -qx 'set -g @thm_fg          "#dac2b1"' "$conf"
+
+    # Old mismatched names must be gone — their presence is exactly the bug:
+    # `-ogq @thm_surface0` / `-ogq @thm_text` never matches our `@thm_surface0`
+    # / `@thm_text` override, so mocha's default silently wins.
+    ! grep -q '@thm_surface0\b' "$conf"
+    ! grep -q '@thm_text\b' "$conf"
+}

--- a/tests/tpm-plugin-install.bats
+++ b/tests/tpm-plugin-install.bats
@@ -60,13 +60,17 @@ GITEOF
 }
 
 run_install_tpm() {
-    PATH="$MOCK_BIN:/usr/bin:/bin" run bash -c "source '$REAL_DOTFILES_DIR/.sync-lib.sh' && install_tpm"
+    local path="${1:-$MOCK_BIN:/usr/bin:/bin}"
+    PATH="$path" run /bin/bash -c "source '$REAL_DOTFILES_DIR/.sync-lib.sh' && install_tpm"
 }
 
 @test "install_tpm no-ops when tmux is not on PATH" {
     mock_git
 
-    run_install_tpm
+    # Hermetic PATH (mock bin only) so `command -v tmux` can't resolve a system
+    # tmux such as /usr/bin/tmux on CI runners; install_tpm returns at the guard
+    # before needing any external tool.
+    run_install_tpm "$MOCK_BIN"
     assert_success
     [[ ! -f "$CLONE_CALLS" ]]
     [[ ! -d "$TPM_DIR" ]]

--- a/tests/tpm-plugin-install.bats
+++ b/tests/tpm-plugin-install.bats
@@ -1,0 +1,104 @@
+#!/usr/bin/env bats
+# Tests for install_tpm (.sync-lib.sh) — TPM (tmux plugin manager) bootstrap +
+# idempotent plugin install. Regression coverage for the bug where an
+# already-present ~/.tmux/plugins/tpm dir short-circuited install_plugins
+# forever (blank status bar / dead C-hjkl nav on machines with older tpm
+# clones, or plugins added to tmux.conf after the first install).
+
+load test_helper
+
+setup() {
+    setup_test_env
+    export MOCK_BIN="$TEST_HOME/bin"
+    mkdir -p "$MOCK_BIN"
+    export TPM_DIR="$TEST_HOME/.tmux/plugins/tpm"
+    export INSTALL_CALLS="$TEST_HOME/install-plugins-calls.log"
+    export CLONE_CALLS="$TEST_HOME/git-clone-calls.log"
+}
+
+teardown() { teardown_test_env; }
+
+mock_tmux() {
+    cat > "$MOCK_BIN/tmux" <<'SH'
+#!/bin/bash
+exit 0
+SH
+    chmod +x "$MOCK_BIN/tmux"
+}
+
+# install_plugins stub that records each invocation.
+write_install_plugins_stub() {
+    local dest="$1"
+    mkdir -p "$(dirname "$dest")"
+    cat > "$dest" <<SH
+#!/bin/bash
+printf 'ran\n' >> "$INSTALL_CALLS"
+exit 0
+SH
+    chmod +x "$dest"
+}
+
+# Mocks `git clone` to record the call and materialize the target dir instead
+# of hitting the network. drop_stub=true also seeds a working install_plugins
+# inside the cloned dir, simulating a real tpm checkout.
+mock_git() {
+    local drop_stub="${1:-false}"
+    write_install_plugins_stub "$MOCK_BIN/install_plugins_stub"
+    cat > "$MOCK_BIN/git" <<GITEOF
+#!/bin/bash
+printf '%s\n' "\$*" >> "$CLONE_CALLS"
+if [[ "\$1" == "clone" ]]; then
+    mkdir -p "\$3"
+    if [[ "$drop_stub" == true ]]; then
+        mkdir -p "\$3/bin"
+        cp "$MOCK_BIN/install_plugins_stub" "\$3/bin/install_plugins"
+    fi
+fi
+exit 0
+GITEOF
+    chmod +x "$MOCK_BIN/git"
+}
+
+run_install_tpm() {
+    PATH="$MOCK_BIN:/usr/bin:/bin" run bash -c "source '$REAL_DOTFILES_DIR/.sync-lib.sh' && install_tpm"
+}
+
+@test "install_tpm no-ops when tmux is not on PATH" {
+    mock_git
+
+    run_install_tpm
+    assert_success
+    [[ ! -f "$CLONE_CALLS" ]]
+    [[ ! -d "$TPM_DIR" ]]
+}
+
+@test "install_tpm clones tpm and runs install_plugins on a fresh machine" {
+    mock_tmux
+    mock_git true
+
+    run_install_tpm
+    assert_success
+    assert_file_exists "$CLONE_CALLS"
+    grep -q '^clone ' "$CLONE_CALLS"
+    assert_file_exists "$INSTALL_CALLS"
+}
+
+@test "REGRESSION: install_tpm still runs install_plugins when the tpm dir already exists" {
+    mock_tmux
+    write_install_plugins_stub "$TPM_DIR/bin/install_plugins"
+
+    run_install_tpm
+    assert_success
+    [[ ! -f "$CLONE_CALLS" ]]
+    assert_file_exists "$INSTALL_CALLS"
+}
+
+@test "install_tpm no-ops without error when tpm dir exists but install_plugins is missing" {
+    mock_tmux
+    mkdir -p "$TPM_DIR"
+
+    run_install_tpm
+    assert_success
+    [[ ! -f "$CLONE_CALLS" ]]
+    [[ ! -f "$INSTALL_CALLS" ]]
+}

--- a/theme/generate.sh
+++ b/theme/generate.sh
@@ -506,16 +506,16 @@ generate_tmux_theme() {
 set -g @thm_bg          "#$(pal base00)"
 set -g @thm_mantle      "#$(pal base11)"
 set -g @thm_crust       "#$(pal base10)"
-set -g @thm_surface0    "#$(pal base01)"
-set -g @thm_surface1    "#$(pal base02)"
-set -g @thm_surface2    "#$(pal base03)"
+set -g @thm_surface_0   "#$(pal base01)"
+set -g @thm_surface_1   "#$(pal base02)"
+set -g @thm_surface_2   "#$(pal base03)"
 # Foregrounds / overlays
-set -g @thm_text        "#$(pal base05)"
-set -g @thm_subtext1    "#$(pal base04)"
-set -g @thm_subtext0    "#$(pal base03)"
-set -g @thm_overlay2    "#$(pal base03)"
-set -g @thm_overlay1    "#$(pal base04)"
-set -g @thm_overlay0    "#$(pal base03)"
+set -g @thm_fg          "#$(pal base05)"
+set -g @thm_subtext_1   "#$(pal base04)"
+set -g @thm_subtext_0   "#$(pal base03)"
+set -g @thm_overlay_2   "#$(pal base03)"
+set -g @thm_overlay_1   "#$(pal base04)"
+set -g @thm_overlay_0   "#$(pal base03)"
 # Accent colours
 set -g @thm_red         "#$(pal base08)"
 set -g @thm_maroon      "#$(pal base12)"
@@ -545,7 +545,7 @@ set -g @catppuccin_window_default_fill "number"
 set -g @catppuccin_window_default_text " #W"
 set -g @catppuccin_window_current_fill "number"
 set -g @catppuccin_window_current_text " #W"
-set -g @catppuccin_window_current_background "#{@thm_surface1}"
+set -g @catppuccin_window_current_background "#{@thm_surface_1}"
 
 # Status-left: session name
 set -g @catppuccin_status_left_separator  " "
@@ -559,15 +559,15 @@ set -g @catppuccin_date_time_text "%H:%M"
 set -g status-right "#{E:@catppuccin_status_date_time}"
 
 # Pane borders (keep in sync with @thm_* palette)
-set -g pane-border-style "fg=#{@thm_surface1}"
+set -g pane-border-style "fg=#{@thm_surface_1}"
 set -g pane-active-border-style "fg=#{@thm_blue}"
 
 # Messages and command line
-set -g message-style "bg=#{@thm_surface1},fg=#{@thm_text}"
-set -g message-command-style "bg=#{@thm_surface1},fg=#{@thm_text}"
+set -g message-style "bg=#{@thm_surface_1},fg=#{@thm_fg}"
+set -g message-command-style "bg=#{@thm_surface_1},fg=#{@thm_fg}"
 
 # Copy mode highlight
-setw -g mode-style "bg=#{@thm_surface1},fg=#{@thm_yellow}"
+setw -g mode-style "bg=#{@thm_surface_1},fg=#{@thm_yellow}"
 TMUX_THEME
 
   log_ok "Generated tmux/theme.conf"

--- a/zsh/claude.zsh
+++ b/zsh/claude.zsh
@@ -61,9 +61,17 @@ _cc_base() {
     local session
     session="$("${DOTFILES_DIR:-$HOME/Dev/dotfiles}/bin/cc-session-name" "${name_args[@]}" "$PWD")"
     if [[ -z "$TMUX" ]]; then
-        # Outside tmux: create-or-attach (-A attaches if it exists; cmd ignored
-        # on attach). With --new the name is unique, so -A always creates.
-        tmux new-session -A -s "$session" "${(j: :)${(@q)cmd}}"
+        # Outside tmux: reattach (-A) only when the target session is absent
+        # or detached (orphan de-sprawl). If it already has a client attached,
+        # -A would mirror this terminal onto that session instead of giving
+        # it its own — spin up a fresh uniquely-named session instead.
+        if tmux list-sessions -F '#{session_name}:#{session_attached}' 2>/dev/null \
+            | grep -Fxq "$session:1"; then
+            session="$("${DOTFILES_DIR:-$HOME/Dev/dotfiles}/bin/cc-session-name" --unique "$PWD")"
+            tmux new-session -s "$session" "${(j: :)${(@q)cmd}}"
+        else
+            tmux new-session -A -s "$session" "${(j: :)${(@q)cmd}}"
+        fi
     elif [[ -n "$force_new" ]]; then
         # Explicit --new from inside tmux:
         # dedicate a session and switch-client (never nests).


### PR DESCRIPTION
Four file-disjoint dotfiles fixes surfaced while debugging "tmux `cc` has no styling" and "second `cc` mirrors the first terminal." Each was diagnosed against source, implemented TDD (red→green), and gated on `just check`. Bundled per request.

## Fixes

**1. `fix(cc)` — stop mirroring an attached tmux session** (`zsh/claude.zsh`)
`_cc_base` ran `tmux new-session -A` outside tmux, and `cc-session-name` returns the bare repo basename, so a second `cc` in the same repo attached to (mirrored) the first terminal's session. Now checks `#{session_attached}` first: reattach only detached/orphaned sessions; spawn a fresh unique session (`cc-session-name --unique`) when the target is already attached. `tests/cc-session-mirror.bats` (3 tests).

**2. `fix(sync)` — run tmux `install_plugins` on every sync** (`.sync-lib.sh`)
`install_tpm` returned early whenever `~/.tmux/plugins/tpm` already existed, so plugins added to `tmux.conf` after the initial clone were never installed (blank status bar, dead pane-nav). Keep the clone guarded by the dir check but always run the idempotent `install_plugins` when its binary is present. `tests/tpm-plugin-install.bats` (incl. regression for the already-cloned path).

**3. `fix(theme)` — emit catppuccin v2 option names** (`theme/generate.sh`)
`generate.sh` emitted `@thm_text`/`@thm_surface0`/`@thm_subtext1`/`@thm_overlay2`, but catppuccin/tmux v2 declares `@thm_fg`/`@thm_surface_0`/`@thm_subtext_1`/`@thm_overlay_2`. `-ogq` only preserves a value under the exact option name, so the mismatched overrides were ignored and mocha defaults won on the session/clock pills. Renamed to match (verified against the vendored plugin source). `tests/theme-palette.bats`.

**4. `test(local-llm)` — deterministic warm-up backgrounding check** (`tests/local-llm.bats`)
The warm-up test asserted wall-clock elapsed time (`end - start < 5`) of a real subprocess, which is load-sensitive under the parallel suite — it flaked repeatedly while passing in isolation. Replaced with a marker-based check: the mock warm-up writes a completion file only after its 10s sleep; the test asserts that file is still absent right after launch returns. A 10s sleep can't complete in that gap regardless of load. Verified 0 failures / 10 loop runs.

## Verification

`just check` on the combined branch: lint / shellcheck / ruff / markdown / smoke all green; full 1084-test suite passes except one **pre-existing, unrelated** parallel-run flake — `chezmoi-wiring.bats:299` ("migrates ~/.copilot/mcp-config.json legacy symlink"), which passes 5/5 in isolation and whose subject (copilot mcp-config in `chezmoi/.sync`) is untouched by this diff. Multiple agents hit this same flake class on unrelated branches this session; not addressed here to keep scope tight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)