### PR TITLE
chore(doc-drift): bump copilot-cli to 1.0.69 (no-op)

### DIFF
--- a/agents/doc-drift/sources.yaml
+++ b/agents/doc-drift/sources.yaml
@@ -43,7 +43,7 @@ sources:
     signal: { type: npm, ref: "@github/copilot" }
     docs: https://docs.github.com/en/copilot/how-tos/copilot-cli
     governs: [harnesses/copilot.md]
-    reconciled: "1.0.68"
+    reconciled: "1.0.69"
 
   - id: context7-mcp
     signal: { type: npm, ref: "@upstash/context7-mcp" }


### PR DESCRIPTION
Weekly doc-drift routine: `@github/copilot` CLI 1.0.68 → 1.0.69.

Reviewed the changelog (GitHub release page for `v1.0.69`, which squashes pre-releases `1.0.69-0` through `-3` since `1.0.68`): model picker UX, sandbox policy labels/behavior, autopilot mode tweaks, MCP OAuth callback flow, `/plugins` dashboard, and various performance/reliability fixes.

None of it touches the schema/file-layout surfaces documented in `.hallouminate/wiki/harnesses/copilot.md` (hook JSON under `.github/hooks/`, sub-agent `.agent.md` format, `mcp-config.json` `mcpServers` schema, `.github/skills/*` layout, instructions precedence, or the `~/.copilot/settings.json` / `config.json` split). So this is a no-op — only bumping `reconciled` in `agents/doc-drift/sources.yaml`.

`just check` was not run (not installed in this environment); relying on CI. This change only touches a YAML metadata field, no code/config surface.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QeDvjoiHodXSXpoYD49JvA)_