### PR TITLE
chore(packages): migrate hallouminate to the npm nightly channel

### DIFF
--- a/chezmoi/.chezmoiscripts/run_onchange_after_install-hallouminate.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/run_onchange_after_install-hallouminate.sh.tmpl
@@ -1,72 +1,53 @@
 #!/bin/bash
-# run_onchange — installs / updates the hallouminate MCP server binary into
-# ~/.cargo/bin so `hallouminate serve` (the wiki MCP) always matches a real
-# release. The dotfiles deploy hallouminate's config + MCP registration but
-# assumed the binary already existed on PATH; this closes that gap (it drifted
-# to a hand-built 0.2.2 while releases moved to 0.2.3).
+# run_onchange — keeps the hallouminate binary on the fork's nightly channel
+# current on every `dots sync`, mirroring install-tilth.sh.tmpl.
 #
-# Default: download the latest PREBUILT release via the cargo-dist installer
-# (no Rust toolchain, no compile — one curl into ~/.cargo/bin). Opt in to a
-# source build by setting, in the dotfiles .env:
-#     HALLOUMINATE_FROM_SOURCE=1
-# which compiles origin/main via `cargo install --git` — it builds REMOTE main,
-# not the local ~/Dev/hallouminate working tree, so a dirty/stale checkout never
-# leaks into the installed binary.
+# hallouminate is Paul's fork (github.com/paulnsorensen/hallouminate). Its
+# nightly workflow publishes a rolling npm package
+# `@paulnsorensen/hallouminate-nightly` (scoped, bin `hallouminate`, versioned
+# 0.0.0-experimental.<run>) off every push to main — that is the channel the
+# hallouminate MCP (`command: hallouminate`, `hallouminate serve`) should run.
+# `npm i -g` needs --allow-scripts because the postinstall (install.js)
+# downloads the platform binary (SHA-256 sidecar verified), which npm blocks by
+# default. This retires both the cargo-dist prebuilt installer and the
+# cargo-git source build — sync now grabs latest, self-gated when current.
 #
-# Re-trigger markers: run_onchange fires only when the rendered body changes.
-# Both markers are computed fail-safe — the inner `sh -c` always exits 0 (a
-# trailing `echo`), so an OFFLINE `dots sync` renders a stable empty marker
-# instead of aborting the whole apply:
-#   latest release tag: {{ output "sh" "-c" "gh api repos/paulnsorensen/hallouminate/releases/latest --jq .tag_name 2>/dev/null | tr -d '[:space:]'; echo" }}
-#   origin/main commit: {{ output "sh" "-c" "git ls-remote https://github.com/paulnsorensen/hallouminate.git main 2>/dev/null | cut -f1 | tr -d '[:space:]'; echo" }}
+# Version note: the Rust binary's `--version` stays 0.3.0 (Cargo "fork law"),
+# so the freshness check compares the *npm package* version, not the binary.
+#
+# Re-trigger marker: run_onchange fires only when the rendered body changes.
+# Computed fail-safe — the inner `sh -c` ends in `echo`, so an OFFLINE
+# `dots sync` renders a stable empty marker instead of aborting the apply:
+#   latest nightly version: {{ output "sh" "-c" "npm view @paulnsorensen/hallouminate-nightly version 2>/dev/null | tr -d '[:space:]'; echo" }}
 
 set -euo pipefail
 
-REPO="paulnsorensen/hallouminate"
-# .env lives at the dotfiles root — parent of chezmoi's sourceDir.
-ENV_FILE="$(cd "{{ .chezmoi.sourceDir }}/.." && pwd)/.env"
+PKG="@paulnsorensen/hallouminate-nightly"
 
-# Read HALLOUMINATE_FROM_SOURCE from .env (naive loader, mirrors
-# lib/install-external.sh). Absent/0 → prebuilt path.
-FROM_SOURCE=0
-if [[ -f "$ENV_FILE" ]]; then
-    val="$(sed -n 's/^[[:space:]]*\(export[[:space:]]\+\)\?HALLOUMINATE_FROM_SOURCE=//p' "$ENV_FILE" | tail -1)"
-    val="${val%\"}"; val="${val#\"}"
-    [[ "$val" == "1" || "$val" == "true" ]] && FROM_SOURCE=1
-fi
+installed_version() {
+    npm ls -g "$PKG" --depth=0 2>/dev/null | sed -n 's/.*hallouminate-nightly@//p' | tr -d '[:space:]' || true
+}
 
-installed_version() { hallouminate --version 2>/dev/null | awk '{print $2}'; }
-
-if [[ "$FROM_SOURCE" == "1" ]]; then
-    if ! command -v cargo &>/dev/null; then
-        echo "Error: HALLOUMINATE_FROM_SOURCE=1 but cargo not found. Install Rust or unset the flag." >&2
-        exit 1
-    fi
-    echo "Building hallouminate from origin/main (HALLOUMINATE_FROM_SOURCE=1)..."
-    cargo install --git "https://github.com/$REPO" --branch main --force
-    echo "✓ hallouminate $(installed_version) installed from source (origin/main)"
-    exit 0
-fi
-
-# Prebuilt path. Skip when already on the latest tag — this script can re-fire
-# because origin/main moved (a new commit with no release), and a prebuilt-mode
-# machine should not re-download an unchanged release for that.
-latest="$(gh api "repos/$REPO/releases/latest" --jq .tag_name 2>/dev/null || true)"
+latest="$(npm view "$PKG" version 2>/dev/null || true)"
 current="$(installed_version)"
