### PR TITLE
feat(chezmoi): auto-update tilth to the fork nightly channel on sync

### DIFF
--- a/chezmoi/.chezmoiscripts/run_onchange_after_install-tilth.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/run_onchange_after_install-tilth.sh.tmpl
@@ -1,0 +1,50 @@
+#!/bin/bash
+# run_onchange — keeps the tilth binary on the fork's nightly channel current
+# on every `dots sync`, mirroring install-hallouminate.sh.tmpl.
+#
+# tilth is Paul's fork (github.com/paulnsorensen/tilth). Its nightly.yml
+# publishes a rolling npm package `@paulnsorensen/tilth-nightly` (scoped, bin
+# `tilth`, versioned 0.0.0-experimental.<run>) off every push to main — that
+# is the channel the tilth MCP (`command: tilth`) should run. `npm i -g` needs
+# --allow-scripts because the postinstall (install.js) downloads the platform
+# binary, which npm blocks by default. This retires the separate nightly npx
+# job — sync now grabs latest, self-gated when already current.
+#
+# Version note: the Rust binary's `--version` stays 0.8.4 (Cargo "fork law"),
+# so the freshness check compares the *npm package* version, not the binary.
+#
+# Re-trigger marker: run_onchange fires only when the rendered body changes.
+# Computed fail-safe — the inner `sh -c` ends in `echo`, so an OFFLINE
+# `dots sync` renders a stable empty marker instead of aborting the apply:
+#   latest nightly version: {{ output "sh" "-c" "npm view @paulnsorensen/tilth-nightly version 2>/dev/null | tr -d '[:space:]'; echo" }}
+
+set -euo pipefail
+
+PKG="@paulnsorensen/tilth-nightly"
+
+installed_version() {
+    npm ls -g "$PKG" --depth=0 2>/dev/null | sed -n 's/.*tilth-nightly@//p' | tr -d '[:space:]'
+}
+
+latest="$(npm view "$PKG" version 2>/dev/null || true)"
+current="$(installed_version)"
+
+if [[ -n "$latest" && "$current" == "$latest" ]]; then
+    echo "✓ tilth (nightly) $current already latest ($latest) — nothing to do"
+elif [[ -z "$latest" ]]; then
+    echo "⚠ Could not resolve latest $PKG from npm (offline?) — keeping installed ${current:-none}" >&2
+else
+    echo "Installing $PKG@latest (was ${current:-none}, latest $latest)..."
+    npm install -g "$PKG@latest" --allow-scripts="$PKG"
+    echo "✓ tilth (nightly) $(installed_version) installed"
+fi
+
+# Keep the fork's nightly the single source of truth for the `tilth` bin.
+# Both the upstream public `tilth` npm package and a `cargo install` build
+# expose a `tilth` binary and would compete for / shadow it on PATH.
+if npm ls -g tilth --depth=0 >/dev/null 2>&1; then
+    echo "⚠ upstream public 'tilth' is also installed globally and competes for the 'tilth' bin — 'npm rm -g tilth' to keep the nightly fork canonical." >&2
+fi
+if [[ -f "$HOME/.cargo/bin/tilth" ]]; then
+    echo "⚠ ~/.cargo/bin/tilth shadows the npm binary on PATH — remove it so 'tilth' resolves to the nightly fork." >&2
+fi

--- a/chezmoi/.chezmoiscripts/run_onchange_after_install-tilth.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/run_onchange_after_install-tilth.sh.tmpl
@@ -23,7 +23,7 @@ set -euo pipefail
 PKG="@paulnsorensen/tilth-nightly"
 
 installed_version() {
-    npm ls -g "$PKG" --depth=0 2>/dev/null | sed -n 's/.*tilth-nightly@//p' | tr -d '[:space:]'
+    npm ls -g "$PKG" --depth=0 2>/dev/null | sed -n 's/.*tilth-nightly@//p' | tr -d '[:space:]' || true
 }
 
 latest="$(npm view "$PKG" version 2>/dev/null || true)"

--- a/tests/chezmoi-wiring.bats
+++ b/tests/chezmoi-wiring.bats
@@ -845,6 +845,17 @@ YAML
     chmod +x "$hallouminate_bin/gh"
     PATH="$hallouminate_bin:$PATH"
 
+    # The tilth run_onchange installer must also stay hermetic during the
+    # end-to-end apply. Simulate offline npm and an absent global package:
+    # the script should warn and continue, not abort under `set -euo pipefail`
+    # from the failed `npm ls` probe or attempt a real install.
+    local npm_bin="$TEST_HOME/fake-npm-bin"
+    mkdir -p "$npm_bin"
+    # shellcheck disable=SC2016
+    printf '#!/usr/bin/env bash\ncase "$1 $2 $3" in\n  "view @paulnsorensen/tilth-nightly version") exit 1 ;;\n  "ls -g @paulnsorensen/tilth-nightly") exit 1 ;;\n  "ls -g tilth") exit 1 ;;\n  "install -g @paulnsorensen/tilth-nightly@latest") echo "unexpected npm install" >&2; exit 99 ;;\n  *) echo "unexpected npm $*" >&2; exit 99 ;;\nesac\n' > "$npm_bin/npm"
+    chmod +x "$npm_bin/npm"
+    PATH="$npm_bin:$PATH"
+
     # Templated dotfiles need [data] for .email and env vars for the
     # copilot template's fail-fast guard. Bootstrap both before .sync runs
     # so chezmoi apply renders cleanly.


### PR DESCRIPTION
## Problem
The tilth MCP (`command: tilth`) should run **Paul's fork nightly**, but two things were wrong:
- The active `tilth` was **upstream public `tilth@0.9.0`** (jahala), not the fork.
- A stale **`cargo install` build (0.8.4)** at `~/.cargo/bin/tilth` shadowed even that on PATH (`~/.cargo/bin` precedes `~/.local/bin`).

## Fix
The fork's `nightly.yml` publishes a rolling scoped npm package **`@paulnsorensen/tilth-nightly`** (bin `tilth`, versioned `0.0.0-experimental.<run>`) off every push to `main`. Make that the single source of truth and grab latest on every `dots sync`, mirroring `install-hallouminate.sh.tmpl`:

- **`run_onchange_after_install-tilth.sh.tmpl`** — re-fires only when `npm view @paulnsorensen/tilth-nightly version` changes (self-gating, offline-safe marker); installs with `npm i -g @paulnsorensen/tilth-nightly@latest --allow-scripts=@paulnsorensen/tilth-nightly`.
  - `--allow-scripts` is required: the package's `postinstall` (`install.js`) downloads the platform binary, which npm blocks by default.
  - Freshness compares the **npm package version**, not the binary — the Rust `--version` stays `0.8.4` ("fork law" keeps Cargo pinned).
  - Warns if upstream public `tilth` **or** a `cargo` build reappears and competes for the `tilth` bin.
  - **Retires the separate nightly npx job** — sync keeps it fresh.

Runs on `dots sync` (chezmoi apply); zero `bin/dots` changes.

## One-time out-of-band (already applied on this machine)
`npm rm -g tilth` (upstream public) + removed stale `~/.cargo/bin/tilth`, then installed the fork nightly. `tilth` now resolves to `@paulnsorensen/tilth-nightly@0.0.0-experimental.15.1`.

## hallouminate
No change — already auto-updates on sync via `install-hallouminate.sh.tmpl`.

## Testing
- shellcheck clean (prek flags).
- Script run directly: `✓ tilth (nightly) 0.0.0-experimental.15.1 already latest — nothing to do`.
- `chezmoi execute-template` renders the version marker with no template error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)