### PR TITLE
chore(doc-drift): bump tavily-mcp to 0.2.21 (no-op)

### DIFF
--- a/agents/doc-drift/sources.yaml
+++ b/agents/doc-drift/sources.yaml
@@ -55,7 +55,7 @@ sources:
     signal: { type: npm, ref: tavily-mcp }
     docs: https://github.com/tavily-ai/tavily-mcp
     governs: [chezmoi/.chezmoidata/claude.yaml, agents/mcp/registry.yaml]
-    reconciled: "0.2.20"
+    reconciled: "0.2.21"
 
   - id: chezmoi
     signal: { type: gh_release, ref: twpayne/chezmoi }


### PR DESCRIPTION
## What
Bumps `reconciled` for `tavily-mcp` from `0.2.20` → `0.2.21` in `agents/doc-drift/sources.yaml`. No other changes.

## Why no-op
Researched via Tavily (upstream repo publishes no GitHub Releases, so I read the repo activity feed + npm/unpkg package metadata):

- **0.2.21** (published ~6 days ago) = merge of [tavily-ai/tavily-mcp#186](https://github.com/tavily-ai/tavily-mcp/pull/186) "research timeout settings for stream pipeline; bump to 0.2.21" — an internal timeout knob for the `tavily_research` tool's streaming pipeline.
- Two preceding Dependabot bumps also landed in this window: #183 (`hono`) and #182 (`form-data`) — transitive dependency version bumps only.

None of this touches the config surface our repo mirrors:
- `chezmoi/.chezmoidata/claude.yaml` and `agents/mcp/registry.yaml` both pin `tavily-mcp@latest`, set only `TAVILY_API_KEY`, and grant `mcp__tavily__*` (wildcard) permission.
- No env var, CLI arg, or tool name changed or was added/removed — the wildcard permission already covers any tool surface changes automatically.

Classified **no-op** per `agents/doc-drift/routine.md`.

## Checks
- Dedup: no existing open PR/issue for `tavily-mcp 0.2.21` and no pre-existing `doc-drift/tavily-mcp-0.2.21` branch (checked via `search_pull_requests` / `search_issues` before starting).
- `just check` was not run — this environment doesn't have the `just` binary. The only change is a one-line YAML version-string bump in `agents/doc-drift/sources.yaml`; CI will gate it as usual.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YVW57Fb9tzQk4a2pgKVSus)_