### PR TITLE
feat(dots): make `dots up` run a refresh sync so skill removals propagate

### DIFF
--- a/bin/dots
+++ b/bin/dots
@@ -64,7 +64,7 @@ ${GREEN}Usage:${NC} dots [command] [args]
 ${BLUE}Commands:${NC}
   ${GREEN}update${NC}          Pull latest changes and run sync
   ${GREEN}sync${NC}            Run the sync script
-  ${GREEN}upgrade${NC}         Upgrade installed packages and refresh remote skills
+  ${GREEN}upgrade${NC}         Upgrade packages, force-refresh skills + vendor cache, apply
   ${GREEN}status${NC}          Show git status of dotfiles
   ${GREEN}rollback${NC}        Show how to undo a sync (git revert + dots sync)
   ${GREEN}doctor${NC}          Run health checks and profile shell
@@ -422,9 +422,14 @@ case "${1:-status}" in
         resume_main "$@"
         ;;
     upgrade|up)
-        echo -e "${BLUE}⬆️  Upgrading packages...${NC}"
+        echo -e "${BLUE}⬆️  Upgrading packages and refreshing config...${NC}"
         cd_dotfiles
-        UPGRADE_MODE=true bash "$DOTFILES_DIR/packages/sync.sh"
+        # Full refresh sync: UPGRADE_MODE upgrades package versions, `refresh`
+        # force-pulls the external-skill vendor cache (plain `dots sync` reuses
+        # a stale cache, so upstream skill removals never reach ~/.claude), then
+        # chezmoi apply prunes anything the fresh assembly dropped. Runs before
+        # the npx skill refresh so package tools (node) are present for it.
+        UPGRADE_MODE=true do_sync refresh
 
         echo
         echo -e "${BLUE}⬆️  Refreshing remote skills...${NC}"

--- a/tests/dots.bats
+++ b/tests/dots.bats
@@ -25,13 +25,20 @@ teardown() {
     assert_output_contains "rollback"
 }
 
-# Stub a dotfiles tree wired for `dots upgrade`: packages/sync.sh prints its
-# UPGRADE_MODE, install-external.sh prints its args. Both must be invoked.
+# Stub a dotfiles tree wired for `dots upgrade`: `.sync` prints its args and
+# runs packages/sync.sh (mirroring the real do_sync path), packages/sync.sh
+# prints its UPGRADE_MODE, install-external.sh prints its args. All must be
+# invoked — `dots upgrade` now runs a refresh sync, then the skill refresh.
 stub_upgrade_dotfiles() {
     local stub_dir="$1"
     mkdir -p "$stub_dir/packages" "$stub_dir/bin" \
              "$stub_dir/chezmoi/lib" "$stub_dir/skills"
     cp "$DOTFILES_DIR/bin/dots" "$stub_dir/bin/dots"
+    cat > "$stub_dir/.sync" <<'STUB'
+#!/bin/bash
+echo "stub-dotsync args=$*"
+bash "$(dirname "$0")/packages/sync.sh"
+STUB
     cat > "$stub_dir/packages/sync.sh" <<'STUB'
 #!/bin/bash
 echo "stub-sync UPGRADE_MODE=${UPGRADE_MODE:-unset}"
@@ -41,26 +48,30 @@ STUB
 echo "stub-skill-sync args=$*"
 STUB
     : > "$stub_dir/skills/_registry.yaml"
-    chmod +x "$stub_dir/packages/sync.sh" \
+    chmod +x "$stub_dir/.sync" "$stub_dir/packages/sync.sh" \
              "$stub_dir/chezmoi/lib/install-external.sh"
 }
 
-@test "dots upgrade runs packages/sync.sh with UPGRADE_MODE=true, then skill-sync --force" {
+@test "dots upgrade runs a refresh sync (UPGRADE_MODE=true), then skill-sync --force" {
     local stub_dir="$TEST_HOME/stub-dotfiles"
     stub_upgrade_dotfiles "$stub_dir"
     DOTFILES_DIR="$stub_dir" run "$stub_dir/bin/dots" upgrade
     assert_success
     assert_output_contains "Upgrading packages"
+    # do_sync refresh: forwards the `refresh` arg (force-pulls the vendor cache)
+    # and runs packages/sync.sh with UPGRADE_MODE=true.
+    assert_output_contains "stub-dotsync args=refresh"
     assert_output_contains "stub-sync UPGRADE_MODE=true"
     assert_output_contains "Refreshing remote skills"
     assert_output_contains "stub-skill-sync args=$stub_dir/skills/_registry.yaml --force"
 
-    # Lock down ordering: package sync must run before skill refresh.
-    local pkg_line skill_line
-    pkg_line=$(printf '%s\n' "$output" | grep -n 'stub-sync UPGRADE_MODE=true' | head -1 | cut -d: -f1)
+    # Lock down ordering: the refresh sync (which installs package tools) must
+    # run before the npx skill refresh that depends on them.
+    local sync_line skill_line
+    sync_line=$(printf '%s\n' "$output" | grep -n 'stub-dotsync args=refresh' | head -1 | cut -d: -f1)
     skill_line=$(printf '%s\n' "$output" | grep -n 'stub-skill-sync args=' | head -1 | cut -d: -f1)
-    [[ "$pkg_line" -lt "$skill_line" ]] || {
-        echo "Expected package sync before skill refresh; got pkg=$pkg_line skill=$skill_line" >&2
+    [[ "$sync_line" -lt "$skill_line" ]] || {
+        echo "Expected refresh sync before skill refresh; got sync=$sync_line skill=$skill_line" >&2
         return 1
     }
 }


### PR DESCRIPTION
## Problem

`dots up` only ran package upgrades + the npx multi-harness skill refresh — it never ran the claude source assembly or `chezmoi apply`. Worse, even plain `dots sync` reuses a **stale external-skill vendor cache** (`~/.cache/dotfiles/claude-skill-sources`), which is force-pulled only under `FORCE_PACKAGES` (i.e. `dots sync refresh`).

Net effect: a skill deleted upstream — e.g. `cheese-factory` removed from `paulnsorensen/easy-cheese` (upstream returns 404) — lingered in `~/.claude/skills/` no matter how often `dots up` ran. Neither `up` nor plain `sync` could prune it.

## Change

`upgrade|up` now runs `UPGRADE_MODE=true do_sync refresh`:

- **one** package pass (upgrade + force re-check, flags compose cleanly),
- a force-pull of the external-skill vendor cache (picks up upstream deletions),
- `chezmoi apply`, whose `exact_` semantics prune anything the fresh assembly dropped.

The npx multi-harness skill refresh runs **after** the sync, so package tools (node) are present for it — preserving the packages-before-skills dependency in a single package pass.

## Tradeoff

`dots up` is now a full refresh sync (symlinks, tmux, prek, tilth, MCP reconcile, forced package re-check) — meaningfully heavier/slower than the old package-only `up`. That's the cost of making upstream skill removals actually propagate.

## Tests

- `tests/dots.bats`: stub gains a `.sync`; the upgrade test asserts the refresh-sync runs with `refresh` and locks sync-before-skills ordering.
- `just check` green (lint + full 1176-test bats suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)