### PR TITLE
chore(doc-drift): bump copilot-cli to 1.0.71 (no-op)

### DIFF
--- a/agents/doc-drift/sources.yaml
+++ b/agents/doc-drift/sources.yaml
@@ -43,7 +43,7 @@ sources:
     signal: { type: npm, ref: "@github/copilot" }
     docs: https://docs.github.com/en/copilot/how-tos/copilot-cli
     governs: [harnesses/copilot.md]
-    reconciled: "1.0.69"
+    reconciled: "1.0.71"
 
   - id: context7-mcp
     signal: { type: npm, ref: "@upstash/context7-mcp" }


### PR DESCRIPTION
## What

Bumps `copilot-cli`'s `reconciled` marker in `agents/doc-drift/sources.yaml` from `1.0.69` to `1.0.71` (current `@github/copilot` npm version). No other changes.

## Why no-op

Read the upstream changelog (`github/copilot-cli/changelog.md`) for the `1.0.70` and `1.0.71` releases against what `harnesses/copilot.md` (governs file) actually documents/mirrors:

**1.0.70 (2026-07-09) highlights:** GPT-5.6 model support; paginated `session.mcp.resources` RPCs; `preToolUse` hooks exiting with code 2 now also deny tool calls (in addition to the existing stdout-JSON path); plugins can pin to an exact commit SHA; `--sandbox`/`--no-sandbox` session-only flags; `/refine`; `--repo`/`--local` flags for `/settings` and `/model`; a trusted repository can now pin model/effort/context-tier and extend the URL/MCP/skill deny lists via `.github/copilot/settings.json`.

**1.0.71 (2026-07-16) highlights:** persist GitHub MCP toolset/tool config via `settings.json`; new `plugins marketplace` browse/update/list/add/remove subcommands; `/voice devices`; invalid `settings.json` now warns instead of silently ignoring; Plan mode hard-blocks built-in mutating tool calls.

None of this touches our governed surface:
- Our two Copilot hooks (`chezmoi/private_dot_copilot/hooks/{git-guard,sensitive-file-guard}.json.tmpl`, scripts in the same dir) already deny via the documented stdout-JSON `permissionDecision` contract — the new exit-code-2 deny path is an additive alternative we don't use, not a breaking change to ours.
- We don't write `.github/copilot/settings.json`; the new trusted-repo model/deny-list pinning is unused, additive surface.
- The MCP row (`~/.copilot/mcp-config.json`, `mcpServers` schema), sub-agents (`agents/registry.yaml` → `.github/agents/<n>.agent.md`), skills, system-prompt precedence, and "isolated settings: not available" note in `harnesses/copilot.md` all remain accurate — nothing in these two releases changes those schemas/flags/precedence rules.
- Plugin marketplace additions (`browse`/`update`) are additive to the subcommands our renderer (`agent-profile/agent_profile/renderers/copilot.py`) already calls (`marketplace add/remove`, `plugin install/uninstall`) — no behavior change to what we invoke.

## Verification

Doc-only/no-op change (single YAML value). `just check` was not run — no `just` binary in this environment; CI gates it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YVW57Fb9tzQk4a2pgKVSus)_