### PR TITLE
fix(agents): tilth whole-file-tag doc drift + macOS test portability

### DIFF
--- a/.hallouminate/wiki/architecture/config-drift.md
+++ b/.hallouminate/wiki/architecture/config-drift.md
@@ -289,5 +289,59 @@ The hallouminate wiki index (LanceDB) is derived from the markdown on disk. If
 vs the schema — run `hallouminate index` to rebuild. A doctor run should treat
 a non-rebuildable index as a dotfiles bug, not just retry.
 
+## Known drift pattern: cargo-source packages silently stale when the Rust toolchain is dev-gated
+
+**Symptom**: A `source: cargo` package drifts commits behind its pinned git
+branch with no error — e.g. `tilth` stuck at an old `main` commit, still
+emitting a read format its current `main` had removed (per-line `<hash>|`
+anchors, deleted in tilth PR #99) and missing a feature its `install` step now
+depends on (the auto-created `~/.claude/tilth/inject-cwd.js` cwd-injection hook,
+tilth PR #118). The stale hook then leaves the `claude.yaml` `mcp__tilth__.*`
+PreToolUse wiring pointing at a missing file.
+
+**Why it happens**: `packages/packages.yaml` gates the toolchain provider
+`rustup: { dev: true }` (dev machines only, `packages/sync.sh:87`), while the
+cargo-source packages that *need* a toolchain to build are ungated —
+`tilth`, `hallouminate`, `rtk`, `cargo-llvm-cov`, `cargo-update` all install on
+every machine (`sync.sh:96` selects `source==cargo AND dev==false`). A machine
+with no toolchain installs the package *entries* but has no `cargo` to build
+them, so `dots sync`/`dots up` can never rebuild or update them. The staleness
+is invisible: the old binary keeps working, just at an old revision.
+
+**Blast radius beyond the binary**: a stale tilth breaks the read/edit contract
+the whole repo documents. When the format changes upstream (PR #99), the
+preamble edit-shape guide, `agents/agent_definitions/coder.md`, and
+`agents/lib/tool-reroute/io.js` still describe the *old* `<line>:<hash>|` anchor
+model — doc drift that only surfaces once the binary is finally rebuilt to the
+format its docs no longer match.
+
+**Fix**: rebuild the toolchain + package (`brew install rustup` →
+`rustup default stable` → `cargo install --git <repo> --branch main <pkg>
+--force --locked` — note multi-binary repos need the explicit `<pkg>` arg), then
+`dots sync` re-runs `install_tilth_claude_code` (`.sync-lib.sh:432`) which
+recreates the hook. Permanent fix tracked in
+[#403](https://github.com/paulnsorensen/dotfiles/issues/403): un-gate `rustup`
+(the cargo packages it builds are wanted everywhere) and make the cargo-install
+leg hard-fail loudly when `cargo` is absent instead of silently skipping.
+
+**Detection**: `tilth --version` / git-hash of the installed binary vs
+`git ls-remote <repo> <branch>`; and `command -v cargo` — absent on a machine
+that lists ungated `source: cargo` packages is the tell.
+
+## Gotcha: `just check` fails locally on macOS while green in CI (GNU-only test idioms)
+
+**Symptom**: `just check` red on a single bats test locally on macOS, but CI
+passes. First hit 2026-07-06: `tests/turn-budget-guard.bats:384` used
+`touch -d "@<epoch>"` — GNU coreutils syntax that BSD `touch` (macOS) rejects
+("illegal time specification"). CI runs `ubuntu-latest`
+(`.github/workflows/test.yml:14,37`), so GNU `touch` accepts it and the failure
+is masked. Because AGENTS.md makes `just check` the single local exit gate on a
+macOS-oriented repo, a GNU-only idiom means the gate *cannot* pass on the
+primary dev OS while CI stays green — an OS-divergence coverage gap, not a
+logic bug. Tracked in
+[#404](https://github.com/paulnsorensen/dotfiles/issues/404). Detection: any
+test using GNU-only flags (`touch -d @epoch`, `date -d`, `sed -i` without a
+backup arg, `readlink -f`) is a portability suspect.
+
 See [[agent-profile]] for the `ap` render/install model and [[../harnesses/claude]]
 for where each Claude config surface lives.

--- a/agents/agent_definitions/coder.md
+++ b/agents/agent_definitions/coder.md
@@ -4,7 +4,7 @@ You are the Coder — the one phase agent that mutates the tree. You take an app
 
 1. **Contract** — restate the task as a verifiable goal: the test(s) that must pass, the behavior that must hold.
 2. **Cut** — write the failing test first (or the reproduction for a bug). It must fail for the right reason.
-3. **Implement** — make it pass with the smallest change that's correct. Edit via `cheez-write` over hash anchors; read first with `cheez-read`.
+3. **Implement** — make it pass with the smallest change that's correct. Edit via `cheez-write` (tag-anchored ops); read first with `cheez-read` to get the `[path#TAG]`.
 4. **Taste-test** — run the project's test/lint/build gates directly (top-level `/cook` forks `whey-drainer` for noise-free failures; a dispatched coder has no fan-out, so it runs the gates inline). Self-check the taste-test lenses (drift, readability, scope) as you go, but don't self-certify them — the authoritative taste-test is the orchestrator's fresh-context pass after you return (see the preamble's "Fresh-context taste-test" phase-flow for why). When your diff clears the cost gate (>1 file or adds public surface), record `taste_test: deferred-to-orchestrator` in the `/cook` slug (`.cheese/cook/<slug>.md`) so it runs.
 5. **Handoff** — report what changed, what's verified, what's left.
 

--- a/agents/lib/tool-reroute/io.js
+++ b/agents/lib/tool-reroute/io.js
@@ -24,10 +24,10 @@ function writeReason(target) {
   const path = target || '<file>';
   return `Blocked: shell write-redirect to ${path} — use the cheez-write skill (tilth_write), not echo/printf/cat with > / >>.
 
-Run instead (whole-file create/overwrite):
-  mcp__tilth__tilth_write(files:[{path:${JSON.stringify(path)}, mode:"overwrite", overwrite:true, content:"…"}])
+New file (seed — omit tag):
+  mcp__tilth__tilth_write(edits:[{path:${JSON.stringify(path)}, ops:[{op:"prepend", content:"…"}]}], cwd:"…")
 
-For a surgical change, tilth_read first for hash anchors, then a hash-mode edit.`;
+Existing file: tilth_read first to get the [path#TAG], then tag-anchored ops (replace/insert_before/insert_after) on the numbered lines.`;
 }
 
 // A write-redirect only needs cheez-write when it targets a file in the working

--- a/agents/preamble.md
+++ b/agents/preamble.md
@@ -48,9 +48,9 @@ Pick by edit *shape*, not preference. Serena is more context-efficient for symbo
 | Insert relative to a known symbol | `serena.insert_before_symbol` / `insert_after_symbol` |
 | Rename a symbol across the codebase | `serena.rename_symbol` (one LSP call vs N text replaces, and correct under overloads) |
 | Safe-delete an unused symbol | `serena.safe_delete_symbol` |
-| Sub-symbol edit (slice inside a function) | `tilth_write` hash-anchor — serena would force shipping the whole body |
+| Sub-symbol edit (slice inside a function) | `tilth_write` tag-anchored ops — serena would force shipping the whole body |
 | Imports, config (YAML/JSON/TOML), Markdown, shell | `tilth_write` |
-| Create new file | `tilth_write` overwrite — serena has no create-file tool |
+| Create new file | `tilth_write` seed (omit `tag`) — serena has no create-file tool |
 | Bulk pattern across files | `tilth_search` + `tilth_write` batch |
 | Language without LSP support here | `tilth_write` |
 

--- a/tests/turn-budget-guard.bats
+++ b/tests/turn-budget-guard.bats
@@ -380,8 +380,10 @@ post_event() {
     seed_state sOld new 1
     # Backdate the stale one's STATE FILE mtime past the 6h cutoff.
     local ts
-    ts=$(node -e 'const d=new Date(Date.now()-10*3600*1000); process.stdout.write(String(Math.floor(d.getTime()/1000)))')
-    touch -d "@$ts" "$CLAUDE_TURN_BUDGET_DIR/sOld/old/state.json"
+    # Portable stamp for `touch -t` ([[CC]YY]MMDDhhmm.SS) — BSD touch (macOS)
+    # rejects GNU's `-d "@<epoch>"`; `-t` is accepted by both.
+    ts=$(node -e 'const d=new Date(Date.now()-10*3600*1000),p=n=>String(n).padStart(2,"0");process.stdout.write(d.getFullYear()+p(d.getMonth()+1)+p(d.getDate())+p(d.getHours())+p(d.getMinutes())+"."+p(d.getSeconds()))')
+    touch -t "$ts" "$CLAUDE_TURN_BUDGET_DIR/sOld/old/state.json"
 
     # Fire an unrelated event to trigger the backstop sweep.
     local json


### PR DESCRIPTION
## Summary

Two fixes surfaced while diagnosing a stale local `tilth` binary (rebuilt from `main` this session; it had drifted behind, still emitting the removed per-line `<hash>|` read format and missing the auto-installed cwd-injection hook).

### 1. tilth read/edit doc drift → whole-file-tag model
tilth `main` replaced the per-line `<line>:<hash>|` read format with a whole-file-tag model (PR #99): edit-mode reads emit a `[path#TAG]` header + `N:content` lines, and `tilth_write` takes `edits:[{path, tag?, ops}]` with a required `cwd`. The in-repo docs still described the old hash-anchor API:

- `agents/preamble.md` — edit-shape guide: `hash-anchor` → `tag-anchored ops`; create-file → `seed (omit tag)`
- `agents/agent_definitions/coder.md` — implement step cites `[path#TAG]` + tag-anchored ops
- `agents/lib/tool-reroute/io.js` — `writeReason` rewritten from the removed `files:/mode:"overwrite"` shape to `edits`/`ops` + `cwd`

(The `cheez-write`/`cook`/`age`/`cure` SKILL.md files carry the same stale model but are vendored from `paulnsorensen/easy-cheese` — fixed there, not here.)

### 2. macOS test portability (#404)
`tests/turn-budget-guard.bats:384` backdated a state file with GNU-only `touch -d "@<epoch>"`, which BSD `touch` (macOS) rejects — so `just check` could not pass locally on the repo's macOS-oriented primary dev OS while `ubuntu-latest` CI stayed green. Now emits a `[[CC]YY]MMDDhhmm.SS` stamp and uses `touch -t` (accepted by both).

### Wiki
`architecture/config-drift.md` gains two drift-pattern sections: the toolchain-gated cargo staleness that caused the tilth drift (#403), and the GNU-only-test-idiom / CI-vs-local OS gap (#404).

## Test plan
- `just check` → exit 0 (1132 bats tests green, including the previously-failing `A8` turn-budget test now passing on macOS)
- lint clean: shellcheck, eslint, ruff, markdownlint

Closes #404. #403 (un-gate `rustup`) tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)