### PR TITLE
chore(doc-drift): bump codex-cli to 0.143.0 (no-op)

### DIFF
--- a/agents/doc-drift/sources.yaml
+++ b/agents/doc-drift/sources.yaml
@@ -31,7 +31,7 @@ sources:
     signal: { type: npm, ref: "@openai/codex" }
     docs: https://developers.openai.com/codex
     governs: [harnesses/codex.md, agents/hooks/registry.yaml, agents/registry.yaml]
-    reconciled: "0.142.5"
+    reconciled: "0.143.0"
 
   - id: opencode
     signal: { type: npm, ref: opencode-ai }


### PR DESCRIPTION
## Summary

Reviewed the `@openai/codex` 0.142.5 → 0.143.0 release notes (a large bundle: plugins/proxy-aware auth, Bedrock models, app-server history/thread tools, multi-agent v2 message rendering, etc). None of it touches our governed config surface (`.hallouminate/wiki/harnesses/codex.md`, `agents/hooks/registry.yaml`, `agents/registry.yaml`):

- The one change that looked directly relevant — PR #30229 "Relax hooks.json top-level metadata validation" — is a no-op for us: our codex renderer (`agent-profile/agent_profile/renderers/codex.py:393`) writes `hooks.json` as exactly `{"hooks": {...}}` with no extra top-level metadata keys, so neither the old strict validation nor the relaxed one changes our output.
- Subagent-delegation-authorization (#30274) and multi-agent v2 changes affect Codex's internal session/delegation UX, not the `~/.codex/agents/*.toml` schema (`name`/`description`/`developer_instructions`/`sandbox_mode`) that `agents/registry.yaml` renders into.
- No changes found to the `config.toml` keys we set (`model_instructions_file`, `approval_policy`, `sandbox_mode`, `[mcp_servers]`) or to the hooks event/matcher schema documented in the wiki page.

This PR only bumps the `reconciled` marker in `agents/doc-drift/sources.yaml` for `codex-cli` from `0.142.5` to `0.143.0`; no other files changed.

## Test plan

- [ ] CI (no local `just check` available in this environment)


---
_Generated by [Claude Code](https://claude.ai/code/session_01QeDvjoiHodXSXpoYD49JvA)_