### PR TITLE
chore(doc-drift): bump claude-code to 2.1.211 (no-op)

### DIFF
--- a/agents/doc-drift/sources.yaml
+++ b/agents/doc-drift/sources.yaml
@@ -25,7 +25,7 @@ sources:
     signal: { type: npm, ref: "@anthropic-ai/claude-code" }
     docs: https://code.claude.com/docs
     governs: [harnesses/claude.md, chezmoi/.chezmoidata/claude.yaml]
-    reconciled: "2.1.205"
+    reconciled: "2.1.211"
 
   - id: codex-cli
     signal: { type: npm, ref: "@openai/codex" }


### PR DESCRIPTION
## Signal
npm `@anthropic-ai/claude-code`: `2.1.205` → `2.1.211`. Docs: https://code.claude.com/docs

## Classification: no-op

Read the upstream `CHANGELOG.md` (anthropics/claude-code, `main`) for the full 2.1.206–2.1.211 range (the changelog page rendered by Tavily/WebFetch is JS-hydrated and doesn't carry release bodies in raw HTML, so I pulled `raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md` directly). Summary of what shipped:

- **2.1.211** — `--forward-subagent-text` flag/env; permission-preview text-spoofing hardening; PreToolUse `ask` no longer overridden by auto mode; various session/MCP-reconnect/model-override bug fixes; Bedrock/Vertex/Mantle/Foundry prompt-caching billing regression fix.
- **2.1.210** — worktree-isolated subagent git-mutation fix; new startup warning for `Write(path)`/`NotebookEdit(path)`/`Glob(path)` permission rules (recommends `Edit(path)`/`Read(path)` instead); assorted attach/crash/perf fixes.
- **2.1.209** — single fix (`/model` dialog blocked in background sessions).
- **2.1.208** — screen reader mode (`axScreenReader`), `vimInsertModeRemaps` setting, `CLAUDE_CODE_PROCESS_WRAPPER` env; large batch of memory-leak/perf/MCP fixes.
- **2.1.207** — auto mode opt-in removed for Bedrock/Vertex/Foundry; `${user_config.*}` rejected in **plugin** hook/monitor/headersHelper shell-form commands (shell-injection hardening); `autoMode` moved from `.claude/settings.local.json` to `~/.claude/settings.json`.
- **2.1.206** — `/doctor` CLAUDE.md-trim check, `/commit-push-pr` push-remote auto-allow, MCP `request_timeout_ms` fix, various UI fixes.
- **2.1.205** — auto mode transcript-tamper guard, `--json-schema` fixes, `/doctor` becomes a full checkup, "Claude Browser" MCP name reservation.

Checked this against our governs surface (`.hallouminate/wiki/harnesses/claude.md` and `chezmoi/.chezmoidata/claude.yaml`, which drive our hooks, MCP servers (`tilth`, `context7`, `tavily`, `serena`), permissions, skills, and agents):

- The 2.1.210 `Write(path)`/`NotebookEdit(path)`/`Glob(path)` permission-rule warning doesn't apply — our `permissions.allow` only has bare `Write`/`Edit` (no path-scoped variants), and we have no `NotebookEdit(...)`/`Glob(...)` rules at all.
- The 2.1.207 `${user_config.*}` shell-injection fix targets **plugin** hooks/monitors/headersHelper; our hooks are wired directly in `settings.json` (via `claude.yaml`'s `hooks:` key) as plain commands using `$HOME` shell expansion, not plugin `user_config`.
- No MCP config schema, hook-wiring shape, settings key we author, or docs-host change touches anything we mirror.

Net: nothing in this range requires a config/wiki edit. This PR only bumps `reconciled` for `claude-code` in `agents/doc-drift/sources.yaml`.

## Verification
`just check` was not run — the `just` binary isn't available in this container. This PR only touches `agents/doc-drift/sources.yaml` (no config/renderer changes), so CI's lint/test run is the real gate.

🤖 Generated as part of the weekly doc-drift routine.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YVW57Fb9tzQk4a2pgKVSus)_