### PR TITLE
feat(de-slop): expand pattern catalogs for Rust, TypeScript, Python, Bash

### DIFF
--- a/skills/de-slop/SKILL.md
+++ b/skills/de-slop/SKILL.md
@@ -141,6 +141,52 @@ silently ignored.
 **Fix:** Always use `set -euo pipefail` in bash scripts. All three flags
 together. `set -e` alone is a half-measure.
 
+### 11. Convention blindness
+
+AI reimplements what the repo already has (HTTP wrappers, utils, config
+mechanisms) and applies textbook idioms instead of the codebase's own —
+generic from-scratch solutions in a codebase that already solved the problem.
+
+**Fix:** Search the repo for an existing utility/convention before writing a
+new one. Match the surrounding style, not a generically "correct" one.
+
+### 12. Copy-paste instead of reuse
+
+The same logic reimplemented slightly differently across files — the model
+can't see the original past its context window. The biggest measured shift in
+AI-assisted code: duplicated lines overtook refactored/moved lines in commits
+for the first time in 2024 (GitClear, 211M-line dataset).
+
+**Fix:** Before adding similar logic, find the existing implementation and
+extract or reuse it. Rising duplication is the primary quantitative slop signal.
+
+### 13. Fake modularity
+
+A new `utils.py`/`helpers.ts` created for a single function, or a God class
+spread across several files — structure that looks decomposed but doesn't
+separate concerns (the "modular mirage").
+
+**Fix:** A new file needs 3+ functions AND a distinct responsibility.
+Otherwise the function goes in the file that uses it.
+
+### 14. Placeholder and apology comments
+
+Prompt residue left in committed code: `// ... rest of the code`,
+`// quick hack, good enough for now`, `// Replace this with your actual
+implementation`, `// In a real implementation ...`.
+
+**Fix:** Delete them — implement the real thing or remove the stub. These are
+directly greppable, the highest-precision AI tell.
+
+### 15. Phantom edge-case handling
+
+Code handling inputs that cannot occur, inflating complexity for near-zero
+risk reduction. Distinct from #2 — that's swallowing real errors; this is
+handling imaginary ones.
+
+**Fix:** Require a concrete failure scenario before keeping an edge-case
+branch. If nobody can name the input that reaches it, delete it.
+
 ## Language References
 
 Read these only for languages present in the code being reviewed:
@@ -182,3 +228,12 @@ Don't over-explain. The fix speaks for itself.
 - `unwrap()` in Rust test code is idiomatic, not slop — only flag in production code
 - Lint suppressions in FFI, generated code, and `#[cfg(test)]` are often legitimate — check context before removing
 - `#[allow(clippy::pedantic)]` at crate level is a style choice, not slop
+
+- Hallucinated dependency names ("slopsquatting") are security territory — flag a new dep that doesn't resolve in the registry, but route vetting to /age or a security review
+
+## Sources
+
+- GitClear "AI Copilot Code Quality" 2025 — the only primary empirical dataset (211M lines): duplication vs refactor trends
+- OX Security "Army of Juniors" (2025) — 10-pattern taxonomy from a 300+-repo review (vendor research)
+- sloplint + slop-guard (GitHub) — encodable ast-grep rules for comment and file-proliferation slop
+- Per-language lint taxonomies backing the reference files: clippy, ruff, typescript-eslint, ShellCheck

