### PR TITLE
perf(zsh): render prompt git info asynchronously

### DIFF
--- a/tests/cheatsheet.bats
+++ b/tests/cheatsheet.bats
@@ -8,7 +8,7 @@ ZSH_DIR="$DOTFILES_DIR/zsh"
 BIN_DIR="$DOTFILES_DIR/bin"
 
 # Internal helpers / prompt machinery — defined in zsh/*.zsh but not user shortcuts.
-INTERNAL="_cc_base _cdd sesh-sessions periodic TRAPWINCH render_prompt update_git_cache git_time_details time_since_commit _vaudeville_register_argcomplete _init_cache"
+INTERNAL="_cc_base _cdd sesh-sessions periodic TRAPWINCH TRAPUSR1 render_prompt update_git_cache git_time_details time_since_commit _prompt_cleanup _prompt_async_start _prompt_async_worker _prompt_git_compute _prompt_load_git_state _vaudeville_register_argcomplete _init_cache"
 # zsh tmux/remote shortcuts — documented in tmux-cheatsheet, not the main sheet.
 TMUX_OWNED="mtmux trl tss tsip ta tls tn tk tsw"
 # Commands provided by external tools (not defined as aliases/functions here).

--- a/tests/prompt.bats
+++ b/tests/prompt.bats
@@ -56,3 +56,96 @@ DOTFILES_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME}")/.." && pwd)"
 @test "prompt.zsh registers precmd hook" {
     grep -q "add-zsh-hook precmd" "$DOTFILES_DIR/zsh/prompt.zsh"
 }
+
+# ── async git rendering (no per-keystroke git forks) ──────────────────────────
+
+@test "prompt_precmd defers git work to the async worker (no synchronous vcs_info)" {
+    local body
+    body=$(sed -n '/^function prompt_precmd()/,/^}/p' "$DOTFILES_DIR/zsh/prompt.zsh")
+    [[ "$body" == *"_prompt_async_start"* ]]
+    [[ "$body" != *"vcs_info"* ]]
+}
+
+@test "render_prompt renders cached git state without forking git" {
+    command -v zsh &>/dev/null || skip "zsh not installed"
+    local mockbin; mockbin="$(mktemp -d)"
+    cat > "$mockbin/git" <<'SH'
+#!/bin/sh
+echo "git $*" >> "$GIT_CALL_LOG"
+SH
+    chmod +x "$mockbin/git"
+    run zsh -c "
+      export GIT_CALL_LOG='$mockbin/calls'; : > \$GIT_CALL_LOG
+      PATH='$mockbin':\$PATH
+      source '$DOTFILES_DIR/zsh/prompt.zsh'
+      _prompt_git_info='mybranch'; _prompt_git_time='9m'
+      render_prompt
+      print -r -- \"P:\$PROMPT\"
+      print -r -- \"CALLS:\$(cat \$GIT_CALL_LOG)\"
+    "
+    rm -rf "$mockbin"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"mybranch"* ]]
+    [[ "$output" == *"9m"* ]]
+    # render must not shell out to git — the async worker owns all git forks
+    [[ "$output" != *"CALLS:git"* ]]
+}
+
+@test "_prompt_git_compute writes branch and time-since-commit to the state file" {
+    command -v zsh &>/dev/null || skip "zsh not installed"
+    local repo; repo="$(mktemp -d)"
+    ( cd "$repo" && git init -q && \
+        git -c user.email=t@t -c user.name=t commit -q --allow-empty -m init )
+    run zsh -c "
+      cd '$repo'
+      source '$DOTFILES_DIR/zsh/prompt.zsh'
+      _prompt_async_tmp='$repo/.state'
+      _prompt_git_compute
+      cat '$repo/.state'
+    "
+    rm -rf "$repo"
+    [ "$status" -eq 0 ]
+    [[ "${lines[0]}" == "main" || "${lines[0]}" == "master" ]]
+    [[ "${lines[1]}" == "0m" ]]
+}
+
+@test "_prompt_load_git_state loads branch and time from the state file" {
+    command -v zsh &>/dev/null || skip "zsh not installed"
+    local tmp; tmp="$(mktemp)"
+    printf 'feature-x\n3h20m\n' > "$tmp"
+    run zsh -c "
+      source '$DOTFILES_DIR/zsh/prompt.zsh'
+      _prompt_async_tmp='$tmp'
+      _prompt_load_git_state
+      print -r -- \"\$_prompt_git_info|\$_prompt_git_time\"
+    "
+    rm -f "$tmp"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"feature-x|3h20m"* ]]
+}
+
+@test "_prompt_async_worker publishes state via atomic rename, leaving no scratch file" {
+    command -v zsh &>/dev/null || skip "zsh not installed"
+    local repo; repo="$(mktemp -d)"
+    ( cd "$repo" && git init -q && \
+        git -c user.email=t@t -c user.name=t commit -q --allow-empty -m init )
+    # Sourcing installs TRAPUSR1; the worker's `kill -USR1 $$` fires it harmlessly
+    # (zle inactive under `zsh -c`, so reset-prompt is skipped). Run the worker in
+    # the foreground so the rename completes before we inspect the tree.
+    run zsh -c "
+      cd '$repo'
+      source '$DOTFILES_DIR/zsh/prompt.zsh'
+      _prompt_async_tmp='$repo/state'
+      _prompt_async_worker
+      print -r -- \"EXISTS:\$([[ -f '$repo/state' ]] && echo yes)\"
+      print -r -- \"BRANCH:\$(sed -n 1p '$repo/state')\"
+      local -a scratch; scratch=('$repo'/state.*(N))
+      print -r -- \"SCRATCHCOUNT:\${#scratch}\"
+    "
+    rm -rf "$repo"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"EXISTS:yes"* ]]
+    [[ "$output" == *"BRANCH:main"* || "$output" == *"BRANCH:master"* ]]
+    # atomic mv leaves no scratch file behind — a direct-write regression would fail this
+    [[ "$output" == *"SCRATCHCOUNT:0"* ]]
+}

