### PR TITLE
fix(hooks): turn-budget grace window, atomic state, opencode enforcement

### DIFF
--- a/.hallouminate/wiki/architecture/subagent-turn-budgets.md
+++ b/.hallouminate/wiki/architecture/subagent-turn-budgets.md
@@ -107,7 +107,6 @@ Claude's internal prompt fleet-wide. The only documented lever on a built-in is
 (headless/SDK only, removes all). Source: code.claude.com/docs/en/sub-agents
 §Built-in subagents and §Choose the subagent scope.
 
-
 ## Enforcement layer: the turn-budget-guard hook (PRs #392, #401, #407)
 
 `agents/hooks/turn-budget-guard.sh` → `agents/lib/turn-budget-guard.js` caps each

--- a/.hallouminate/wiki/architecture/subagent-turn-budgets.md
+++ b/.hallouminate/wiki/architecture/subagent-turn-budgets.md
@@ -8,6 +8,12 @@ frugal" instructions, which drift. This page records the measured turn and
 context distributions the caps were grounded in, so the values can be revisited
 when legitimate work gets clipped rather than re-derived from scratch.
 
+**Update (PRs #392/#401/#407):** `maxTurns` frontmatter turned out to be
+unenforced upstream (claude-code#41143 — the hardcoded default always wins), so
+enforcement moved to the `turn-budget-guard` hook. The data below still grounds
+the budget values; the hook's non-obvious mechanics are at the bottom of this
+page.
+
 See [[agents-dir]] for the registry mechanics, [[agent-profile]] for the renderer
 that emits the field, and [[agent-vs-skill-tiering]] for why each agent earns its
 own context window in the first place.
@@ -100,3 +106,50 @@ Claude's internal prompt fleet-wide. The only documented lever on a built-in is
 *removes* it, not caps it — or `CLAUDE_AGENT_SDK_DISABLE_BUILTIN_AGENTS=1`
 (headless/SDK only, removes all). Source: code.claude.com/docs/en/sub-agents
 §Built-in subagents and §Choose the subagent scope.
+
+
+## Enforcement layer: the turn-budget-guard hook (PRs #392, #401, #407)
+
+`agents/hooks/turn-budget-guard.sh` → `agents/lib/turn-budget-guard.js` caps each
+sub-agent on a dual ceiling — tool-call turns AND transcript bytes, whichever
+trips first — via PreToolUse hard-deny, a one-time PostToolUse wrap-up nudge, and
+SubagentStop cleanup. Keyed on `agent_id` (hook events inside a sub-agent carry
+it; orchestrator calls don't, so the guard no-ops on them). Fail-open on every
+error path — the guard caps runaways, it must never become a denial-of-service.
+
+Non-obvious facts a future agent would re-derive (learned in PR #407):
+
+- **Continued agents vs the byte wall.** SubagentStop wipes the turn counter but
+  the transcript persists, so a SendMessage-continued agent already over the
+  byte hard ceiling was denied on its *first* tool call with no handoff window
+  (observed live in the decision log). Hence the 3-call grace window past the
+  byte ceiling plus a hard nudge instructing the agent to persist a handoff and
+  return `status: blocked: out of context` — the orchestrator's re-dispatch
+  contract. The turn ceiling gets no grace: it ramps slowly and the soft nudge
+  precedes it by design.
+- **State is append-only on purpose.** Parallel tool calls in one batch fire
+  concurrent PreToolUse hooks; the original state.json read-modify-write lost
+  increments (duplicate turn counts observed live). Counters are the byte size
+  of an append-only file (O_APPEND writes are atomic); nudge flags are `wx`
+  marker files (EEXIST = already set, never re-emit).
+- **The byte signal is a proxy, not a conversion.** Transcript JSONL size ≈
+  context: the JSON envelope inflates bytes/token while the untranscripted
+  system prompt deflates it. Thresholds are calibrated against live denies —
+  don't treat the 4-bytes/token arithmetic as exact.
+- **The decision log is debug-gated for the orchestrator.** Orchestrator
+  no-agent-id records were 64% of `decisions.jsonl` volume on the hot path of
+  every tool call; they only log under `CLAUDE_TURN_BUDGET_DEBUG`. The log
+  rotates at 5MB (single `.1` generation) beside the SubagentStop sweep.
+- **opencode tool hooks carry no identity.** `tool.execute.before/after` input
+  is only `{tool, sessionID, callID}` — the adapter resolves
+  `client.session.get()` and treats parentID-set AND agent-non-empty as
+  sub-agent, with sessionID as the identity key and `session.idle`/`deleted` as
+  the SubagentStop equivalent. Deny-by-throw is safe there: opencode v1.17.14
+  triggers plugins inside the AI SDK tool `execute()`, and `ai@6.0.168`
+  `execute-tool-call.ts` catches every execute throw into a model-visible
+  `tool-error`, not a turn crash. The byte signal is inert on opencode (no
+  transcript path) — turn-ceiling-only enforcement.
+- **New heavy agent types must be added to `BUDGETS`.** Unknown types fall to
+  `default` (40 soft / 50 hard turns). `general-purpose` — the ultracook /
+  cheese-factory full-peer worker — sits at coder tier (75/100) for this reason;
+  a new pipeline-scale agent type left off the table gets half a coder's budget.

--- a/agents/hooks/registry.yaml
+++ b/agents/hooks/registry.yaml
@@ -151,17 +151,22 @@ hooks:
   # ─── Sub-agent turn/context budget ──────────────────────────────────
   # Enforces a per-sub-agent turn + context-byte ceiling that Claude Code's
   # `maxTurns` frontmatter fails to (upstream #41143: the hardcoded default
-  # always wins; background spawns drop the config entirely) and applies the
-  # same shared logic to Codex where Codex exposes sub-agent hook fields.
+  # always wins; background spawns drop the config entirely). Claude-only —
+  # Codex has no hook deployment for this guard today.
   # Three events fire inside the sub-agent with a consistent `agent_id`; the
   # main orchestrator's tool calls carry none, so the shared logic fail-opens
   # on them. Budgets are keyed by `agent_type`.
   #   turn-budget-guard-pre  — PreToolUse: increment the per-agent turn
   #                            counter, read live context bytes, DENY the call
-  #                            at the hard ceiling (turns OR bytes).
+  #                            at the turn hard ceiling immediately; the byte
+  #                            hard ceiling gets a short grace window before
+  #                            it denies (a resumed sub-agent's transcript can
+  #                            already sit above it on the very first call).
   #   turn-budget-guard-post — PostToolUse: inject a one-time wrap-up nudge
   #                            (additionalContext) when either signal crosses
-  #                            its soft threshold — the graceful handoff window.
+  #                            its soft threshold — the graceful handoff
+  #                            window — plus a sterner one-time nudge when
+  #                            bytes cross the hard ceiling.
   #   turn-budget-guard-stop — SubagentStop: delete the agent's counter dir.
   # All three share the one Node logic module and dispatch on hook_event_name.
   # matcher ".*" on pre/post covers every supported tool (the no-agent_id
@@ -173,7 +178,7 @@ hooks:
     script: agents/hooks/turn-budget-guard.sh
     shared_assets:
       - agents/lib/turn-budget-guard.js
-    harnesses: [claude, codex]
+    harnesses: [claude]
     matcher: ".*"
     timeout: 5
     description: Deny sub-agent tool calls past the per-agent_type turn/context hard ceiling
@@ -183,7 +188,7 @@ hooks:
     script: agents/hooks/turn-budget-guard.sh
     shared_assets:
       - agents/lib/turn-budget-guard.js
-    harnesses: [claude, codex]
+    harnesses: [claude]
     matcher: ".*"
     timeout: 5
     description: Nudge a sub-agent to wrap up once past the soft turn/context threshold
@@ -193,7 +198,7 @@ hooks:
     script: agents/hooks/turn-budget-guard.sh
     shared_assets:
       - agents/lib/turn-budget-guard.js
-    harnesses: [claude, codex]
+    harnesses: [claude]
     timeout: 5
     description: Delete the sub-agent's turn-budget counter dir on SubagentStop
 

--- a/agents/lib/turn-budget-guard.js
+++ b/agents/lib/turn-budget-guard.js
@@ -9,17 +9,29 @@
 // consistent `agent_id`. The main orchestrator's tool calls carry no
 // `agent_id`, so the hook no-ops on them — only sub-agents are capped.
 //   PreToolUse  — increment the per-agent turn counter, read live context
-//                 bytes; deny the call if EITHER exceeds its hard ceiling.
+//                 bytes; deny at the turn hard ceiling immediately. The byte
+//                 hard ceiling gets a short grace window (BYTE_GRACE_CALLS)
+//                 instead of an immediate deny — a continued sub-agent
+//                 (SendMessage resume) can already sit above byteHard on its
+//                 very first call, with no soft-nudge window behind it.
 //   PostToolUse — once per agent, inject a wrap-up nudge when either signal
-//                 crosses its soft threshold (the graceful handoff window).
-//   SubagentStop — delete the agent's counter dir, and sweep stale dirs so a
-//                 missed Stop can't leak forever.
+//                 crosses its soft threshold (the graceful handoff window);
+//                 a sterner one-time hard nudge fires when bytes cross the
+//                 byte hard ceiling, even if the soft nudge already fired.
+//   SubagentStop — delete the agent's counter dir, sweep stale dirs so a
+//                 missed Stop can't leak forever, and rotate the decision
+//                 log past a size cap.
 //
 // Budgets are keyed by `agent_type` (table + default fallback). The byte
 // ceiling is the sharper proxy for context rot: the sub-agent's own
 // transcript (`agent-<agent_id>.jsonl`) is located live under the project
 // dir and stat'd. If it can't be found the byte signal is 0 (fail-open to
 // the turn ceiling alone).
+//
+// Per-agent counters live as append/marker files (turns, grace, nudged,
+// hard-nudged) under one dir per (session_id, agent_id) — no read-modify-
+// write of a single state.json, so concurrent tool calls can't race a lost
+// increment or fail-open on a torn read.
 //
 // Fail-open everywhere: malformed/empty stdin, missing agent_id, unreadable
 // state, or an unlocatable transcript → allow. The guard caps runaways; it
@@ -38,18 +50,37 @@ function debug(msg) {
   if (process.env.CLAUDE_TURN_BUDGET_DEBUG) process.stderr.write(`[turn-budget-guard] ${msg}\n`);
 }
 
-// Prune counter dirs whose state file is older than this — backstop for a
+// Prune counter dirs whose turns file is older than this — backstop for a
 // missed SubagentStop.
 const STALE_HOURS = 6;
 
+// A continued sub-agent's transcript may already sit above byteHard on its
+// first call after resume (SubagentStop wipes turn state but the transcript
+// persists) — allow this many over-hard calls before denying, so there's a
+// window to persist a handoff instead of an instant wall.
+const BYTE_GRACE_CALLS = 3;
+
+// Cap decisions.jsonl; rotated to one `.1` generation on SubagentStop once
+// it crosses this (see rotateLogIfLarge).
+const DECISION_LOG_MAX_BYTES = 5 * 1024 * 1024;
+
 // Per-agent_type budgets. Turn ceilings are hand-set; byte ceilings use a
-// uniform byte proxy for ~110K-token soft and ~130K-token hard context caps
-// (4 bytes/token estimate against JSONL transcript size). Unknown types fall
-// to `default`.
+// byte proxy hand-calibrated against JSONL transcript size, not an exact
+// bytes/token conversion — the JSON envelope (keys, escaping, tool-call
+// wrappers) inflates bytes per token, while the untranscripted system
+// prompt deflates it. ~110K-token soft / ~130K-token hard at a 4-bytes/
+// token estimate. Unknown types fall to `default`.
 const CONTEXT_SOFT_BYTES = 110 * 1024 * 4;
 const CONTEXT_HARD_BYTES = 130 * 1024 * 4;
 const BUDGETS = {
   coder: { turnSoft: 75, turnHard: 100, byteSoft: CONTEXT_SOFT_BYTES, byteHard: CONTEXT_HARD_BYTES },
+  // general-purpose sub-agents run the same coder-shaped workloads.
+  'general-purpose': { turnSoft: 75, turnHard: 100, byteSoft: CONTEXT_SOFT_BYTES, byteHard: CONTEXT_HARD_BYTES },
+  // milknado worker's exact reported agent_type is unobserved — key both
+  // plausible spellings at coder tier so whichever the plugin emits resolves
+  // correctly instead of silently falling to `default`.
+  'milknado-worker': { turnSoft: 75, turnHard: 100, byteSoft: CONTEXT_SOFT_BYTES, byteHard: CONTEXT_HARD_BYTES },
+  'milknado:milknado-worker': { turnSoft: 75, turnHard: 100, byteSoft: CONTEXT_SOFT_BYTES, byteHard: CONTEXT_HARD_BYTES },
   reviewer: { turnSoft: 40, turnHard: 50, byteSoft: CONTEXT_SOFT_BYTES, byteHard: CONTEXT_HARD_BYTES },
   explorer: { turnSoft: 40, turnHard: 50, byteSoft: CONTEXT_SOFT_BYTES, byteHard: CONTEXT_HARD_BYTES },
   researcher: { turnSoft: 40, turnHard: 50, byteSoft: CONTEXT_SOFT_BYTES, byteHard: CONTEXT_HARD_BYTES },
@@ -132,7 +163,7 @@ function assertSafeBase() {
   try {
     st = fs.lstatSync(baseDir());
   } catch {
-    return; // absent — writeState's mkdir with mode 0o700 creates it safely
+    return; // absent — ensureCounterDir's mkdir with mode 0o700 creates it safely
   }
   const uid = process.getuid && process.getuid();
   if (st.isSymbolicLink() || !st.isDirectory() ||
@@ -146,7 +177,9 @@ function sanitize(id) {
   return String(id || '').replace(/[^A-Za-z0-9._-]/g, '_');
 }
 
-// The per-(session_id, agent_id) counter directory. Holds state.json.
+// The per-(session_id, agent_id) counter directory. Holds append/marker
+// files: turns, grace, nudged, hard-nudged (plus a legacy state.json from a
+// pre-rewrite agent, tolerated only by sweepStale's fallback).
 function counterPath(sessionId, agentId) {
   return path.join(baseDir(), sanitize(sessionId), sanitize(agentId));
 }
@@ -155,34 +188,96 @@ function stateFile(dir) {
   return path.join(dir, 'state.json');
 }
 
-// Read the counter state. Missing / malformed → fresh zeroed state.
-function readState(dir) {
+function turnsFile(dir) {
+  return path.join(dir, 'turns');
+}
+
+function graceFile(dir) {
+  return path.join(dir, 'grace');
+}
+
+function nudgedFile(dir) {
+  return path.join(dir, 'nudged');
+}
+
+function hardNudgedFile(dir) {
+  return path.join(dir, 'hard-nudged');
+}
+
+function fileSize(file) {
   try {
-    const raw = fs.readFileSync(stateFile(dir), 'utf8');
-    const s = JSON.parse(raw);
-    return { turns: Number(s.turns) || 0, nudged: s.nudged === true };
+    return fs.statSync(file).size;
   } catch {
-    return { turns: 0, nudged: false };
+    return 0;
   }
 }
 
-function writeState(dir, state) {
+function fileExists(file) {
+  try {
+    fs.statSync(file);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Read the counter state from the append/marker files. Missing → zero/false.
+// Counts derive from file size (one byte per append), not a JSON field, so a
+// torn read can't zero out a live counter.
+function readState(dir) {
+  return {
+    turns: fileSize(turnsFile(dir)),
+    graceUsed: fileSize(graceFile(dir)),
+    nudged: fileExists(nudgedFile(dir)),
+    hardNudged: fileExists(hardNudgedFile(dir)),
+  };
+}
+
+function ensureCounterDir(dir) {
   assertSafeBase();
   fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
-  fs.writeFileSync(stateFile(dir), JSON.stringify(state));
+}
+
+// Append one byte to `file` and return the new size — O_APPEND appends are
+// atomic, so concurrent batched tool calls can't race a read-modify-write
+// and lose an increment the way a shared state.json could.
+function appendCounter(dir, file) {
+  ensureCounterDir(dir);
+  fs.appendFileSync(file, 'x');
+  return fileSize(file);
 }
 
 // One increment per attempted tool call (PreToolUse only).
 function incrementTurn(dir) {
-  const s = readState(dir);
-  const next = { turns: s.turns + 1, nudged: s.nudged };
-  writeState(dir, next);
-  return next;
+  appendCounter(dir, turnsFile(dir));
+  return readState(dir);
+}
+
+// One increment per grace-consumed over-hard byte call (PreToolUse only).
+function incrementGrace(dir) {
+  return appendCounter(dir, graceFile(dir));
+}
+
+// Create `file` iff absent — atomic create-if-absent via the 'wx' flag.
+// Returns true if THIS call created it, false if another process already won
+// the race (EEXIST) — the caller must not emit a duplicate nudge.
+function markOnce(dir, file) {
+  ensureCounterDir(dir);
+  try {
+    fs.writeFileSync(file, '', { flag: 'wx' });
+    return true;
+  } catch (err) {
+    if (err && err.code === 'EEXIST') return false;
+    throw err;
+  }
 }
 
 function markNudged(dir) {
-  const s = readState(dir);
-  writeState(dir, { turns: s.turns, nudged: true });
+  return markOnce(dir, nudgedFile(dir));
+}
+
+function markHardNudged(dir) {
+  return markOnce(dir, hardNudgedFile(dir));
 }
 
 function cleanup(dir) {
@@ -212,11 +307,16 @@ function contextBytes(transcriptPath, sessionId, agentId) {
   }
 }
 
+// A failed stat of the primary (Codex) path must fall through to the
+// walk-based fallback, not short-circuit to 0 — the fallback is exactly for
+// when the primary path doesn't resolve.
 function contextBytesFromEvent(event) {
-  try {
-    if (event.agent_transcript_path) return fs.statSync(event.agent_transcript_path).size;
-  } catch {
-    return 0;
+  if (event.agent_transcript_path) {
+    try {
+      return fs.statSync(event.agent_transcript_path).size;
+    } catch {
+      /* fall through to the walk-based fallback below */
+    }
   }
   return contextBytes(event.transcript_path, event.session_id, event.agent_id);
 }
@@ -244,10 +344,13 @@ function findFile(dir, name, depth) {
   return null;
 }
 
-// Prune agent counter dirs whose state.json mtime is older than the cutoff.
-// Checks the STATE FILE's mtime, not the dir's — a dir's mtime freezes at
-// mkdir on Linux and would falsely spare a leaked dir / falsely flag a live
-// one. Best-effort; never throws to the caller.
+// Prune agent counter dirs whose turns file mtime is older than the cutoff,
+// falling back to a legacy state.json mtime for a dir left by a pre-rewrite
+// agent (no migration shim — those just reset to zero, which is fail-open
+// and acceptable). A dir with neither file is mid-creation; leave it.
+// Checks a FILE's mtime, not the dir's — a dir's mtime freezes at mkdir on
+// Linux and would falsely spare a leaked dir / falsely flag a live one.
+// Best-effort; never throws to the caller.
 function sweepStale(base, maxAgeHours) {
   const cutoff = Date.now() - maxAgeHours * 3600 * 1000;
   let sessions;
@@ -270,9 +373,13 @@ function sweepStale(base, maxAgeHours) {
       const agDir = path.join(sessDir, ag.name);
       let mtime;
       try {
-        mtime = fs.statSync(stateFile(agDir)).mtimeMs;
+        mtime = fs.statSync(turnsFile(agDir)).mtimeMs;
       } catch {
-        continue; // no state file → leave it
+        try {
+          mtime = fs.statSync(stateFile(agDir)).mtimeMs; // legacy leftover dir
+        } catch {
+          continue; // neither file → mid-creation or already-swept; leave it
+        }
       }
       if (mtime < cutoff) cleanup(agDir);
     }
@@ -285,13 +392,29 @@ function sweepStale(base, maxAgeHours) {
   }
 }
 
+// Rotate decisions.jsonl to one `.1` generation once it crosses maxBytes.
+// Best-effort: a missing log file or a failed rename both fail-open (the
+// log just keeps growing rather than blocking enforcement).
+function rotateLogIfLarge(maxBytes) {
+  try {
+    const file = logPath();
+    if (fs.statSync(file).size > maxBytes) {
+      fs.renameSync(file, `${file}.1`);
+    }
+  } catch {
+    /* fail-open */
+  }
+}
+
 function denyReason(agentType, turns, bytes, budget) {
   const kb = Math.round(bytes / 1024);
   const hardKb = Math.round(budget.byteHard / 1024);
   return `Sub-agent budget exceeded (type '${agentType || 'default'}': ` +
     `turns ${turns}/${budget.turnHard}, context ~${kb}KB/${hardKb}KB). ` +
     `Stop calling tools now — synthesize your findings and return your final ` +
-    `text response. Every further tool call is denied until this sub-agent returns.`;
+    `text response. Every further tool call is denied until this sub-agent returns. ` +
+    `If your task is incomplete, open your final reply with ` +
+    `"status: blocked: out of context" so the orchestrator re-dispatches a fresh agent.`;
 }
 
 function nudgeContext(agentType, budget) {
@@ -300,6 +423,18 @@ function nudgeContext(agentType, budget) {
     `Persist your handoff or partial results now and wrap up: tool calls are ` +
     `hard-blocked at the ceiling, so prefer returning a concise final answer ` +
     `over further exploration.`;
+}
+
+// Sterner one-time nudge for crossing the byte HARD ceiling (as opposed to
+// the soft-threshold nudgeContext above) — the grace window is short, so
+// this must land before it runs out.
+function hardNudgeContext(agentType, budget, remainingCalls) {
+  return `Context hard ceiling exceeded (type '${agentType || 'default'}': ` +
+    `~${Math.round(budget.byteHard / 1024)}KB). At most ${remainingCalls} further ` +
+    `tool call(s) will be allowed before this sub-agent is denied outright. ` +
+    `Persist your handoff NOW — do not keep exploring. If your task is ` +
+    `incomplete, open your final reply with "status: blocked: out of context" ` +
+    `so the orchestrator re-dispatches a fresh agent.`;
 }
 
 function emitDeny(reason) {
@@ -324,7 +459,12 @@ function emitNudge(context) {
 function handle(event, emit = { deny: emitDeny, nudge: emitNudge }) {
   const agentId = event.agent_id;
   if (!agentId) {
-    writeDecision(event, { action: 'allow', reason: 'no-agent-id' });
+    // These used to be 64% of all records — the orchestrator's own tool
+    // calls, written on every call of every session. Gate behind the debug
+    // env var so the always-on log only carries actual sub-agent decisions.
+    if (process.env.CLAUDE_TURN_BUDGET_DEBUG) {
+      writeDecision(event, { action: 'allow', reason: 'no-agent-id' });
+    }
     return { action: 'allow', reason: 'no-agent-id' };
   }
 
@@ -342,6 +482,7 @@ function handle(event, emit = { deny: emitDeny, nudge: emitNudge }) {
     // sub-agent and the sweep walks all sessions, so leaked dirs are still
     // reclaimed by the next agent that stops cleanly.
     try { sweepStale(baseDir(), STALE_HOURS); } catch { /* fail-open */ }
+    try { rotateLogIfLarge(DECISION_LOG_MAX_BYTES); } catch { /* fail-open */ }
     writeDecision(event, {
       action: 'cleanup',
       reason: 'subagent-stop',
@@ -355,14 +496,26 @@ function handle(event, emit = { deny: emitDeny, nudge: emitNudge }) {
     const state = incrementTurn(dir);
     const bytes = contextBytesFromEvent(event);
     debug(`pre type=${type} turns=${state.turns}/${budget.turnHard} ` +
-      `bytes=${bytes}/${budget.byteHard}`);
+      `bytes=${bytes}/${budget.byteHard} grace=${state.graceUsed}/${BYTE_GRACE_CALLS}`);
     const fields = {
       budget_type: type,
       turns: state.turns,
       bytes,
+      graceUsed: state.graceUsed,
       ...thresholdFields(budget),
     };
-    if (state.turns > budget.turnHard || bytes > budget.byteHard) {
+    if (state.turns > budget.turnHard) {
+      const reason = denyReason(type, state.turns, bytes, budget);
+      writeDecision(event, { ...fields, action: 'deny', reason: 'hard-ceiling' });
+      emit.deny(reason);
+      return { action: 'deny', reason };
+    }
+    if (bytes > budget.byteHard) {
+      if (state.graceUsed < BYTE_GRACE_CALLS) {
+        const graceUsed = incrementGrace(dir);
+        writeDecision(event, { ...fields, graceUsed, action: 'allow', reason: 'byte-grace' });
+        return { action: 'allow', reason: 'byte-grace' };
+      }
       const reason = denyReason(type, state.turns, bytes, budget);
       writeDecision(event, { ...fields, action: 'deny', reason: 'hard-ceiling' });
       emit.deny(reason);
@@ -373,14 +526,32 @@ function handle(event, emit = { deny: emitDeny, nudge: emitNudge }) {
   }
 
   if (evt === 'PostToolUse') {
-    const state = readState(dir);
+    let state = readState(dir);
     const bytes = contextBytesFromEvent(event);
     const fields = {
       budget_type: type,
       turns: state.turns,
       bytes,
+      graceUsed: state.graceUsed,
       ...thresholdFields(budget),
     };
+
+    if (bytes > budget.byteHard && !state.hardNudged) {
+      const created = markHardNudged(dir);
+      if (created) {
+        markNudged(dir); // suppress the soft nudge too — one nudge per agent max
+        const remaining = Math.max(0, BYTE_GRACE_CALLS - state.graceUsed);
+        debug(`hard-nudge type=${type} turns=${state.turns} bytes=${bytes} remaining=${remaining}`);
+        const context = hardNudgeContext(type, budget, remaining);
+        writeDecision(event, { ...fields, action: 'nudge', reason: 'hard-threshold' });
+        emit.nudge(context);
+        return { action: 'nudge', reason: context };
+      }
+      // Lost the create-if-absent race — another process is already emitting
+      // the hard nudge; fall through as if already nudged.
+      state = { ...state, hardNudged: true, nudged: true };
+    }
+
     if (state.nudged) {
       writeDecision(event, { ...fields, action: 'allow', reason: 'already-nudged' });
       return { action: 'allow', reason: 'already-nudged' };
@@ -421,7 +592,9 @@ module.exports = {
   counterPath,
   readState,
   incrementTurn,
+  incrementGrace,
   markNudged,
+  markHardNudged,
   cleanup,
   contextBytes,
   logPath,
@@ -430,5 +603,9 @@ module.exports = {
   handle,
   denyReason,
   nudgeContext,
+  hardNudgeContext,
   sweepStale,
+  rotateLogIfLarge,
+  BYTE_GRACE_CALLS,
+  DECISION_LOG_MAX_BYTES,
 };

--- a/chezmoi/dot_config/opencode/plugins/turn-budget-guard.js
+++ b/chezmoi/dot_config/opencode/plugins/turn-budget-guard.js
@@ -1,8 +1,45 @@
-// turn-budget-guard opencode plugin — best-effort sub-agent budget adapter.
+// turn-budget-guard opencode plugin — sub-agent budget adapter.
 //
-// The shared turn-budget-guard logic is authoritative. This plugin only adapts
-// opencode tool events when they carry a stable sub-agent identity; otherwise it
-// records a fail-open decision and lets the tool run.
+// The shared turn-budget-guard logic (agents/lib/turn-budget-guard.js) is
+// authoritative; this adapter's only job is mapping opencode's plugin hooks
+// onto the shared event shape.
+//
+// Identity: opencode's `tool.execute.before`/`.after` hook payloads carry
+// only `{tool, sessionID, callID}` (+ `args`) — no agent identity field
+// (verified against sst/opencode v1.17.14, packages/plugin/src/index.ts
+// L266-281). Sub-agent dispatch creates a *child session* with `parentID`
+// (caller session) and `agent` (sub-agent type name) set at creation
+// (packages/opencode/src/tool/task.ts L142-158). This adapter resolves
+// identity per call via `ctx.client.session.get({path:{id: sessionID}})`
+// and caches the result in memory (this module lives for the opencode
+// process). `parentID` alone doesn't disambiguate sub-agents from plain
+// session forks (both set it), so a session only counts as a sub-agent when
+// BOTH `parentID` and a non-empty `agent` are present. Any client error or
+// missing fields fails open — no identity means the shared guard's own
+// `no-agent-id` no-op fires.
+//
+// Byte signal: opencode exposes no transcript path, so the shared guard's
+// byte probe always resolves to 0 here — enforcement is turn-ceiling-only
+// on opencode. Not building a message-based byte estimator (YAGNI, out of
+// this adapter's scope).
+//
+// Cleanup: the `event` hook watches `session.idle`/`session.deleted` for any
+// sessionID cached as a sub-agent, emits a SubagentStop to the shared guard,
+// then evicts the cache entry.
+//
+// Deny gate: `tool.execute.before` throwing is safe to keep as the deny
+// mechanism. The trigger call site (packages/opencode/src/session/tools.ts
+// L106-120, v1.17.14) runs inside the AI SDK tool's `execute()` (package
+// `ai`, pinned to `ai@6.0.168`). That package's `executeToolCall`
+// (packages/ai/src/generate-text/execute-tool-call.ts, vercel/ai tag
+// ai@6.0.168) wraps the whole `execute()` call — including our thrown deny —
+// in a try/catch that converts any thrown/rejected error into a
+// `{type: "tool-error", ...}` tool output, which flows into the model-visible
+// tool result exactly like any other tool error. It does not crash the turn.
+// `emit.deny = throw` stays wired.
+//
+// The nudge stays a stub: opencode has no context-injection channel for a
+// completed tool call.
 
 import { createRequire } from "node:module";
 import { homedir } from "node:os";
@@ -21,30 +58,42 @@ function loadGuard() {
   }
 }
 
-function firstString(...values) {
-  for (const value of values) {
-    if (typeof value === "string" && value.trim()) return value;
+// Resolve {parentID, agent} for `sessionID` via the opencode client, caching
+// both hits and misses (including client errors) so repeat tool calls in the
+// same session don't re-fetch. Returns null when the session isn't a
+// sub-agent (no parentID/agent) or the lookup failed — either way the caller
+// fails open.
+async function resolveIdentity(client, cache, sessionID) {
+  if (cache.has(sessionID)) return cache.get(sessionID);
+  let identity = null;
+  try {
+    const res = await client.session.get({ path: { id: sessionID } });
+    const info = res?.data;
+    if (info && info.parentID && typeof info.agent === "string" && info.agent.trim()) {
+      identity = { parentID: info.parentID, agent: info.agent };
+    }
+  } catch {
+    identity = null;
   }
-  return "";
+  cache.set(sessionID, identity);
+  return identity;
 }
 
-function eventFor(ctx, input, output, hook_event_name) {
-  const args = output?.args || {};
-  const meta = input?.metadata || output?.metadata || {};
-  const session = input?.session || output?.session || ctx?.session || {};
-  const agent = input?.agent || output?.agent || meta.agent || {};
+async function eventFor(ctx, cache, input, output, hook_event_name) {
+  const sessionID = typeof input?.sessionID === "string" ? input.sessionID : "";
+  const identity = sessionID && ctx?.client ? await resolveIdentity(ctx.client, cache, sessionID) : null;
 
   return {
     harness: "opencode",
     hook_event_name,
-    session_id: firstString(input?.session_id, input?.sessionID, session.id, meta.session_id),
-    agent_id: firstString(input?.agent_id, input?.agentID, agent.id, meta.agent_id),
-    agent_type: firstString(input?.agent_type, input?.agentType, agent.type, meta.agent_type),
-    transcript_path: firstString(input?.transcript_path, session.transcript_path, meta.transcript_path),
-    agent_transcript_path: firstString(input?.agent_transcript_path, agent.transcript_path, meta.agent_transcript_path),
+    session_id: identity ? identity.parentID : "",
+    agent_id: identity ? sessionID : "",
+    agent_type: identity ? identity.agent : "",
+    transcript_path: "",
+    agent_transcript_path: "",
     cwd: ctx?.directory || ctx?.worktree || process.cwd(),
     tool_name: input?.tool || "unknown",
-    tool_input: args,
+    tool_input: output?.args || input?.args || {},
   };
 }
 
@@ -52,6 +101,7 @@ export const TurnBudgetGuard = async (ctx) => {
   const guard = loadGuard();
   if (!guard) return {};
 
+  const cache = new Map();
   const emit = {
     deny: (reason) => { throw new Error(reason); },
     nudge: () => {},
@@ -59,10 +109,26 @@ export const TurnBudgetGuard = async (ctx) => {
 
   return {
     "tool.execute.before": async (input, output) => {
-      guard.handle(eventFor(ctx, input, output, "PreToolUse"), emit);
+      guard.handle(await eventFor(ctx, cache, input, output, "PreToolUse"), emit);
     },
     "tool.execute.after": async (input, output) => {
-      guard.handle(eventFor(ctx, input, output, "PostToolUse"), emit);
+      guard.handle(await eventFor(ctx, cache, input, output, "PostToolUse"), emit);
+    },
+    event: async ({ event }) => {
+      const type = event?.type;
+      if (type !== "session.idle" && type !== "session.deleted") return;
+      const sessionID = type === "session.idle" ? event.properties?.sessionID : event.properties?.info?.id;
+      if (!sessionID || !cache.has(sessionID)) return;
+      const identity = cache.get(sessionID);
+      cache.delete(sessionID);
+      if (!identity) return;
+      guard.handle({
+        harness: "opencode",
+        hook_event_name: "SubagentStop",
+        session_id: identity.parentID,
+        agent_id: sessionID,
+        agent_type: identity.agent,
+      }, emit);
     },
   };
 };

--- a/chezmoi/dot_config/opencode/plugins/turn-budget-guard.js
+++ b/chezmoi/dot_config/opencode/plugins/turn-budget-guard.js
@@ -103,16 +103,33 @@ export const TurnBudgetGuard = async (ctx) => {
 
   const cache = new Map();
   const emit = {
-    deny: (reason) => { throw new Error(reason); },
+    deny: (reason) => {
+      const err = new Error(reason);
+      err.turnBudgetDeny = true;
+      throw err;
+    },
     nudge: () => {},
+  };
+
+  // Fail-open shim. On Claude the CLI entry point's outer try/catch turns any
+  // internal guard fault into an allow; here there is no outer catch, so a
+  // stray throw (e.g. an fs error writing counter state) would reach the AI
+  // SDK exactly like a deny and fail the tool call closed. Only the
+  // intentional deny may escape.
+  const guarded = (event) => {
+    try {
+      guard.handle(event, emit);
+    } catch (err) {
+      if (err && err.turnBudgetDeny) throw err;
+    }
   };
 
   return {
     "tool.execute.before": async (input, output) => {
-      guard.handle(await eventFor(ctx, cache, input, output, "PreToolUse"), emit);
+      guarded(await eventFor(ctx, cache, input, output, "PreToolUse"));
     },
     "tool.execute.after": async (input, output) => {
-      guard.handle(await eventFor(ctx, cache, input, output, "PostToolUse"), emit);
+      guarded(await eventFor(ctx, cache, input, output, "PostToolUse"));
     },
     event: async ({ event }) => {
       const type = event?.type;
@@ -122,13 +139,13 @@ export const TurnBudgetGuard = async (ctx) => {
       const identity = cache.get(sessionID);
       cache.delete(sessionID);
       if (!identity) return;
-      guard.handle({
+      guarded({
         harness: "opencode",
         hook_event_name: "SubagentStop",
         session_id: identity.parentID,
         agent_id: sessionID,
         agent_type: identity.agent,
-      }, emit);
+      });
     },
   };
 };

--- a/tests/agents-hooks-sync.bats
+++ b/tests/agents-hooks-sync.bats
@@ -813,62 +813,46 @@ SH
     [[ "$has_matcher" == "false" ]]
 }
 
-@test "the real registry's turn-budget-guard entries carry expected events for claude and codex" {
+@test "the real registry's turn-budget-guard entries carry expected events for claude" {
     # Guards the wiring: the three sub-agent budget hooks must sit on
     # PreToolUse / PostToolUse / SubagentStop and share the one logic asset.
-    local reg harness
-    for harness in claude codex; do
-        reg=$(hook_filter_for_harness "$harness" "$REGISTRY_JSON")
-        [[ "$(jq -r '.["turn-budget-guard-pre"].event'  <<<"$reg")" == "PreToolUse"   ]]
-        [[ "$(jq -r '.["turn-budget-guard-post"].event' <<<"$reg")" == "PostToolUse"  ]]
-        [[ "$(jq -r '.["turn-budget-guard-stop"].event' <<<"$reg")" == "SubagentStop" ]]
-        [[ "$(jq -r '.["turn-budget-guard-pre"].shared_assets[0]' <<<"$reg")" == "agents/lib/turn-budget-guard.js" ]]
-    done
+    # Codex support was dropped (harnesses: [claude] only) — see the codex
+    # absence tests below.
+    local reg
+    reg=$(hook_filter_for_harness claude "$REGISTRY_JSON")
+    [[ "$(jq -r '.["turn-budget-guard-pre"].event'  <<<"$reg")" == "PreToolUse"   ]]
+    [[ "$(jq -r '.["turn-budget-guard-post"].event' <<<"$reg")" == "PostToolUse"  ]]
+    [[ "$(jq -r '.["turn-budget-guard-stop"].event' <<<"$reg")" == "SubagentStop" ]]
+    [[ "$(jq -r '.["turn-budget-guard-pre"].shared_assets[0]' <<<"$reg")" == "agents/lib/turn-budget-guard.js" ]]
 }
 
-@test "turn-budget-guard renders runnable Codex hook commands" {
-    HARNESS_DESIRED_JSON=$(hook_filter_for_harness codex "$REGISTRY_JSON")
-    local pre post stop
-    pre=$(hook_desired_signature turn-budget-guard-pre codex)
-    post=$(hook_desired_signature turn-budget-guard-post codex)
-    stop=$(hook_desired_signature turn-budget-guard-stop codex)
-    [[ "$pre"  == 'bash "$HOME/.codex/hooks/turn-budget-guard.sh"'$'\t'"PreToolUse"$'\t'".*"$'\t'"5"$'\t' ]]
-    [[ "$post" == 'bash "$HOME/.codex/hooks/turn-budget-guard.sh"'$'\t'"PostToolUse"$'\t'".*"$'\t'"5"$'\t' ]]
-    [[ "$stop" == 'bash "$HOME/.codex/hooks/turn-budget-guard.sh"'$'\t'"SubagentStop"$'\t'$'\t'"5"$'\t' ]]
+@test "turn-budget-guard is absent from the codex-filtered registry" {
+    local reg
+    reg=$(hook_filter_for_harness codex "$REGISTRY_JSON")
+    [[ "$(jq -r 'has("turn-budget-guard-pre")'  <<<"$reg")" == "false" ]]
+    [[ "$(jq -r 'has("turn-budget-guard-post")' <<<"$reg")" == "false" ]]
+    [[ "$(jq -r 'has("turn-budget-guard-stop")' <<<"$reg")" == "false" ]]
 }
 
-@test "codex filters in turn-budget-guard entries and renders the codex hook path" {
-    local reg pre_sig post_sig stop_sig
+@test "codex filters out turn-budget-guard entries entirely" {
+    local reg
     reg=$(hook_filter_for_harness codex "$REGISTRY_JSON")
 
-    [[ "$(jq -r 'has("turn-budget-guard-pre")'  <<<"$reg")" == "true" ]]
-    [[ "$(jq -r 'has("turn-budget-guard-post")' <<<"$reg")" == "true" ]]
-    [[ "$(jq -r 'has("turn-budget-guard-stop")' <<<"$reg")" == "true" ]]
-
-    HARNESS_DESIRED_JSON="$reg"
-    pre_sig=$(hook_desired_signature turn-budget-guard-pre codex)
-    post_sig=$(hook_desired_signature turn-budget-guard-post codex)
-    stop_sig=$(hook_desired_signature turn-budget-guard-stop codex)
-
-    grep -qF $'bash "$HOME/.codex/hooks/turn-budget-guard.sh"\tPreToolUse\t.*\t5\t' <<<"$pre_sig"
-    grep -qF $'bash "$HOME/.codex/hooks/turn-budget-guard.sh"\tPostToolUse\t.*\t5\t' <<<"$post_sig"
-    grep -qF $'bash "$HOME/.codex/hooks/turn-budget-guard.sh"\tSubagentStop\t\t5\t' <<<"$stop_sig"
+    [[ "$(jq -r 'has("turn-budget-guard-pre")'  <<<"$reg")" == "false" ]]
+    [[ "$(jq -r 'has("turn-budget-guard-post")' <<<"$reg")" == "false" ]]
+    [[ "$(jq -r 'has("turn-budget-guard-stop")' <<<"$reg")" == "false" ]]
 }
 
-@test "codex upsert preserves turn-budget-guard matcher behavior" {
+@test "codex upsert has no turn-budget-guard matcher behavior to preserve" {
     local reg
     reg=$(hook_filter_for_harness codex "$REGISTRY_JSON")
 
     HARNESS_DESIRED_JSON="$reg"
     : > "$CODEX_CONFIG_FILE"
-    hook_codex_apply turn-budget-guard-pre
-    hook_codex_apply turn-budget-guard-post
-    hook_codex_apply turn-budget-guard-stop
 
-    [[ "$(yq -p=toml -o=json '.hooks.PreToolUse[0].matcher'  "$CODEX_CONFIG_FILE")" == '".*"' ]]
-    [[ "$(yq -p=toml -o=json '.hooks.PostToolUse[0].matcher' "$CODEX_CONFIG_FILE")" == '".*"' ]]
-    [[ "$(yq -p=toml -o=json '.hooks.SubagentStop[0] | has("matcher")' "$CODEX_CONFIG_FILE")" == "false" ]]
-    [[ "$(yq -p=toml -o=json '.hooks.PreToolUse[0].hooks[0].command' "$CODEX_CONFIG_FILE")" == '"bash \"$HOME/.codex/hooks/turn-budget-guard.sh\""' ]]
+    [[ "$(jq -r 'has("turn-budget-guard-pre")'  <<<"$reg")" == "false" ]]
+    [[ "$(jq -r 'has("turn-budget-guard-post")' <<<"$reg")" == "false" ]]
+    [[ "$(jq -r 'has("turn-budget-guard-stop")' <<<"$reg")" == "false" ]]
 }
 
 @test "hook_filter_for_harness rejects entries with both script and command" {

--- a/tests/turn-budget-guard-opencode.bats
+++ b/tests/turn-budget-guard-opencode.bats
@@ -141,3 +141,36 @@ teardown() {
     '
     assert_success
 }
+
+@test "opencode turn-budget-guard plugin fails open when counter state is unwritable" {
+    printf '' > "$TEST_HOME/not-a-dir"
+    CLAUDE_TURN_BUDGET_DIR="$TEST_HOME/not-a-dir" DOTFILES_DIR="$REAL_DOTFILES_DIR" OG_PLUGIN="$OPENCODE_PLUGIN" run node --input-type=module -e '
+      const mod = await import(process.env.OG_PLUGIN);
+      const client = { session: { get: async () => ({ data: { parentID: "p1", agent: "explorer" } }) } };
+      const hooks = await mod.TurnBudgetGuard({ directory: process.env.DOTFILES_DIR, worktree: process.env.DOTFILES_DIR, client });
+      // Counter writes throw ENOTDIR under a file base dir; the hook must
+      // swallow that (fail-open), not fail the tool call.
+      await hooks["tool.execute.before"]({ tool: "bash", sessionID: "child-fs", callID: "c1" }, { args: {} });
+      await hooks["tool.execute.after"]({ tool: "bash", sessionID: "child-fs", callID: "c1" }, { args: {} });
+    '
+    assert_success
+}
+
+@test "opencode turn-budget-guard plugin still denies at the turn hard ceiling" {
+    mkdir -p "$CLAUDE_TURN_BUDGET_DIR/p1/child-deny"
+    printf '%050d' 0 > "$CLAUDE_TURN_BUDGET_DIR/p1/child-deny/turns"  # explorer turnHard = 50
+    DOTFILES_DIR="$REAL_DOTFILES_DIR" OG_PLUGIN="$OPENCODE_PLUGIN" run node --input-type=module -e '
+      const mod = await import(process.env.OG_PLUGIN);
+      const client = { session: { get: async () => ({ data: { parentID: "p1", agent: "explorer" } }) } };
+      const hooks = await mod.TurnBudgetGuard({ directory: process.env.DOTFILES_DIR, worktree: process.env.DOTFILES_DIR, client });
+      let threw = null;
+      try {
+        await hooks["tool.execute.before"]({ tool: "bash", sessionID: "child-deny", callID: "c1" }, { args: {} });
+      } catch (err) {
+        threw = err;
+      }
+      if (!threw) throw new Error("expected the deny to propagate");
+      if (!threw.turnBudgetDeny) throw new Error(`deny escaped untagged: ${threw.message}`);
+    '
+    assert_success
+}

--- a/tests/turn-budget-guard-opencode.bats
+++ b/tests/turn-budget-guard-opencode.bats
@@ -63,3 +63,81 @@ teardown() {
     '
     assert_success
 }
+
+@test "opencode turn-budget-guard plugin maps sub-agent session to agent_id/agent_type" {
+    DOTFILES_DIR="$REAL_DOTFILES_DIR" OG_PLUGIN="$OPENCODE_PLUGIN" LOG="$CLAUDE_TURN_BUDGET_LOG" run node --input-type=module -e '
+      import { readFileSync } from "node:fs";
+      const mod = await import(process.env.OG_PLUGIN);
+      const client = { session: { get: async () => ({ data: { parentID: "p1", agent: "explorer" } }) } };
+      const hooks = await mod.TurnBudgetGuard({ directory: process.env.DOTFILES_DIR, worktree: process.env.DOTFILES_DIR, client });
+      await hooks["tool.execute.before"]({ tool: "bash", sessionID: "child-1", callID: "c1" }, { args: {} });
+      const lines = readFileSync(process.env.LOG, "utf8").trim().split("\n");
+      const record = JSON.parse(lines[lines.length - 1]);
+      if (record.agent_id !== "child-1") throw new Error(`agent_id: ${record.agent_id}`);
+      if (record.agent_type !== "explorer") throw new Error(`agent_type: ${record.agent_type}`);
+      if (record.session_id !== "p1") throw new Error(`session_id: ${record.session_id}`);
+    '
+    assert_success
+}
+
+@test "opencode turn-budget-guard plugin no-ops when session has no parentID" {
+    CLAUDE_TURN_BUDGET_DEBUG=1 DOTFILES_DIR="$REAL_DOTFILES_DIR" OG_PLUGIN="$OPENCODE_PLUGIN" LOG="$CLAUDE_TURN_BUDGET_LOG" run node --input-type=module -e '
+      import { readFileSync } from "node:fs";
+      const mod = await import(process.env.OG_PLUGIN);
+      const client = { session: { get: async () => ({ data: { agent: "explorer" } }) } };
+      const hooks = await mod.TurnBudgetGuard({ directory: process.env.DOTFILES_DIR, worktree: process.env.DOTFILES_DIR, client });
+      await hooks["tool.execute.before"]({ tool: "bash", sessionID: "top-1", callID: "c1" }, { args: {} });
+      const lines = readFileSync(process.env.LOG, "utf8").trim().split("\n");
+      const record = JSON.parse(lines[lines.length - 1]);
+      if (record.action !== "allow" || record.reason !== "no-agent-id") {
+        throw new Error(`unexpected: ${JSON.stringify(record)}`);
+      }
+    '
+    assert_success
+}
+
+@test "opencode turn-budget-guard plugin fails open when session.get throws" {
+    CLAUDE_TURN_BUDGET_DEBUG=1 DOTFILES_DIR="$REAL_DOTFILES_DIR" OG_PLUGIN="$OPENCODE_PLUGIN" LOG="$CLAUDE_TURN_BUDGET_LOG" run node --input-type=module -e '
+      import { readFileSync } from "node:fs";
+      const mod = await import(process.env.OG_PLUGIN);
+      const client = { session: { get: async () => { throw new Error("boom"); } } };
+      const hooks = await mod.TurnBudgetGuard({ directory: process.env.DOTFILES_DIR, worktree: process.env.DOTFILES_DIR, client });
+      await hooks["tool.execute.before"]({ tool: "bash", sessionID: "err-1", callID: "c1" }, { args: {} });
+      const lines = readFileSync(process.env.LOG, "utf8").trim().split("\n");
+      const record = JSON.parse(lines[lines.length - 1]);
+      if (record.action !== "allow" || record.reason !== "no-agent-id") {
+        throw new Error(`unexpected: ${JSON.stringify(record)}`);
+      }
+    '
+    assert_success
+}
+
+@test "opencode turn-budget-guard plugin caches session identity across calls" {
+    DOTFILES_DIR="$REAL_DOTFILES_DIR" OG_PLUGIN="$OPENCODE_PLUGIN" run node --input-type=module -e '
+      const mod = await import(process.env.OG_PLUGIN);
+      let calls = 0;
+      const client = { session: { get: async () => { calls++; return { data: { parentID: "p1", agent: "explorer" } }; } } };
+      const hooks = await mod.TurnBudgetGuard({ directory: process.env.DOTFILES_DIR, worktree: process.env.DOTFILES_DIR, client });
+      await hooks["tool.execute.before"]({ tool: "bash", sessionID: "child-2", callID: "c1" }, { args: {} });
+      await hooks["tool.execute.before"]({ tool: "bash", sessionID: "child-2", callID: "c2" }, { args: {} });
+      if (calls !== 1) throw new Error(`expected 1 client call, got ${calls}`);
+    '
+    assert_success
+}
+
+@test "opencode turn-budget-guard plugin cleans up sub-agent state on session.idle" {
+    DOTFILES_DIR="$REAL_DOTFILES_DIR" OG_PLUGIN="$OPENCODE_PLUGIN" LOG="$CLAUDE_TURN_BUDGET_LOG" run node --input-type=module -e '
+      import { readFileSync } from "node:fs";
+      const mod = await import(process.env.OG_PLUGIN);
+      const client = { session: { get: async () => ({ data: { parentID: "p1", agent: "explorer" } }) } };
+      const hooks = await mod.TurnBudgetGuard({ directory: process.env.DOTFILES_DIR, worktree: process.env.DOTFILES_DIR, client });
+      await hooks["tool.execute.before"]({ tool: "bash", sessionID: "child-3", callID: "c1" }, { args: {} });
+      await hooks.event({ event: { type: "session.idle", properties: { sessionID: "child-3" } } });
+      const lines = readFileSync(process.env.LOG, "utf8").trim().split("\n");
+      const record = JSON.parse(lines[lines.length - 1]);
+      if (record.action !== "cleanup" || record.agent_id !== "child-3") {
+        throw new Error(`unexpected: ${JSON.stringify(record)}`);
+      }
+    '
+    assert_success
+}

--- a/tests/turn-budget-guard.bats
+++ b/tests/turn-budget-guard.bats
@@ -8,6 +8,12 @@
 # deployed-layout fixture (hooks/ + lib/ siblings), so the test covers both
 # the bridge's path resolution and the Node logic. CLAUDE_TURN_BUDGET_DIR
 # sandboxes state away from the real budget dir.
+#
+# State is append/marker files under the per-(session,agent) counter dir, not
+# a single state.json: `turns` (1 byte per PreToolUse call, count = file
+# size), `grace` (same pattern, byte-hard grace calls used), `nudged` /
+# `hard-nudged` (marker files, existence = flag). Helpers below seed those
+# files directly instead of writing a JSON blob.
 
 load test_helper
 
@@ -36,13 +42,48 @@ teardown() {
 
 # ── helpers ──────────────────────────────────────────────────────────
 
-# Seed a counter dir's state.json with a given turn count / nudged flag.
-seed_state() {
-    local session="$1" agent="$2" turns="$3" nudged="${4:-false}"
+# Seed the turns counter to N by appending N bytes to the `turns` file.
+seed_turns() {
+    local session="$1" agent="$2" turns="$3"
     local dir="$CLAUDE_TURN_BUDGET_DIR/$session/$agent"
     mkdir -p "$dir"
-    node -e 'require("fs").writeFileSync(process.argv[1], JSON.stringify({turns:Number(process.argv[2]),nudged:process.argv[3]==="true"}))' \
-        "$dir/state.json" "$turns" "$nudged"
+    node -e 'require("fs").writeFileSync(process.argv[1], "x".repeat(Number(process.argv[2])))' \
+        "$dir/turns" "$turns"
+}
+
+# Seed the grace counter to N by appending N bytes to the `grace` file.
+seed_grace() {
+    local session="$1" agent="$2" grace="$3"
+    local dir="$CLAUDE_TURN_BUDGET_DIR/$session/$agent"
+    mkdir -p "$dir"
+    node -e 'require("fs").writeFileSync(process.argv[1], "x".repeat(Number(process.argv[2])))' \
+        "$dir/grace" "$grace"
+}
+
+mark_nudged() {
+    local session="$1" agent="$2"
+    local dir="$CLAUDE_TURN_BUDGET_DIR/$session/$agent"
+    mkdir -p "$dir"
+    : > "$dir/nudged"
+}
+
+mark_hard_nudged() {
+    local session="$1" agent="$2"
+    local dir="$CLAUDE_TURN_BUDGET_DIR/$session/$agent"
+    mkdir -p "$dir"
+    : > "$dir/hard-nudged"
+}
+
+# Current turns count for (session, agent) — 0 when the file is absent.
+turns_count() {
+    local file="$CLAUDE_TURN_BUDGET_DIR/$1/$2/turns"
+    [[ -f "$file" ]] && wc -c < "$file" | tr -d ' ' || echo 0
+}
+
+# Current grace-used count for (session, agent) — 0 when the file is absent.
+grace_count() {
+    local file="$CLAUDE_TURN_BUDGET_DIR/$1/$2/grace"
+    [[ -f "$file" ]] && wc -c < "$file" | tr -d ' ' || echo 0
 }
 
 # Write a transcript fixture of N bytes at the real located path.
@@ -52,6 +93,10 @@ seed_transcript() {
     mkdir -p "$dir"
     node -e 'require("fs").writeFileSync(process.argv[1], "x".repeat(Number(process.argv[2])))' \
         "$dir/agent-$agent.jsonl" "$bytes"
+}
+
+file_size() {
+    node -e 'try { process.stdout.write(String(require("fs").statSync(process.argv[1]).size)) } catch { process.stdout.write("0") }' "$1"
 }
 
 log_record() {
@@ -102,44 +147,50 @@ post_event() {
 # ── A1 — hard turn wall ──────────────────────────────────────────────
 
 @test "A1: coder at 100 turns -> next call (101) is denied" {
-    seed_state s1 a1 100
+    seed_turns s1 a1 100
     fire "$(pre_event s1 a1 coder)"
     [[ "$(verdict)" == "deny" ]]
     [[ "$output" == *"budget exceeded"* ]]
 }
 
 @test "A1: coder at 99 turns -> next call (100) is allowed" {
-    seed_state s1 a1 99
+    seed_turns s1 a1 99
     fire "$(pre_event s1 a1 coder)"
     [[ "$(verdict)" == "allow" ]]
 }
 
-@test "A1: PreToolUse increments the counter by exactly one" {
-    seed_state s1 a1 10
+@test "A1: PreToolUse increments the turns counter by exactly one" {
+    seed_turns s1 a1 10
     fire "$(pre_event s1 a1 coder)"
-    local turns
-    turns=$(jq -r '.turns' "$CLAUDE_TURN_BUDGET_DIR/s1/a1/state.json")
-    [[ "$turns" == "11" ]]
+    [[ "$(turns_count s1 a1)" == "11" ]]
+}
+
+@test "A1: hard-ceiling deny message tells the orchestrator to re-dispatch" {
+    seed_turns s1 a1 100
+    fire "$(pre_event s1 a1 coder)"
+    [[ "$(verdict)" == "deny" ]]
+    [[ "$output" == *"status: blocked: out of context"* ]]
 }
 
 # ── A2 — hard byte wall ──────────────────────────────────────────────
 
 @test "A2: byte size over the byte-hard ceiling denies even under the turn wall" {
-    seed_state s2 b1 5
+    seed_turns s2 b1 5
+    seed_grace s2 b1 3  # grace already exhausted
     seed_transcript s2 b1 $((521 * 1024))  # hard cap = ~130K tokens = 520 KiB proxy
     fire "$(pre_event s2 b1 coder)"
     [[ "$(verdict)" == "deny" ]]
 }
 
 @test "A2: under both turn and byte ceilings -> allow" {
-    seed_state s2 b1 5
+    seed_turns s2 b1 5
     seed_transcript s2 b1 $((100 * 1024))
     fire "$(pre_event s2 b1 coder)"
     [[ "$(verdict)" == "allow" ]]
 }
 
 @test "A2: PreToolUse allow writes a JSONL decision without stdout noise" {
-    seed_state s2 log1 5
+    seed_turns s2 log1 5
     seed_transcript s2 log1 $((100 * 1024))
     fire "$(pre_event s2 log1 coder)"
     [[ "$(verdict)" == "allow" ]]
@@ -157,21 +208,22 @@ post_event() {
     # byteHard = 130*1024*4 = 532480. The wall is `bytes > byteHard`,
     # so a transcript sitting exactly on the ceiling must still pass. Mirrors
     # the A1 turn boundary; a `>=` regression would deny here.
-    seed_state s2 b2 5
+    seed_turns s2 b2 5
     seed_transcript s2 b2 $((130 * 1024 * 4))
     fire "$(pre_event s2 b2 coder)"
     [[ "$(verdict)" == "allow" ]]
 }
 
-@test "A2: bytes one over the byte-hard ceiling -> deny" {
-    seed_state s2 b3 5
+@test "A2: bytes one over the byte-hard ceiling -> allowed via grace, not denied" {
+    seed_turns s2 b3 5
     seed_transcript s2 b3 $((130 * 1024 * 4 + 1))
     fire "$(pre_event s2 b3 coder)"
-    [[ "$(verdict)" == "deny" ]]
+    [[ "$(verdict)" == "allow" ]]
+    [[ "$(log_record | jq -r '.reason')" == "byte-grace" ]]
 }
 
 @test "A2: PreToolUse deny writes a deny record while stdout stays hook JSON" {
-    seed_state s2 log2 100
+    seed_turns s2 log2 100
     fire "$(pre_event s2 log2 coder)"
     [[ "$(verdict)" == "deny" ]]
     jq -e '.hookSpecificOutput.permissionDecision == "deny"' <<<"$output" >/dev/null
@@ -182,7 +234,8 @@ post_event() {
 }
 
 @test "A2: Codex direct agent_transcript_path drives byte ceiling" {
-    seed_state s2 codex1 1
+    seed_turns s2 codex1 1
+    seed_grace s2 codex1 3  # grace exhausted so the over-hard byte size denies outright
     local agent_tx="$TEST_HOME/codex-agent.jsonl"
     node -e 'require("fs").writeFileSync(process.argv[1], "x".repeat(Number(process.argv[2])))' \
         "$agent_tx" $((521 * 1024))
@@ -196,7 +249,7 @@ post_event() {
 }
 
 @test "A2: Codex standard agent_id and agent_type still enforce the turn wall" {
-    seed_state s2 codex2 100
+    seed_turns s2 codex2 100
     seed_transcript s2 codex2 $((100 * 1024))
     local json
     json=$(jq -nc --arg p "$PROJ/s2.jsonl" \
@@ -206,11 +259,35 @@ post_event() {
     jq -s -e 'length == 1 and .[0].harness == "codex" and .[0].action == "deny" and .[0].budget_type == "coder"' "$CLAUDE_TURN_BUDGET_LOG" >/dev/null
 }
 
+# ── A2b — byte-hard grace window ─────────────────────────────────────
+
+@test "A2b: over-byteHard agent gets exactly 3 grace allows, then a deny" {
+    seed_turns s2b grace1 5
+    seed_transcript s2b grace1 $((130 * 1024 * 4 + 1))
+
+    fire "$(pre_event s2b grace1 coder)"
+    [[ "$(verdict)" == "allow" ]]
+    [[ "$(log_record | jq -r '.reason')" == "byte-grace" ]]
+    [[ "$(grace_count s2b grace1)" == "1" ]]
+
+    fire "$(pre_event s2b grace1 coder)"
+    [[ "$(verdict)" == "allow" ]]
+    [[ "$(grace_count s2b grace1)" == "2" ]]
+
+    fire "$(pre_event s2b grace1 coder)"
+    [[ "$(verdict)" == "allow" ]]
+    [[ "$(grace_count s2b grace1)" == "3" ]]
+
+    fire "$(pre_event s2b grace1 coder)"
+    [[ "$(verdict)" == "deny" ]]
+    [[ "$(grace_count s2b grace1)" == "3" ]]  # grace does not increment past the cap
+    [[ "$output" == *"status: blocked: out of context"* ]]
+}
 
 # ── A3 — soft nudge fires once ───────────────────────────────────────
 
 @test "A3: PostToolUse crossing the soft turn threshold nudges once, then never repeats" {
-    seed_state s3 c1 75  # coder turnSoft = 75
+    seed_turns s3 c1 75  # coder turnSoft = 75
     fire "$(post_event s3 c1 coder)"
     [[ "$(verdict)" == "nudge" ]]
     [[ "$output" == *"wrap up"* ]]
@@ -221,7 +298,7 @@ post_event() {
 }
 
 @test "A3: nudge is logged once and later PostToolUse records already-nudged" {
-    seed_state s3 log3 75
+    seed_turns s3 log3 75
     fire "$(post_event s3 log3 coder)"
     [[ "$(verdict)" == "nudge" ]]
     fire "$(post_event s3 log3 coder)"
@@ -234,18 +311,44 @@ post_event() {
 }
 
 @test "A3: PostToolUse does not increment the turn counter" {
-    seed_state s3 c1 75
+    seed_turns s3 c1 75
     fire "$(post_event s3 c1 coder)"
-    local turns
-    turns=$(jq -r '.turns' "$CLAUDE_TURN_BUDGET_DIR/s3/c1/state.json")
-    [[ "$turns" == "75" ]]
+    [[ "$(turns_count s3 c1)" == "75" ]]
 }
 
 @test "A3: soft byte threshold nudges even when turns are low" {
-    seed_state s3 c2 1
+    seed_turns s3 c2 1
     seed_transcript s3 c2 $((440 * 1024))  # soft cap = ~110K tokens = 440 KiB proxy
     fire "$(post_event s3 c2 coder)"
     [[ "$(verdict)" == "nudge" ]]
+}
+
+# ── A3b — hard nudge (byte hard ceiling, PostToolUse) ────────────────
+
+@test "A3b: hard nudge fires once on first crossing and suppresses the soft nudge too" {
+    seed_turns s3b d1 1
+    seed_transcript s3b d1 $((130 * 1024 * 4 + 1))
+    fire "$(post_event s3b d1 coder)"
+    [[ "$(verdict)" == "nudge" ]]
+    [[ "$output" == *"hard ceiling"* ]]
+    [[ "$output" == *"status: blocked: out of context"* ]]
+    [[ -f "$CLAUDE_TURN_BUDGET_DIR/s3b/d1/hard-nudged" ]]
+    [[ -f "$CLAUDE_TURN_BUDGET_DIR/s3b/d1/nudged" ]]
+
+    # Second PostToolUse: already fully nudged, no repeat.
+    fire "$(post_event s3b d1 coder)"
+    [[ "$(verdict)" == "allow" ]]
+    [[ "$(log_record | jq -r '.reason')" == "already-nudged" ]]
+}
+
+@test "A3b: hard nudge still fires even when the soft nudge already fired" {
+    seed_turns s3b d2 1
+    mark_nudged s3b d2
+    seed_transcript s3b d2 $((130 * 1024 * 4 + 1))
+    fire "$(post_event s3b d2 coder)"
+    [[ "$(verdict)" == "nudge" ]]
+    [[ "$output" == *"hard ceiling"* ]]
+    [[ -f "$CLAUDE_TURN_BUDGET_DIR/s3b/d2/hard-nudged" ]]
 }
 
 # ── A4 — orchestrator never capped ───────────────────────────────────
@@ -260,22 +363,39 @@ post_event() {
     [[ "$(verdict)" == "allow" ]]
 }
 
-@test "A4: missing agent_id fail-opens and logs no-agent" {
+@test "A4: missing agent_id fail-opens and does NOT log without debug" {
     local json
     json=$(jq -nc --arg p "$PROJ/s.jsonl" \
         '{hook_event_name:"PreToolUse", agent_type:"coder", session_id:"s", transcript_path:$p, tool_name:"Bash", tool_input:{}}')
     fire "$json"
     [[ "$(verdict)" == "allow" ]]
+    [[ "$(log_count)" == "0" ]]
+}
+
+@test "A4: missing agent_id IS logged when CLAUDE_TURN_BUDGET_DEBUG is set" {
+    export CLAUDE_TURN_BUDGET_DEBUG=1
+    local json
+    json=$(jq -nc --arg p "$PROJ/s.jsonl" \
+        '{hook_event_name:"PreToolUse", agent_type:"coder", session_id:"s", transcript_path:$p, tool_name:"Bash", tool_input:{}}')
+    fire "$json"
+    [[ "$(verdict)" == "allow" ]]
+    [[ "$(log_count)" == "1" ]]
     [[ "$(log_record | jq -r '.action')" == "allow" ]]
     [[ "$(log_record | jq -r '.reason')" == "no-agent-id" ]]
 }
 
-@test "A4: Codex payload without agent_id fail-opens and logs no-agent" {
+@test "A4: Codex payload without agent_id fail-opens and logs no-agent only under debug" {
     local json
     json=$(jq -nc --arg p "$PROJ/s.jsonl" \
         '{harness:"codex",hook_event_name:"PreToolUse",agent_type:"coder",session_id:"s",transcript_path:$p,tool_name:"Bash",tool_input:{}}')
     fire "$json"
     [[ "$(verdict)" == "allow" ]]
+    [[ "$(log_count)" == "0" ]]
+
+    export CLAUDE_TURN_BUDGET_DEBUG=1
+    fire "$json"
+    [[ "$(verdict)" == "allow" ]]
+    [[ "$(log_count)" == "1" ]]
     [[ "$(log_record | jq -r '.harness')" == "codex" ]]
     [[ "$(log_record | jq -r '.reason')" == "no-agent-id" ]]
 }
@@ -283,13 +403,13 @@ post_event() {
 # ── A5 — unknown agent_type -> default budget ────────────────────────
 
 @test "A5: unknown agent_type falls to the default budget (hard 50)" {
-    seed_state s5 e1 50  # default turnHard = 50
+    seed_turns s5 e1 50  # default turnHard = 50
     fire "$(pre_event s5 e1 wizard)"
     [[ "$(verdict)" == "deny" ]]
 }
 
 @test "A5: unknown agent_type at 49 turns is allowed" {
-    seed_state s5 e1 49
+    seed_turns s5 e1 49
     fire "$(pre_event s5 e1 wizard)"
     [[ "$(verdict)" == "allow" ]]
 }
@@ -298,18 +418,34 @@ post_event() {
     # The message must report the budget actually in force ('default'), not the
     # phantom incoming type — a triager reading 'wizard' would hunt for a
     # wizard-specific budget that was never applied.
-    seed_state s5 e1 50
+    seed_turns s5 e1 50
     fire "$(pre_event s5 e1 wizard)"
     [[ "$(verdict)" == "deny" ]]
     [[ "$output" == *"type 'default'"* ]]
     [[ "$output" != *wizard* ]]
 }
 
+# ── A5b — general-purpose resolves the coder tier ────────────────────
+
+@test "A5b: general-purpose at 99 turns -> next call (100) is allowed (coder ceiling)" {
+    seed_turns s5b gp1 99
+    fire "$(pre_event s5b gp1 general-purpose)"
+    [[ "$(verdict)" == "allow" ]]
+    [[ "$(log_record | jq -r '.budget_type')" == "general-purpose" ]]
+}
+
+@test "A5b: general-purpose at 100 turns -> next call (101) is denied (coder ceiling, not default)" {
+    seed_turns s5b gp1 100
+    fire "$(pre_event s5b gp1 general-purpose)"
+    [[ "$(verdict)" == "deny" ]]
+    [[ "$(log_record | jq -r '.turnHard')" == "100" ]]
+}
+
 # ── A6 — independent counters + scoped cleanup ───────────────────────
 
 @test "A6: distinct agent_ids under one session count independently" {
-    seed_state s6 f1 99   # coder, one below the wall
-    seed_state s6 f2 100  # coder, at the wall
+    seed_turns s6 f1 99   # coder, one below the wall
+    seed_turns s6 f2 100  # coder, at the wall
     fire "$(pre_event s6 f1 coder)"
     [[ "$(verdict)" == "allow" ]]
     fire "$(pre_event s6 f2 coder)"
@@ -320,8 +456,8 @@ post_event() {
     # counterPath keys on BOTH session_id and agent_id. Two sub-agents that
     # happen to share an agent_id across different sessions must not collide;
     # a session-drop regression would read one shared counter and mis-verdict.
-    seed_state isoA z 5     # session isoA, agent z — well under the wall
-    seed_state isoB z 100   # session isoB, agent z — at the coder wall
+    seed_turns isoA z 5     # session isoA, agent z — well under the wall
+    seed_turns isoB z 100   # session isoB, agent z — at the coder wall
     fire "$(pre_event isoA z coder)"
     [[ "$(verdict)" == "allow" ]]
     fire "$(pre_event isoB z coder)"
@@ -329,8 +465,8 @@ post_event() {
 }
 
 @test "A6: SubagentStop removes only its own agent dir" {
-    seed_state s6 f1 5
-    seed_state s6 f2 5
+    seed_turns s6 f1 5
+    seed_turns s6 f2 5
     local json
     json=$(jq -nc '{hook_event_name:"SubagentStop", agent_id:"f1", agent_type:"coder", session_id:"s6"}')
     fire "$json"
@@ -350,16 +486,18 @@ post_event() {
     [[ "$(verdict)" == "allow" ]]
 }
 
-@test "A7: unreadable/malformed state file -> treated as zero, allow" {
+@test "A7: unreadable turns file -> treated as zero, allow" {
     local dir="$CLAUDE_TURN_BUDGET_DIR/s7/g1"
     mkdir -p "$dir"
-    printf 'garbage' > "$dir/state.json"
+    printf 'x%.0s' {1..100} > "$dir/turns"
+    chmod 000 "$dir/turns"
     fire "$(pre_event s7 g1 coder)"
     [[ "$(verdict)" == "allow" ]]
+    chmod 644 "$dir/turns"
 }
 
 @test "A7: unlocatable transcript -> byte signal 0, allow when turns are low" {
-    seed_state s7 g2 1
+    seed_turns s7 g2 1
     # No transcript fixture written; contextBytes must resolve to 0.
     fire "$(pre_event s7 g2 coder)"
     [[ "$(verdict)" == "allow" ]]
@@ -367,21 +505,41 @@ post_event() {
 
 @test "A7: logger write failure does not change enforcement" {
     export CLAUDE_TURN_BUDGET_LOG="$TEST_HOME"
-    seed_state s7 logfail 100
+    seed_turns s7 logfail 100
     fire "$(pre_event s7 logfail coder)"
     [[ "$(verdict)" == "deny" ]]
     jq -e '.hookSpecificOutput.permissionDecision == "deny"' <<<"$output" >/dev/null
 }
 
+# ── A7b — Codex agent_transcript_path stat failure falls through ────
+
+@test "A7b: failed agent_transcript_path stat falls through to the transcript walk" {
+    seed_turns s7b g3 1
+    seed_transcript s7b g3 $((130 * 1024 * 4 + 1))  # over-hard, locatable via the walk
+    local json
+    json=$(jq -nc --arg s "s7b" --arg a "g3" --arg p "$PROJ/s7b.jsonl" --arg atp "$TEST_HOME/does-not-exist.jsonl" \
+        '{hook_event_name:"PreToolUse", agent_id:$a, agent_type:"coder", session_id:$s, transcript_path:$p, agent_transcript_path:$atp, tool_name:"Bash", tool_input:{}}')
+    fire "$json"
+    [[ "$(verdict)" == "allow" ]]
+    [[ "$(log_record | jq -r '.reason')" == "byte-grace" ]]
+    [[ "$(log_record | jq -r '.bytes')" == "$((130 * 1024 * 4 + 1))" ]]
+}
+
 # ── A8 — stale sweep ─────────────────────────────────────────────────
 
-@test "A8: any invocation prunes agent dirs whose state.json is stale, keeps fresh ones" {
-    seed_state sOld old 1
-    seed_state sOld new 1
-    # Backdate the stale one's STATE FILE mtime past the 6h cutoff.
-    local ts
-    ts=$(node -e 'const d=new Date(Date.now()-10*3600*1000); process.stdout.write(String(Math.floor(d.getTime()/1000)))')
-    touch -d "@$ts" "$CLAUDE_TURN_BUDGET_DIR/sOld/old/state.json"
+# Set a file's mtime N hours in the past. `touch -d "@epoch"` is a GNU-ism
+# that BSD/macOS touch rejects, so backdate via fs.utimesSync instead.
+backdate_mtime() {
+    local file="$1" hours="$2"
+    node -e 'const fs=require("fs"); const past=new Date(Date.now()-Number(process.argv[2])*3600*1000); fs.utimesSync(process.argv[1], past, past);' \
+        "$file" "$hours"
+}
+
+@test "A8: any invocation prunes agent dirs whose turns file is stale, keeps fresh ones" {
+    seed_turns sOld old 1
+    seed_turns sOld new 1
+    # Backdate the stale one's TURNS FILE mtime past the 6h cutoff.
+    backdate_mtime "$CLAUDE_TURN_BUDGET_DIR/sOld/old/turns" 10
 
     # Fire an unrelated event to trigger the backstop sweep.
     local json
@@ -392,9 +550,9 @@ post_event() {
     [[ -d "$CLAUDE_TURN_BUDGET_DIR/sOld/new" ]]
 }
 
-@test "A8: sweepStale spares a dir with no state file" {
-    # A dir mid-creation (mkdir done, state.json not yet written) must not be
-    # swept just because it exists — the sweep keys on the state file.
+@test "A8: sweepStale spares a dir with no turns file" {
+    # A dir mid-creation (mkdir done, turns not yet written) must not be
+    # swept just because it exists — the sweep keys on the turns file.
     mkdir -p "$CLAUDE_TURN_BUDGET_DIR/sHalf/h1"
     local json
     json=$(jq -nc '{hook_event_name:"SubagentStop", agent_id:"zzz", session_id:"sZ"}')
@@ -402,13 +560,68 @@ post_event() {
     [[ -d "$CLAUDE_TURN_BUDGET_DIR/sHalf/h1" ]]
 }
 
+@test "A8: sweepStale falls back to a legacy state.json mtime when turns is absent" {
+    local dir="$CLAUDE_TURN_BUDGET_DIR/sLegacy/leg1"
+    mkdir -p "$dir"
+    printf '{"turns":5}' > "$dir/state.json"
+    backdate_mtime "$dir/state.json" 10
+
+    local json
+    json=$(jq -nc '{hook_event_name:"SubagentStop", agent_id:"zzz", session_id:"sZ"}')
+    fire "$json"
+
+    [[ ! -d "$dir" ]]
+}
+
+# ── A10 — decision log rotation ──────────────────────────────────────
+
+@test "A10: decisions.jsonl rotates to one .1 generation once it crosses 5MB" {
+    dd if=/dev/zero of="$CLAUDE_TURN_BUDGET_LOG" bs=1M count=6 2>/dev/null
+    local json
+    json=$(jq -nc '{hook_event_name:"SubagentStop", agent_id:"rot1", agent_type:"coder", session_id:"sRot"}')
+    fire "$json"
+
+    [[ -f "$CLAUDE_TURN_BUDGET_LOG.1" ]]
+    local rotated_size
+    rotated_size=$(file_size "$CLAUDE_TURN_BUDGET_LOG.1")
+    [[ "$rotated_size" -ge $((6 * 1024 * 1024)) ]]
+    [[ "$(log_count)" == "1" ]]
+}
+
+@test "A10: a second rotation overwrites .1 instead of accumulating a .2" {
+    dd if=/dev/zero of="$CLAUDE_TURN_BUDGET_LOG" bs=1M count=6 2>/dev/null
+    local json
+    json=$(jq -nc '{hook_event_name:"SubagentStop", agent_id:"rot2", agent_type:"coder", session_id:"sRot"}')
+    fire "$json"
+    [[ -f "$CLAUDE_TURN_BUDGET_LOG.1" ]]
+
+    dd if=/dev/zero of="$CLAUDE_TURN_BUDGET_LOG" bs=1M count=6 2>/dev/null
+    json=$(jq -nc '{hook_event_name:"SubagentStop", agent_id:"rot3", agent_type:"coder", session_id:"sRot"}')
+    fire "$json"
+
+    [[ -f "$CLAUDE_TURN_BUDGET_LOG.1" ]]
+    [[ ! -f "$CLAUDE_TURN_BUDGET_LOG.2" ]]
+}
+
+# ── A11 — turn counts derive from file size ──────────────────────────
+
+@test "A11: two PreToolUse increments produce a turns file of size 2 (no lost counts)" {
+    local json
+    json=$(pre_event s11 h1 coder)
+    fire "$json"
+    fire "$json"
+    [[ "$(turns_count s11 h1)" == "2" ]]
+}
+
 # ── A9 — opencode plugin adapter ─────────────────────────────────────
 
 @test "A9: opencode plugin fail-opens and logs when no stable sub-agent id exists" {
+    export CLAUDE_TURN_BUDGET_DEBUG=1
     run env \
         DOTFILES_DIR="$REAL_DOTFILES_DIR" \
         CLAUDE_TURN_BUDGET_DIR="$CLAUDE_TURN_BUDGET_DIR" \
         CLAUDE_TURN_BUDGET_LOG="$CLAUDE_TURN_BUDGET_LOG" \
+        CLAUDE_TURN_BUDGET_DEBUG="$CLAUDE_TURN_BUDGET_DEBUG" \
         OPENCODE_PLUGIN="$OPENCODE_PLUGIN" \
         node --input-type=module -e '
             const plugin = await import(process.env.OPENCODE_PLUGIN);
@@ -423,7 +636,7 @@ post_event() {
 }
 
 @test "A9: opencode plugin denies when shared guard denies stable sub-agent" {
-    seed_state op-s op-a 100
+    seed_turns op-s op-a 100
     run env \
         DOTFILES_DIR="$REAL_DOTFILES_DIR" \
         CLAUDE_TURN_BUDGET_DIR="$CLAUDE_TURN_BUDGET_DIR" \
@@ -431,9 +644,10 @@ post_event() {
         OPENCODE_PLUGIN="$OPENCODE_PLUGIN" \
         node --input-type=module -e '
             const plugin = await import(process.env.OPENCODE_PLUGIN);
-            const hooks = await plugin.TurnBudgetGuard({ directory: process.cwd(), session: { id: "op-s" } });
+            const client = { session: { get: async () => ({ data: { parentID: "op-s", agent: "coder" } }) } };
+            const hooks = await plugin.TurnBudgetGuard({ directory: process.cwd(), client });
             await hooks["tool.execute.before"](
-                { tool: "bash", agent_id: "op-a", agent_type: "coder", session_id: "op-s" },
+                { tool: "bash", sessionID: "op-a", callID: "c1" },
                 { args: { command: "echo ok" } },
             );
         '


### PR DESCRIPTION
## Summary

Fixes seven issues found by live decision-log analysis of the per-sub-agent turn/context budget hook (#392, #401). The log (`~/.local/state/claude-turn-budget/decisions.jsonl`) provided ground-truth evidence for each: 455 sub-agent PreToolUse events, 3 denies, 3 nudges — including one agent denied on its **first** tool call after being continued.

## Fixes

| # | Issue (live evidence) | Fix |
|---|---|---|
| 1 | Continued sub-agent bricked at turn 1: `SubagentStop` wipes turn state, transcript persists — a resumed agent over the byte hard ceiling (observed: 48 turns → 444KB → stop → continue at 535KB → deny at turns=1) gets no handoff window | `BYTE_GRACE_CALLS = 3` grace allows past the byte hard ceiling (turn ceiling still immediate) + one-time hard nudge on PostToolUse instructing the agent to persist a handoff and return `status: blocked: out of context`; deny messages carry the same re-dispatch line |
| 2 | `BUDGETS` had no entry for heavy full-peer types — `general-purpose` (cheese-factory/ultracook workers) fell to the 50-turn default | `general-purpose` + both milknado worker spellings at coder tier (75/100) |
| 3 | `decisions.jsonl` unbounded (~1.4MB/day), 64% of records orchestrator no-ops written on every tool call | no-agent-id records gated behind `CLAUDE_TURN_BUDGET_DEBUG`; 5MB rotation to a single `.1` generation beside the SubagentStop sweep |
| 4 | `state.json` read-modify-write races under parallel tool calls — duplicate turn counts observed live; torn read resets state | Append-only `turns`/`grace` counters (count = file size, atomic O_APPEND) + `wx` marker files for nudge flags; `sweepStale` keys off `turns` mtime with legacy fallback |
| 5 | opencode adapter probed identity fields that don't exist on the hook payload (`{tool, sessionID, callID}` only) — permanent no-op | Cached `client.session.get()` parentage lookup (`parentID` set AND `agent` non-empty), `agent_id`=sessionID, cleanup on `session.idle`/`session.deleted`. Deny-by-throw verified model-visible: opencode v1.17.14 `session/tools.ts` triggers plugins inside the AI SDK tool `execute()`, and `ai@6.0.168` `execute-tool-call.ts` catches all execute throws into a `tool-error` ToolOutput |
| 6 | Failed `agent_transcript_path` stat short-circuited to 0, making the walk fallback unreachable | stat failure falls through to `contextBytes` walk |
| 7 | Registry claimed `harnesses: [claude, codex]` but codex has no hook deployment | Dropped codex; sync tests assert absence |

Byte enforcement remains inert on opencode (no transcript path exists there) — turn-ceiling-only for that harness, documented in the adapter header.

## Verification

- `just check` exit 0 — 1149 tests (lint + full bats suite)
- `tests/turn-budget-guard.bats` 33 → 45 tests: grace exhaustion (exactly 3 allows then deny), hard-nudge-once (incl. after soft nudge), deny-message contract, debug gating both branches, 5MB rotation, `general-purpose` tier resolution, stat-failure fallthrough, file-size turn counting
- `tests/turn-budget-guard-opencode.bats` 3 → 8: identity mapping, no-parentID no-op, client-throw fail-open, session-cache dedup, idle-event cleanup
- Two independent review passes over the diff (contract conformance, fail-open on every new path, no orchestrator-blocking path, locked decisions) — clean
- Includes a test-only portability fix: `backdate_mtime` helper replaces GNU `touch -d "@epoch"` (pre-existing failure under macOS BSD touch, confirmed against the unmodified file)

Fail-open philosophy preserved throughout: no new path can deny the orchestrator or turn the guard into a denial-of-service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
