### PR TITLE
chore(doc-drift): bump opencode to 1.17.16 (no-op)

### DIFF
--- a/agents/doc-drift/sources.yaml
+++ b/agents/doc-drift/sources.yaml
@@ -37,7 +37,7 @@ sources:
     signal: { type: npm, ref: opencode-ai }
     docs: https://opencode.ai/docs
     governs: [harnesses/opencode.md]
-    reconciled: "1.17.13"
+    reconciled: "1.17.16"
 
   - id: copilot-cli
     signal: { type: npm, ref: "@github/copilot" }


### PR DESCRIPTION
## Summary

Weekly doc-drift routine: `opencode-ai` npm package advanced from `1.17.13` (last reconciled) to `1.17.16`.

Reviewed the release notes for v1.17.14, v1.17.15, and v1.17.16 (opencode.ai/changelog + GitHub releases at github.com/anomalyco/opencode, the renamed sst/opencode repo):

- **v1.17.14**: opt-in code-mode MCP adapter (execute tool hidden unless enabled), desktop UI improvements, provider bugfixes (OpenRouter reasoning, GitHub Copilot routing, Cerebras reasoning replay).
- **v1.17.15**: Z.ai context-overflow error classification, a home-relative permission-path expansion bugfix, desktop UI/theme polish.
- **v1.17.16**: Grok reasoning-effort variants, xAI prompt-cache routing + PDF support, desktop file-browser/composer additions.

None of this touches the config surface our `.hallouminate/wiki/harnesses/opencode.md` page documents: no hook/plugin API changes, no sub-agent config changes, no MCP config schema changes (the code-mode adapter is additive/opt-in), no system-prompt/rules changes, no `opencode.json`/`tui.json`/theme schema changes, no skills changes, no local-LLM provider-merge changes.

This PR only bumps `reconciled` for the `opencode` entry in `agents/doc-drift/sources.yaml` — no other files touched.

## Test plan

- [ ] CI (no code/config changes; single-line YAML value bump)

🤖 Generated with the dotfiles repo's weekly doc-drift routine.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QeDvjoiHodXSXpoYD49JvA)_