### PR TITLE
feat(chezmoi): install/update hallouminate binary on apply

### DIFF
--- a/chezmoi/.chezmoiscripts/run_onchange_after_install-hallouminate.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/run_onchange_after_install-hallouminate.sh.tmpl
@@ -1,0 +1,72 @@
+#!/bin/bash
+# run_onchange — installs / updates the hallouminate MCP server binary into
+# ~/.cargo/bin so `hallouminate serve` (the wiki MCP) always matches a real
+# release. The dotfiles deploy hallouminate's config + MCP registration but
+# assumed the binary already existed on PATH; this closes that gap (it drifted
+# to a hand-built 0.2.2 while releases moved to 0.2.3).
+#
+# Default: download the latest PREBUILT release via the cargo-dist installer
+# (no Rust toolchain, no compile — one curl into ~/.cargo/bin). Opt in to a
+# source build by setting, in the dotfiles .env:
+#     HALLOUMINATE_FROM_SOURCE=1
+# which compiles origin/main via `cargo install --git` — it builds REMOTE main,
+# not the local ~/Dev/hallouminate working tree, so a dirty/stale checkout never
+# leaks into the installed binary.
+#
+# Re-trigger markers: run_onchange fires only when the rendered body changes.
+# Both markers are computed fail-safe — the inner `sh -c` always exits 0 (a
+# trailing `echo`), so an OFFLINE `dots sync` renders a stable empty marker
+# instead of aborting the whole apply:
+#   latest release tag: {{ output "sh" "-c" "gh api repos/paulnsorensen/hallouminate/releases/latest --jq .tag_name 2>/dev/null | tr -d '[:space:]'; echo" }}
+#   origin/main commit: {{ output "sh" "-c" "git ls-remote https://github.com/paulnsorensen/hallouminate.git main 2>/dev/null | cut -f1 | tr -d '[:space:]'; echo" }}
+
+set -euo pipefail
+
+REPO="paulnsorensen/hallouminate"
+# .env lives at the dotfiles root — parent of chezmoi's sourceDir.
+ENV_FILE="$(cd "{{ .chezmoi.sourceDir }}/.." && pwd)/.env"
+
+# Read HALLOUMINATE_FROM_SOURCE from .env (naive loader, mirrors
+# lib/install-external.sh). Absent/0 → prebuilt path.
+FROM_SOURCE=0
+if [[ -f "$ENV_FILE" ]]; then
+    val="$(sed -n 's/^[[:space:]]*\(export[[:space:]]\+\)\?HALLOUMINATE_FROM_SOURCE=//p' "$ENV_FILE" | tail -1)"
+    val="${val%\"}"; val="${val#\"}"
+    [[ "$val" == "1" || "$val" == "true" ]] && FROM_SOURCE=1
+fi
+
+installed_version() { hallouminate --version 2>/dev/null | awk '{print $2}'; }
+
+if [[ "$FROM_SOURCE" == "1" ]]; then
+    if ! command -v cargo &>/dev/null; then
+        echo "Error: HALLOUMINATE_FROM_SOURCE=1 but cargo not found. Install Rust or unset the flag." >&2
+        exit 1
+    fi
+    echo "Building hallouminate from origin/main (HALLOUMINATE_FROM_SOURCE=1)..."
+    cargo install --git "https://github.com/$REPO" --branch main --force
+    echo "✓ hallouminate $(installed_version) installed from source (origin/main)"
+    exit 0
+fi
+
+# Prebuilt path. Skip when already on the latest tag — this script can re-fire
+# because origin/main moved (a new commit with no release), and a prebuilt-mode
+# machine should not re-download an unchanged release for that.
+latest="$(gh api "repos/$REPO/releases/latest" --jq .tag_name 2>/dev/null || true)"
+current="$(installed_version)"
+if [[ -n "$latest" && "v$current" == "$latest" ]]; then
+    echo "✓ hallouminate $current already latest ($latest) — nothing to do"
+    exit 0
+fi
+if [[ -z "$latest" && -n "$current" ]]; then
+    echo "⚠ Could not resolve latest release (offline?) — keeping installed $current" >&2
+    exit 0
+fi
+
+echo "Installing latest prebuilt hallouminate${latest:+ ($latest)}..."
+# ~/.cargo/bin is already on PATH; HALLOUMINATE_NO_MODIFY_PATH=1 stops the
+# cargo-dist installer from touching shell rc files (replaces the deprecated
+# --no-modify-path flag).
+curl --proto '=https' --tlsv1.2 -LsSf \
+    "https://github.com/$REPO/releases/latest/download/hallouminate-installer.sh" \
+    | HALLOUMINATE_NO_MODIFY_PATH=1 sh
+echo "✓ hallouminate $(installed_version) installed (prebuilt)"

