### PR TITLE
fix(hooks): correct tool-reroute search deny message; wiki gotcha on rtk diff false drift

### DIFF
--- a/.hallouminate/wiki/operations/rtk-diff-false-drift.md
+++ b/.hallouminate/wiki/operations/rtk-diff-false-drift.md
@@ -1,0 +1,12 @@
+# rtk `diff` rewrite can fake file drift
+
+The rtk PreToolUse delegation rewrites a bare `diff a b` to a `git diff` form. Two consequences an agent comparing files must know:
+
+- `git diff` reads `~/.gitattributes`; when it errors there (observed: "too many levels of symbolic links" on the `~/.gitattributes → $DOTFILES/gitattributes` symlink inside a sandboxed Bash tool, even though the target exists), the command exits non-zero **regardless of file equality**.
+- Any `diff -q … && echo sync || echo DRIFT` exit-code check therefore reports false DRIFT for every file.
+
+**Why it matters**: during the 2026-07-07 tool-reroute hook verification this produced a false "all deployed hook files drifted" conclusion; checksums showed everything in sync.
+
+**Do instead**: compare with `shasum -a 256` / `cmp`, or bypass the rewrite with `rtk proxy diff a b`.
+
+Related: [[dev-environment]] (rtk wiring), [[../architecture/config-drift]] (real drift classes — this gotcha is how to avoid *misdiagnosing* one).

--- a/agents/lib/tool-reroute/search.js
+++ b/agents/lib/tool-reroute/search.js
@@ -35,9 +35,9 @@ const EXOTIC_SHORT = new Set('lLcovwxEPABCefmiI'.split(''));
 // narrow the match set.
 const REGEX_META = /[\\.^$*+?()[\]{}|]/;
 
-function reason(label, pattern, cwd) {
+function reason(label, pattern) {
   const q = pattern || '<pattern>';
-  const example = `mcp__tilth__tilth_search(queries:[{query:${JSON.stringify(q)}}], root:${JSON.stringify(cwd)})`;
+  const example = `mcp__tilth__tilth_search(queries:[{query:${JSON.stringify(q)}}])`;
   return `Blocked: ${label} — use the cheez-search skill (tilth_search), not the raw search tool.
 
 tilth_search is AST-aware and far cheaper in context than grep/find. Run instead:
@@ -84,10 +84,9 @@ function findRewrite(args) {
   return `tilth ${shQuote(glob)}${paths.length ? ` --scope ${shQuote(paths[0])}` : ''}`;
 }
 
-function detect(toolName, input, cwd) {
-  cwd = cwd || process.cwd();
+function detect(toolName, input) {
   if (toolName === 'Grep' || toolName === 'Glob') {
-    return { reason: reason(`the ${toolName} tool`, (input && input.pattern) || null, cwd) };
+    return { reason: reason(`the ${toolName} tool`, (input && input.pattern) || null) };
   }
   if (toolName !== 'Bash') return null;
   const segs = parse((input && input.command) || '');


### PR DESCRIPTION
## Why

Verification of the rtk/tilth tool-reroute hook (52/52 bats green, 7 live probes through the deployed hook all correct) turned up one repo defect and one re-learnable gotcha:

- **`agents/lib/tool-reroute/search.js`** — the Grep/Glob deny message told the model to call `tilth_search(..., root:"<cwd>")`. The tool schema has no `root` parameter, and `cwd` is injected by the tilth hook ("do NOT set it"), so every deny taught an invalid call shape. Now emits `mcp__tilth__tilth_search(queries:[{query:"…"}])`.
- **`.hallouminate/wiki/operations/rtk-diff-false-drift.md`** — new gotcha page: rtk rewrites bare `diff` to `git diff`, which exits non-zero on a `~/.gitattributes` read error even for identical files, so `diff -q` exit-code sync checks report false drift. Use `shasum`/`cmp` or `rtk proxy diff`.

## Verification

- `bats tests/tool-reroute.bats`: 52/52 pass (tests don't pin the old string; no test changes needed)
- Live probe: `Grep` PreToolUse event through the dispatcher emits the corrected deny message
- `just check`: exit 0

Related live-only fix (not in this diff): refreshed the stale `~/.codex/lib/tool-reroute/io.js` render, which still taught the removed `tilth_write(files:…, overwrite)` API — codex renders are frozen, so no sync would have healed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)