### PR TITLE
chore(doc-drift): bump chezmoi to v2.71.0 (no-op)

### DIFF
--- a/agents/doc-drift/sources.yaml
+++ b/agents/doc-drift/sources.yaml
@@ -61,7 +61,7 @@ sources:
     signal: { type: gh_release, ref: twpayne/chezmoi }
     docs: https://www.chezmoi.io/reference/
     governs: [chezmoi/]
-    reconciled: "v2.70.5"
+    reconciled: "v2.71.0"
 
 
   - id: serena


### PR DESCRIPTION
## What

Bumps the `chezmoi` doc-drift tracker's `reconciled` version (`agents/doc-drift/sources.yaml`) from `v2.70.5` to `v2.71.0`. No other changes.

## Why: no-op classification

Upstream: https://github.com/twpayne/chezmoi/releases/tag/v2.71.0 (released 2026-07-07, directly follows v2.70.5 — no intermediate patch releases).

Changelog delta (v2.70.5 → v2.71.0):

**Features**
- `feat: Enable KeePassXC open mode on Windows`
- `feat: Add --error-on-conflict flag`
- `feat: Switch to github.com/bartventer/httpcache for HTTP caching`
- `feat: Build Windows MSIX packages`
- `feat: Add --revision and --tag flags to init command`

**Documentation**: link additions only (no schema/behavior docs changed).

Checked against our governed surface (`chezmoi/`, invocation sites in `chezmoi/.sync`, and the design rationale in `.hallouminate/wiki/operations/sync-and-chezmoi.md`):

- We invoke `chezmoi init --source "$script_dir"` against our own local source dir (`chezmoi/.sync:117`) — not a remote/tag-pinned init, so the new `--revision`/`--tag` flags on `init` don't apply.
- We invoke `chezmoi --source "$script_dir" apply --force` (`chezmoi/.sync:168`) — no `--error-on-conflict` usage, and no conflict-detection behavior we currently rely on.
- We don't use KeePassXC as a secret manager anywhere in `chezmoi/`.
- The HTTP-caching backend swap (`bartventer/httpcache`) is an internal implementation detail of chezmoi's `.chezmoiexternal` fetching, not a config surface we author.
- We don't ship/target Windows (MSIX packaging is irrelevant).

Nothing in the delta touches a flag, key, schema, or behavior our config mirrors, so this is a pure version-bump per the doc-drift routine's no-op class (`agents/doc-drift/routine.md`).

## Verification

This PR only touches `agents/doc-drift/sources.yaml` (a data file, not `chezmoi/`), so there's no `chezmoi/`-surface change to run `just check` against. `just` isn't available in this execution environment regardless; CI will still run the full gate on this PR.

🤖 Generated by the doc-drift weekly routine (chezmoi subagent).


---
_Generated by [Claude Code](https://claude.ai/code/session_01YVW57Fb9tzQk4a2pgKVSus)_