### PR TITLE
fix(rectangle,zsh): numeric shortcut leaves + cap completion fuzzy cost

### DIFF
--- a/rectangle/lib.sh
+++ b/rectangle/lib.sh
@@ -41,19 +41,17 @@ EOF
 }
 
 # Write every shortcut plus quality-of-life defaults to $bundle. Idempotent --
-# each `defaults write` overwrites cleanly.
+# every keyCode/modifierFlags leaf is rewritten each run.
 #
-# SCHEMA CAVEAT: each shortcut is written as the old-style ASCII plist-dict
-# STRING "{ keyCode = N; modifierFlags = M; }". Whether Rectangle Pro parses
-# this shape cannot be verified off-macOS. After a real sync, round-trip one
-# shortcut manually to confirm:
-#   defaults read com.knollsoft.Hookshot leftHalf
-# then check Rectangle Pro actually honors the binding in its UI.
+# Each shortcut is a dict of NUMERIC keyCode/modifierFlags, written via
+# `-dict-add ... -float N` per Rectangle's documented schema
+# (TerminalCommands.md). An ASCII plist-dict string "{ keyCode = N; ... }"
+# lands the leaves as NSString, which Rectangle's shortcut parser ignores.
 rectangle_write_shortcuts() {
     local bundle="$1" cmd keycode mods
     while IFS='|' read -r cmd keycode mods; do
         [[ -z "$cmd" ]] && continue
-        defaults write "$bundle" "$cmd" "{ keyCode = $keycode; modifierFlags = $mods; }"
+        defaults write "$bundle" "$cmd" -dict-add keyCode -float "$keycode" modifierFlags -float "$mods"
     done < <(rectangle_shortcuts)
 
     defaults write "$bundle" subsequentExecutionMode -int 0  # cycle 1/2 -> 2/3 -> 1/3 on repeat

--- a/tests/rectangle.bats
+++ b/tests/rectangle.bats
@@ -90,6 +90,19 @@ EOF
     [[ "$output" == *"relaunch failed"* ]]
 }
 
+# ── rectangle_write_shortcuts typing ──
+
+@test "rectangle_write_shortcuts writes numeric-typed dict leaves, not an ASCII plist string" {
+    source "$LIB"
+    run rectangle_write_shortcuts com.knollsoft.Hookshot
+    [ "$status" -eq 0 ]
+    # Rectangle's documented schema: -dict-add with -float leaves (NSNumber),
+    # so keyCode/modifierFlags land as numbers the shortcut parser honors.
+    grep -qF 'defaults write com.knollsoft.Hookshot leftHalf -dict-add keyCode -float 123 modifierFlags -float 1835008' "$MOCK_LOG"
+    # the old ASCII plist-dict string form (lands leaves as NSString) must be gone
+    ! grep -qF '{ keyCode =' "$MOCK_LOG"
+}
+
 # ── rectangle_sync guards ──
 
 @test "rectangle_sync skips on non-macOS and writes nothing" {

--- a/tests/window-mgmt.bats
+++ b/tests/window-mgmt.bats
@@ -72,13 +72,15 @@ MOCK
     [ -z "$dupes" ]
 }
 