-if [[ -n "$latest" && "v$current" == "$latest" ]]; then
-    echo "✓ hallouminate $current already latest ($latest) — nothing to do"
-    exit 0
-fi
-if [[ -z "$latest" && -n "$current" ]]; then
-    echo "⚠ Could not resolve latest release (offline?) — keeping installed $current" >&2
-    exit 0
+
+if [[ -n "$latest" && "$current" == "$latest" ]]; then
+    echo "✓ hallouminate (nightly) $current already latest ($latest) — nothing to do"
+elif [[ -z "$latest" ]]; then
+    echo "⚠ Could not resolve latest $PKG from npm (offline?) — keeping installed ${current:-none}" >&2
+else
+    echo "Installing $PKG@latest (was ${current:-none}, latest $latest)..."
+    npm install -g "$PKG@latest" --allow-scripts="$PKG"
+    echo "✓ hallouminate (nightly) $(installed_version) installed"
 fi
 
-echo "Installing latest prebuilt hallouminate${latest:+ ($latest)}..."
-# ~/.cargo/bin is already on PATH; HALLOUMINATE_NO_MODIFY_PATH=1 stops the
-# cargo-dist installer from touching shell rc files (replaces the deprecated
-# --no-modify-path flag).
-curl --proto '=https' --tlsv1.2 -LsSf \
-    "https://github.com/$REPO/releases/latest/download/hallouminate-installer.sh" \
-    | HALLOUMINATE_NO_MODIFY_PATH=1 sh
-echo "✓ hallouminate $(installed_version) installed (prebuilt)"
+# Keep the fork's nightly the single source of truth for the `hallouminate` bin.
+# Both the upstream public `hallouminate` npm package and a `cargo install` /
+# cargo-dist build expose a `hallouminate` binary and would compete for / shadow
+# it on PATH.
+if npm ls -g hallouminate --depth=0 >/dev/null 2>&1; then
+    echo "⚠ upstream public 'hallouminate' is also installed globally and competes for the 'hallouminate' bin — 'npm rm -g hallouminate' to keep the nightly fork canonical." >&2
+fi
+if [[ -f "$HOME/.cargo/bin/hallouminate" ]]; then
+    echo "⚠ ~/.cargo/bin/hallouminate shadows the npm binary on PATH — remove it so 'hallouminate' resolves to the nightly fork." >&2
+fi

--- a/packages/packages.yaml
+++ b/packages/packages.yaml
@@ -132,10 +132,10 @@ packages:
   # Cargo
   - cargo-llvm-cov: { source: cargo }
   - cargo-update: { source: cargo }            # provides `cargo install-update` for idempotent `dots up`
-  # tilth is installed from its npm nightly channel (@paulnsorensen/tilth-nightly)
-  # by chezmoi/.chezmoiscripts/run_onchange_after_install-tilth.sh.tmpl — a
-  # cargo build here would shadow that nightly binary on PATH (0.8.4 < nightly).
-  - hallouminate: { source: cargo, git: "https://github.com/paulnsorensen/hallouminate", branch: main }
+  # tilth and hallouminate are installed from their npm nightly channels
+  # (@paulnsorensen/{tilth,hallouminate}-nightly) by the run_onchange_after_
+  # install-{tilth,hallouminate}.sh.tmpl scripts — a cargo build here would
+  # shadow that nightly binary on PATH.
   # Install from Git because the crates.io `rtk` collides with the desired package.
   # If an unrelated `rtk` is already present from `cargo install rtk`, remove it first
   # so `dots sync` does not incorrectly treat the Git-sourced package as already satisfied.

--- a/packages/packages.yaml
+++ b/packages/packages.yaml
@@ -132,7 +132,9 @@ packages:
   # Cargo
   - cargo-llvm-cov: { source: cargo }
   - cargo-update: { source: cargo }            # provides `cargo install-update` for idempotent `dots up`
-  - tilth: { source: cargo, git: "https://github.com/paulnsorensen/tilth", branch: main }
+  # tilth is installed from its npm nightly channel (@paulnsorensen/tilth-nightly)
+  # by chezmoi/.chezmoiscripts/run_onchange_after_install-tilth.sh.tmpl — a
+  # cargo build here would shadow that nightly binary on PATH (0.8.4 < nightly).
   - hallouminate: { source: cargo, git: "https://github.com/paulnsorensen/hallouminate", branch: main }
   # Install from Git because the crates.io `rtk` collides with the desired package.
   # If an unrelated `rtk` is already present from `cargo install rtk`, remove it first


### PR DESCRIPTION
## What

Mirror the tilth npm-nightly migration for hallouminate:
- Rewrite `run_onchange_after_install-hallouminate.sh.tmpl` to install `@paulnsorensen/hallouminate-nightly` via `npm i -g --allow-scripts` (the SHA-256-verified postinstall shim), replacing the cargo-dist prebuilt installer + `HALLOUMINATE_FROM_SOURCE` cargo path.
- Drop the `hallouminate` cargo-git entry from `packages.yaml` so the nightly binary isn't shadowed on PATH by a competing `~/.cargo/bin` build.

## Unblocked

Depended on `paulnsorensen/hallouminate#202` (`nightly.yml`), now merged and run: it builds the three targets, uploads `hallouminate-<target>.tar.xz` + `.sha256` sidecars to a rolling `nightly` prerelease, and publishes the npm package. The `nightly` release now serves all assets (was `release not found`).

## Verification

- `npm i -g @paulnsorensen/hallouminate-nightly` succeeds end-to-end locally — postinstall downloads + checksum-verifies the binary.
- `hallouminate` resolves to `/opt/homebrew/bin/hallouminate` (nightly symlink) after clearing the cargo shadow.
- `just check` — (updating below once the run completes).

## Notes

- **Stacked on #430** (`chore/retire-tilth-cargo`) — includes that commit until #430 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)