--- a/skills/de-slop/references/python.md
+++ b/skills/de-slop/references/python.md
@@ -117,3 +117,122 @@ total = sum([x * x for x in range(1_000_000)])
 # CLEAN — generator expression, lazy evaluation
 total = sum(x * x for x in range(1_000_000))
 ```
+
+## 9. Mutable default arguments
+
+`def f(x=[])` shares one list across every call.
+
+```python
+# SLOP
+def append_item(item, items=[]):
+    items.append(item)
+    return items
+
+# CLEAN
+def append_item(item, items=None):
+    if items is None:
+        items = []
+    items.append(item)
+    return items
+```
+
+Ruff: `B006`.
+
+## 10. HTTP calls without a timeout
+
+`requests`/`httpx` calls with no `timeout=` hang forever when the server does.
+
+```python
+# SLOP
+response = requests.get(url)
+
+# CLEAN
+response = requests.get(url, timeout=10)
+```
+
+Ruff: `S113`.
+
+## 11. try/except shape slop
+
+Oversized `try` blocks with logging noise — the tryceratops family.
+
+```python
+# SLOP — log-and-raise duplicates the traceback up the stack
+try:
+    process(item)
+except ValueError as e:
+    logger.error(f"failed: {e}")   # TRY400: use logger.exception
+    raise
+
+# SLOP — raise inside try, caught by its own except (TRY301);
+# success path buried inside try (TRY300)
+try:
+    value = compute()
+    if value < 0:
+        raise ValueError("negative")
+    return transform(value)
+except ValueError:
+    ...
+
+# CLEAN — narrow try, raise outside it, else for the success path
+value = compute()
+if value < 0:
+    raise ValueError("negative")
+try:
+    data = load(value)
+except OSError:
+    logger.exception("load failed")
+    raise
+else:
+    return transform(data)
+```
+
+Ruff: `TRY300`, `TRY301`, `TRY400`, `TRY401`.
+
+## 12. Deprecated typing forms
+
+Models trained on pre-3.9 code emit `typing.List`/`Optional`/`Union`.
+
+```python
+# SLOP
+from typing import Dict, List, Optional, Union
+def find(ids: List[int]) -> Optional[Dict[str, Union[int, str]]]: ...
+
+# CLEAN — builtin generics (3.9+) and | unions (3.10+)
+def find(ids: list[int]) -> dict[str, int | str] | None: ...
+```
+
+Ruff: `UP006`, `UP007`, `UP045`.
+
+## 13. os.path / pathlib mixing
+
+`os.path.join`, `os.path.exists`, and `Path` interleaved in the same module.
+
+```python
+# SLOP
+path = os.path.join(base, "config.yaml")
+if os.path.exists(path): ...
+
+# CLEAN
+path = Path(base) / "config.yaml"
+if path.exists(): ...
+```
+
+Ruff: `PTH` family. Caveat: `open(path)` on a `Path` is fine — `PTH123`
+(force `Path.open()`) is contested among core devs; don't "fix" it.
+
+## 14. print() debugging in library code
+
+```python
+# SLOP
+print(f"processing {item}")
+
+# CLEAN — logging, or delete if the code is self-evident
+logger.debug("processing %s", item)
+```
+
+## Sources
+
+- Ruff rule docs (docs.astral.sh/ruff/rules) — every rule code above is verifiable there
+- charlax/professional-programming, error-handling anti-patterns — before/after exception examples
+- Greg-style caveat: PTH123 dispute thread (discuss.python.org/t/106904) — calibration for the pathlib rule

--- a/skills/de-slop/references/rust.md
+++ b/skills/de-slop/references/rust.md
@@ -492,3 +492,123 @@ AI generates functions that don't exist or uses outdated API patterns
 - Pin specific crate versions
 - Use Clippy: `cargo clippy -- -W clippy::all`
 - When in doubt, check docs with Context7
+
+## 13. Deref polymorphism (fake inheritance)
+
+Implementing `Deref` on a wrapper so it "inherits" the inner type's methods —
+simulating the OO inheritance Rust deliberately doesn't have.
+
+```rust
+// SLOP
+struct AppConfig { base: Config }
+impl Deref for AppConfig {
+    type Target = Config;
+    fn deref(&self) -> &Config { &self.base }
+}
+
+// CLEAN — delegate explicitly, or implement the shared trait
+impl AppConfig {
+    fn timeout(&self) -> Duration { self.base.timeout() }
+}
+```
+
+`Deref` is for smart pointers. No clippy lint catches this — review by hand.
+(rust-unofficial/patterns, anti-patterns chapter.)
+
+## 14. Boxing reflex
+
+`Box`/`Arc` where plain ownership or a borrow works — indirection reached for
+to make the borrow checker go away.
+
+```rust
+// SLOP
+fn process(data: &Box<MyStruct>) { ... }        // borrowed_box
+struct Registry { items: Vec<Box<String>> }      // vec_box
+let cfg: Box<Config> = Box::new(Default::default()); // box_default
+
+// CLEAN
+fn process(data: &MyStruct) { ... }
+struct Registry { items: Vec<String> }
+let cfg = Config::default();
+```
+
+clippy: `borrowed_box`, `vec_box`, `box_collection`, `box_default`.
+Inverse case: a very large enum variant SHOULD be boxed
+(`large_enum_variant`) — boxing isn't wrong, unmotivated boxing is.
+
+## 15. `async fn` with no `.await`
+
+Functions marked async by habit. An async fn that never awaits forces every
+caller into the async machinery for nothing.
+
+```rust
+// SLOP
+async fn config_path() -> PathBuf {
+    dirs::config_dir().expect("config dir").join("app")
+}
+
+// CLEAN
+fn config_path() -> PathBuf { ... }
+```
+
+clippy: `unused_async` (has false-negative gaps — also check by hand).
+
+## 16. `#![deny(warnings)]`
+
+Turns every future compiler warning into a build break — the crate stops
+compiling on a new toolchain that added a lint.
+
+```rust
+// SLOP
+#![deny(warnings)]
+
+// CLEAN — enforce in CI instead:
+// RUSTFLAGS="-D warnings" cargo build
+```
+
+(rust-unofficial/patterns, anti-patterns chapter.)
+
+## 17. `anyhow::Error` in a library's public API
+
+`anyhow` is for applications. A library returning `anyhow::Error` gives
+callers nothing to match on.
+
+```rust
+// SLOP (in a lib crate)
+pub fn parse(s: &str) -> anyhow::Result<Config> { ... }
+
+// CLEAN — concrete error type; thiserror for the boilerplate
+#[derive(Debug, thiserror::Error)]
+pub enum ParseError {
+    #[error("invalid syntax at line {0}")]
+    Syntax(usize),
+}
+pub fn parse(s: &str) -> Result<Config, ParseError> { ... }
+```
+
+Convention, not a lint — check whether the crate is a lib or a bin before
+flagging. `anyhow` in binaries and tests is fine.
+
+## 18. `unsafe` to make it compile
+
+Agent-speed pressure produces `unsafe` as a borrow-checker escape hatch.
+Bun's audit of its AI-assisted Zig→Rust port found 13,365 unsafe call sites
+needing review. For every `unsafe` block ask: is there a safe alternative, is
+the invariant documented, is it tested?
+
+```rust
+// SLOP — no SAFETY comment, no bounds reasoning
+let val = unsafe { *ptr.add(i) };
+
+// CLEAN — safe alternative existed all along
+let val = slice.get(i).copied().ok_or(Error::OutOfBounds)?;
+
+// If unsafe is genuinely required:
+// SAFETY: i < self.len is checked by the caller contract above.
+```
+
+## Sources
+
+- rust-unofficial/patterns (Rust Design Patterns book) — the official anti-pattern chapter
+- clippy lint list (rust-lang.github.io/rust-clippy/master) — ground truth for every lint named above
+- Bun unsafe audit (bun.com/bun-unsafe-audit) — quantified case study of AI-agent Rust output

