### PR TITLE
chore(shell): ignore test scratch + guard Antigravity PATH

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,9 @@ chezmoi/dot_claude/exact_*/
 
 # Node install artifacts (hook runner deps; package-lock.json is tracked)
 node_modules/
+
+# Throwaway test scratch (ap-* temp dirs, pytest cache, uv locks)
+.tmp-tests/
+
+# Generated skills lockfile (produced by skills sync)
+skills-lock.json

--- a/zshrc
+++ b/zshrc
@@ -31,3 +31,6 @@ clear
 
 # local-llm stack aliases (opt-in; absent on machines without the stack)
 [ -f "$HOME/local-llm/scripts/aliases.sh" ] && source "$HOME/local-llm/scripts/aliases.sh"
+
+# Antigravity CLI (opt-in; absent on machines without it)
+[ -d "$HOME/.antigravity/antigravity/bin" ] && export PATH="$HOME/.antigravity/antigravity/bin:$PATH"


### PR DESCRIPTION
Two small shell-hygiene fixes surfaced as uncommitted changes on `main`.

## `.gitignore`
- Ignore `.tmp-tests/` (throwaway test scratch — ap-* temp dirs, pytest cache, uv locks).
- Ignore generated `skills-lock.json` (produced by skills sync).

## `zshrc`
The Antigravity installer had appended an unguarded, hardcoded absolute PATH
line directly into the repo source (`~/.zshrc` symlinks into the clone).
Rewritten to the repo's existing convention — guarded existence check + `$HOME`
— so it no-ops on machines without Antigravity instead of polluting PATH:

```sh
[ -d "$HOME/.antigravity/antigravity/bin" ] && export PATH="$HOME/.antigravity/antigravity/bin:$PATH"
```

`just check` passes (exit 0); prek hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
