### PR TITLE
feat(bin): guarded claude launcher — session ceiling + RAM gate + heap cap

### DIFF
--- a/bin/claude
+++ b/bin/claude
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Guarded launcher for Claude Code — shadows ~/.local/bin/claude via PATH order.
+# Purpose: stop session storms from toppling crabbot (see ~/crabbot-stability-report.md).
+# Bypass all checks: CLAUDE_GUARD=0 claude ...
+
+set -euo pipefail
+REAL=/home/paul/.local/bin/claude
+
+if [[ "${CLAUDE_GUARD:-1}" != "0" ]]; then
+  sessions=$(pgrep -cx claude || true)
+  avail_kb=$(awk '/MemAvailable/ {print $2}' /proc/meminfo)
+  total_kb=$(awk '/MemTotal/ {print $2}' /proc/meminfo)
+  avail_pct=$(( avail_kb * 100 / total_kb ))
+
+  if (( avail_pct < 15 )); then
+    echo "claude-guard: BLOCKED — only ${avail_pct}% RAM available (<15%). Close a session or CLAUDE_GUARD=0 to override." >&2
+    exit 1
+  fi
+  if (( sessions >= 4 )); then
+    echo "claude-guard: BLOCKED — ${sessions} claude sessions already running (ceiling 4). CLAUDE_GUARD=0 to override." >&2
+    exit 1
+  fi
+  if (( sessions >= 3 )); then
+    echo "claude-guard: warning — ${sessions} sessions running, ${avail_pct}% RAM available. Treat sessions like browser tabs." >&2
+  fi
+fi
+
+# Cap Claude Code's own V8 heap (documented unbounded-growth leaks).
+# Per-server NODE_OPTIONS in MCP configs override this for MCP children.
+export NODE_OPTIONS="${NODE_OPTIONS:---max-old-space-size=8192}"
+
+exec "$REAL" "$@"


### PR DESCRIPTION
## What

`bin/claude` — a guarded launcher that PATH-shadows `~/.local/bin/claude`:

- **Blocks** a new session when available RAM < 15% or ≥ 4 claude sessions are already running; **warns** at 3.
- **Caps** Claude Code's own V8 heap at 8 GB (`NODE_OPTIONS=--max-old-space-size=8192`); per-server `NODE_OPTIONS` in MCP configs still override for MCP children.
- Bypass: `CLAUDE_GUARD=0 claude ...`.

## Why

crabbot's 2026-07-12 OOM topple: N claude sessions × M stdio MCP servers inside a 40G user slice, with documented unbounded-heap-growth issues in Claude Code core (anthropics/claude-code #4953, #30470) and per-session MCP multiplication (#45880). The launcher enforces the session ceiling and heap ceiling at the only chokepoint every session passes through.

Smoke-tested on crabbot: correctly blocked a 5th session on a live box; `CLAUDE_GUARD=0` passthrough verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
