### PR TITLE
fix(bin): make claude-guard launcher portable to macOS

### DIFF
--- a/bin/claude
+++ b/bin/claude
@@ -4,9 +4,10 @@
 # Bypass all checks: CLAUDE_GUARD=0 claude ...
 
 set -euo pipefail
-REAL=/home/paul/.local/bin/claude
+REAL="$HOME/.local/bin/claude"
 
-if [[ "${CLAUDE_GUARD:-1}" != "0" ]]; then
+# Guard checks are Linux-only (crabbot): pgrep -c and /proc/meminfo don't exist on macOS.
+if [[ "${CLAUDE_GUARD:-1}" != "0" && -r /proc/meminfo ]]; then
   sessions=$(pgrep -cx claude || true)
   avail_kb=$(awk '/MemAvailable/ {print $2}' /proc/meminfo)
   total_kb=$(awk '/MemTotal/ {print $2}' /proc/meminfo)


### PR DESCRIPTION
PR #434's guarded `claude` launcher was written for crabbot (Linux) but `bin/` runs live from the clone on every machine, so it shadowed the real binary on macOS and broke it three ways:

- `REAL=/home/paul/.local/bin/claude` — Linux home path
- `awk ... /proc/meminfo` — Linux-only; with `set -e` this killed the script on macOS
- `pgrep -cx` — macOS pgrep has no `-c` flag

This broke both `cc`/`claude` launches and `dots sync`'s MCP reconcile (which shells out to `claude mcp update`).

## Fix

- `REAL="$HOME/.local/bin/claude"` — portable to both machines
- Gate the session/RAM guard on `-r /proc/meminfo` so it stays Linux-only (crabbot); the NODE_OPTIONS heap cap remains everywhere

## Verified

- `claude --version` works on macOS via the wrapper (guard path and `CLAUDE_GUARD=0` bypass)
- `dots sync` reconciles the tilth MCP cleanly
- `just check` exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)