### PR TITLE
fix(omp): deploy global skills during sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,6 +107,7 @@ tmux/theme.conf
 # (sync_claude_chezmoi_sources); repo dirs skills/, agents/, claude/ are the
 # source of truth.
 chezmoi/dot_claude/exact_*/
+chezmoi/dot_omp/private_agent/exact_skills/
 
 # Node install artifacts (hook runner deps; package-lock.json is tracked)
 node_modules/

--- a/.sync-lib.sh
+++ b/.sync-lib.sh
@@ -250,15 +250,15 @@ _cz_render_claude_agent() {
     } > "$out"
 }
 
-# Vendor external skills (skills/_registry.yaml sources that include claude)
-# into <dst>. Clones each source into a cache dir; offline falls back to the
-# cached checkout with a warning. A source that has never been cloned and
-# cannot be cloned fails the assembly (loud, per fail-fast). Unpinned sources
-# float to latest of their default branch on every sync (offline → cached
-# checkout); a pin change is always honored, an unchanged pin costs no network.
-#   _cz_vendor_external_skills <skills_registry_yaml> <dst_dir>
+# Vendor external skills from skills/_registry.yaml into <dst>. Clones each
+# source into a cache dir; offline falls back to the cached checkout with a
+# warning. A source that has never been cloned and cannot be cloned fails the
+# assembly (loud, per fail-fast). Unpinned sources float to latest of their
+# default branch on every sync (offline → cached checkout); a pin change is
+# always honored, an unchanged pin costs no network.
+#   _cz_vendor_external_skills <skills_registry_yaml> <dst_dir> <harness>
 _cz_vendor_external_skills() {
-    local registry="$1" dst="$2"
+    local registry="$1" dst="$2" harness="$3"
     [[ -f "$registry" ]] || return 0
     local cache_root="${XDG_CACHE_HOME:-$HOME/.cache}/dotfiles/claude-skill-sources"
     mkdir -p "$cache_root"
@@ -266,10 +266,10 @@ _cz_vendor_external_skills() {
     local source
     while IFS= read -r source; do
         [[ -z "$source" ]] && continue
-        # Per-source harness filter: absent → all harnesses (claude included).
+        # Per-source harness filter: absent means every harness.
         local harnesses
-        harnesses=$(yq -r ".sources.\"$source\".harnesses // [\"claude\"] | join(\" \")" "$registry")
-        [[ " $harnesses " == *" claude "* ]] || continue
+        harnesses=$(yq -r ".sources.\"$source\".harnesses // [] | join(\" \")" "$registry")
+        [[ -z "$harnesses" || " $harnesses " == *" $harness "* ]] || continue
 
         local pin cache
         pin=$(yq -r ".sources.\"$source\".pin // \"\"" "$registry")
@@ -357,7 +357,7 @@ sync_claude_chezmoi_sources() {
         fi
         _cz_copy_encoded "$root/skills/$name" "$staging/exact_skills/$(_cz_encode_name "$name" true false)" || return 1
     done < <(yq -r '.claude.skills // [] | .[]' "$claude_reg")
-    _cz_vendor_external_skills "$root/skills/_registry.yaml" "$staging/exact_skills" || return 1
+    _cz_vendor_external_skills "$root/skills/_registry.yaml" "$staging/exact_skills" claude || return 1
     mkdir -p "$staging/exact_skills"
 
     # agents — rendered from agents/registry.yaml
@@ -407,6 +407,51 @@ sync_claude_chezmoi_sources() {
         fi
     done
     log_info "Assembled claude chezmoi source state (dot_claude/exact_*)"
+    return 0
+}
+
+# Assemble the OMP-native global skills payload from the same selected sources
+# as Claude. OMP discovers ~/.omp/agent/skills independently; it never reads
+# ~/.agents/skills or ~/.claude/skills.
+#   sync_omp_chezmoi_sources <dotfiles_root> [<chezmoi_source_dir>]
+sync_omp_chezmoi_sources() {
+    local root="$1"
+    local src="${2:-$root/chezmoi}"
+    local claude_reg="$src/.chezmoidata/claude.yaml"
+
+    if ! command -v yq &>/dev/null; then
+        log_warning "yq not found — skipping OMP chezmoi source assembly"
+        return 0
+    fi
+    if [[ ! -f "$claude_reg" ]]; then
+        log_error "claude registry not found: $claude_reg"
+        return 1
+    fi
+
+    local staging
+    staging=$(mktemp -d "${TMPDIR:-/tmp}/omp-cz-src.XXXXXX") || return 1
+    # shellcheck disable=SC2064
+    trap "rm -rf '$staging'" RETURN
+
+    local name
+    while IFS= read -r name; do
+        [[ -z "$name" ]] && continue
+        if [[ ! -d "$root/skills/$name" ]]; then
+            log_error "OMP skill selection references unknown skill: $name (no skills/$name)"
+            return 1
+        fi
+        _cz_copy_encoded "$root/skills/$name" "$staging/exact_skills/$(_cz_encode_name "$name" true false)" || return 1
+    done < <(yq -r '.claude.skills // [] | .[]' "$claude_reg")
+    _cz_vendor_external_skills "$root/skills/_registry.yaml" "$staging/exact_skills" omp || return 1
+    mkdir -p "$staging/exact_skills"
+
+    if ! rm -rf "${src:?}/dot_omp/private_agent/exact_skills" \
+        || ! mkdir -p "$src/dot_omp/private_agent" \
+        || ! mv "$staging/exact_skills" "$src/dot_omp/private_agent/exact_skills"; then
+        log_error "OMP source assembly: staging swap failed for exact_skills — source state may be incomplete; rerun dots sync before chezmoi apply"
+        return 1
+    fi
+    log_info "Assembled OMP chezmoi source state (dot_omp/private_agent/exact_skills)"
     return 0
 }
 

--- a/chezmoi/.sync
+++ b/chezmoi/.sync
@@ -144,6 +144,14 @@ if ! sync_claude_chezmoi_sources "$dotfiles_dir" "$script_dir"; then
     exit 1
 fi
 
+# Assemble the OMP-native global skill payload separately. OMP only discovers
+# ~/.omp/agent/skills, so the Claude/global skills directories are not a
+# substitute.
+if ! sync_omp_chezmoi_sources "$dotfiles_dir" "$script_dir"; then
+    echo "  ERROR: OMP chezmoi source assembly failed — aborting chezmoi apply" >&2
+    exit 1
+fi
+
 # Trigger chezmoi apply from this checkout so workspace syncs use the source
 # tree that launched dots sync, not a stale sourceDir preserved in
 # ~/.config/chezmoi/chezmoi.toml. Partial-OK — we don't abort the rest of

--- a/tests/sync-claude-sources.bats
+++ b/tests/sync-claude-sources.bats
@@ -368,3 +368,13 @@ YAML
     [ "$status" -eq 0 ]
     [ ! -e "$SRC/dot_claude/exact_skills/exact_ext-skill" ]
 }
+
+
+@test "OMP assembly: mirrors selected and OMP-eligible external skills into native discovery path" {
+    run bash -c "source '$REAL_DOTFILES_DIR/.sync-lib.sh' && sync_omp_chezmoi_sources '$ROOT' '$SRC'"
+    [ "$status" -eq 0 ]
+    local base="$SRC/dot_omp/private_agent/exact_skills"
+    [ -f "$base/exact_alpha-skill/SKILL.md" ]
+    [ -f "$base/exact_beta-skill/SKILL.md" ]
+    [ -f "$base/exact_ext-skill/SKILL.md" ]
+}


### PR DESCRIPTION
## Problem
OMP only discovers global skills from `~/.omp/agent/skills`; `dots sync` previously populated no native OMP skills.

## Fix
Assemble Claude-selected and OMP-eligible external skills into chezmoi's OMP agent source, then deploy it during `dots sync` with deletion propagation.

## Verification
- `bats tests/sync-claude-sources.bats` (21/21)
- `dots sync` completed and populated `~/.omp/agent/skills`