### PR TITLE
chore(doc-drift): bump opencode to 1.18.2 (no-op)

### DIFF
--- a/agents/doc-drift/sources.yaml
+++ b/agents/doc-drift/sources.yaml
@@ -37,7 +37,7 @@ sources:
     signal: { type: npm, ref: opencode-ai }
     docs: https://opencode.ai/docs
     governs: [harnesses/opencode.md]
-    reconciled: "1.17.16"
+    reconciled: "1.18.2"
 
   - id: copilot-cli
     signal: { type: npm, ref: "@github/copilot" }


### PR DESCRIPTION
## Drift
`opencode-ai` npm package: `1.17.16` → `1.18.2` (docs: https://opencode.ai/docs).

## What I checked
Read every release between the two versions (npm `opencode-ai`, GitHub releases for `anomalyco/opencode` — the repo formerly published as `sst/opencode`; org rebrand, no URL/package-name change): v1.17.17, v1.17.18, v1.17.19, v1.17.20, v1.18.0, v1.18.1, v1.18.2.

Summary of the delta:
- **v1.17.17** — Core: improved Meta model reasoning-variant handling. Desktop: UI polish (tabs intro popup, sub-agent task row styling, v2 free-model selector).
- **v1.17.18** — Core: fixed a crash from GitHub Copilot returning zero-billing-batch-size models; added a model-specific system prompt for Meta Muse Spark.
- **v1.17.19** — Core: OpenAI pro reasoning mode support, xAI Responses storage disabled by default, OAuth for Luna Responses Lite, GPT-5.6 Codex context limits. TUI: forwarded CLI env vars to the TUI worker.
- **v1.17.20** — Core: removed an obsolete Codex workaround; Azure AI GPT-5.6 support update.
- **v1.18.0** — Desktop v2 migration (new layout, onboarding, many Desktop-only bugfixes). No CLI/core config changes.
- **v1.18.1** — Desktop-only spacing bugfix.
- **v1.18.2** — Core: subagents no longer launch nested subagents by default (new, undocumented `subagent_depth` limit when you need more); improved default reasoning depth for Meta models. Desktop: `Mod+N` new-tab shortcut + bugfixes.

## Classification: no-op
Nothing here touches what `harnesses/opencode.md` documents: no hook/plugin API change, no MCP config change, no sub-agent *schema* change (the new nesting-depth default isn't in the official `opencode.ai/docs/agents` or `/docs/config` pages as of this check — it's an internal safety default, not a documented key we'd mirror), no system-prompt/`AGENTS.md`/`instructions` precedence change, no `opencode.json`/`tui.json` schema change, and none of the documented quirks (no `mcp add` CLI, `.json` vs `.jsonc`, no vim modal editing) changed. Everything else in the delta is Desktop-app UI work, which this repo doesn't install or configure.

This PR only bumps `reconciled` for `opencode` in `agents/doc-drift/sources.yaml`.

## Caveat
`just` isn't installed in this run's container, so `just check` could not be run here — this is a single-line YAML value bump with no config/renderer surface touched, but CI should still gate it per the routine's invariants.

---
Part of the weekly doc-drift routine (`agents/doc-drift/routine.md`), opencode item.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YVW57Fb9tzQk4a2pgKVSus)_