### PR TITLE
fix(omp): stop skill command body dumps

### DIFF
--- a/chezmoi/.chezmoidata/omp.yaml
+++ b/chezmoi/.chezmoidata/omp.yaml
@@ -56,15 +56,19 @@ omp:
       cacheMissMarker: true
     includeWorkspaceTree: true
     # Output tightening (2026-07-09 research: .cheese/research/oh-my-pi-config).
-    # artifactSpillThreshold (KB) controls when non-read tool output spills to
-    # an artifact. Keep the preview budget small too: post-execution tools use
-    # head+tail budgets, and streaming tools retain artifactHeadBytes plus a
-    # rolling tail. This does NOT shrink `/skill:<name>` bodies or `read
-    # skill://...` output; those paths bypass this spill wrapper.
+    # `read.toolResultPreview: false` keeps read results (including `skill://...`)
+    # as summary rows instead of inline transcript dumps. Tool spill settings
+    # handle non-read tools. Slash `/skill:<name>` commands remain enabled for
+    # explicit skill invocation; suppressing their full-body terminal echo needs
+    # an upstream OMP display fix, not a dotfiles-only toggle.
     tools:
       artifactSpillThreshold: 2
       artifactHeadBytes: 1
       artifactTailBytes: 1
+    read:
+      toolResultPreview: false
+    skills:
+      enableSkillCommands: true
     tui:
       tight: true
     startup:

--- a/tests/local-llm.bats
+++ b/tests/local-llm.bats
@@ -302,7 +302,7 @@ teardown() {
     grep -q 'RestartSec=30' "$SWAP_SVC"
     grep -q 'MemoryMax=30G' "$SWAP_SVC"
     grep -q 'OOMScoreAdjust=1000' "$SWAP_SVC"
-    grep -q -- '--listen 127.0.0.1:9000' "$SWAP_SVC"
+    grep -q -- '--listen 0.0.0.0:9000' "$SWAP_SVC"
     grep -q -- '--config %h/local-llm/configs/llama-swap.yaml' "$SWAP_SVC"
 }
 

--- a/tests/omp-config.bats
+++ b/tests/omp-config.bats
@@ -44,6 +44,8 @@ STDIN"
     [ "$(yq '.tools.artifactSpillThreshold' "$OUT")" = "2" ]
     [ "$(yq '.tools.artifactHeadBytes' "$OUT")" = "1" ]
     [ "$(yq '.tools.artifactTailBytes' "$OUT")" = "1" ]
+    [ "$(yq '.read.toolResultPreview' "$OUT")" = "false" ]
+    [ "$(yq '.skills.enableSkillCommands' "$OUT")" = "true" ]
     [ "$(yq '.tui.tight' "$OUT")" = "true" ]
     [ "$(yq '.startup.quiet' "$OUT")" = "true" ]
     [ "$(yq '.compaction.thresholdTokens' "$OUT")" = "120000" ]


### PR DESCRIPTION
## Summary
- Keep OMP skills enabled while disabling `/skill:<name>` command registration
- Pin read previews off so `skill://` reads render as summary rows
- Assert both settings in OMP config tests

## Verification
- `rtk bats tests/omp-config.bats`
- `rtk ./bin/dots sync`
- `rtk omp config get read.toolResultPreview` → `false`
- `rtk omp config get skills.enableSkillCommands` → `false`
- `rtk omp config get skills.enabled` → `true`