### PR TITLE
chore(doc-drift): bump claude-code to 2.1.205 (no-op)

### DIFF
--- a/agents/doc-drift/sources.yaml
+++ b/agents/doc-drift/sources.yaml
@@ -25,7 +25,7 @@ sources:
     signal: { type: npm, ref: "@anthropic-ai/claude-code" }
     docs: https://code.claude.com/docs
     governs: [harnesses/claude.md, chezmoi/.chezmoidata/claude.yaml]
-    reconciled: "2.1.201"
+    reconciled: "2.1.205"
 
   - id: codex-cli
     signal: { type: npm, ref: "@openai/codex" }


### PR DESCRIPTION
## Summary

Weekly doc-drift check for `@anthropic-ai/claude-code`: reconciled `2.1.201` → latest `2.1.205`.

Reviewed the GitHub release notes for v2.1.202, v2.1.203, v2.1.204, and v2.1.205 against our governed config surface (`chezmoi/.chezmoidata/claude.yaml` — mcps/hooks/enabledPlugins/permissions/skills/agents — and `.hallouminate/wiki/harnesses/claude.md`). Notable items in the delta:

- v2.1.202: dynamic workflow size setting, workflow OTel attributes, `/review` reverted to single-pass (use `/code-review` for multi-agent), MCP error-message clarity for `url`-typed servers (we only use `command`-based stdio MCPs), various crash/UX fixes.
- v2.1.203: MCP `roots/list` now includes session additional working directories (we already declare `permissions.additionalDirectories`, this is upstream behavior, no key change needed), many background-agent/worktree daemon bug fixes, "claude command missing" warnings moved into `/doctor`/`/status`.
- v2.1.204: single fix for hook-event streaming during `SessionStart` in headless sessions.
- v2.1.205: auto-mode rule blocking transcript tampering, `/doctor` becomes a full setup checkup (`/checkup` alias), "Claude Browser" MCP server name reserved (we don't use that name), assorted background-agent UI fixes.

None of these touch a flag/key/schema our registry depends on (no new hook event types, no MCP schema change affecting our stdio-based servers, no settings.json key we set), so this is a no-op reconciliation bump only.

## Test plan

- [ ] CI (this environment has no `just`/`gh`; only the version bump in `agents/doc-drift/sources.yaml` changed, no config/wiki edits to validate)

https://claude.ai/code/session_01QeDvjoiHodXSXpoYD49JvA


---
_Generated by [Claude Code](https://claude.ai/code/session_01QeDvjoiHodXSXpoYD49JvA)_