### PR TITLE
chore(doc-drift): bump context7-mcp to 3.2.3 (no-op)

### DIFF
--- a/agents/doc-drift/sources.yaml
+++ b/agents/doc-drift/sources.yaml
@@ -49,7 +49,7 @@ sources:
     signal: { type: npm, ref: "@upstash/context7-mcp" }
     docs: https://github.com/upstash/context7
     governs: [chezmoi/.chezmoidata/claude.yaml, agents/mcp/registry.yaml]
-    reconciled: "3.2.2"
+    reconciled: "3.2.3"
 
   - id: tavily-mcp
     signal: { type: npm, ref: tavily-mcp }


### PR DESCRIPTION
Weekly doc-drift routine: `@upstash/context7-mcp` 3.2.2 → 3.2.3.

Reviewed the upstream changelog (packages/mcp/CHANGELOG.md at upstash/context7):

- `41878ec`: Skip loopback/link-local/CGNAT/IPv6-loopback/link-local/unique-local addresses when extracting client IP from `X-Forwarded-For` — internal server-side hardening only.
- `33229cb`: Clarify the `query-docs` tool description to ask for one concept per query — a wording change to the tool's own description, not a schema/flag/arg change.

Neither change touches anything in our governed config surface (`command: npx`, `args: ["-y", "@upstash/context7-mcp"]`, `env.CONTEXT7_API_KEY`) in `chezmoi/.chezmoidata/claude.yaml` or `agents/mcp/registry.yaml`. No config edits needed — this PR only bumps `reconciled` in `agents/doc-drift/sources.yaml`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QeDvjoiHodXSXpoYD49JvA)_