### PR TITLE
feat(fe-profile): add hallouminate + milknado MCPs to closed world

### DIFF
--- a/profiles/fe/CLAUDE.md
+++ b/profiles/fe/CLAUDE.md
@@ -14,6 +14,8 @@ Defined in `profile.yaml` (closed world — `--strict-mcp-config`):
 - **context7** — `mcp__context7__*` — React, Tailwind, Next.js, and other lib docs.
 - **tilth** — `mcp__tilth__*` — AST-aware search/read when navigating components.
 - **tavily** — `mcp__tavily__*` — pattern research ("how do people build X in Next.js 15?").
+- **hallouminate** — `mcp__hallouminate__*` — repo-wiki grounding (`ground` / `read_markdown`); check for design-system / component conventions before writing.
+- **milknado** — `mcp__milknado__*` — Mikado execution (goal decomposition, batch planning) for larger FE work.
 - **Playwright (plugin)** — `mcp__plugin_playwright_playwright__*` — browser verification.
 - **claude.ai Figma** — `mcp__claude_ai_Figma__*` — design context when the user shares a figma.com URL.
 

--- a/profiles/fe/profile.yaml
+++ b/profiles/fe/profile.yaml
@@ -1,6 +1,12 @@
 # fe — frontend / design-to-code (ccp parity).
 # Closed MCP world: library docs, AST nav, structural impact, web research,
-# plus shadcn (profile-local). Re-enables claude.ai connectors for Figma.
+# repo-wiki grounding (hallouminate), Mikado execution (milknado), plus shadcn
+# (profile-local). Re-enables claude.ai connectors for Figma.
+# NOTE: hallouminate + milknado are declared as plain MCP servers here (not via
+# enabled_plugins) so they load under --strict-mcp-config — the isolated launch
+# only loads MCPs from the generated --mcp-config, and does not restore custom
+# plugin marketplaces. Tool names are the bare mcp__hallouminate__* /
+# mcp__milknado__* forms (not the plugin-scoped mcp__plugin_*__ names).
 name: fe
 description: Frontend + shadcn/Figma/Playwright
 # Cheese sub-agents are available in this closed world too
@@ -40,3 +46,9 @@ mcps:
   - name: shadcn
     command: npx
     args: ["shadcn@latest", "mcp"]
+  - name: hallouminate
+    command: hallouminate
+    args: ["serve"]
+  - name: milknado
+    command: uvx
+    args: ["--from", "git+https://github.com/paulnsorensen/milknado@main", "milknado-mcp"]


### PR DESCRIPTION
## What

Wire **hallouminate** (repo-wiki grounding) and **milknado** (Mikado execution) into the `fe` (`ccp fe`) profile's MCP set, alongside the existing tilth, context7, tavily, and shadcn servers.

## Why

The `fe` profile is `isolated: true`, which launches claude with `--strict-mcp-config` — only MCPs from the generated `--mcp-config` load, and global / native-plugin MCPs are **not inherited**. So hallouminate and milknado were absent from the closed world.

Declaring them in the profile's `mcps:` block (rather than `enabled_plugins`) guarantees they load under strict mode regardless of plugin/marketplace resolution — the same guaranteed path tilth already uses.

## Changes

- `profiles/fe/profile.yaml` — add two MCP servers:
  - `hallouminate` → `hallouminate serve` (tools: `mcp__hallouminate__*`)
  - `milknado` → `uvx --from git+https://github.com/paulnsorensen/milknado@main milknado-mcp` (tools: `mcp__milknado__*`)
- `profiles/fe/CLAUDE.md` — add both to the in-scope MCP list.

## Verification

- Rendered the isolated launch from the workspace copy: all six servers land in the generated `--strict-mcp-config` config; strict flag present.
- All three binaries (`hallouminate`, `uvx`, `tilth`) confirmed on PATH.
- `just check` exits 0.

## Follow-up

Deploy with `dots profile install fe` to push to the live clone — `ccp fe` uses the deployed copy until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)