### PR TITLE
tmux: streamline config and make bindings self-documenting

### DIFF
--- a/.hallouminate/wiki/operations/tmux-plugin-gotchas.md
+++ b/.hallouminate/wiki/operations/tmux-plugin-gotchas.md
@@ -49,11 +49,14 @@ run '~/.tmux/plugins/tpm/tpm'
 **Sanctioned exception — post-TPM `set` lines that don't touch `status-right`.**
 "Always last" is specifically about `status-right` (and anything continuum
 appends to it). Re-asserting an *unrelated* option after the TPM run is safe.
-`tmux.conf` deliberately runs `set -g status-keys vi` after the TPM line to undo
-`tmux-sensible`'s unconditional `status-keys emacs` (tmux-sensible flips it on
-load). That touches `status-keys`, not `status-right`, so continuum's save hook
-is untouched. The rule to remember: never rewrite `status-right` after TPM; any
-other post-TPM `set` is fine.
+As of July 2026, `tmux.conf` has no post-TPM `set` line — tmux-sensible was
+removed (nearly-dead-weight; its two useful effects, `display-time 4000` and
+`status-keys vi`, were inlined into the Quality of life block instead), which
+was the only reason a post-TPM re-assert existed: tmux-sensible unconditionally
+flipped `status-keys` to emacs on load (verified in its source), so the old
+config re-asserted vi after TPM to win the race. The rule to remember stands
+regardless: never rewrite `status-right` after TPM; any other post-TPM `set`
+is fine if one is ever needed again.
 
 ## catppuccin/tmux palette injection via theme/generate.sh
 

--- a/bin/tmux-cheatsheet
+++ b/bin/tmux-cheatsheet
@@ -14,6 +14,22 @@ RESET=$'\033[0m'
 hdr() { printf "\n${BOLD}${CYAN}%s${RESET}\n" "$1"; }
 row() { printf "  ${GREEN}%-28s${RESET} ${DIM}%s${RESET}\n" "$1" "$2"; }
 
