### PR TITLE
chore(packages): retire tilth cargo build in favor of the npm nightly

### DIFF
--- a/packages/packages.yaml
+++ b/packages/packages.yaml
@@ -132,7 +132,9 @@ packages:
   # Cargo
   - cargo-llvm-cov: { source: cargo }
   - cargo-update: { source: cargo }            # provides `cargo install-update` for idempotent `dots up`
-  - tilth: { source: cargo, git: "https://github.com/paulnsorensen/tilth", branch: main }
+  # tilth is installed from its npm nightly channel (@paulnsorensen/tilth-nightly)
+  # by chezmoi/.chezmoiscripts/run_onchange_after_install-tilth.sh.tmpl — a
+  # cargo build here would shadow that nightly binary on PATH (0.8.4 < nightly).
   - hallouminate: { source: cargo, git: "https://github.com/paulnsorensen/hallouminate", branch: main }
   # Install from Git because the crates.io `rtk` collides with the desired package.
   # If an unrelated `rtk` is already present from `cargo install rtk`, remove it first


### PR DESCRIPTION
## What

Remove the `tilth` cargo-git entry from `packages/packages.yaml`. tilth now comes solely from its npm nightly channel (`@paulnsorensen/tilth-nightly`).

## Why

`run_onchange_after_install-tilth.sh.tmpl` already installs the npm nightly (via `npm i -g --allow-scripts`, the hardened download-and-run shim from paulnsorensen/tilth#133) on every `dots sync`. But the leftover cargo entry kept a `~/.cargo/bin/tilth` binary (0.8.4, built from `main`) that sorts **ahead** of the npm symlink on PATH:

```
which -a tilth:
  ~/.cargo/bin/tilth          ← 0.8.4 cargo build   ← won
  /opt/homebrew/bin/tilth     ← nightly 0.0.0-experimental.15.1 (npm)
```

So the tilth MCP (`command: tilth`) was running the **stale cargo build**, not the nightly it was supposed to. The install script had been printing shadow warnings about exactly this.

## Change

- Drop `packages/packages.yaml` cargo entry for tilth; leave a comment pointing at the nightly install script so future readers know why it isn't there (hallouminate directly below is still cargo).
- Out of band on the maintainer's machine: `cargo uninstall tilth` clears the shadowing binary so `tilth` resolves to `/opt/homebrew/bin/tilth` (nightly). Verified post-uninstall.

No install-script change needed — the npm nightly path already exists and self-gates on freshness.

## Verification

`just check` → exit 0. `which tilth` → `/opt/homebrew/bin/tilth` (nightly symlink) after uninstall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)