### PR TITLE
perf(zsh): speed up shell startup with caching and static homebrew env

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,0 +1,3 @@
+[scripts.run.check]
+command = "just check"
+default = true

--- a/.gitignore
+++ b/.gitignore
@@ -75,7 +75,7 @@ vim/undo/
 
 # Git worktrees (Claude Code task isolation)
 .worktrees/
-.conductor/
+.conductor/settings.local.toml
 
 # Workspace-local notebooks and context
 .context/

--- a/.hallouminate/wiki/operations/sync-and-chezmoi.md
+++ b/.hallouminate/wiki/operations/sync-and-chezmoi.md
@@ -32,6 +32,7 @@ chezmoi renders the files that need per-machine templating (work vs. personal gi
 **Source:** the `chezmoi/` subdir. Currently manages, among others:
 
 - `~/.gitconfig` — `chezmoi/private_dot_gitconfig.tmpl` (templated `{{ .email }}`; includes an `[http "https://gopkg.in"] followRedirects = true` block — an HTTP-redirect setting, **not** a `[url] insteadOf` rewrite).
+- `~/.zprofile` — `chezmoi/dot_zprofile` (plain, not templated). A **static** equivalent of `eval "$(brew shellenv zsh)"` (the eval costs ~40ms per login shell) guarded by `[[ -d /opt/homebrew ]]`, plus the multiplier-dots overlay block (markers must stay byte-identical — multiplier-dots greps for them). **nvm is deliberately NOT initialized here**: the overlay's `profile.sh` owns nvm entirely (it has a `MULTIPLIER_PROFILE_SOURCED` re-source guard; `nvm.sh` itself has none, so a standalone nvm block double-sources it, ~50ms wasted — that was the pre-chezmoi state). Regenerate the static block with `brew shellenv zsh` if Homebrew relocates.
 - `~/.copilot/mcp-config.json` — env-rendered API keys (fails fast if unset).
 - `~/.claude/settings.json` — `dot_claude/modify_settings.json` authors the file WHOLESALE on every apply from `chezmoi/lib/claude-settings-authoritative.json` (static keys) + `chezmoi/.chezmoidata/claude.yaml` (registry-authored `hooks`, `enabledPlugins`, `extraKnownMarketplaces`, `permissions.*`). Live drift on managed keys is wiped; an unknown live key-path HALTS apply (fold it into a source, then re-sync). (An earlier revision of this page wrongly named the file `create_settings.json` — it has been `modify_settings.json` since the modify_ rewrite.)
 - Harness-global settings files (`~/.codex/config.toml`, `~/.config/opencode/opencode.json`, `~/.cursor/mcp.json`, `~/.copilot/mcp-config.json`, `~/.config/crush/crush.json`) are no longer mutated by non-isolated `ap install global`; their durable defaults belong in chezmoi or the harness's own runtime state. `ap` still writes generated agents/hooks/skills/plugin artifacts.
@@ -61,6 +62,13 @@ Drop a templated source under `chezmoi/` using the [source-state attributes](htt
 A `run_onchange`/`.chezmoiscripts` shell script (or any repo `.sh`) that nests a `case … esac` **inside a `$(…)` command substitution** must parenthesize every pattern — `(git) … ;;`, not `git) … ;;`. macOS ships GNU bash 3.2.57 (the GPLv2 freeze), whose parser naively counts parens while scanning for the end of `$(…)` and treats the pattern's closing `)` as closing the substitution → `syntax error near unexpected token ';;'` **at parse time** (so it fails even on machines where the code path never executes). Linux/Homebrew bash 5.x parses both forms fine, which is why it survives CI/review and only bites on a real macOS `dots sync`.
 
 Two safe forms: parenthesize the patterns (`(git)`), or define the `case` in a named function and call it via `$(fn)` — the `case` is then not textually inside the substitution. `chezmoi/dot_claude/modify_settings.json` uses the function form deliberately; `run_onchange_after_sync-claude-plugins.sh.tmpl` (added #378) hit the bug and was fixed to the parenthesized form.
+
+### Gotcha: startup caches that never refresh
+
+Two zsh-startup caching patterns in this repo looked correct but silently degraded; both are fixed, remember the *why*:
+
+- **`compinit` never touches an unchanged `.zcompdump`** — a "-C when the dump is <24h old" gate therefore stops firing ~24h after the dump is first written (mtime goes stale forever, every shell pays the full compaudit sweep again). `zsh/completion.zsh` explicitly `touch`es the dump in the full-`compinit` branch to reset the window. Verified empirically: backdating the dump and running full `compinit` leaves the mtime unchanged.
+- **Caching `eval "$(<tool> init zsh)"` output makes transient failures permanent** — the uncached eval self-heals next shell; a cache written with a bare `> $cache` persists partial output from a failed init and sources it forever. `_init_cache` in `zsh/tools.zsh` writes to a temp file, checks the exit code, and atomically swaps — a failed init leaves the old cache intact (or none), never a poisoned one. Caches live in `~/.cache/zsh-init/`, keyed on binary mtime via zsh's fork-free `$commands[tool]`.
 
 ## Shell functions need tests
 

--- a/chezmoi/dot_zprofile
+++ b/chezmoi/dot_zprofile
@@ -1,0 +1,19 @@
+# Homebrew — static equivalent of `eval "$(brew shellenv zsh)"` (which costs ~40ms).
+# Regenerate with `brew shellenv zsh` if Homebrew relocates.
+if [[ -d /opt/homebrew ]]; then
+  export HOMEBREW_PREFIX="/opt/homebrew"
+  export HOMEBREW_CELLAR="/opt/homebrew/Cellar"
+  export HOMEBREW_REPOSITORY="/opt/homebrew"
+  path=(/opt/homebrew/bin /opt/homebrew/sbin $path)
+  fpath=(/opt/homebrew/share/zsh/site-functions $fpath)
+  export PATH FPATH
+  [ -z "${MANPATH-}" ] || export MANPATH=":${MANPATH#:}"
+  export INFOPATH="/opt/homebrew/share/info:${INFOPATH:-}"
+fi
+
+# nvm is initialized by the multiplier overlay below — do not duplicate here.
+
+# >>> multiplier overlay >>>
+# Managed by multiplier-dots; remove this block (open marker through close marker) to uninstall.
+[ -f "$HOME/.config/multiplier/profile.sh" ] && source "$HOME/.config/multiplier/profile.sh"
+# <<< multiplier overlay <<<

--- a/tests/cheatsheet.bats
+++ b/tests/cheatsheet.bats
@@ -8,7 +8,7 @@ ZSH_DIR="$DOTFILES_DIR/zsh"
 BIN_DIR="$DOTFILES_DIR/bin"
 
 # Internal helpers / prompt machinery — defined in zsh/*.zsh but not user shortcuts.
-INTERNAL="_cc_base _cdd sesh-sessions periodic TRAPWINCH render_prompt update_git_cache git_time_details time_since_commit _vaudeville_register_argcomplete"
+INTERNAL="_cc_base _cdd sesh-sessions periodic TRAPWINCH render_prompt update_git_cache git_time_details time_since_commit _vaudeville_register_argcomplete _init_cache"
 # zsh tmux/remote shortcuts — documented in tmux-cheatsheet, not the main sheet.
 TMUX_OWNED="mtmux trl tss tsip ta tls tn tk tsw"
 # Commands provided by external tools (not defined as aliases/functions here).

--- a/tests/chezmoi-wiring.bats
+++ b/tests/chezmoi-wiring.bats
@@ -649,6 +649,26 @@ YAML
     assert_file_exists "$REAL_DOTFILES_DIR/chezmoi/private_dot_gitconfig.tmpl"
     assert_file_exists "$REAL_DOTFILES_DIR/chezmoi/private_dot_copilot/mcp-config.json.tmpl"
     assert_file_exists "$REAL_DOTFILES_DIR/chezmoi/.gitattributes"
+    assert_file_exists "$REAL_DOTFILES_DIR/chezmoi/dot_zprofile"
+}
+
+@test "dot_zprofile is static homebrew shellenv, no duplicate nvm, overlay markers intact" {
+    local zprofile="$REAL_DOTFILES_DIR/chezmoi/dot_zprofile"
+    # Static shellenv equivalent, not a `brew shellenv` fork on every login shell.
+    grep -q 'export HOMEBREW_PREFIX="/opt/homebrew"' "$zprofile"
+    # shellcheck disable=SC2016  # literal string to match in the file, not for expansion
+    if grep -v '^#' "$zprofile" | grep -qF '$(brew shellenv'; then
+        echo "dot_zprofile still forks brew shellenv instead of the static block" >&2
+        return 1
+    fi
+    # nvm.sh must not be sourced directly here — the multiplier overlay owns it.
+    if grep -q 'nvm.sh' "$zprofile"; then
+        echo "dot_zprofile still double-sources nvm.sh outside the overlay" >&2
+        return 1
+    fi
+    # multiplier-dots greps for these exact markers; they must stay byte-identical.
+    grep -q '^# >>> multiplier overlay >>>$' "$zprofile"
+    grep -q '^# <<< multiplier overlay <<<$' "$zprofile"
 }
 
 @test ".chezmoi.toml.tmpl prompts for email and persists sourceDir" {

--- a/zsh/completion.zsh
+++ b/zsh/completion.zsh
@@ -9,8 +9,19 @@ setopt ALWAYS_TO_END        # Push cursor on completions.
 
 # Use modern completion system
 autoload -Uz compinit
-
-compinit
+# compinit's compaudit sweep costs ~50ms; trust the dump (-C) when it's <24h old.
+() {
+  setopt local_options extended_glob
+  local dump=${ZDOTDIR:-$HOME}/.zcompdump
+  if [[ -n $dump(#qN.mh-24) ]]; then
+    compinit -C
+  else
+    compinit
+    # compinit doesn't touch an unchanged dump — refresh mtime or the fast
+    # path never fires again after the first 24h.
+    [[ -s $dump ]] && touch $dump
+  fi
+}
 
 # cache completions
 zstyle ':completion:*' use-cache on

--- a/zsh/core.zsh
+++ b/zsh/core.zsh
@@ -11,7 +11,16 @@ if [[ $OSTYPE == darwin* ]]; then
     /opt/homebrew/bin
     $path
   )
-  _brew_prefix="${HOMEBREW_PREFIX:-/opt/homebrew}"
+  # Fork-free prefix: honor HOMEBREW_PREFIX (set statically in ~/.zprofile on
+  # Apple Silicon), else pick the arch's install dir by existence — /opt/homebrew
+  # (Apple Silicon) or /usr/local (Intel). Avoids a `brew --prefix` fork.
+  if [[ -n $HOMEBREW_PREFIX ]]; then
+    _brew_prefix=$HOMEBREW_PREFIX
+  elif [[ -d /opt/homebrew ]]; then
+    _brew_prefix=/opt/homebrew
+  else
+    _brew_prefix=/usr/local
+  fi
   [[ -d "${_brew_prefix}/opt/openssl/bin" ]] && export PATH="${_brew_prefix}/opt/openssl/bin:$PATH"
   [[ -d "${_brew_prefix}/opt/rustup/bin" ]] && export PATH="${_brew_prefix}/opt/rustup/bin:$PATH"
   unset _brew_prefix

--- a/zsh/core.zsh
+++ b/zsh/core.zsh
@@ -11,7 +11,7 @@ if [[ $OSTYPE == darwin* ]]; then
     /opt/homebrew/bin
     $path
   )
-  _brew_prefix="$(brew --prefix 2>/dev/null)"
+  _brew_prefix="${HOMEBREW_PREFIX:-/opt/homebrew}"
   [[ -d "${_brew_prefix}/opt/openssl/bin" ]] && export PATH="${_brew_prefix}/opt/openssl/bin:$PATH"
   [[ -d "${_brew_prefix}/opt/rustup/bin" ]] && export PATH="${_brew_prefix}/opt/rustup/bin:$PATH"
   unset _brew_prefix

--- a/zsh/tools.zsh
+++ b/zsh/tools.zsh
@@ -1,14 +1,30 @@
 # tools.zsh — zoxide, atuin, yazi integration
 # Source order: AFTER fzf.zsh (atuin takes Ctrl+R from fzf)
 
+# Cache `<tool> init` output; regenerate when the tool binary is newer than the cache.
+_init_cache() {
+  local bin=$commands[$1] cache=$HOME/.cache/zsh-init/$1.zsh
+  shift
+  if [[ ! -s $cache || $bin -nt $cache ]]; then
+    mkdir -p $HOME/.cache/zsh-init
+    # Write-temp + atomic swap: a failed init must not poison (or truncate) a good cache.
+    if "$@" > $cache.tmp; then
+      mv $cache.tmp $cache
+    else
+      rm -f $cache.tmp
+    fi
+  fi
+  [[ -s $cache ]] && source $cache
+}
+
 # ─── zoxide (smarter cd with frecency) ──────────────────────────────────────
 if command -v zoxide &>/dev/null; then
-    eval "$(zoxide init zsh)"
+    _init_cache zoxide zoxide init zsh
 fi
 
 # ─── atuin (shell history search) ───────────────────────────────────────────
 if command -v atuin &>/dev/null; then
-    eval "$(atuin init zsh --disable-up-arrow)"
+    _init_cache atuin atuin init zsh --disable-up-arrow
 fi
 
 # ─── yazi (terminal file manager, cd-on-exit) ──────────────────────────────

--- a/zsh/tools.zsh
+++ b/zsh/tools.zsh
@@ -2,13 +2,16 @@
 # Source order: AFTER fzf.zsh (atuin takes Ctrl+R from fzf)
 
 # Cache `<tool> init` output; regenerate when the tool binary is newer than the cache.
+# Keyed on the binary mtime only — changing the init *flags* here won't invalidate a
+# cache built with the old flags, so `rm ~/.cache/zsh-init/<tool>.zsh` after editing them.
 _init_cache() {
   local bin=$commands[$1] cache=$HOME/.cache/zsh-init/$1.zsh
   shift
   if [[ ! -s $cache || $bin -nt $cache ]]; then
     mkdir -p $HOME/.cache/zsh-init
     # Write-temp + atomic swap: a failed init must not poison (or truncate) a good cache.
-    if "$@" > $cache.tmp; then
+    # `>|` overrides noclobber (not set here, but states the overwrite intent explicitly).
+    if "$@" >| $cache.tmp; then
       mv $cache.tmp $cache
     else
       rm -f $cache.tmp

--- a/zshenv
+++ b/zshenv
@@ -7,6 +7,8 @@
 # forwards LANG/LC_* to mosh-server over SSH. Respect an already-set locale.
 export LANG="${LANG:-en_US.UTF-8}"
 
+typeset -gU path fpath  # dedupe PATH/FPATH (first occurrence wins)
+
 # Homebrew bin on PATH for non-interactive SSH/mosh sessions. On Apple Silicon
 # /opt/homebrew/bin is NOT in macOS path_helper's default PATH, so an inbound
 # `mosh thismac` can't find mosh-server without this. Interactive shells get it

--- a/zshrc
+++ b/zshrc
@@ -24,7 +24,7 @@ source "$DOTFILES_DIR/zsh/prompt.zsh"
 source "$DOTFILES_DIR/zsh/claude.zsh"
 source "$DOTFILES_DIR/zsh/skhd.zsh"
 
-clear
+[[ -t 1 ]] && clear
 
 # opencode
 [ -d "$HOME/.opencode/bin" ] && export PATH="$HOME/.opencode/bin:$PATH"


### PR DESCRIPTION
## Summary

Cut interactive-shell startup cost across several hot paths in the zsh config.

- **completion** (`zsh/completion.zsh`): trust an unchanged `.zcompdump` via `compinit -C` when it's <24h old, and `touch` the dump on full `compinit` — `compinit` never mtime-updates an unchanged dump, so the fast-path window otherwise closes forever ~24h after first write.
- **tools** (`zsh/tools.zsh`): new `_init_cache` caches `<tool> init zsh` output (zoxide, atuin) keyed on binary mtime, with write-temp + atomic swap so a failed init can't poison (or truncate) a good cache.
- **homebrew env** (`zsh/core.zsh`, new `chezmoi/dot_zprofile`): replace `brew --prefix` / `brew shellenv` forks (~40ms each) with a static env block. `dot_zprofile` owns login-shell PATH/FPATH; nvm stays owned by the multiplier overlay to avoid double-sourcing (~50ms).
- **zshenv**: dedupe PATH/FPATH via `typeset -gU`.
- **zshrc**: guard `clear` on a tty so non-interactive sources don't emit escape codes.

## Tests

- New bats coverage for `dot_zprofile` wiring (static shellenv, no duplicate nvm, overlay markers intact).
- `_init_cache` added to the cheatsheet internal-function list.
- Caching gotchas documented in the `sync-and-chezmoi` wiki page.

`just check` passes locally (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)