### PR TITLE
feat(dots): add `dots resume` for post-reboot tmux + agent-session restore

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@ A personal dotfiles repo configuring a vim-centric, terminal-based dev environme
 - `dots rollback` — prints the git-backed undo path (`git revert` + `dots sync`); no stateful snapshots.
 - `dots claude diff` — preview pending chezmoi changes under `~/.claude` (settings.json + exact_ trees) before a sync overwrites them wholesale; does not cover `~/.claude.json` MCP drift (reconciles via the claude CLI).
 - `dots profile launch claude <name>` · `dots profile list` · `dots profile describe <name>`
+- `dots resume [--dry-run] [--session <name>]` — restore last tmux-resurrect snapshot and type per-pane agent-resume commands
 
 ### Agent config — edit a registry, then sync
 

--- a/bin/dots
+++ b/bin/dots
@@ -415,6 +415,12 @@ case "${1:-status}" in
                 ;;
         esac
         ;;
+    resume)
+        shift
+        # shellcheck source=bin/lib/resume.sh
+        source "$DOTFILES_DIR/bin/lib/resume.sh"
+        resume_main "$@"
+        ;;
     upgrade|up)
         echo -e "${BLUE}⬆️  Upgrading packages...${NC}"
         cd_dotfiles

--- a/bin/lib/resume.sh
+++ b/bin/lib/resume.sh
@@ -14,6 +14,13 @@ resume_encode_claude_dir() {
     echo "${cwd//[.\/]/-}"
 }
 
