### PR TITLE
feat(omp): hallouminate + milknado parity, plus claude plugin-enable drift fix

### DIFF
--- a/.hallouminate/wiki/architecture/config-drift.md
+++ b/.hallouminate/wiki/architecture/config-drift.md
@@ -258,6 +258,35 @@ Order matters: prune-first loses the race.
 **Detection**: A pruned key that resurrects, or any process whose command line
 points into `~/.claude/plugins/cache/`.
 
+## Known drift pattern: native-plugin `enabledPlugins` entries stripped on every session start
+
+**Symptom**: `hallouminate@hallouminate` / `milknado@milknado` vanish from
+`enabledPlugins` in live `~/.claude/settings.json` shortly after every
+`dots sync` restores them; plugin MCPs disconnect in new sessions. First hit
+2026-07-15.
+
+**Why it happens**: The Claude CLI rewrites `enabledPlugins` from its own
+runtime state at session start, and drops entries for plugins missing from
+`~/.claude/plugins/installed_plugins.json`. The reconcile that installs the
+native plugins (`chezmoi/lib/claude-plugin-reconcile.sh`, install leg) is
+dispatched by a `run_onchange` script keyed on the **hash of
+`agents/plugins/registry.yaml`** — so if the CLI's installed state is lost (or
+predates the install leg) while the registry is unchanged, nothing ever
+reinstalls, and `dots sync` ↔ CLI-strip loop forever. Restoring the settings
+entry alone is treating the symptom.
+
+**Fix**: `claude plugin install <name>@<name>` at user scope for each native
+plugin. The install writes both `installed_plugins.json` and the
+`enabledPlugins` entries; once the runtime knows the plugin, CLI rewrites
+preserve the entry.
+
+**Detection**: `jq '.plugins | keys' ~/.claude/plugins/installed_plugins.json`
+missing a plugin that `enabledPlugins` (per the chezmoi render) enables.
+
+**Open hardening idea**: make the reconcile re-run condition include
+`installed_plugins.json` state (or teach `/harness-doctor` this check), so a
+lost install self-heals without a registry edit.
+
 ## Gotcha: official plugins are enabled by `claude/plugins/registry.yaml`, not the claude.yaml base
 
 `enabledPlugins` in `chezmoi/.chezmoidata/claude.yaml` is only the BASE layer;

