### PR TITLE
chore(doc-drift): bump oh-my-pi to v16.3.10 (no-op)

### DIFF
--- a/agents/doc-drift/sources.yaml
+++ b/agents/doc-drift/sources.yaml
@@ -77,4 +77,4 @@ sources:
     signal: { type: gh_release, ref: can1357/oh-my-pi }
     docs: https://github.com/can1357/oh-my-pi
     governs: [chezmoi/.chezmoidata/omp.yaml, chezmoi/dot_omp/private_agent/modify_config.yml]
-    reconciled: "v16.3.8"
+    reconciled: "v16.3.10"


### PR DESCRIPTION
## Drift

`oh-my-pi` (can1357/oh-my-pi): `v16.3.8` → `v16.3.10`.

## Changelog reviewed (v16.3.8 → v16.3.10)

**v16.3.9** — `@oh-my-pi/pi-catalog` (OpenCode Go DeepSeek V4 `max_tokens` fix), `@oh-my-pi/pi-coding-agent` (`say` command `--file`/streaming/voice-validation additions, split-commit lock-file pairing fix, skill-loading fix for disabled-provider precedence), `@oh-my-pi/pi-mnemopi` (extractor JSON unwrap fix), `@oh-my-pi/omp-stats` (sentiment-detection tuning), `@oh-my-pi/pi-tui` (absolute-path autocomplete fix).

**v16.3.10** — `@oh-my-pi/pi-ai` (Ollama empty-stop retry, Claude Sonnet 5 strict-tools gateway fallback), `@oh-my-pi/pi-catalog` (LiteLLM `/v2/model/info` discovery fix), `@oh-my-pi/pi-coding-agent` (subagent HUD cap + TUI performance, several crash/CPU/render fixes including llama.cpp vision-model `/props` metadata refresh, IRC wake/wait fixes), `@oh-my-pi/pi-tui` (terminal-restore registration fix), `@oh-my-pi/pi-utils` (postmortem cleanup-error handling + bounded cleanup deadline).

## Impact assessment

Checked both `governs` files:
- `chezmoi/.chezmoidata/omp.yaml` — our `omp.config` subtree (`symbolPreset`, `colorBlindMode`, `theme`, `defaultThinkingLevel`, `disabledProviders`, `display`, `includeWorkspaceTree`, `advisor`, `compaction`, `lsp`, `github.enabled`, `task.eager`, `dev.autoqa.consent`, `modelRoles`) and the `omp.models.providers.local-llm` schema (`baseUrl`/`api`/`auth`/`models[].{id,name,reasoning,input,contextWindow,maxTokens}`).
- `chezmoi/dot_omp/private_agent/modify_config.yml` — the wholesale-author script that enforces the above onto `~/.omp/agent/config.yml`.

None of the v16.3.9/v16.3.10 changes add, rename, or change the schema/behavior of any key in that surface. The closest-adjacent items are pure bug fixes rather than config/schema changes:
- The disabled-provider skill-loading fix (v16.3.9) makes our existing `disabledProviders` list behave *more* correctly — no key change.
- The llama.cpp vision-model `/props` metadata fixes (v16.3.9 + v16.3.10) improve the local-llm vision-model story we run under `omp.models.providers.local-llm`, but again fix upstream behavior rather than introduce a new flag/key we'd need to mirror.
- The LiteLLM `/v2/model/info` discovery fix (v16.3.10) is relevant to how omp talks to our local-llm/LiteLLM proxy, but is an internal robustness fix, not a schema change on our side.

Classified **no-op**. This PR only bumps `reconciled` in `agents/doc-drift/sources.yaml`; no edits to the `governs` files.

Never auto-merge — please review and merge, then `dots sync`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JdSfNSguemXEHLaCoeCGJ6)_