### PR TITLE
fix(tmux): extended-keys always so Shift+Enter reaches Claude Code

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -38,10 +38,11 @@ set -sa terminal-overrides ",xterm-256color:RGB"
 # Ghostty ($TERM=xterm-ghostty) defaults to the kitty keyboard protocol and
 # encodes Ctrl+Space as a CSI-u sequence, not the legacy NUL byte tmux reads
 # as C-Space. Advertise extkeys so tmux negotiates an encoding it recognizes.
-# The xterm* glob also covers iTerm2 (xterm-256color). 'on' (not 'always')
-# only forwards extended keys to inner apps that opt in — keeps Ctrl+C/Z/L safe.
+# The xterm* glob also covers iTerm2 (xterm-256color). 'always' (not 'on')
+# because Claude Code never sends the kitty-protocol activation sequence, so
+# under 'on' tmux never forwards Shift+Enter to it (claude-code#26629).
 set -as terminal-features 'xterm*:extkeys'
-set -s extended-keys on
+set -s extended-keys always
 set -s extended-keys-format csi-u
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

Shift+Enter stopped inserting a newline in Claude Code inside tmux. Root cause: `extended-keys on` only forwards CSI-u sequences to inner apps that send the kitty-protocol activation sequence — Claude Code never does ([claude-code#26629](https://github.com/anthropics/claude-code/issues/26629)), so tmux swallowed the Shift modifier and delivered plain Enter. Not a tmux 3.7 regression: upstream CHANGES for 3.6→3.7b contain no extended-keys entries.

## Change

- `set -s extended-keys on` → `always` (comment updated with the rationale)

Tradeoff: `always` forwards extended keys to all panes, not just opt-in apps. Plain Ctrl+C/Z still arrive as legacy bytes; this is the standard Claude Code ↔ tmux workaround.

## Verification

- `just check` green
- Applied to the running server via `tmux set -s extended-keys always`; keypress behavior pending manual confirmation
- Note: tmux caches terminal negotiation per server process — full effect on fresh starts needs `tmux kill-server`, not just detach/reattach

🤖 Generated with [Claude Code](https://claude.com/claude-code)