+# resume_file_mtime <path> — portable epoch mtime. GNU stat uses `-c %Y`;
+# BSD/macOS stat uses `-f %m`.
+resume_file_mtime() {
+    local file="$1"
+    stat -c %Y "$file" 2>/dev/null || stat -f %m "$file" 2>/dev/null
+}
+
 # resume_claude_session <cwd> — newest *.jsonl under the matching claude
 # project dir. Prints "<session-id>\t<mtime-epoch>"; returns 1 on no match.
 resume_claude_session() {
@@ -22,7 +29,7 @@ resume_claude_session() {
     [[ -d "$dir" ]] || return 1
     for file in "$dir"/*.jsonl; do
         [[ -f "$file" ]] || continue
-        mtime=$(stat -c %Y "$file" 2>/dev/null) || continue
+        mtime=$(resume_file_mtime "$file") || continue
         if (( mtime > newest_mtime )); then
             newest_mtime=$mtime
             newest="$file"
@@ -39,16 +46,20 @@ resume_claude_session() {
 resume_codex_session() {
     local cwd="$1" root="${RESUME_CODEX_SESSIONS_DIR:-$HOME/.codex/sessions}"
     [[ -d "$root" ]] || return 1
-    local mtime file file_cwd file_id
-    while IFS=' ' read -r mtime file; do
+    local mtime file file_cwd file_id best_id="" best_mtime=-1
+    while IFS= read -r -d '' file; do
+        mtime=$(resume_file_mtime "$file") || continue
         file_cwd=$(head -1 "$file" | jq -r '.payload.cwd // empty' 2>/dev/null) || continue
         [[ "$file_cwd" == "$cwd" ]] || continue
         file_id=$(head -1 "$file" | jq -r '.payload.id // empty' 2>/dev/null) || true
         [[ -n "$file_id" ]] || continue
-        printf '%s\t%s\n' "$file_id" "${mtime%.*}"
-        return 0
-    done < <(find "$root" -name 'rollout-*.jsonl' -mtime -7 -printf '%T@ %p\n' 2>/dev/null | sort -rn)
-    return 1
+        if (( mtime > best_mtime )); then
+            best_mtime=$mtime
+            best_id=$file_id
+        fi
+    done < <(find "$root" -name 'rollout-*.jsonl' -mtime -7 -print0 2>/dev/null)
+    [[ -n "$best_id" ]] || return 1
+    printf '%s\t%s\n' "$best_id" "$best_mtime"
 }
 
 # resume_opencode_session <cwd> — newest session row whose directory matches.
@@ -163,39 +174,27 @@ resume_command_for() {
     esac
 }
 
-# resume_main [--dry-run] [--session <name>] — orchestrates the full flow:
-# restore the snapshot if needed, enumerate panes, print the summary table,
-# and (unless --dry-run) type the resume command into each matched pane.
-resume_main() {
+# resume_parse_args [--dry-run] [--session <name>] — prints
+# "<dry-run>\t<session>".
+resume_parse_args() {
     local dry_run=false session=""
     while (($#)); do
         case "$1" in
-            --dry-run)
-                dry_run=true
-                shift
-                ;;
-            --session)
-                session="${2:?--session requires a value}"
-                shift 2
-                ;;
+            --dry-run) dry_run=true; shift ;;
+            --session) session="${2:?--session requires a value}"; shift 2 ;;
             *)
                 echo "resume: unknown argument: $1" >&2
                 return 1
                 ;;
         esac
     done
+    printf '%s\t%s\n' "$dry_run" "$session"
+}
 
-    local dotfiles_dir="${DOTFILES_DIR:-$HOME/Dev/dotfiles}"
-
-    if resume_needs_restore "$session"; then
-        resume_restore_snapshot "$dotfiles_dir" || true
-    fi
-
-    local now
-    now=$(date +%s)
-
-    printf 'PANE\tCWD\tHARNESS\tSESSION\tAGE\n'
+resume_resume_panes() {
+    local dry_run="$1" now="$2"
     local _ pane_id cwd match harness rest id epoch age
+    printf 'PANE\tCWD\tHARNESS\tSESSION\tAGE\n'
     while IFS=$'\t' read -r _ _ _ pane_id cwd; do
         [[ -n "$pane_id" ]] || continue
         match=$(resume_best_match "$cwd") || continue
@@ -205,8 +204,24 @@ resume_main() {
         epoch="${rest##*$'\t'}"
         age="$(resume_format_age "$now" "$epoch")"
         printf '%s\t%s\t%s\t%s\t%s\n' "$pane_id" "$cwd" "$harness" "$id" "$age"
-        if [[ "$dry_run" != true ]]; then
-            tmux send-keys -t "$pane_id" "$(resume_command_for "$harness" "$id")"
-        fi
+        [[ "$dry_run" == true ]] || tmux send-keys -t "$pane_id" "$(resume_command_for "$harness" "$id")"
     done < <(resume_list_panes)
+}
+
+
+# resume_main [--dry-run] [--session <name>] — orchestrates the full flow:
+# restore the snapshot if needed, enumerate panes, print the summary table,
+# and (unless --dry-run) type the resume command into each matched pane.
+resume_main() {
+    local parsed dry_run session dotfiles_dir
+    parsed=$(resume_parse_args "$@") || return
+    dry_run="${parsed%%$'\t'*}"
+    session="${parsed#*$'\t'}"
+    dotfiles_dir="${DOTFILES_DIR:-$HOME/Dev/dotfiles}"
+
+    if resume_needs_restore "$session"; then
+        resume_restore_snapshot "$dotfiles_dir" || true
+    fi
+
+    resume_resume_panes "$dry_run" "$(date +%s)"
 }

--- a/bin/lib/resume.sh
+++ b/bin/lib/resume.sh
@@ -1,0 +1,212 @@
+# shellcheck shell=bash
+# resume.sh — post-reboot tmux resume helpers, sourced by bin/dots.
+#
+# Parallels the .sync <-> .sync-lib.sh "lib beside script" precedent (see
+# bin/lib/worktree.sh). Functions only — no top-level side effects, so
+# sourcing is safe from bats tests.
+
+# resume_encode_claude_dir <cwd> — mirror the `~/.claude/projects/<encoded>`
+# naming: every "/" (including the leading one) AND every "." becomes "-".
+# e.g. /home/paul/Dev/dotfiles -> -home-paul-Dev-dotfiles;
+# /home/paul/Dev/dotfiles/.worktrees/oclp -> -home-paul-Dev-dotfiles--worktrees-oclp.
+resume_encode_claude_dir() {
+    local cwd="$1"
+    echo "${cwd//[.\/]/-}"
+}
+
+# resume_claude_session <cwd> — newest *.jsonl under the matching claude
+# project dir. Prints "<session-id>\t<mtime-epoch>"; returns 1 on no match.
+resume_claude_session() {
+    local cwd="$1" dir file newest="" newest_mtime=0 mtime
+    dir="$HOME/.claude/projects/$(resume_encode_claude_dir "$cwd")"
+    [[ -d "$dir" ]] || return 1
+    for file in "$dir"/*.jsonl; do
+        [[ -f "$file" ]] || continue
+        mtime=$(stat -c %Y "$file" 2>/dev/null) || continue
+        if (( mtime > newest_mtime )); then
+            newest_mtime=$mtime
+            newest="$file"
+        fi
+    done
+    [[ -n "$newest" ]] || return 1
+    printf '%s\t%s\n' "$(basename "$newest" .jsonl)" "$newest_mtime"
+}
+
+# resume_codex_session <cwd> — newest rollout file (last 7 days) whose
+# session_meta.payload.cwd matches. Prints "<session-id>\t<mtime-epoch>";
+# returns 1 on no match. RESUME_CODEX_SESSIONS_DIR overrides the scan root
+# for tests.
+resume_codex_session() {
+    local cwd="$1" root="${RESUME_CODEX_SESSIONS_DIR:-$HOME/.codex/sessions}"
+    [[ -d "$root" ]] || return 1
+    local mtime file file_cwd file_id
+    while IFS=' ' read -r mtime file; do
+        file_cwd=$(head -1 "$file" | jq -r '.payload.cwd // empty' 2>/dev/null) || continue
+        [[ "$file_cwd" == "$cwd" ]] || continue
+        file_id=$(head -1 "$file" | jq -r '.payload.id // empty' 2>/dev/null) || true
+        [[ -n "$file_id" ]] || continue
+        printf '%s\t%s\n' "$file_id" "${mtime%.*}"
+        return 0
+    done < <(find "$root" -name 'rollout-*.jsonl' -mtime -7 -printf '%T@ %p\n' 2>/dev/null | sort -rn)
+    return 1
+}
+
+# resume_opencode_session <cwd> — newest session row whose directory matches.
+# Prints "<session-id>\t<updated-epoch-seconds>"; returns 1 on no match.
+# RESUME_OPENCODE_DB overrides the db path for tests.
+resume_opencode_session() {
+    local cwd="$1" db="${RESUME_OPENCODE_DB:-$HOME/.local/share/opencode/opencode.db}"
+    [[ -f "$db" ]] || return 1
+    local escaped row id ms
+    escaped=${cwd//\'/\'\'}
+    row=$(sqlite3 -readonly "$db" \
+        "SELECT id, time_updated FROM session WHERE directory = '$escaped' ORDER BY time_updated DESC LIMIT 1;" \
+        2>/dev/null) || true
+    [[ -n "$row" ]] || return 1
+    id="${row%%|*}"
+    ms="${row##*|}"
+    printf '%s\t%s\n' "$id" "$((ms / 1000))"
+}
+
+# resume_resurrect_dir — mirror tmux-resurrect's own default resolution
+# (scripts/helpers.sh): ~/.tmux/resurrect if present, else the XDG data dir.
+# No @resurrect-dir override is set in tmux.conf.
+resume_resurrect_dir() {
+    if [[ -d "$HOME/.tmux/resurrect" ]]; then
+        echo "$HOME/.tmux/resurrect"
+    else
+        echo "${XDG_DATA_HOME:-$HOME/.local/share}/tmux/resurrect"
+    fi
+}
+
+# resume_needs_restore [session] — exit 0 when a restore should run: no tmux
+# server at all, or (when a session name is given) that session is missing.
+resume_needs_restore() {
+    local session="${1:-}"
+    if [[ -n "$session" ]]; then
+        tmux has-session -t "$session" 2>/dev/null && return 1
+        return 0
+    fi
+    tmux list-sessions >/dev/null 2>&1 && return 1
+    return 0
+}
+
+# resume_restore_snapshot <dotfiles_dir> — start a detached server if none is
+# running (tmux-resurrect's restore.sh needs a live server to query options
+# and create sessions against), then run the vendored restore script.
+# No-ops (returns 1) when there's no saved snapshot to restore.
+resume_restore_snapshot() {
+    local dotfiles_dir="$1" resurrect_dir restore_script
+    resurrect_dir="$(resume_resurrect_dir)"
+    [[ -f "$resurrect_dir/last" ]] || return 1
+    restore_script="$dotfiles_dir/tmux/plugins/tmux-resurrect/scripts/restore.sh"
+    [[ -f "$restore_script" ]] || return 1
+    tmux list-sessions >/dev/null 2>&1 || tmux new-session -d
+    bash "$restore_script"
+}
+
+# resume_list_panes — tab-separated session/window/pane/pane_id/cwd, one
+# pane per line.
+resume_list_panes() {
+    tmux list-panes -a -F '#{session_name}	#{window_index}	#{pane_index}	#{pane_id}	#{pane_current_path}'
+}
+
+# resume_format_age <now-epoch> <then-epoch> — compact age like "2d3h",
+# "1h5m", or "12m".
+resume_format_age() {
+    local now="$1" then="$2" diff days hours mins
+    diff=$(( now - then ))
+    (( diff < 0 )) && diff=0
+    days=$(( diff / 86400 ))
+    hours=$(( (diff % 86400) / 3600 ))
+    mins=$(( (diff % 3600) / 60 ))
+    if (( days > 0 )); then
+        printf '%dd%dh' "$days" "$hours"
+    elif (( hours > 0 )); then
+        printf '%dh%dm' "$hours" "$mins"
+    else
+        printf '%dm' "$mins"
+    fi
+}
+
+# resume_best_match <cwd> — the newest session across all three harnesses.
+# Prints "<harness>\t<session-id>\t<epoch>"; returns 1 when none match.
+resume_best_match() {
+    local cwd="$1" line id epoch
+    local best_harness="" best_id="" best_epoch=-1
+
+    if line=$(resume_claude_session "$cwd"); then
+        id="${line%%$'\t'*}"; epoch="${line##*$'\t'}"
+        if (( epoch > best_epoch )); then best_epoch=$epoch; best_id=$id; best_harness="claude"; fi
+    fi
+    if line=$(resume_codex_session "$cwd"); then
+        id="${line%%$'\t'*}"; epoch="${line##*$'\t'}"
+        if (( epoch > best_epoch )); then best_epoch=$epoch; best_id=$id; best_harness="codex"; fi
+    fi
+    if line=$(resume_opencode_session "$cwd"); then
+        id="${line%%$'\t'*}"; epoch="${line##*$'\t'}"
+        if (( epoch > best_epoch )); then best_epoch=$epoch; best_id=$id; best_harness="opencode"; fi
+    fi
+
+    [[ -n "$best_harness" ]] || return 1
+    printf '%s\t%s\t%s\n' "$best_harness" "$best_id" "$best_epoch"
+}
+
+# resume_command_for <harness> <session-id> — the exact resume command to
+# type into the pane.
+resume_command_for() {
+    local harness="$1" id="$2"
+    case "$harness" in
+        claude) printf 'claude --resume %s' "$id" ;;
+        codex) printf 'codex resume %s' "$id" ;;
+        opencode) printf 'opencode --session %s' "$id" ;;
+    esac
+}
+
+# resume_main [--dry-run] [--session <name>] — orchestrates the full flow:
+# restore the snapshot if needed, enumerate panes, print the summary table,
+# and (unless --dry-run) type the resume command into each matched pane.
+resume_main() {
+    local dry_run=false session=""
+    while (($#)); do
+        case "$1" in
+            --dry-run)
+                dry_run=true
+                shift
+                ;;
+            --session)
+                session="${2:?--session requires a value}"
+                shift 2
+                ;;
+            *)
+                echo "resume: unknown argument: $1" >&2
+                return 1
+                ;;
+        esac
+    done
+
+    local dotfiles_dir="${DOTFILES_DIR:-$HOME/Dev/dotfiles}"
+
+    if resume_needs_restore "$session"; then
+        resume_restore_snapshot "$dotfiles_dir" || true
+    fi
+
+    local now
+    now=$(date +%s)
+
+    printf 'PANE\tCWD\tHARNESS\tSESSION\tAGE\n'
+    local _ pane_id cwd match harness rest id epoch age
+    while IFS=$'\t' read -r _ _ _ pane_id cwd; do
+        [[ -n "$pane_id" ]] || continue
+        match=$(resume_best_match "$cwd") || continue
+        harness="${match%%$'\t'*}"
+        rest="${match#*$'\t'}"
+        id="${rest%%$'\t'*}"
+        epoch="${rest##*$'\t'}"
+        age="$(resume_format_age "$now" "$epoch")"
+        printf '%s\t%s\t%s\t%s\t%s\n' "$pane_id" "$cwd" "$harness" "$id" "$age"
+        if [[ "$dry_run" != true ]]; then
+            tmux send-keys -t "$pane_id" "$(resume_command_for "$harness" "$id")"
+        fi
+    done < <(resume_list_panes)
+}

--- a/tests/resume.bats
+++ b/tests/resume.bats
@@ -1,0 +1,176 @@
+#!/usr/bin/env bats
+# Tests for bin/lib/resume.sh (post-reboot tmux resume) and `dots resume`.
+
+load test_helper
+
+setup() {
+    setup_test_env
+    # shellcheck source=bin/lib/resume.sh
+    source "$REAL_DOTFILES_DIR/bin/lib/resume.sh"
+}
+
+teardown() {
+    teardown_test_env
+}
+
+@test "resume_encode_claude_dir maps / to - including the leading slash" {
+    run resume_encode_claude_dir "/home/paul/Dev/dotfiles"
+    assert_success
+    [[ "$output" == "-home-paul-Dev-dotfiles" ]]
+}
+
+@test "resume_encode_claude_dir maps dots in worktree paths too" {
+    run resume_encode_claude_dir "/home/paul/Dev/dotfiles/.worktrees/x"
+    assert_success
+    [[ "$output" == "-home-paul-Dev-dotfiles--worktrees-x" ]]
+}
+
+@test "resume_claude_session picks the newest jsonl by mtime" {
+    local proj="$HOME/.claude/projects/-home-paul-Dev-dotfiles"
+    mkdir -p "$proj"
+    : > "$proj/old-session.jsonl"
+    touch -d '2 days ago' "$proj/old-session.jsonl"
+    : > "$proj/new-session.jsonl"
+    touch -d '1 hour ago' "$proj/new-session.jsonl"
+
+    run resume_claude_session "/home/paul/Dev/dotfiles"
+    assert_success
+    [[ "$output" == "new-session	"* ]]
+}
+
+@test "resume_claude_session returns 1 when no project dir exists" {
+    run resume_claude_session "/home/paul/Dev/nonexistent"
+    [[ "$status" -eq 1 ]]
+}
+
+@test "resume_codex_session matches session_meta.payload.cwd within the last 7 days" {
+    local sessions="$HOME/.codex/sessions/2026/07/08"
+    mkdir -p "$sessions"
+    local f="$sessions/rollout-2026-07-08T00-00-00-0000abcd-abcd-abcd-abcd-000000000001.jsonl"
+    printf '{"payload":{"id":"0000abcd-abcd-abcd-abcd-000000000001","cwd":"/home/paul/Dev/dotfiles"}}\n' > "$f"
+
+    run resume_codex_session "/home/paul/Dev/dotfiles"
+    assert_success
+    [[ "$output" == "0000abcd-abcd-abcd-abcd-000000000001	"* ]]
+}
+
+@test "resume_codex_session returns 1 when no rollout matches the cwd" {
+    local sessions="$HOME/.codex/sessions/2026/07/08"
+    mkdir -p "$sessions"
+    local f="$sessions/rollout-2026-07-08T00-00-00-0000abcd-abcd-abcd-abcd-000000000002.jsonl"
+    printf '{"payload":{"id":"0000abcd-abcd-abcd-abcd-000000000002","cwd":"/some/other/path"}}\n' > "$f"
+
+    run resume_codex_session "/home/paul/Dev/dotfiles"
+    [[ "$status" -eq 1 ]]
+}
+
+@test "resume_opencode_session finds the newest session for a directory" {
+    local db="$TEST_HOME/opencode.db"
+    sqlite3 "$db" "CREATE TABLE session (id text PRIMARY KEY, directory text NOT NULL, time_updated integer NOT NULL);"
+    sqlite3 "$db" "INSERT INTO session (id, directory, time_updated) VALUES ('ses_old', '/home/paul/Dev/dotfiles', 1000000);"
+    sqlite3 "$db" "INSERT INTO session (id, directory, time_updated) VALUES ('ses_new', '/home/paul/Dev/dotfiles', 9000000);"
+
+    RESUME_OPENCODE_DB="$db" run resume_opencode_session "/home/paul/Dev/dotfiles"
+    assert_success
+    [[ "$output" == "ses_new	9000" ]]
+}
+
+@test "resume_opencode_session returns 1 when the db is missing" {
+    RESUME_OPENCODE_DB="$TEST_HOME/no-such.db" run resume_opencode_session "/home/paul/Dev/dotfiles"
+    [[ "$status" -eq 1 ]]
+}
+
+@test "resume_format_age renders days, hours, and minutes" {
+    run resume_format_age 200000 100000
+    assert_success
+    [[ "$output" == "1d3h" ]]
+
+    run resume_format_age 10000 6000
+    assert_success
+    [[ "$output" == "1h6m" ]]
+
+    run resume_format_age 1000 700
+    assert_success
+    [[ "$output" == "5m" ]]
+}
+
+@test "resume_command_for produces the exact per-harness resume command" {
+    run resume_command_for claude abc123
+    [[ "$output" == "claude --resume abc123" ]]
+
+    run resume_command_for codex 0000abcd-abcd-abcd-abcd-000000000001
+    [[ "$output" == "codex resume 0000abcd-abcd-abcd-abcd-000000000001" ]]
+
+    run resume_command_for opencode ses_new
+    [[ "$output" == "opencode --session ses_new" ]]
+}
+
+# --- dots resume integration: mock tmux on PATH, verify table + send-keys ---
+
+stub_tmux() {
+    local bin_dir="$1" panes="$2"
+    mkdir -p "$bin_dir"
+    cat > "$bin_dir/tmux" <<STUB
+#!/bin/bash
+case "\$1" in
+    list-sessions)
+        exit 0
+        ;;
+    has-session)
+        exit 0
+        ;;
+    list-panes)
+        printf '%s\n' '$panes'
+        ;;
+    send-keys)
+        echo "SEND-KEYS: \$*" >> "$TEST_HOME/send-keys.log"
+        ;;
+    *)
+        exit 0
+        ;;
+esac
+STUB
+    chmod +x "$bin_dir/tmux"
+}
+
+@test "dots resume --dry-run prints the table and sends no keys" {
+    local proj="$HOME/.claude/projects/-home-paul-Dev-dotfiles"
+    mkdir -p "$proj"
+    : > "$proj/dry-run-session.jsonl"
+
+    local bin_dir="$TEST_HOME/mockbin"
+    stub_tmux "$bin_dir" "dotfiles	0	0	%1	/home/paul/Dev/dotfiles"
+    PATH="$bin_dir:$PATH" run dots resume --dry-run
+
+    assert_success
+    assert_output_contains "PANE"
+    assert_output_contains "%1"
+    assert_output_contains "claude"
+    assert_output_contains "dry-run-session"
+    [[ ! -f "$TEST_HOME/send-keys.log" ]]
+}
+
+@test "dots resume (no --dry-run) types the resume command into the matched pane" {
+    local proj="$HOME/.claude/projects/-home-paul-Dev-dotfiles"
+    mkdir -p "$proj"
+    : > "$proj/type-session.jsonl"
+
+    local bin_dir="$TEST_HOME/mockbin"
+    stub_tmux "$bin_dir" "dotfiles	0	0	%2	/home/paul/Dev/dotfiles"
+    PATH="$bin_dir:$PATH" run dots resume
+
+    assert_success
+    [[ -f "$TEST_HOME/send-keys.log" ]]
+    grep -qx -- "SEND-KEYS: send-keys -t %2 claude --resume type-session" "$TEST_HOME/send-keys.log"
+    ! grep -qE -- "Enter|C-m" "$TEST_HOME/send-keys.log"
+}
+
+@test "dots resume skips panes with no resumable session" {
+    local bin_dir="$TEST_HOME/mockbin"
+    stub_tmux "$bin_dir" "dotfiles	0	0	%3	/no/agent/session/here"
+    PATH="$bin_dir:$PATH" run dots resume --dry-run
+
+    assert_success
+    assert_output_contains "PANE"
+    [[ "$output" != *"%3"* ]]
+}

--- a/tests/resume.bats
+++ b/tests/resume.bats
@@ -29,13 +29,27 @@ teardown() {
     local proj="$HOME/.claude/projects/-home-paul-Dev-dotfiles"
     mkdir -p "$proj"
     : > "$proj/old-session.jsonl"
-    touch -d '2 days ago' "$proj/old-session.jsonl"
+    touch -t 202001010000 "$proj/old-session.jsonl"
     : > "$proj/new-session.jsonl"
-    touch -d '1 hour ago' "$proj/new-session.jsonl"
+    touch -t 202601010000 "$proj/new-session.jsonl"
 
     run resume_claude_session "/home/paul/Dev/dotfiles"
     assert_success
     [[ "$output" == "new-session	"* ]]
+}
+
+@test "resume_claude_session falls back to BSD stat mtimes" {
+    local proj="$HOME/.claude/projects/-home-paul-Dev-dotfiles" bin_dir="$TEST_HOME/bsd-bin"
+    mkdir -p "$proj" "$bin_dir"
+    : > "$proj/old-session.jsonl"
+    : > "$proj/new-session.jsonl"
+    # shellcheck disable=SC2016
+    printf '#!/usr/bin/env bash\n[[ "$1" == "-c" ]] && exit 1\ncase "$3" in\n  *new-session*) echo 200 ;;\n  *) echo 100 ;;\nesac\n' > "$bin_dir/stat"
+    chmod +x "$bin_dir/stat"
+
+    PATH="$bin_dir:$PATH" run resume_claude_session "/home/paul/Dev/dotfiles"
+    assert_success
+    [[ "$output" == "new-session	200" ]]
 }
 
 @test "resume_claude_session returns 1 when no project dir exists" {


### PR DESCRIPTION
Restore the last tmux-resurrect snapshot after a reboot and type the correct per-pane agent-resume command by matching each pane's cwd to the newest session in that harness's logs.

## What
- `bin/lib/resume.sh` — sourced helpers: per-harness session lookup (claude `~/.claude/projects/<encoded-cwd>/*.jsonl`, codex `~/.codex/sessions/**/rollout-*.jsonl` by `payload.cwd`, opencode `opencode.db` `session` table), snapshot restore, pane enumeration, compact age formatting. Functions only, no top-level side effects (bats can source it).
- `bin/dots` — `resume` subcommand dispatch.
- `tests/resume.bats` — 13 tests incl. mocked `tmux send-keys` and the worktree-path encoding case (`.` maps to `-`).
- `AGENTS.md` — document the command.

## Usage
`dots resume [--dry-run] [--session <name>]` — `--dry-run` prints the matched-pane table without typing anything.

## Testing
`tests/run-tests.sh resume.bats` → 13/13. Full `just check` green (1174 tests).

Origin: the 2026-07-08 PSI-livelock reboot response (Phase 2). Split out of the merged wheypoint branch as its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)