--- a/tests/chezmoi-wiring.bats
+++ b/tests/chezmoi-wiring.bats
@@ -809,6 +809,22 @@ YAML
     chmod +x "$claude_bin/claude"
     PATH="$claude_bin:$PATH"
 
+    # The hallouminate run_onchange installer hits the network (gh api +
+    # curl-piped installer) when the binary isn't already present. CI's
+    # isolated $HOME has no gh auth, so `gh api` fails hard (exit 4, not
+    # just empty output) and the script would fall through to a REAL
+    # release download — non-hermetic and flaky. Stub both `hallouminate`
+    # (already "installed") and `gh`'s releases/latest lookup to the same
+    # fake tag so the script's existing already-latest short-circuit fires
+    # and no network call happens, mirroring the claude-CLI stub above.
+    local hallouminate_bin="$TEST_HOME/fake-hallouminate-bin"
+    mkdir -p "$hallouminate_bin"
+    printf '#!/usr/bin/env bash\necho "hallouminate 0.0.0-test"\n' > "$hallouminate_bin/hallouminate"
+    chmod +x "$hallouminate_bin/hallouminate"
+    printf '#!/usr/bin/env bash\ncase "$*" in\n  *"releases/latest"*) echo "v0.0.0-test" ;;\n  *) exit 1 ;;\nesac\n' > "$hallouminate_bin/gh"
+    chmod +x "$hallouminate_bin/gh"
+    PATH="$hallouminate_bin:$PATH"
+
     # Templated dotfiles need [data] for .email and env vars for the
     # copilot template's fail-fast guard. Bootstrap both before .sync runs
     # so chezmoi apply renders cleanly.


### PR DESCRIPTION
## Why

The dotfiles deploy hallouminate's **config** (`dot_config/hallouminate/config.toml.tmpl`) and **MCP registration** (Claude plugin, `private_dot_copilot/mcp-config.json.tmpl`) but assumed the `hallouminate` binary already existed on PATH. With nothing owning the binary, it drifted to a hand-built **0.2.2** (281 MB debug build in `~/.cargo/bin`) while releases moved to **0.2.3** — the MCP server kept launching the stale binary.

## What

New `chezmoi/.chezmoiscripts/run_onchange_after_install-hallouminate.sh.tmpl`, following the existing `run_onchange_after_install-*` + `{{ output "sh" "-c" ... }}` marker idiom:

- **Default (no flag):** download the latest **prebuilt** release via the cargo-dist installer into `~/.cargo/bin` — no toolchain, no compile. Skips the download when already on the latest tag.
- **`HALLOUMINATE_FROM_SOURCE=1` in the dotfiles env file:** compile **origin/main** via `cargo install --git … --branch main --force` (remote main, not the local working tree — no dirty-checkout leakage). Reuses the runtime-flag pattern from `lib/install-external.sh`.
- **Re-triggers** on a new release tag **or** a new `origin/main` commit. Both markers are fail-safe (inner `sh -c` always exits 0), so an **offline** `dots sync` renders stably instead of aborting the apply.

## Verification

- `chezmoi execute-template` renders clean; markers resolve (`v0.2.3`, current main SHA).
- `shellcheck` clean on the rendered script.
- Ran the rendered script end-to-end: `0.2.2 → 0.2.3` prebuilt install succeeded.

## Note

The env file is not a chezmoi template input, so flipping `HALLOUMINATE_FROM_SOURCE` alone won't re-trigger the script — it takes effect on the next release/commit, or force with `chezmoi state delete-bucket --bucket=scriptState && dots sync`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
