### PR TITLE
fix(packages): ungate rustup and fail loud on missing cargo toolchain

### DIFF
--- a/.sync-lib.sh
+++ b/.sync-lib.sh
@@ -436,6 +436,9 @@ install_tilth_claude_code() {
     tilth install claude-code --edit 2>&1 | while read -r line; do
         log_info "  $line"
     done
+    if [[ ! -f "${HOME}/.claude/tilth/inject-cwd.js" ]]; then
+        log_warning "tilth install claude-code --edit ran but ~/.claude/tilth/inject-cwd.js is missing — hook wiring may be stale"
+    fi
 }
 
 # Re-reconcile user-scope claude MCPs as the FINAL write of every sync.

--- a/packages/packages.yaml
+++ b/packages/packages.yaml
@@ -96,7 +96,7 @@ packages:
   # Dev (DOTFILES_DEV=true)
   - pyenv: { dev: true }
   - uv
-  - rustup: { dev: true }
+  - rustup
   - docker-desktop: { source: cask, dev: true, platform: mac, greedy: false } # self-updates in-app; greedy upgrade triggers repeated sudo prompts
 
   # LSP servers (for Claude Code LSP plugins)

--- a/packages/sync.sh
+++ b/packages/sync.sh
@@ -288,7 +288,8 @@ sync_cargo() {
             fi
         fi
         if ! command -v cargo &>/dev/null; then
-            log_warning "cargo not found — skipping cargo packages (install rustup to enable)"
+            log_error "cargo not found — cannot install cargo-source packages (rustup is no longer dev-gated; install failed?)"
+            FAILED+=("cargo-toolchain")
             return 0
         fi
     fi

--- a/tests/packages.bats
+++ b/tests/packages.bats
@@ -593,23 +593,21 @@ scrub_toolchain_path() {
     echo "$stub:${filtered%:}"
 }
 
-@test "sync warns + proceeds when cargo AND rustup are missing" {
-    # Behavior change: the linux-bootstrap PR (commit 5369aa3) softened
-    # missing-cargo from `log_error + FAILED+=("cargo")` to `log_warning +
-    # return 0`. Rationale: a fresh Ubuntu box without rust shouldn't
-    # FAIL the whole `dots sync` — the cargo packages just won't install
-    # until rustup is set up, while everything else (brew, npm, uv tools)
-    # proceeds normally. The cache IS saved on the successful sync.
+@test "sync errors + fails when cargo AND rustup are missing" {
+    # Issue #403: rustup is no longer dev-gated (packages.yaml), so a
+    # toolchain-less machine is a real misconfiguration, not an expected
+    # steady state — missing cargo is now loud (log_error + FAILED, causing
+    # the whole sync to exit non-zero) instead of a silent warn-and-skip.
     write_test_yaml
     rm -f "$MOCK_BIN/cargo" "$MOCK_BIN/rustup"
 
     PATH="$MOCK_BIN:$(scrub_toolchain_path)" run_sync
 
-    assert_success
+    assert_failure
     assert_output_contains "cargo not found"
-    assert_output_contains "skipping cargo packages"
-    # Cache saved because the sync completed without failure.
-    [[ -f "$CACHE_FILE" ]]
+    assert_output_contains "cannot install cargo-source packages"
+    # Cache NOT saved because the sync failed.
+    [[ ! -f "$CACHE_FILE" ]]
 }
 
 @test "sync bootstraps rust toolchain when rustup exists but cargo missing" {

--- a/tests/tilth-claude-code-hook.bats
+++ b/tests/tilth-claude-code-hook.bats
@@ -41,3 +41,31 @@ SH
     assert_output_contains "tilth not installed, skipping claude-code hook wiring"
     [[ ! -f "$TILTH_CALLS" ]]
 }
+
+@test "install_tilth_claude_code warns loudly when inject-cwd.js is missing after install" {
+    # tilth mock "succeeds" but never drops the hook script — simulates a
+    # stale/broken \`tilth install claude-code --edit\` (issue #403).
+    cat > "$MOCK_BIN/tilth" <<'SH'
+#!/bin/bash
+exit 0
+SH
+    chmod +x "$MOCK_BIN/tilth"
+
+    run_install_tilth
+    assert_success
+    assert_output_contains "inject-cwd.js is missing"
+}
+
+@test "install_tilth_claude_code is silent about inject-cwd.js when the file exists" {
+    mkdir -p "$TEST_HOME/.claude/tilth"
+    touch "$TEST_HOME/.claude/tilth/inject-cwd.js"
+    cat > "$MOCK_BIN/tilth" <<'SH'
+#!/bin/bash
+exit 0
+SH
+    chmod +x "$MOCK_BIN/tilth"
+
+    run_install_tilth
+    assert_success
+    assert_output_not_contains "inject-cwd.js is missing"
+}


### PR DESCRIPTION
## Why

Fixes #403. cargo-source packages (`tilth`, `hallouminate`, `rtk`, `cargo-llvm-cov`, `cargo-update`) install on every machine, but the toolchain provider `rustup` was dev-gated (`dev: true`) — so a non-dev / toolchain-less machine silently failed to build or update them. Observed: a stale `tilth` 2 commits behind main and a missing `~/.claude/tilth/inject-cwd.js`, leaving the PreToolUse cwd-injection hook pointing at nothing.

## What

- **packages/packages.yaml** — remove `dev: true` from `rustup`, matching the ungated cargo-source packages it backs.
- **packages/sync.sh (`sync_cargo`)** — cargo still missing after the rustup bootstrap attempt is now `log_error` + a `FAILED` entry (sync exits non-zero, cache not saved) instead of a soft warn that let the sync report success with cargo packages silently unset. Supersedes the deliberate soft-warn from 5369aa3 — the ungate removes its rationale.
- **.sync-lib.sh (`install_tilth_claude_code`)** — after `tilth install claude-code --edit`, assert `~/.claude/tilth/inject-cwd.js` exists and warn loudly if not.

## Tests

- `tests/packages.bats` — missing-cargo path now asserts failure + error text + cache-not-saved (rewritten from the old warn-and-proceed expectation); positive bootstrap-path test retained.
- `tests/tilth-claude-code-hook.bats` — two new tests: warns when `inject-cwd.js` missing post-install, silent when present.

## Verification

- `just check` exit 0 (lint + 1134/1134 bats + smoke), run after the final commit.
- Fresh-context review across drift/production-path/wired-callers/locked-decision lenses: clean pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)