### PR TITLE
chore(doc-drift): bump oh-my-pi to v17.0.1 (no-op)

### DIFF
--- a/agents/doc-drift/sources.yaml
+++ b/agents/doc-drift/sources.yaml
@@ -77,4 +77,4 @@ sources:
     signal: { type: gh_release, ref: can1357/oh-my-pi }
     docs: https://github.com/can1357/oh-my-pi
     governs: [chezmoi/.chezmoidata/omp.yaml, chezmoi/dot_omp/private_agent/modify_config.yml]
-    reconciled: "v16.3.10"
+    reconciled: "v17.0.1"


### PR DESCRIPTION
## Drift

`oh-my-pi` (can1357/oh-my-pi): `v16.3.10` → `v17.0.1`. Major version jump (v16.3.10 → v17.0.0 → v17.0.1), so I read the v17.0.0 major-bump release notes in full, not just the v17.0.1 patch delta.

## Changelog reviewed

**v17.0.0** (the actual major bump) — breaking changes and notable items, by package:
- `@oh-my-pi/pi-agent-core`: reworked the internal **task tool wire schema** (agent field moved into task items, `assignment`→`task`, `id`→`name` rename, `role`/`description` fields removed) — this is the wire protocol for task/subagent tool calls, not a user-facing config key. Removed the tool-discovery system (`search-tool-bm25` tool) and its settings `tools.discoveryMode`, `tools.essentialOverride`, `mcp.discoveryMode`, `mcp.discoveryDefaultServers` (dead keys are auto-cleaned from existing configs on load). Removed the `resolve` tool in favor of `xd://propose` writes.
- `@oh-my-pi/pi-coding-agent`: replaced the `--reasoning-slide-*` CLI flag family with a unified `--prewalk` mechanism. Added the new `xd://` virtual device protocol (`tools.xdev`, default `true`), `edit.enforceSeenLines` (default `false`), per-agent prewalk (`task.agentPrewalk`, `task.prewalk`, default `false`), a fullscreen Model Hub (`/model`), and a `/pause` command.
- Google provider: removed automatic `/interactions` chaining and its `useInteractionsApi` / `storeInteraction` / `previousInteractionId` stream options.

**v17.0.1** (patch on top) — provider/model-catalog fixes (OpenRouter cost reporting, OpenAI Responses/Chat Completions sampling-param forwarding, Google/Cloud Code Assist boolean-JSON-Schema coercion, Anthropic spend-limit fast-fail) and TUI fixes, spanning `pi-ai`, `pi-catalog`, `pi-coding-agent`, `collab-web`, `pi-mnemopi`, `pi-natives`, `pi-tui`, `pi-utils`.

## Impact assessment

Checked both `governs` files against every key/flag above:
- `chezmoi/.chezmoidata/omp.yaml` — our `omp.config` subtree (`symbolPreset`, `colorBlindMode`, `theme`, `defaultThinkingLevel`, `textVerbosity`, `disabledProviders`, `display.*`, `includeWorkspaceTree`, `tools.artifactSpillThreshold/artifactHeadBytes/artifactTailBytes`, `read.toolResultPreview`, `skills.enableSkillCommands`, `tui.tight`, `startup.quiet`, `advisor.enabled`, `compaction.*`, `lsp.*`, `github.enabled`, `task.eager`, `dev.autoqa.consent`, `modelRoles.*`) and the `omp.models.providers.local-llm` schema (`baseUrl`/`api`/`auth`/`models[].{id,name,reasoning,input,contextWindow,maxTokens}`).
- `chezmoi/dot_omp/private_agent/modify_config.yml` — the wholesale-author script enforcing the above onto `~/.omp/agent/config.yml`.

None of the removed/renamed/new keys touch our surface:
- The removed BM25-discovery keys (`tools.discoveryMode`, `tools.essentialOverride`, `mcp.discoveryMode`, `mcp.discoveryDefaultServers`) are not set by us, and upstream self-cleans them on load anyway.
- The new `task.agentPrewalk` / `task.prewalk` keys are additive and distinct from our existing `task.eager` — no rename/collision.
- The task-tool wire schema rework and the `--reasoning-slide-*`→`--prewalk` CLI flag replacement are internal/CLI-invocation concerns we don't mirror in the registry.
- The new `xd://` device protocol (`tools.xdev`) defaults on and needs no opt-in from us; nothing in our governs files references it.
- The Google `/interactions` removal doesn't touch any Google-provider config we set.
- The v17.0.1 provider/catalog/TUI fixes are pure bug fixes, not schema changes.

Classified **no-op**. This PR only bumps `reconciled` in `agents/doc-drift/sources.yaml`; no edits to the `governs` files.

`just check` was not run — this container has no `just` binary. The only change is a YAML string value in `agents/doc-drift/sources.yaml`, so CI's lint/test legs should be a clean gate.

Never auto-merge — please review and merge, then `dots sync`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YVW57Fb9tzQk4a2pgKVSus)_