--- a/skills/de-slop/references/shell.md
+++ b/skills/de-slop/references/shell.md
@@ -52,6 +52,22 @@ All three flags together. `set -e` alone is a half-measure — especially
 dangerous in scripts that pipe through `jq`/`yq`/`grep` where a failure
 on the left side is silently swallowed.
 
+### Strict mode is not a cure-all
+
+`set -e` has sharp edges (BashFAQ/105) — don't assume it catches everything:
+
+```bash
+# MASKED — `local`'s own success hides the command's failure
+local output=$(failing_cmd)      # -e does NOT fire
+
+# CLEAN — declare and assign in two steps
+local output
+output=$(failing_cmd)            # -e fires here
+
+# MASKED — -e is disabled inside a function used as a conditional
+if my_func; then ...             # failures inside my_func won't exit
+```
+
 ## 3. Parsing `ls` output
 
 `ls` output is not machine-readable. Filenames with spaces, newlines,
@@ -156,3 +172,132 @@ exit 1
 die() { echo >&2 "$@"; exit 1; }
 die "file not found"
 ```
+
+## 10. Checking `$?` instead of the command
+
+```bash
+# SLOP
+some_command
+if [ $? -eq 0 ]; then
+    echo "ok"
+fi
+
+# CLEAN
+if some_command; then
+    echo "ok"
+fi
+
+# CLEAN — error path
+if ! some_command; then
+    die "some_command failed"
+fi
+```
+
+ShellCheck: SC2181.
+
+## 11. `cd` without a fallback
+
+The highest-consequence tell: a failed `cd` (typo, permissions) lets every
+following command — including `rm -rf` — run in the wrong directory.
+
+```bash
+# SLOP
+cd "$build_dir"
+rm -rf ./*
+
+# CLEAN
+cd "$build_dir" || exit 1
+rm -rf ./*
+```
+
+ShellCheck: SC2164.
+
+## 12. Iterating command output with `for`
+
+`for x in $(cmd)` splits on whitespace, not lines — breaks on spaces and globs.
+
+```bash
+# SLOP
+for f in $(find . -name '*.log'); do
+    process "$f"
+done
+
+# CLEAN — NUL-delimited for filenames
+find . -name '*.log' -print0 | while IFS= read -r -d '' f; do
+    process "$f"
+done
+
+# CLEAN — line-oriented command output
+readarray -t lines < <(cmd)
+```
+
+ShellCheck: SC2044 (find loops), SC2046 (unquoted `$(...)` generally).
+
+## 13. Piping into `while read` and losing variables
+
+Each side of a pipe runs in a subshell — assignments inside the loop vanish.
+
+```bash
+# SLOP — prints 0
+count=0
+cat file | while read -r line; do
+    count=$((count + 1))
+done
+echo "$count"
+
+# CLEAN — redirect (or process-substitute); no subshell
+count=0
+while read -r line; do
+    count=$((count + 1))
+done < file
+```
+
+## 14. `echo -e` / `echo -n`
+
+`echo`'s flag behavior differs between the bash builtin and `/bin/echo` and
+isn't POSIX-portable.
+
+```bash
+# SLOP
+echo -e "line1\nline2"
+echo -n "no newline"
+
+# CLEAN
+printf '%s\n' "line1" "line2"
+printf '%s' "no newline"
+```
+
+## 15. `expr`, `let`, `$[ ]` arithmetic
+
+External processes and deprecated syntax for what the shell does natively.
+
+```bash
+# SLOP
+i=$(expr $i + 1)
+let i=i+1
+result=$[ a + b ]
+
+# CLEAN
+(( i += 1 ))
+result=$(( a + b ))
+```
+
+Google Shell Style Guide: always `(( ))` / `$(( ))`.
+
+## 16. Bare `$@` / `$*` for argument forwarding
+
+Unquoted, both split on internal spaces and drop empty arguments.
+
+```bash
+# SLOP
+my_func $@
+
+# CLEAN
+my_func "$@"
+```
+
+## Sources
+
+- ShellCheck wiki (shellcheck.net/wiki/SCxxxx) — canonical slop→fix rationale per code
+- Greg's Wiki: BashPitfalls + BashFAQ/105 — the `set -e` calibration source
+- Google Shell Style Guide — arithmetic, quoting, loop idioms, when not to use bash at all

--- a/skills/de-slop/references/typescript.md
+++ b/skills/de-slop/references/typescript.md
@@ -98,6 +98,9 @@ function greet(name: string | null): string {
 }
 ```
 
+Lint: `@typescript-eslint/no-unnecessary-condition` — catches provably
+true/false conditions in general, not just null checks.
+
 ## 6. `JSON.parse(JSON.stringify())` for deep cloning
 
 ```typescript
@@ -136,3 +139,135 @@ import { UserService, UserModel, UserDTO, UserMapper, UserValidator } from "./us
 // CLEAN — import only what you use
 import { UserService } from "./users";
 ```
+
+## 9. Non-null assertion as narrowing substitute
+
+`!` tells the compiler to shut up; a guard tells it something true. AI-authored
+PRs use `!` and `as` at a much higher rate than human PRs (arXiv 2602.17955).
+
+```typescript
+// SLOP
+const user = users.find(u => u.id === id)!;
+processUser(user);
+
+// CLEAN
+const user = users.find(u => u.id === id);
+if (!user) throw new Error(`unknown user: ${id}`);
+processUser(user);
+```
+
+Lint: `@typescript-eslint/no-non-null-assertion`.
+
+## 10. Double assertion to force a type
+
+`as unknown as T` makes any value claim any type — it erases the type system
+at exactly the spot most likely to be wrong.
+
+```typescript
+// SLOP
+const config = JSON.parse(raw) as unknown as Config;
+
+// CLEAN — validate at the boundary
+const config = configSchema.parse(JSON.parse(raw)); // zod or similar
+```
+
+## 11. `@ts-ignore` instead of `@ts-expect-error`
+
+`@ts-ignore` silences forever — when the underlying error is fixed, the stale
+directive stays. `@ts-expect-error` fails when it no longer suppresses anything.
+
+```typescript
+// SLOP
+// @ts-ignore
+legacyCall(data);
+
+// CLEAN
+// @ts-expect-error — legacy API typed wrong upstream (issue #123)
+legacyCall(data);
+```
+
+Lint: `@typescript-eslint/ban-ts-comment` (set `minimumDescriptionLength`).
+
+## 12. Floating promises
+
+Fire-and-forget async calls — rejections vanish, ordering is accidental.
+
+```typescript
+// SLOP
+saveUser(user);                          // not awaited — errors disappear
+items.map(async i => await process(i));  // array of dropped promises
+
+// CLEAN
+await saveUser(user);
+await Promise.all(items.map(i => process(i)));
+
+// Intentionally fire-and-forget? Say so:
+void saveUser(user);
+```
+
+Lint: `@typescript-eslint/no-floating-promises`, `no-misused-promises`.
+
+## 13. `enum` where a union suffices
+
+Enums imported from other languages' habits. Literal unions are erasable,
+serializable, and need no runtime object.
+
+```typescript
+// SLOP
+enum Status { Active = "active", Inactive = "inactive" }
+
+// CLEAN
+type Status = "active" | "inactive";
+
+// When you need the values at runtime:
+const STATUSES = ["active", "inactive"] as const;
+type Status = (typeof STATUSES)[number];
+```
+
+## 14. Catch-block slop
+
+`catch (e: any)` plus log-and-rethrow: the error is logged at every level and
+handled at none.
+
+```typescript
+// SLOP
+try {
+  await handler(req);
+} catch (e: any) {
+  console.error(e);
+  throw e;
+}
+
+// CLEAN — catch only where you add value; the error is unknown, not any
+try {
+  await handler(req);
+} catch (e) {
+  if (e instanceof ValidationError) return res.status(400).json(e.detail);
+  throw e; // the boundary logger handles the rest
+}
+```
+
+Lint: `@typescript-eslint/only-throw-error`,
+`use-unknown-in-catch-callback-variable`.
+
+## 15. `useEffect` for derived state (React)
+
+Effects reached for to compute values or chain fetches.
+
+```typescript
+// SLOP — derived state via effect
+const [fullName, setFullName] = useState("");
+useEffect(() => { setFullName(`${first} ${last}`); }, [first, last]);
+
+// CLEAN — derive during render
+const fullName = `${first} ${last}`;
+```
+
+No lint catches this (`react-hooks/exhaustive-deps` doesn't) — review by hand.
+See react.dev "You Might Not Need an Effect".
+
+## Sources
+
+- typescript-eslint `strict-type-checked` config + rule docs — ground truth for every rule named above
+- Effective TypeScript, 2nd ed. (Vanderkam, 2024) — ch. 5 on narrowing `any`'s scope
+- arXiv 2602.17955 — empirical AI-vs-human PR comparison (`!`/`as` overuse)


### PR DESCRIPTION
## Summary

Research-backed expansion of the de-slop skill's pattern catalogs (+574 lines across 5 files). Five parallel research passes gathered primary sources per language; only lint-backed or empirically sourced patterns were encoded — weakly sourced candidates (magic literals, interface-everywhere, unverified shell tells) were dropped and are logged as open questions in the research artifacts.

## Changes

| File | Added |
|---|---|
| `SKILL.md` | +5 cross-language patterns: convention blindness, copy-paste over reuse (GitClear 2025: duplicated lines overtook refactored lines in 2024), fake modularity, placeholder/apology comments, phantom edge-case handling. Plus slopsquatting gotcha + sources section |
| `references/rust.md` | +6: Deref polymorphism, boxing reflex (`borrowed_box`/`vec_box`/`box_collection`/`box_default`), `unused_async`, `#![deny(warnings)]`, anyhow in library APIs, unsafe-to-compile (Bun audit: 13,365 unsafe sites) |
| `references/typescript.md` | +7: non-null assertion, double assertion, `@ts-ignore` vs `@ts-expect-error`, floating promises, enum vs union, catch-block slop, `useEffect` derived state — each mapped to its typescript-eslint rule where one exists |
| `references/python.md` | +6: mutable defaults (B006), missing timeouts (S113), try/except shape (TRY300/301/400/401), deprecated typing forms (UP006/007/045), pathlib mixing (PTH, with the contested-PTH123 caveat), print debugging |
| `references/shell.md` | +7: `$?` checks (SC2181), bare `cd` (SC2164), for-over-command-output (SC2044/SC2046), while-read subshell variable loss, `echo -e/-n`, `expr`/`let`/`$[ ]`, bare `$@` — plus `set -e` masking caveats (BashFAQ/105) under the strict-mode pattern |

## Sourcing

Primary lint taxonomies (clippy, typescript-eslint strict-type-checked, ruff, ShellCheck wiki) + rust-unofficial/patterns, Google Shell Style Guide, Greg's Wiki, GitClear 2025 report, OX Security "Army of Juniors", sloplint/slop-guard rule sets. Full claim tables with per-claim confidence are in `.cheese/research/de-slop-references/` (gitignored, local).

## Verification

- `just check` green (exit 0)
- prek pre-commit hooks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)