--- a/zsh/prompt.zsh
+++ b/zsh/prompt.zsh
@@ -53,6 +53,17 @@ _git_cache_head=""
 _git_cache_time=""
 _git_cache_last_commit=""
 
+# Async prompt state. All git work runs in a background job so the prompt never
+# blocks on git forks; the worker signals SIGUSR1 and we repaint from these
+# vars. They hold the last computed values (stale by at most one prompt).
+_prompt_git_info=""
+_prompt_git_time=""
+_prompt_async_pid=0
+_prompt_async_tmp="${TMPDIR:-/tmp}/zsh-prompt-git.$$"
+
+_prompt_cleanup() { rm -f "$_prompt_async_tmp" "$_prompt_async_tmp".*(N) 2>/dev/null; }
+add-zsh-hook zshexit _prompt_cleanup
+
 # Refresh prompt periodically (PERIOD avoids repurposing TMOUT idle timer)
 PERIOD=30
 periodic() {
@@ -66,18 +77,61 @@ TRAPWINCH() {
 }
 
 function prompt_precmd() {
-  fmt_branch="%b%u%c"
-  zstyle ':vcs_info:*:prompt:*' formats "${fmt_branch}"
-
-  vcs_info 'prompt'
-
+  # Paint immediately from the last-known git state, then refresh in the
+  # background. render_prompt never forks; the worker owns every git call.
   render_prompt
+  _prompt_async_start
+}
+
+# Recompute git info in a disowned background job. Kill any still-running worker
+# first so a slow git call can't stack up behind rapid prompts. The kill -0
+# guard avoids signaling a recycled PID if the tracked worker already exited.
+_prompt_async_start() {
+  [[ $_prompt_async_pid -ne 0 ]] && kill -0 $_prompt_async_pid 2>/dev/null \
+    && kill $_prompt_async_pid 2>/dev/null
+  _prompt_async_worker &!
+  _prompt_async_pid=$!
+}
+
+# Compute into a private scratch file, then atomically rename onto the shared
+# state file so TRAPUSR1 never reads a half-written file, then signal.
+_prompt_async_worker() {
+  local scratch="$_prompt_async_tmp.$RANDOM"
+  _prompt_git_compute "$scratch"
+  mv -f "$scratch" "$_prompt_async_tmp" 2>/dev/null
+  kill -USR1 $$ 2>/dev/null
+}
+
+# Compute branch + time-since-commit and write them (two lines) to $1 (defaults
+# to the state file). Separated from the worker so the signal isn't tangled into
+# the git work (and so it's testable without self-signaling).
+_prompt_git_compute() {
+  local out=${1:-$_prompt_async_tmp}
+  vcs_info 'prompt'
+  print -r -- "$vcs_info_msg_0_"   >  "$out"
+  print -r -- "$(git_time_details)" >> "$out"
+}
+
+_prompt_load_git_state() {
+  [[ -r $_prompt_async_tmp ]] || return
+  local -a state
+  state=("${(@f)$(<$_prompt_async_tmp)}")
+  _prompt_git_info=${state[1]}
+  _prompt_git_time=${state[2]}
+}
+
+# The worker signals here once fresh git state is on disk: load it and repaint.
+TRAPUSR1() {
+  _prompt_async_pid=0
+  _prompt_load_git_state
+  render_prompt
+  zle && zle reset-prompt
 }
 
 render_prompt() {
   POWERLINE_LEFT_A="%K{$POWERLINE_LEFT_A_BG}%F{$POWERLINE_LEFT_A_FG} %~ %k%f%F{$POWERLINE_LEFT_A_BG}%K{$POWERLINE_LEFT_B_BG}"$POWERLINE_SEPARATOR
-  POWERLINE_LEFT_B="%k%f%F{$POWERLINE_LEFT_B_FG}%K{$POWERLINE_LEFT_B_BG} "${vcs_info_msg_0_}" %k%f%F{$POWERLINE_LEFT_B_BG}%K{$POWERLINE_LEFT_C_BG}"$POWERLINE_SEPARATOR
-  POWERLINE_LEFT_C=" %k%f%F{$POWERLINE_LEFT_C_FG}%K{$POWERLINE_LEFT_C_BG}"$(git_time_details)" %k%f%F{$POWERLINE_LEFT_C_BG}"$POWERLINE_SEPARATOR
+  POWERLINE_LEFT_B="%k%f%F{$POWERLINE_LEFT_B_FG}%K{$POWERLINE_LEFT_B_BG} "${_prompt_git_info}" %k%f%F{$POWERLINE_LEFT_B_BG}%K{$POWERLINE_LEFT_C_BG}"$POWERLINE_SEPARATOR
+  POWERLINE_LEFT_C=" %k%f%F{$POWERLINE_LEFT_C_FG}%K{$POWERLINE_LEFT_C_BG}"${_prompt_git_time}" %k%f%F{$POWERLINE_LEFT_C_BG}"$POWERLINE_SEPARATOR
   POWERLINE_LEFT_D="%k%f%F{$POWERLINE_LEFT_D_FG} %D %T %k%f%F{$POWERLINE_LEFT_D_FG}$POWERLINE_THIN_SEPARATOR%f "
 
   PROMPT=$POWERLINE_LEFT_A$POWERLINE_LEFT_B$POWERLINE_LEFT_C$POWERLINE_LEFT_D


### PR DESCRIPTION
## Why

Diagnosing "the zsh prompt is slow" turned up the real cause: `prompt.zsh`'s `precmd` forked **6–10 git subprocesses on every Enter** (`vcs_info` + `git_time_details`), adding **~110–190ms** of synchronous latency before every prompt redraw in any git repo. (`omp.yaml` — oh-my-**pi**, an agent CLI — is unrelated to the shell prompt.)

## Fix

Move all git work off the keystroke path into a disowned background job:

- `precmd` paints instantly from cached vars `_prompt_git_info` / `_prompt_git_time` and starts the worker.
- The worker computes `vcs_info` + time-since-commit, **atomically** publishes them (scratch file → `mv`) to a per-shell state file, then signals `kill -USR1 $$`.
- `TRAPUSR1` loads the state and repaints via `zle && zle reset-prompt`.
- `render_prompt` reads the cached vars — **no synchronous git fork**.

**`vcs_info` is retained** (correct across worktrees, detached HEAD, and rebase/merge states) rather than hand-parsing `.git/HEAD` — this repo leans on git worktrees via `ccw`, so correctness there matters. That was the deciding factor for async over filesystem parsing.

`precmd` measured **~1.2ms** (down from ~110–190ms).

## Tests
- precmd defers to the worker (no synchronous `vcs_info`)
- `render_prompt` renders cached state without forking git (git-mock call log stays empty)
- worker atomically publishes state, leaving no scratch file (a direct-write regression fails this)
- state loads back into the cache vars
- `just check` → exit 0 (lint + full bats + smoke)

## Known residuals (Low, documented)
- `kill -0` guards the recycled-PID window but doesn't fully close the sub-second TOCTOU — bounded to one SIGTERM, acceptable for a prompt.
- The interactive `zle reset-prompt` repaint leg is exercised indirectly; headless zle assertion isn't worth the complexity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)