-@test "rectangle_write_shortcuts: writes the exact plist-dict string per shortcut" {
+@test "rectangle_write_shortcuts: writes numeric-typed dict leaves per shortcut" {
     source "$RECT_LIB"
     rectangle_write_shortcuts com.test
     run cat "$DEFAULTS_LOG"
-    assert_output_contains "write com.test leftHalf { keyCode = 123; modifierFlags = 1835008; }"
-    assert_output_contains "write com.test firstThird { keyCode = 2; modifierFlags = 786432; }"
-    assert_output_contains "write com.test topLeft { keyCode = 123; modifierFlags = 917504; }"
+    # -dict-add ... -float lands NSNumber leaves per Rectangle's documented
+    # schema; the old ASCII plist-dict string form lands NSString (parser ignores).
+    assert_output_contains "write com.test leftHalf -dict-add keyCode -float 123 modifierFlags -float 1835008"
+    assert_output_contains "write com.test firstThird -dict-add keyCode -float 2 modifierFlags -float 786432"
+    assert_output_contains "write com.test topLeft -dict-add keyCode -float 123 modifierFlags -float 917504"
 }
 
 @test "rectangle_write_shortcuts: writes all 19 shortcuts plus 3 quality-of-life defaults" {

--- a/tests/zsh-config.bats
+++ b/tests/zsh-config.bats
@@ -163,6 +163,38 @@ SH
     ! grep -q "HISTSIZE" "$completion_file"
 }
 
+@test "completion.zsh bounds approximate-completion cost and compiles the dump" {
+    local f="$REAL_DOTFILES_DIR/zsh/completion.zsh"
+
+    # _approximate must be capped so a failed completion over a large candidate
+    # set (e.g. 300+ git branches) can't run an unbounded edit-distance search.
+    grep -Eq "zstyle ':completion:\*:approximate:\*' max-errors" "$f"
+
+    # the per-keypress-cost trap _correct is dropped in favor of _match
+    grep -Eq "completer .*_complete _match _approximate" "$f"
+    ! grep -Eq "completer .*_correct" "$f"
+
+    # compile the dump so compinit -C sources bytecode, not plain text
+    grep -q "zrecompile" "$f"
+}
+
+@test "completion.zsh: completer + max-errors zstyles resolve (not just present in text)" {
+    command -v zsh &>/dev/null || skip "zsh not installed"
+    # Behavioural, not a grep: source the file and read back what zsh's own
+    # zstyle engine resolved — a bad context pattern would pass a grep but fail
+    # here. Isolated HOME so compinit/zrecompile can't touch the real ~/.zcompdump.
+    local zhome; zhome="$(mktemp -d)"
+    run zsh -c "HOME='$zhome'; ZDOTDIR='$zhome'; source '$REAL_DOTFILES_DIR/zsh/completion.zsh' 2>/dev/null
+        zstyle -L ':completion:*' completer
+        zstyle -L ':completion:*:approximate:*' max-errors"
+    rm -rf "$zhome"
+    assert_success
+    # capped fuzzy fallback: _match in, _correct out, max-errors bounded
+    [[ "$output" == *"completer _oldlist _expand _complete _match _approximate"* ]]
+    [[ "$output" != *"_correct"* ]]
+    [[ "$output" == *"approximate:*' max-errors 1 numeric"* ]]
+}
+
 @test "zshenv sets a mosh-server idle-network timeout (moshi reconnect-storm hardening)" {
     local zshenv_file="$REAL_DOTFILES_DIR/zshenv"
 

--- a/zsh/completion.zsh
+++ b/zsh/completion.zsh
@@ -21,6 +21,9 @@ autoload -Uz compinit
     # path never fires again after the first 24h.
     [[ -s $dump ]] && touch $dump
   fi
+  # Compile the dump so compinit -C sources bytecode, not plain text. zrecompile
+  # is lock-safe and only rewrites when the .zwc is missing or stale.
+  autoload -Uz zrecompile && zrecompile -pq $dump
 }
 
 # cache completions
@@ -36,7 +39,11 @@ zstyle ':completion:*:descriptions' format '%B%d%b'
 zstyle ':completion:*:messages' format '%d'
 zstyle ':completion:*:warnings' format 'No matches for: %d'
 zstyle ':completion:*' group-name ''
-zstyle ':completion:*' completer _oldlist _expand _complete _correct _approximate
+# _correct/_approximate are fallback-only (run only when _complete finds nothing),
+# but unbounded they run an O(candidates) edit-distance search on every failed
+# completion. _match enables pattern completion; max-errors caps the fuzzy search.
+zstyle ':completion:*' completer _oldlist _expand _complete _match _approximate
+zstyle ':completion:*:approximate:*' max-errors 1 numeric
 # Have the newer files last so I see them first
 zstyle ':completion:*' file-sort modification reverse
 


### PR DESCRIPTION
## Why

Two independent bugs surfaced while diagnosing "Rectangle Pro settings aren't written correctly" and "zsh prompt/completions are slow".

### Rectangle Pro shortcuts silently never applied
`rectangle_write_shortcuts` wrote each shortcut as an old-style ASCII plist-dict **string** (`"{ keyCode = N; modifierFlags = M; }"`), which `defaults` stores with **NSString** leaves. Rectangle Pro's shortcut parser expects **NSNumber** and ignores string-typed leaves. Verified on-machine: `plutil -p ~/Library/Preferences/com.knollsoft.Hookshot.plist` showed quoted (string) `keyCode`/`modifierFlags`.

Fix: write via `defaults ... -dict-add keyCode -float N modifierFlags -float N`, the invocation in Rectangle's own [TerminalCommands.md](https://github.com/rxhanson/Rectangle/blob/main/TerminalCommands.md) (Hookshot uses the same commands as free Rectangle).

### zsh completions did unbounded fuzzy matching on failed completions
The completer chain ran `_correct`/`_approximate` with no `max-errors` cap. They're fallback-only (fire when `_complete` finds nothing), but unbounded a failed completion runs an O(candidates) edit-distance search over large sets (300+ git branches).

Fix: swap `_correct`→`_match` and add `zstyle ':completion:*:approximate:*' max-errors 1 numeric` (Prezto-style). Also compile the compdump via `zrecompile` so `compinit -C` sources bytecode.

## Tests
- Assert numeric `-dict-add -float` leaves (`tests/rectangle.bats`, `tests/window-mgmt.bats` — the latter previously encoded the buggy string form).
- Assert the completer/`max-errors` zstyles **resolve** through zsh's own engine, not just appear in the file text (`tests/zsh-config.bats`).
- `just check` → exit 0 (lint + full bats + smoke).

## Not addressed here
The separate prompt git-fork storm (~110–190ms/prompt from `zsh/prompt.zsh` `precmd`) is a bigger latency lever but out of scope for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)