### PR TITLE
feat(sync): float external skills to latest main on every dots sync

### DIFF
--- a/.sync-lib.sh
+++ b/.sync-lib.sh
@@ -253,9 +253,9 @@ _cz_render_claude_agent() {
 # Vendor external skills (skills/_registry.yaml sources that include claude)
 # into <dst>. Clones each source into a cache dir; offline falls back to the
 # cached checkout with a warning. A source that has never been cloned and
-# cannot be cloned fails the assembly (loud, per fail-fast). Float-to-latest
-# pulls run only under `dots sync refresh` (FORCE_PACKAGES) to keep network
-# off the plain-sync hot path; a pin change is always honored.
+# cannot be cloned fails the assembly (loud, per fail-fast). Unpinned sources
+# float to latest of their default branch on every sync (offline → cached
+# checkout); a pin change is always honored, an unchanged pin costs no network.
 #   _cz_vendor_external_skills <skills_registry_yaml> <dst_dir>
 _cz_vendor_external_skills() {
     local registry="$1" dst="$2"
@@ -296,7 +296,9 @@ _cz_vendor_external_skills() {
                     return 1
                 fi
             fi
-        elif [[ "${FORCE_PACKAGES:-false}" == true ]]; then
+        else
+            # Unpinned: float to latest of the default branch on every sync.
+            # Offline (pull fails) falls back to the existing cached checkout.
             git -C "$cache" pull --ff-only >/dev/null 2>&1 \
                 || log_warning "external skill source $source: pull failed, using cached checkout"
         fi

--- a/tests/sync-claude-sources.bats
+++ b/tests/sync-claude-sources.bats
@@ -172,22 +172,13 @@ EXPECTED
     [ -f "$SRC/dot_claude/exact_reference/bank.md" ]
 }
 
-@test "assembly: vendors external skills from the cache when offline (refresh mode)" {
-    # FORCE_PACKAGES (dots sync refresh) opts into the float-to-latest pull;
-    # the failing git shim simulates offline — cache fallback with a warning.
-    export FORCE_PACKAGES=true
+@test "assembly: plain sync floats an unpinned source to latest (git pull --ff-only)" {
+    # Every sync pulls the default branch; the failing git shim simulates
+    # offline, so the pull falls back to the cached checkout with a warning.
     run_assembly
     [ "$status" -eq 0 ]
+    grep -q "pull --ff-only" "$GIT_CALLS"
     [[ "$output" == *"using cached checkout"* ]]
-    [ -f "$SRC/dot_claude/exact_skills/exact_ext-skill/SKILL.md" ]
-}
-
-@test "assembly: plain sync never hits the network for a cached unpinned source" {
-    # Float-to-latest is opt-in (dots sync refresh); the plain-sync hot path
-    # must vendor straight from the cache with zero git invocations.
-    run_assembly
-    [ "$status" -eq 0 ]
-    [ ! -f "$GIT_CALLS" ]
     [ -f "$SRC/dot_claude/exact_skills/exact_ext-skill/SKILL.md" ]
 }
 


### PR DESCRIPTION
## What

Plain `dots sync` now floats unpinned `skills/_registry.yaml` sources (easy-cheese, skillz-that-grillz) to the latest tip of their default branch, instead of only under `dots sync refresh` / `dots upgrade`.

## Why

`_cz_vendor_external_skills` gated the `git pull --ff-only` behind `FORCE_PACKAGES`. A plain `dots sync` reused the existing cached clone with zero network, so upstream skill changes on `main` never reached `~/.claude/skills/` until a `refresh`/`upgrade`. This made "edit skill → push → dots sync" silently no-op.

## Change

- `.sync-lib.sh`: drop the `FORCE_PACKAGES` branch → unpinned sources `git pull --ff-only` every sync. Pinned sources (pin fetch/checkout) and offline cache-fallback-with-warning are unchanged.
- Doc comment updated to match.
- `tests/sync-claude-sources.bats`: inverted the former "plain sync never hits the network" test to assert the pull happens and offline falls back to the cached checkout. 20/20 pass.

## Verification

`just check` → exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)