+# Appends a "Live bindings" section rendering `tmux list-keys -N` when run
+# inside tmux; silently absent otherwise. Guarded so a tmux failure can't
+# trip `set -e`.
+tmux_live_bindings() {
+    [[ -n "${TMUX:-}" ]] && command -v tmux >/dev/null 2>&1 || return 0
+
+    local live
+    live=$(tmux list-keys -N 2>/dev/null) || return 0
+    [[ -n "$live" ]] || return 0
+
+    hdr "Live bindings (tmux list-keys -N)"
+    while IFS= read -r line; do
+        printf "  ${DIM}%s${RESET}\n" "$line"
+    done <<< "$live"
+}
+
 print_cheatsheet() {
     printf '\n%stmux cheatsheet%s  %s(prefix = Ctrl+Space)%s\n' "$BOLD" "$RESET" "$DIM" "$RESET"
 
@@ -50,7 +66,8 @@ print_cheatsheet() {
     row "prefix d"               "detach from session"
     row "prefix s"               "choose session/window tree"
     row "prefix \$"               "rename session"
-    row "prefix ( / )"           "previous / next session"
+    row "prefix Ctrl+s"          "resurrect: save session layout"
+    row "prefix Ctrl+r"          "resurrect: restore saved session"
     row "prefix T"               "sesh: fuzzy session picker (popup)"
     row "prefix \` (backtick)"   "sesh: switch to last session"
 
@@ -82,10 +99,13 @@ print_cheatsheet() {
     row "prefix u"               "Claude session picker (working/waiting/idle)"
     row "prefix o"               "popup: yazi (file manager)"
     row "prefix t"               "popup: scratch terminal"
+    row "prefix Tab"             "extrakto: fuzzy text picker (copy words/lines)"
     row "prefix ?"               "general dotfiles cheatsheet"
     row "prefix /"               "this tmux cheatsheet (popup)"
     row "prefix r"               "reload tmux config"
     row "tmux-cheatsheet"        "this reference"
+
+    tmux_live_bindings
     printf "\n"
 }
 

--- a/tests/tmux-cheatsheet.bats
+++ b/tests/tmux-cheatsheet.bats
@@ -97,3 +97,64 @@ assert_section() {
     assert_section "tss"
     assert_section "tsip"
 }
+
+
+@test "documents the extrakto fuzzy text picker" {
+    run tmux-cheatsheet
+    assert_section "prefix Tab"
+    assert_section "extrakto"
+}
+
+@test "documents resurrect save/restore bindings" {
+    run tmux-cheatsheet
+    assert_section "prefix Ctrl+s"
+    assert_section "prefix Ctrl+r"
+    assert_section "resurrect"
+}
+
+@test "shows live bindings section when inside tmux" {
+    MOCK_BIN="$(mktemp -d)"
+    cat > "$MOCK_BIN/tmux" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" == "list-keys" && "$2" == "-N" ]]; then
+    printf 'C-Space |       split vertically (keeps cwd)\nC-Space M-1     jump to window N\n'
+    exit 0
+fi
+exit 0
+EOF
+    chmod +x "$MOCK_BIN/tmux"
+    PATH="$MOCK_BIN:$PATH" TMUX=fake run tmux-cheatsheet
+    rm -rf "$MOCK_BIN"
+    [[ "$status" -eq 0 ]]
+    assert_section "Live bindings"
+    assert_section "split vertically (keeps cwd)"
+    assert_section "jump to window N"
+}
+
+@test "omits live bindings section when TMUX is unset" {
+    MOCK_BIN="$(mktemp -d)"
+    cat > "$MOCK_BIN/tmux" <<'EOF'
+#!/usr/bin/env bash
+printf 'C-Space |       split vertically (keeps cwd)\n'
+exit 0
+EOF
+    chmod +x "$MOCK_BIN/tmux"
+    unset TMUX
+    PATH="$MOCK_BIN:$PATH" run tmux-cheatsheet
+    rm -rf "$MOCK_BIN"
+    [[ "$status" -eq 0 ]]
+    clean=$(strip_ansi "$output")
+    [[ "$clean" != *"Live bindings"* ]]
+}
+
+@test "still exits 0 when the tmux list-keys call fails inside tmux" {
+    MOCK_BIN="$(mktemp -d)"
+    cat > "$MOCK_BIN/tmux" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+    chmod +x "$MOCK_BIN/tmux"
+    PATH="$MOCK_BIN:$PATH" TMUX=fake run tmux-cheatsheet
+    rm -rf "$MOCK_BIN"
+    [[ "$status" -eq 0 ]]
+}

--- a/tmux.conf
+++ b/tmux.conf
@@ -5,7 +5,7 @@
 # ---------------------------------------------------------------------------
 unbind C-b
 set -g prefix C-Space
-bind C-Space send-prefix
+bind -N "send prefix key to the pane" C-Space send-prefix
 
 # ---------------------------------------------------------------------------
 # Quality of life
@@ -17,9 +17,12 @@ set -g mouse on
 set -sg escape-time 0
 set -g history-limit 50000
 set -g focus-events on
+set -g display-time 4000
 setw -g mode-keys vi
+set -g status-keys vi
 set -s set-clipboard on
 set -g detach-on-destroy off
+set -g allow-passthrough on         # kitty-graphics image previews (yazi popup); off by default tmux >= 3.3
 set -g window-size latest          # follow most-recently-active client (tmux >= 3.1)
 setw -g aggressive-resize on       # inert under window-size latest; affects largest/smallest
 
@@ -55,60 +58,61 @@ set -g pane-border-format "#{pane_index} #{pane_current_command}"
 # ---------------------------------------------------------------------------
 # Splits (in current directory)
 # ---------------------------------------------------------------------------
-bind | split-window -h -c "#{pane_current_path}"
-bind - split-window -v -c "#{pane_current_path}"
+bind -N "split vertically (keeps cwd)" | split-window -h -c "#{pane_current_path}"
+bind -N "split horizontally (keeps cwd)" - split-window -v -c "#{pane_current_path}"
 unbind '"'
 unbind %
 
 # ---------------------------------------------------------------------------
 # Vim-style pane navigation (prefix)
 # ---------------------------------------------------------------------------
-bind h select-pane -L
-bind j select-pane -D
-bind k select-pane -U
-bind l select-pane -R
+bind -N "move between panes (vim)" h select-pane -L
+bind -N "move between panes (vim)" j select-pane -D
+bind -N "move between panes (vim)" k select-pane -U
+bind -N "move between panes (vim)" l select-pane -R
 
 # Prefix-less C-hjkl pane nav + copy-mode passthrough come from the
 # vim-tmux-navigator plugin (declared below).
 
 # Pane resize (repeatable)
-bind -r H resize-pane -L 5
-bind -r J resize-pane -D 5
-bind -r K resize-pane -U 5
-bind -r L resize-pane -R 5
+bind -r -N "resize pane (repeatable)" H resize-pane -L 5
+bind -r -N "resize pane (repeatable)" J resize-pane -D 5
+bind -r -N "resize pane (repeatable)" K resize-pane -U 5
+bind -r -N "resize pane (repeatable)" L resize-pane -R 5
 
 # ---------------------------------------------------------------------------
 # Window switching
 # ---------------------------------------------------------------------------
-bind c new-window -c "#{pane_current_path}"
-bind -r n next-window
-bind -r p previous-window
-bind Space last-window
-bind -r < swap-window -t -1 \; previous-window
-bind -r > swap-window -t +1 \; next-window
+bind -N "new window (keeps cwd)" c new-window -c "#{pane_current_path}"
+bind -r -N "next / previous window (repeatable)" n next-window
+bind -r -N "next / previous window (repeatable)" p previous-window
+bind -N "last window" Space last-window
+bind -r -N "move window left / right" < swap-window -t -1 \; previous-window
+bind -r -N "move window left / right" > swap-window -t +1 \; next-window
 # Alt+number jumps straight to a window (no prefix)
-bind -n M-1 select-window -t 1
-bind -n M-2 select-window -t 2
-bind -n M-3 select-window -t 3
-bind -n M-4 select-window -t 4
-bind -n M-5 select-window -t 5
-bind -n M-6 select-window -t 6
-bind -n M-7 select-window -t 7
-bind -n M-8 select-window -t 8
-bind -n M-9 select-window -t 9
+bind -n -N "jump to window N" M-1 select-window -t 1
+bind -n -N "jump to window N" M-2 select-window -t 2
+bind -n -N "jump to window N" M-3 select-window -t 3
+bind -n -N "jump to window N" M-4 select-window -t 4
+bind -n -N "jump to window N" M-5 select-window -t 5
+bind -n -N "jump to window N" M-6 select-window -t 6
+bind -n -N "jump to window N" M-7 select-window -t 7
+bind -n -N "jump to window N" M-8 select-window -t 8
+bind -n -N "jump to window N" M-9 select-window -t 9
 
 # ---------------------------------------------------------------------------
 # Broadcast input to all panes
 # ---------------------------------------------------------------------------
-bind S setw synchronize-panes \; display-message "sync #{?pane_synchronized,ON,OFF}"
+bind -N "toggle broadcast typing to all panes" S setw synchronize-panes \; display-message "sync #{?pane_synchronized,ON,OFF}"
 
 # ---------------------------------------------------------------------------
 # Copy mode (vim bindings)
 # ---------------------------------------------------------------------------
-bind -T copy-mode-vi v send-keys -X begin-selection
-bind -T copy-mode-vi y send-keys -X copy-selection-and-cancel
-bind -T copy-mode-vi C-v send-keys -X rectangle-toggle
-bind -T copy-mode-vi Escape send-keys -X cancel
+bind -N "begin selection" -T copy-mode-vi v send-keys -X begin-selection
+# tmux-yank rebinds y to copy-pipe (pbcopy) at TPM load; this is the fallback when the plugin is absent.
+bind -N "yank selection -> clipboard" -T copy-mode-vi y send-keys -X copy-selection-and-cancel
+bind -N "toggle block (rectangle) selection" -T copy-mode-vi C-v send-keys -X rectangle-toggle
+bind -N "cancel copy mode" -T copy-mode-vi Escape send-keys -X cancel
 
 # ---------------------------------------------------------------------------
 # Quiet
@@ -122,41 +126,40 @@ set -g bell-action none
 # ---------------------------------------------------------------------------
 # Reload
 # ---------------------------------------------------------------------------
-bind r source-file ~/.tmux.conf \; display-message "Config reloaded"
+bind -N "reload tmux config" r source-file ~/.tmux.conf \; display-message "Config reloaded"
 
 # ---------------------------------------------------------------------------
 # Cheatsheets (prefix + ? general, prefix + / tmux)
 # ---------------------------------------------------------------------------
-bind ? display-popup -E -xC -yC -w 80% -h 90% -d "#{pane_current_path}" "$HOME/Dev/dotfiles/bin/cheatsheet"
-bind / display-popup -E -xC -yC -w 80% -h 90% -d "#{pane_current_path}" "$HOME/Dev/dotfiles/bin/tmux-cheatsheet"
+bind -N "general dotfiles cheatsheet" ? display-popup -E -xC -yC -w 80% -h 90% -d "#{pane_current_path}" "$HOME/Dev/dotfiles/bin/cheatsheet"
+bind -N "this tmux cheatsheet (popup)" / display-popup -E -xC -yC -w 80% -h 90% -d "#{pane_current_path}" "$HOME/Dev/dotfiles/bin/tmux-cheatsheet"
 
 # ---------------------------------------------------------------------------
 # Floating popups
 # ---------------------------------------------------------------------------
-bind g display-popup -E -xC -yC -w 80% -h 80% -d "#{pane_current_path}" "lazygit"
-bind o display-popup -E -xC -yC -w 80% -h 80% -d "#{pane_current_path}" "yazi"
-bind t display-popup -E -xC -yC -w 60% -h 60% -d "#{pane_current_path}"
+bind -N "popup: lazygit" g display-popup -E -xC -yC -w 80% -h 80% -d "#{pane_current_path}" "lazygit"
+bind -N "popup: yazi (file manager)" o display-popup -E -xC -yC -w 80% -h 80% -d "#{pane_current_path}" "yazi"
+bind -N "popup: scratch terminal" t display-popup -E -xC -yC -w 60% -h 60% -d "#{pane_current_path}"
 
 # ---------------------------------------------------------------------------
 # Session management (sesh)
 # ---------------------------------------------------------------------------
 # sesh is a Go binary (joshmedeski/sesh); guarded until provisioned
 # backtick for last-session keeps `L` free for the resize-pane -R binding above.
-if-shell "command -v sesh" \
-  "bind T display-popup -E -xC -yC -w 55% -h 60% \"sesh list -i | fzf-tmux -p 55%,60% --no-sort --border-label ' sesh ' --prompt '⚡  ' --header '  ^a all ^t tmux ^x zoxide ^d kill' --bind 'ctrl-a:change-prompt(⚡  )+reload(sesh list -i)' --bind 'ctrl-t:change-prompt(🪟  )+reload(sesh list -it)' --bind 'ctrl-x:change-prompt(📁  )+reload(sesh list -iz)' --bind 'ctrl-d:execute(tmux kill-session -t {})+reload(sesh list)' | xargs sesh connect\""
-if-shell "command -v sesh" \
-  "bind ` run-shell 'sesh last || tmux display-message -d 1000 \"Only one session\"'"
+if-shell "command -v sesh" {
+  bind -N "sesh: fuzzy session picker (popup)" T display-popup -E -xC -yC -w 55% -h 60% "sesh list -i | fzf-tmux -p 55%,60% --no-sort --border-label ' sesh ' --prompt '⚡  ' --header '  ^a all ^t tmux ^x zoxide ^d kill' --bind 'ctrl-a:change-prompt(⚡  )+reload(sesh list -i)' --bind 'ctrl-t:change-prompt(🪟  )+reload(sesh list -it)' --bind 'ctrl-x:change-prompt(📁  )+reload(sesh list -iz)' --bind 'ctrl-d:execute(tmux kill-session -t {})+reload(sesh list)' | xargs sesh connect"
+  bind -N "sesh: switch to last session" ` run-shell 'sesh last || tmux display-message -d 1000 "Only one session"'
+}
 
 # ---------------------------------------------------------------------------
 # Theme (generated by theme/generate.sh — run `dots sync` to regenerate)
 # ---------------------------------------------------------------------------
-if-shell "test -f ~/Dev/dotfiles/tmux/theme.conf" "source-file ~/Dev/dotfiles/tmux/theme.conf"
+source-file -q ~/Dev/dotfiles/tmux/theme.conf
 
 # ---------------------------------------------------------------------------
 # Plugins (TPM)
 # ---------------------------------------------------------------------------
 set -g @plugin 'tmux-plugins/tpm'
-set -g @plugin 'tmux-plugins/tmux-sensible'
 set -g @plugin 'christoomey/vim-tmux-navigator'
 set -g @plugin 'catppuccin/tmux'
 set -g @plugin 'tmux-plugins/tmux-resurrect'
@@ -172,6 +175,3 @@ set -g @continuum-restore 'off'
 
 # Initialize TPM (keep at very bottom)
 run '~/.tmux/plugins/tpm/tpm'
-
-# tmux-sensible flips status-keys to emacs on load; re-assert vi (matches mode-keys vi)
-set -g status-keys vi


### PR DESCRIPTION
Deep review of the tmux settings, with fixes applied and a discoverability layer added.

## Config review fixes

- **Drop `tmux-plugins/tmux-sensible`** — verified against its source: with our explicit options, its only live effects were `display-time 4000` and an unconditional `status-keys emacs` flip that the post-TPM re-assert existed to undo. Both useful values are now inlined; the post-TPM hack is deleted. Status refresh returns to the default 15s, cutting tmux-continuum's save-hook forks 3× (it runs on every status redraw).
- **`allow-passthrough on`** — kitty-graphics image previews now work in the yazi popup (off by default since tmux 3.3).
- **`source-file -q`** for the generated theme instead of an `if-shell test -f` fork; the two sesh `if-shell` calls merged into one brace block (drops a quote-escaping layer).
- **Copy-mode `y`** annotated as tmux-yank's fallback (the plugin shadows it at TPM load).

## Discoverability (learn-the-bindings layer)

- Every custom bind (prefix table, copy-mode-vi, root `M-1..9`, sesh block) now carries a `-N` note mirroring its cheatsheet row text — `tmux list-keys -N` renders a live, never-drifting reference.
- `bin/tmux-cheatsheet` gains a "Live bindings" section (`list-keys -N`, only inside tmux, guarded for `set -euo pipefail`) and the previously missing rows: extrakto (`prefix Tab`) and resurrect save/restore (`prefix Ctrl+s` / `Ctrl+r`), both verified against the plugins' default-key sources.
- Wiki: `tmux-plugin-gotchas` sanctioned-exception paragraph updated for the sensible removal; the never-rewrite-`status-right`-after-TPM rule stands.

## Verification

- Isolated-socket config load (tmux 3.7b): no errors; continuum save hook confirmed armed (`continuum_save.sh` leads `status-right`); `status-keys vi`, `display-time 4000`, `status-interval 15`, `allow-passthrough on`; `-N` notes render in `list-keys -N` (prefix, `-a -T copy-mode-vi`, `-a -T root`).
- `bats tests/tmux-cheatsheet.bats`: 20/20 (5 new tests; new assertions verified to fail against the old script).
- `just check`: exit 0.
- Fresh-context review passes on both change-sets (structural invariants, quoting semantics of the sesh brace-block conversion, plugin-default citations).

**Post-merge note:** after `~/Dev/dotfiles` pulls this, run `prefix + alt + u` once so TPM removes the orphaned tmux-sensible clone, then reload (`prefix r`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)