### PR TITLE
feat(bin): raise claude-guard session ceiling to 8, warn at 6

### DIFF
--- a/bin/claude
+++ b/bin/claude
@@ -16,11 +16,11 @@ if [[ "${CLAUDE_GUARD:-1}" != "0" ]]; then
     echo "claude-guard: BLOCKED — only ${avail_pct}% RAM available (<15%). Close a session or CLAUDE_GUARD=0 to override." >&2
     exit 1
   fi
-  if (( sessions >= 4 )); then
-    echo "claude-guard: BLOCKED — ${sessions} claude sessions already running (ceiling 4). CLAUDE_GUARD=0 to override." >&2
+  if (( sessions >= 8 )); then
+    echo "claude-guard: BLOCKED — ${sessions} claude sessions already running (ceiling 8). CLAUDE_GUARD=0 to override." >&2
     exit 1
   fi
-  if (( sessions >= 3 )); then
+  if (( sessions >= 6 )); then
     echo "claude-guard: warning — ${sessions} sessions running, ${avail_pct}% RAM available. Treat sessions like browser tabs." >&2
   fi
 fi


### PR DESCRIPTION
Bumps the guarded launcher's session ceiling 4→8 and the warning threshold 3→6. The 15% RAM gate is unchanged and remains the hard floor — the ceiling was the binding constraint during normal multi-session + agent fan-out use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)