### PR TITLE
chore(doc-drift): bump codex-cli to 0.144.5 (no-op)

### DIFF
--- a/agents/doc-drift/sources.yaml
+++ b/agents/doc-drift/sources.yaml
@@ -31,7 +31,7 @@ sources:
     signal: { type: npm, ref: "@openai/codex" }
     docs: https://developers.openai.com/codex
     governs: [harnesses/codex.md, agents/hooks/registry.yaml, agents/registry.yaml]
-    reconciled: "0.143.0"
+    reconciled: "0.144.5"
 
   - id: opencode
     signal: { type: npm, ref: opencode-ai }


### PR DESCRIPTION
## What
Bumps `reconciled` for `codex-cli` in `agents/doc-drift/sources.yaml` from `0.143.0` to `0.144.5`. No other files touched.

## Why
Weekly doc-drift routine flagged `@openai/codex` (npm) at `0.144.5` vs our last-reconciled `0.143.0`.

## Changelog reviewed (rust-v0.143.0 → rust-v0.144.5)
Source: GitHub releases for `openai/codex` + npmx.dev changelog aggregation.

- **0.144.0** — usage-limit reset credits show type/expiration + which credit to redeem; new `writes` app-approval mode (declared read-only actions auto-allowed, writes still prompt) for MCP **apps**; MCP tools can request interactive auth without an experimental opt-in; app-server hosts can provide runtime auth + hosted login redirects; pnpm-managed installs are now detected for diagnostics/updates; Ultra reasoning now warns on high multi-agent concurrency. Bug fixes: resumed-thread retired-model retry, Intel macOS Code Mode crash, Windows sandbox delete-in-writable-roots, TUI paste-corruption, WebSocket/proxy fixes. Chores: skill-loading perf, faster `/review` branch picker, Guardian auto-review prompting tweaks, clearer Bedrock GPT-5.6 display names.
- **0.144.1** — backported installer reliability fixes (GitHub release metadata edge cases) and Code Mode host packaging/fallback fixes.
- **0.144.2** — reverted a Guardian auto-review prompting regression, restoring prior policy/request format/tool behavior.
- **0.144.3** — version-only release, no merged PR changes.
- **0.144.4** — internal stability / under-the-hood maintenance only, no user-facing changes.
- **0.144.5** — same maintenance-patch pattern as 0.144.3/0.144.4 (no changelog entries surfaced beyond internal stability work).

## Why this is a no-op for our config surface
Checked every change above against what we actually mirror:
- `harnesses/codex.md` (`.hallouminate/wiki/harnesses/codex.md`) — capabilities table (hooks/sub-agents/MCP/system-prompt/settings/skills), isolated-settings defaults (`approval_policy = "on-request"`, `sandbox_mode = "workspace-write"`), and the quirks/skill-discovery notes are all untouched. The new `writes` mode is a distinct per-app key (`apps.<id>.default_tools_approval_mode`) for Codex "apps"/MCP connectors — not the top-level `approval_policy` we set for isolated launches, and we don't configure `[apps]` at all.
- `agents/hooks/registry.yaml` — no changes to hook event schema, `SessionStart` matcher semantics, or `timeout` units (still seconds) surfaced in this range.
- `agents/registry.yaml` — no model-catalog or sandbox-derivation changes affecting the `codex: gpt-5.6-*` model fields we set (the Bedrock GPT-5.6 display-name tweak is scoped to the Bedrock provider path, which we don't use).

Classified **no-op** per `agents/doc-drift/routine.md` — this PR only advances `reconciled`.

## Verification
`just check` could not be run in this environment (no `just` binary here) — this is a metadata-only YAML edit with no config/renderer surface to lint or test, so CI's `lint`/`test` jobs are the gate.

🤖 Generated with a doc-drift subagent run.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YVW57Fb9tzQk4a2pgKVSus)_