--- a/.sync-lib.sh
+++ b/.sync-lib.sh
@@ -275,6 +275,12 @@ _cz_vendor_external_skills() {
         local pin cache sp
         pin=$(yq -r ".sources.\"$source\".pin // \"\"" "$registry")
         sp=$(yq -r ".sources.\"$source\".skills_path // \"skills\"" "$registry")
+        # skills_path is interpolated into cache paths — reject values that
+        # would escape the source's cache subtree (fail loud, per fail-fast).
+        if [[ -z "$sp" || "$sp" == /* || "$sp" == *..* ]]; then
+            log_error "external skill source $source: invalid skills_path '$sp' (must be relative, no '..')"
+            return 1
+        fi
         cache="$cache_root/${source//\//__}"
 
         if [[ ! -d "$cache/.git" ]]; then

--- a/.sync-lib.sh
+++ b/.sync-lib.sh
@@ -255,8 +255,9 @@ _cz_render_claude_agent() {
 # warning. A source that has never been cloned and cannot be cloned fails the
 # assembly (loud, per fail-fast). Unpinned sources float to latest of their
 # default branch on every sync (offline → cached checkout); a pin change is
-# always honored, an unchanged pin costs no network.
-#   _cz_vendor_external_skills <skills_registry_yaml> <dst_dir> <harness>
+# always honored, an unchanged pin costs no network. Per-source `skills_path`
+# (default "skills") relocates the in-repo skills dir the source is scanned
+# under, for sources that bundle skills at a nested path (e.g. plugin repos).
 _cz_vendor_external_skills() {
     local registry="$1" dst="$2" harness="$3"
     [[ -f "$registry" ]] || return 0
@@ -271,8 +272,9 @@ _cz_vendor_external_skills() {
         harnesses=$(yq -r ".sources.\"$source\".harnesses // [] | join(\" \")" "$registry")
         [[ -z "$harnesses" || " $harnesses " == *" $harness "* ]] || continue
 
-        local pin cache
+        local pin cache sp
         pin=$(yq -r ".sources.\"$source\".pin // \"\"" "$registry")
+        sp=$(yq -r ".sources.\"$source\".skills_path // \"skills\"" "$registry")
         cache="$cache_root/${source//\//__}"
 
         if [[ ! -d "$cache/.git" ]]; then
@@ -311,7 +313,7 @@ _cz_vendor_external_skills() {
         done < <(yq -r ".sources.\"$source\".skills // [] | .[]" "$registry")
         if (( ${#names[@]} == 0 )); then
             local d
-            for d in "$cache"/skills/*/; do
+            for d in "$cache/$sp"/*/; do
                 [[ -f "$d/SKILL.md" ]] && names+=("$(basename "$d")")
             done
         fi
@@ -319,11 +321,11 @@ _cz_vendor_external_skills() {
         local skill
         for skill in "${names[@]:-}"; do
             [[ -z "$skill" ]] && continue
-            if [[ ! -d "$cache/skills/$skill" ]]; then
+            if [[ ! -d "$cache/$sp/$skill" ]]; then
                 log_warning "external skill source $source: skill '$skill' not found, skipping"
                 continue
             fi
-            _cz_copy_encoded "$cache/skills/$skill" "$dst/$(_cz_encode_name "$skill" true false)" || return 1
+            _cz_copy_encoded "$cache/$sp/$skill" "$dst/$(_cz_encode_name "$skill" true false)" || return 1
         done
     done < <(yq -r '.sources | keys | .[]' "$registry")
 }

--- a/chezmoi/dot_omp/private_agent/mcp.json
+++ b/chezmoi/dot_omp/private_agent/mcp.json
@@ -10,6 +10,14 @@
       "env": {
         "CONTEXT7_API_KEY": "${CONTEXT7_API_KEY}"
       }
+    },
+    "hallouminate": {
+      "command": "hallouminate",
+      "args": ["serve"]
+    },
+    "milknado": {
+      "command": "uvx",
+      "args": ["--from", "git+https://github.com/paulnsorensen/milknado@main", "milknado-mcp"]
     }
   }
 }

--- a/chezmoi/lib/claude-settings-authoritative.json
+++ b/chezmoi/lib/claude-settings-authoritative.json
@@ -1,6 +1,6 @@
 {
-  "model": "opus",
-  "effortLevel": "medium",
+  "model": "claude-fable-5[1m]",
+  "effortLevel": "high",
   "env": {
     "ENABLE_TOOL_SEARCH": "true",
     "SSL_CERT_FILE": "/etc/ssl/cert.pem"

--- a/skills/_registry.yaml
+++ b/skills/_registry.yaml
@@ -5,9 +5,16 @@
 # agentskills.io specification.
 #
 # Optional fields:
-#   skills:  explicit list of skill names (passed as repeated --skill; else '*')
-#   pin:     git branch or tag (appended as <repo>@<ref> → `git clone --branch`;
-#            commit SHAs are NOT supported by the clone-based fetch)
+#   skills:      explicit list of skill names (passed as repeated --skill; else '*')
+#   pin:         git branch or tag (appended as <repo>@<ref> → `git clone --branch`;
+#                commit SHAs are NOT supported by the clone-based fetch)
+#   skills_path: in-repo dir to scan for skills (default "skills"); consumed by
+#                the chezmoi assembly path (_cz_vendor_external_skills in
+#                .sync-lib.sh) for harnesses restricted via `harnesses:`. The
+#                npx `skills add` path (chezmoi/lib/install-external.sh) does
+#                NOT read it — sources restricted to `harnesses: [omp]` are
+#                skipped there because omp is absent from
+#                agent-profile/agent_profile/skill_agents.txt (intended).
 #
 # Installs always run with --copy (overwrite); the source repo is shallow-cloned
 # once per entry and copied into every configured harness in one invocation.
@@ -24,3 +31,12 @@ sources:
   paulnsorensen/skillz-that-grillz:
     description: Other useful skills
     harnesses: [claude]
+  paulnsorensen/hallouminate:
+    description: hallouminate plugin-bundled wiki skills (vendored for omp; claude/codex get them via the native plugin)
+    skills_path: plugins/hallouminate/skills
+    harnesses: [omp]
+    skills: [wiki-ingest, wiki-init, wiki-query, wiki-reindex, wiki-roadmap]
+  paulnsorensen/milknado:
+    description: milknado plugin-bundled skills (vendored for omp; claude gets them via the native plugin)
+    skills_path: plugins/milknado/skills
+    harnesses: [omp]

--- a/tests/chezmoi-wiring.bats
+++ b/tests/chezmoi-wiring.bats
@@ -315,11 +315,17 @@ EOF
 # Seed the external-skill cache + a git shim so no network is touched.
 seed_skill_cache_offline() {
     local cache="$TEST_HOME/.cache/dotfiles/claude-skill-sources"
-    local src
-    for src in paulnsorensen__easy-cheese paulnsorensen__skillz-that-grillz; do
-        mkdir -p "$cache/$src/.git" "$cache/$src/skills/dummy-$src"
-        echo "# dummy" > "$cache/$src/skills/dummy-$src/SKILL.md"
-    done
+    local registry="$REAL_DOTFILES_DIR/skills/_registry.yaml"
+    # Registry-driven: seed every source at its skills_path so a registry
+    # addition can't strand the offline vendor on a fake-git clone.
+    local src enc sp
+    while IFS= read -r src; do
+        [[ -z "$src" ]] && continue
+        enc="${src//\//__}"
+        sp=$(yq -r ".sources.\"$src\".skills_path // \"skills\"" "$registry")
+        mkdir -p "$cache/$enc/.git" "$cache/$enc/$sp/dummy-$enc"
+        echo "# dummy" > "$cache/$enc/$sp/dummy-$enc/SKILL.md"
+    done < <(yq -r '.sources | keys | .[]' "$registry")
     local fake_bin="$TEST_HOME/fake-git-bin"
     mkdir -p "$fake_bin"
     printf '#!/usr/bin/env bash\nexit 1\n' > "$fake_bin/git"

--- a/tests/chezmoi-wiring.bats
+++ b/tests/chezmoi-wiring.bats
@@ -317,14 +317,25 @@ seed_skill_cache_offline() {
     local cache="$TEST_HOME/.cache/dotfiles/claude-skill-sources"
     local registry="$REAL_DOTFILES_DIR/skills/_registry.yaml"
     # Registry-driven: seed every source at its skills_path so a registry
-    # addition can't strand the offline vendor on a fake-git clone.
-    local src enc sp
+    # addition can't strand the offline vendor on a fake-git clone. Sources
+    # with an explicit `skills:` list get those names seeded (the vendor
+    # resolves the list against the cache; a dummy name would match nothing
+    # and silently vendor zero skills); default-scan sources get dummy-<enc>.
+    local src enc sp skill
     while IFS= read -r src; do
         [[ -z "$src" ]] && continue
         enc="${src//\//__}"
         sp=$(yq -r ".sources.\"$src\".skills_path // \"skills\"" "$registry")
-        mkdir -p "$cache/$enc/.git" "$cache/$enc/$sp/dummy-$enc"
-        echo "# dummy" > "$cache/$enc/$sp/dummy-$enc/SKILL.md"
+        mkdir -p "$cache/$enc/.git"
+        local -a names=()
+        while IFS= read -r skill; do
+            [[ -n "$skill" && "$skill" != "null" ]] && names+=("$skill")
+        done < <(yq -r ".sources.\"$src\".skills // [] | .[]" "$registry")
+        (( ${#names[@]} > 0 )) || names=("dummy-$enc")
+        for skill in "${names[@]}"; do
+            mkdir -p "$cache/$enc/$sp/$skill"
+            echo "# dummy" > "$cache/$enc/$sp/$skill/SKILL.md"
+        done
     done < <(yq -r '.sources | keys | .[]' "$registry")
     local fake_bin="$TEST_HOME/fake-git-bin"
     mkdir -p "$fake_bin"

--- a/tests/claude-settings.bats
+++ b/tests/claude-settings.bats
@@ -37,8 +37,8 @@ STDIN"
     run bash -c "CHEZMOI_SOURCE_DIR='$CZ_SRC' sh '$SCRIPT' </dev/null >'$OUT'"
     [ "$status" -eq 0 ]
     # Static authoritative keys present.
-    [ "$(jq -r '.model' "$OUT")" = "opus" ]
-    [ "$(jq -r '.effortLevel' "$OUT")" = "medium" ]
+    [ "$(jq -r '.model' "$OUT")" = "$(jq -r '.model' "$AUTH")" ]
+    [ "$(jq -r '.effortLevel' "$OUT")" = "$(jq -r '.effortLevel' "$AUTH")" ]
     # Registry-authored keys composed in.
     jq -e '.enabledPlugins | has("plugin-dev@claude-plugins-official")' "$OUT" >/dev/null
     jq -e '.hooks.PreToolUse | length > 0' "$OUT" >/dev/null
@@ -57,11 +57,12 @@ STDIN"
 
 @test "modify_settings: class-a drift is overwritten from source" {
     # In-app /model + theme change must be discarded on the next apply.
-    run_modify '{"model":"sonnet","theme":"light","effortLevel":"high"}'
+    # Drift values are chosen to differ from the authoritative source.
+    run_modify '{"model":"drifted-model","theme":"light","effortLevel":"drifted-effort"}'
     [ "$status" -eq 0 ]
-    [ "$(jq -r '.model' "$OUT")" = "opus" ]
+    [ "$(jq -r '.model' "$OUT")" = "$(jq -r '.model' "$AUTH")" ]
     [ "$(jq -r '.theme' "$OUT")" = "dark-daltonized" ]
-    [ "$(jq -r '.effortLevel' "$OUT")" = "medium" ]
+    [ "$(jq -r '.effortLevel' "$OUT")" = "$(jq -r '.effortLevel' "$AUTH")" ]
 }
 
 @test "modify_settings: formerly-ap keys are registry-authored — live drift is WIPED" {
@@ -86,7 +87,7 @@ STDIN"
     [ "$status" -ne 0 ]
     # registry values authored in
     [ "$(jq -r '.permissions.defaultMode' "$OUT")" = "auto" ]
-    [ "$(jq -r '.model' "$OUT")" = "opus" ]
+    [ "$(jq -r '.model' "$OUT")" = "$(jq -r '.model' "$AUTH")" ]
     jq -e '.enabledPlugins | has("plugin-dev@claude-plugins-official")' "$OUT" >/dev/null
     jq -e '.permissions.deny | length > 0' "$OUT" >/dev/null
 }
@@ -206,7 +207,7 @@ cz_apply() {
     setup_chezmoi_apply_env
     cz_apply
     [ "$status" -eq 0 ]
-    [ "$(jq -r .model "$SETTINGS")" = "opus" ]
+    [ "$(jq -r .model "$SETTINGS")" = "$(jq -r .model "$AUTH")" ]
     # lib/ is .chezmoiignore'd — the authoritative source is never deployed.
     [ ! -e "$CZ_INT_DEST/lib" ]
 }

--- a/tests/omp-config.bats
+++ b/tests/omp-config.bats
@@ -152,26 +152,31 @@ STDIN"
     [[ "$output" == *".chezmoidata/omp.yaml"* ]]      # registry path named
 }
 
-@test "omp-mcp: native user config keeps only direct MCP servers" {
+@test "omp-mcp: native user config keeps direct MCP servers, no omp-scoped plugin duplicates" {
     local cfg="$REAL_DOTFILES_DIR/chezmoi/dot_omp/private_agent/mcp.json"
     local plugin_registry="$REAL_DOTFILES_DIR/agents/plugins/registry.yaml"
     jq -e '.mcpServers.context7.command == "npx"' "$cfg"
     jq -e '.mcpServers.context7.args == ["-y", "@upstash/context7-mcp"]' "$cfg"
     jq -e '.mcpServers.context7.env.CONTEXT7_API_KEY == "${CONTEXT7_API_KEY}"' "$cfg"
-    jq -e '.mcpServers | has("hallouminate") | not' "$cfg"
-    jq -e '.mcpServers | has("milknado") | not' "$cfg"
+    jq -e '.mcpServers.hallouminate.command == "hallouminate"' "$cfg"
+    jq -e '.mcpServers.hallouminate.args == ["serve"]' "$cfg"
+    jq -e '.mcpServers.milknado.command == "uvx"' "$cfg"
+    jq -e '.mcpServers.milknado.args == ["--from", "git+https://github.com/paulnsorensen/milknado@main", "milknado-mcp"]' "$cfg"
 
-    # Plugin-owned MCPs arrive through OMP's native plugin discovery as
-    # plugin:server namespaces. Listing the same server here creates duplicate
-    # bare + plugin-prefixed MCP instances.
+    # hallouminate/milknado are vendored here directly: neither lists `omp` in
+    # agents/plugins/registry.yaml `harnesses:`, so OMP never gets them via
+    # plugin decomposition (that mechanism is claude/codex/opencode/cursor/
+    # copilot/crush only). Listing a server here only duplicates a
+    # plugin-owned MCP for a harness the plugin registry actually decomposes
+    # onto.
     local duplicates
     duplicates=$(
         comm -12 \
             <(jq -r '.mcpServers | keys[]' "$cfg" | sort) \
-            <(yq -r '.plugins | keys | .[]' "$plugin_registry" | sort)
+            <(yq -r '.plugins | to_entries | map(select(.value.harnesses // [] | index("omp"))) | .[].key' "$plugin_registry" | sort)
     )
     if [ -n "$duplicates" ]; then
-        echo "dot_omp/private_agent/mcp.json duplicates plugin-owned MCP server(s):"
+        echo "dot_omp/private_agent/mcp.json duplicates omp-scoped plugin-owned MCP server(s):"
         printf '%s\n' "$duplicates"
         return 1
     fi

--- a/tests/sync-claude-sources.bats
+++ b/tests/sync-claude-sources.bats
@@ -378,3 +378,40 @@ YAML
     [ -f "$base/exact_beta-skill/SKILL.md" ]
     [ -f "$base/exact_ext-skill/SKILL.md" ]
 }
+
+@test "assembly: a source with skills_path vendors skills discovered under the nested dir" {
+    cat > "$ROOT/skills/_registry.yaml" <<'YAML'
+sources:
+  owner/plugin-repo:
+    skills_path: plugins/thing/skills
+YAML
+    local nested="$TEST_HOME/.cache/dotfiles/claude-skill-sources/owner__plugin-repo"
+    mkdir -p "$nested/.git" "$nested/plugins/thing/skills/nested-skill"
+    echo "# nested" > "$nested/plugins/thing/skills/nested-skill/SKILL.md"
+    run_assembly
+    [ "$status" -eq 0 ]
+    [ -f "$SRC/dot_claude/exact_skills/exact_nested-skill/SKILL.md" ]
+}
+
+@test "assembly: a source without skills_path still vendors from repo-root skills/ (default unchanged)" {
+    # owner/ext-repo (setup fixture) has no skills_path; its skill lives at
+    # the repo-root skills/ext-skill, the pre-skills_path default location.
+    run_assembly
+    [ "$status" -eq 0 ]
+    [ -f "$SRC/dot_claude/exact_skills/exact_ext-skill/SKILL.md" ]
+}
+
+@test "assembly: explicit skills list resolves under skills_path" {
+    cat > "$ROOT/skills/_registry.yaml" <<'YAML'
+sources:
+  owner/plugin-repo:
+    skills_path: plugins/thing/skills
+    skills: [nested-skill]
+YAML
+    local nested="$TEST_HOME/.cache/dotfiles/claude-skill-sources/owner__plugin-repo"
+    mkdir -p "$nested/.git" "$nested/plugins/thing/skills/nested-skill"
+    echo "# nested" > "$nested/plugins/thing/skills/nested-skill/SKILL.md"
+    run_assembly
+    [ "$status" -eq 0 ]
+    [ -f "$SRC/dot_claude/exact_skills/exact_nested-skill/SKILL.md" ]
+}

--- a/tests/sync-claude-sources.bats
+++ b/tests/sync-claude-sources.bats
@@ -401,6 +401,21 @@ YAML
     [ -f "$SRC/dot_claude/exact_skills/exact_ext-skill/SKILL.md" ]
 }
 
+@test "assembly: a skills_path escaping the cache subtree fails loud" {
+    for bad in "../evil" "/abs/path" '""'; do
+        cat > "$ROOT/skills/_registry.yaml" <<YAML
+sources:
+  owner/plugin-repo:
+    skills_path: $bad
+YAML
+        local nested="$TEST_HOME/.cache/dotfiles/claude-skill-sources/owner__plugin-repo"
+        mkdir -p "$nested/.git"
+        run_assembly
+        [ "$status" -ne 0 ] || { echo "skills_path '$bad' did not fail"; return 1; }
+        [[ "$output" == *"invalid skills_path"* ]]
+    done
+}
+
 @test "assembly: explicit skills list resolves under skills_path" {
     cat > "$ROOT/skills/_registry.yaml" <<'YAML'
 sources:


### PR DESCRIPTION
## Summary

Two related fixes from the same investigation ("why aren't my hallouminate plugins loading?"):

### 1. Claude: native-plugin enables kept vanishing (`fab141a`)
The Claude CLI rewrites `enabledPlugins` from `installed_plugins.json` at session start, dropping repo-authored entries for plugins it never installed — `hallouminate@hallouminate` / `milknado@milknado` were stripped on every launch, and `dots sync` just restored them into the next strip. Root heal was `claude plugin install` at user scope (done live; documented as a new drift pattern in `architecture/config-drift.md`). This commit also updates the authoritative `model`/`effortLevel` defaults the same rewrite kept reverting, and derives the bats expectations from the authoritative source (`$AUTH`) so a future model change can't break the suite again.

### 2. omp: full hallouminate + milknado parity (`97288dc`)
omp wasn't in the plugin registry's harness vocabulary, so it never received either plugin. Now:

- **MCPs** — `hallouminate serve` + `milknado` (uvx from git) added to `chezmoi/dot_omp/private_agent/mcp.json`
- **Skills** — plugin-bundled skills (5× `wiki-*`, `harvest`, `load-roadmap`, `milknado-config`) vendor through `skills/_registry.yaml` via a new per-source `skills_path:` field (both repos keep skills under `plugins/<name>/skills/`, which the vendor's root-`skills/` assumption couldn't see)
- **Scoping** — sources are `harnesses: [omp]` so claude/codex don't double-get what their native plugins provide; the npx `skill-sync` path skips them (omp absent from `skill_agents.txt`, intended); hallouminate's `install` skill deliberately excluded
- **Tests** — 3 new `skills_path` vendor tests; positive assertions for the new servers in `omp-config.bats`; the offline seeder in `chezmoi-wiring.bats` is now registry-driven so future source additions can't strand the assembly on its fake-git clone

## Verification

- `just check` green (exit 0, 0 failures) with the full diff
- Live deploy verified: `~/.omp/agent/mcp.json` has all three servers; `~/.omp/agent/skills/` has all 8 vendored skills, `install` absent
- Clean-HEAD baseline run (63/63) used to root-cause the seeder failures before fixing

🤖 Generated with [Claude Code](https://claude.com/claude-code)