### PR TITLE
fix(sync): register turn-budget-guard hooks in chezmoi claude.yaml

### DIFF
--- a/chezmoi/.chezmoidata/claude.yaml
+++ b/chezmoi/.chezmoidata/claude.yaml
@@ -98,6 +98,11 @@ claude:
           - type: command
             command: 'if [ -x "$HOME/.tmux/plugins/tmux-claude-session-manager/scripts/state.sh" ]; then "$HOME/.tmux/plugins/tmux-claude-session-manager/scripts/state.sh" waiting; fi'
             timeout: 5
+      - matcher: ".*"
+        hooks:
+          - type: command
+            command: '"$HOME/.claude/hooks/turn-budget-guard.sh"'
+            timeout: 5
     Notification:
       - matcher: "permission_prompt"
         hooks:
@@ -130,6 +135,17 @@ claude:
       - hooks:
           - type: command
             command: 'if [ -x "$HOME/.tmux/plugins/tmux-claude-session-manager/scripts/state.sh" ]; then "$HOME/.tmux/plugins/tmux-claude-session-manager/scripts/state.sh" idle; fi'
+            timeout: 5
+    PostToolUse:
+      - matcher: ".*"
+        hooks:
+          - type: command
+            command: '"$HOME/.claude/hooks/turn-budget-guard.sh"'
+            timeout: 5
+    SubagentStop:
+      - hooks:
+          - type: command
+            command: '"$HOME/.claude/hooks/turn-budget-guard.sh"'
             timeout: 5
 
   # ── settings.json plugin keys ───────────────────────────────────────────────


### PR DESCRIPTION
## Problem

Every `dots sync` failed with `chezmoi apply failed (exit 1)`:

```
Claude settings.json has key-path(s) the repo does not know about:
  + hooks.PostToolUse (...)
  + hooks.SubagentStop (...)
```

## Root cause

PR #392 (6e2aa77) wired the turn-budget-guard into `agents/hooks/registry.yaml` and deployed it live to `~/.claude/settings.json`, but never added the corresponding entries to `chezmoi/.chezmoidata/claude.yaml` — the chezmoi-authoritative source `dots sync` renders from. The unknown-key halt gate in `chezmoi/dot_claude/modify_settings.json` then (correctly) refused to clobber the live `PostToolUse`/`SubagentStop` keys and halted the sync.

## Fix

Register the three turn-budget-guard hook entries in `claude.yaml`'s `hooks:` block, matching what's already live and the intent in `agents/hooks/registry.yaml`:

- `PreToolUse` — matcher `.*` → `turn-budget-guard.sh`
- `PostToolUse` — matcher `.*` → `turn-budget-guard.sh` (new key)
- `SubagentStop` — `turn-budget-guard.sh` (new key)

## Verification

- `dots sync` exits 0, twice (idempotent — no drift on re-run)
- `just check` exits 0 (lint clean, 1124/1124 bats tests, workflow parse checks)
- Hook behavior independently verified: deployed script/lib byte-identical to repo source; deny at hard ceiling, nudge at soft threshold, SubagentStop counter cleanup, fail-open on malformed stdin; 115/115 hook-suite bats tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
