### PR TITLE
feat(workflows): add curd-flock saved workflow

### DIFF
--- a/claude/workflows/curd-flock.js
+++ b/claude/workflows/curd-flock.js
@@ -1,0 +1,277 @@
+export const meta = {
+  name: 'curd-flock',
+  description:
+    'Fan worktree-isolated coders over N file-disjoint tasks, taste-test each against a read-only reviewer, and correct on revise (bounded rounds) — never merges or commits to main.',
+  phases: [
+    { title: 'Implement', detail: 'one coder per task in an isolated git worktree, branch from origin/main' },
+    { title: 'Review', detail: 'read-only reviewer over each worktree diff (drift/readability/scope, production path, wired callers)' },
+    { title: 'Correct', detail: 'bounded corrective coder pass in the same worktree on any revise verdict, then re-review once' },
+    { title: 'Report', detail: 'barrier synthesis of per-task status + worktree/branch handoff' },
+  ],
+}
+
+// Tracked source: claude/workflows/curd-flock.js in the dotfiles repo.
+// Canonicalizes a worktree-isolated coder fan-out used ad-hoc in three prior
+// one-off Workflow scripts (rennet-easy-wins, ship-three-ready-units,
+// manifest-flock). Convergence: all three fan coder agent() calls with
+// isolation:'worktree' over file-disjoint tasks and never push/PR/commit to
+// main from inside the workflow — durability is the returned branch, not a
+// remote ref. This script follows rennet-easy-wins's shape most closely (the
+// only one of the three with a review + bounded-correction loop) and adds the
+// re-review-after-correction step and the corrective-round cap explicitly.
+//
+// Args: { tasks: [{ slug, brief, files? }], correctiveRounds? }
+//   - tasks MUST be file-disjoint (declare `files` to get the overlap check —
+//     it's advisory: an overlap logs a warning but does not block the run).
+//   - correctiveRounds defaults to 1: on a 'revise' verdict, one corrective
+//     coder pass runs in the SAME worktree, then the reviewer re-checks once;
+//     if still 'revise' and rounds remain, repeat up to the cap.
+//
+// This workflow never merges, commits to main, pushes, or opens a PR — it
+// hands back worktree paths + branch names for the orchestrator to carry
+// forward (matches ship-three-ready-units' and rennet-easy-wins' contract of
+// leaving publish/push decisions to the caller).
+
+const input = typeof args === 'string' ? (() => { try { return JSON.parse(args) } catch (e) { log(`args was a string but not valid JSON (${e.message}) — treating as no tasks`); return {} } })() : args || {}
+const TASKS = Array.isArray(input.tasks) ? input.tasks : []
+const CORRECTIVE_ROUNDS = Number.isInteger(input.correctiveRounds) && input.correctiveRounds >= 0 ? input.correctiveRounds : 1
+
+if (!TASKS.length) {
+  log('No tasks provided. Usage: /curd-flock with args = { tasks: [{ slug, brief, files? }], correctiveRounds? }')
+  return { error: 'No tasks provided.' }
+}
+
+// ---- file-disjoint check (advisory — logs, never blocks) ----
+function warnOnFileOverlap(tasks) {
+  for (let i = 0; i < tasks.length; i++) {
+    const a = tasks[i]
+    if (!Array.isArray(a.files) || !a.files.length) continue
+    for (let j = i + 1; j < tasks.length; j++) {
+      const b = tasks[j]
+      if (!Array.isArray(b.files) || !b.files.length) continue
+      const overlap = a.files.filter((f) => b.files.includes(f))
+      if (overlap.length) {
+        log(`WARNING: tasks '${a.slug}' and '${b.slug}' declare overlapping files: ${overlap.join(', ')} — tasks must be file-disjoint`)
+      }
+    }
+  }
+}
+warnOnFileOverlap(TASKS)
+
+// ---- duplicate-slug guard (fail-fast — same branch would collide) ----
+function findDuplicateSlugs(tasks) {
+  const seen = new Set()
+  const dupes = new Set()
+  for (const t of tasks) {
+    if (seen.has(t.slug)) dupes.add(t.slug)
+    seen.add(t.slug)
+  }
+  return [...dupes]
+}
+const duplicateSlugs = findDuplicateSlugs(TASKS)
+if (duplicateSlugs.length) {
+  log(`Duplicate task slug(s): ${duplicateSlugs.join(', ')} — slugs must be unique (branch curd/<slug> would collide)`)
+  return { error: `Duplicate task slug(s): ${duplicateSlugs.join(', ')}` }
+}
+
+// ---- shared git/isolation contract handed to every coder ----
+const ISO = (branch) => `
+## Isolation contract (read first)
+- You are running in a FRESH, ISOLATED git worktree dedicated to this one task. Other tasks run concurrently in their own worktrees — never reach outside your scope.
+- First command: \`git checkout -B ${branch} origin/main\` — start from a clean origin/main base on your own branch.
+- Work ONLY this task. Do NOT implement sibling tasks. Do NOT touch files outside the declared scope.
+- Do NOT push. Do NOT open a PR. Do NOT run \`git fetch\`/\`pull\`. Commit locally on ${branch} only.
+- Final commit: \`git add -A && git commit\` with a Conventional Commits subject. No flair, no emojis in the commit message.
+- Honesty (Rule 9): if a gate fails or you skipped something, say so in your digest — never report done on partial work.
+`
+
+const CODER_SCHEMA = {
+  type: 'object',
+  required: ['slug', 'branch', 'status', 'summary', 'files_changed', 'verification', 'committed', 'worktree_path'],
+  properties: {
+    slug: { type: 'string' },
+    branch: { type: 'string' },
+    status: { type: 'string', enum: ['done', 'blocked'] },
+    summary: { type: 'string', description: 'what changed, 1-3 sentences' },
+    files_changed: { type: 'array', items: { type: 'string' } },
+    verification: { type: 'string', description: 'exact gate command + result, or why no automated gate applies' },
+    committed: { type: 'boolean' },
+    commit_sha: { type: 'string' },
+    worktree_path: { type: 'string', description: 'absolute path of the worktree this task ran in — a corrective pass cds here instead of creating a new worktree' },
+    notes: { type: 'string', description: 'caveats, anything a reviewer must know' },
+  },
+}
+
+const REVIEW_SCHEMA = {
+  type: 'object',
+  required: ['slug', 'verdict', 'lenses', 'issues'],
+  properties: {
+    slug: { type: 'string' },
+    verdict: { type: 'string', enum: ['pass', 'revise'] },
+    lenses: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['lens', 'verdict'],
+        properties: {
+          lens: { type: 'string', enum: ['drift', 'readability', 'scope', 'production-path', 'wired-callers'] },
+          verdict: { type: 'string', enum: ['pass', 'revise'] },
+          note: { type: 'string' },
+        },
+      },
+    },
+    issues: { type: 'array', items: { type: 'string' } },
+    recommendation: { type: 'string' },
+  },
+}
+
+const CORRECT_SCHEMA = {
+  type: 'object',
+  required: ['slug', 'branch', 'status', 'summary', 'committed'],
+  properties: {
+    slug: { type: 'string' },
+    branch: { type: 'string' },
+    status: { type: 'string', enum: ['fixed', 'partial', 'blocked'] },
+    summary: { type: 'string' },
+    files_changed: { type: 'array', items: { type: 'string' } },
+    verification: { type: 'string' },
+    committed: { type: 'boolean' },
+    notes: { type: 'string' },
+  },
+}
+
+const branchFor = (slug) => `curd/${slug}`
+
+function buildCoderPrompt(t) {
+  const branch = branchFor(t.slug)
+  return `You are a TDD-disciplined coder implementing ONE file-disjoint task in a fan-out batch.
+
+Task: ${t.slug}
+Branch: ${branch}  (fork point: origin/main)
+${t.files && t.files.length ? `Scope (edit ONLY these): ${t.files.join(', ')}\n` : ''}
+Instruction (authoritative):
+${t.brief}
+
+${ISO(branch)}
+
+## How to work
+1. \`git checkout -B ${branch} origin/main\`.
+2. Read the in-scope files (use tilth/serena MCP, not host Read/grep) before changing anything.
+3. Make the minimal change that satisfies the instruction. No scope creep, no speculative extras — every changed line traces to the ask.
+4. Verify with the project's relevant gate(s). Read the FULL output before claiming. If no automated gate applies, say so explicitly.
+5. Commit on ${branch} (Conventional Commits, no flair). Do NOT push.
+6. Report \`worktree_path\`: the absolute path of this worktree (\`git rev-parse --show-toplevel\`) — a corrective pass will cd into it later instead of creating a new worktree.
+7. Return the structured digest. If anything was skipped or a gate failed, set status:blocked and explain — do not fake completion.`
+}
+
+function buildReviewerPrompt(t, branch, impl) {
+  return `You are a read-only reviewer running a taste-test over one freshly-implemented task.
+
+Branch under review: ${branch}
+The diff is: \`git diff origin/main...${branch}\`  (read-only git only — NEVER checkout, edit, or modify anything; other branches are being built concurrently in other worktrees).
+
+What it was supposed to do:
+${t.brief}
+
+Coder's self-report: ${JSON.stringify({ status: impl.status, summary: impl.summary, files_changed: impl.files_changed, verification: impl.verification, notes: impl.notes })}
+
+## Lenses (judge each pass | revise)
+- drift: the diff actually implements the task's intent (not an adjacent or weaker thing).
+- readability: minimal, clean, matches surrounding code style; nothing speculative.
+- scope: only files traceable to the task changed; no scope creep, no unrelated edits, no orphaned cruft.
+- production-path: the change is reachable on the real code path (wired in), not merely asserted in prose or a test that manufactures the state.
+- wired-callers: any changed signature/export has its callers updated; nothing left calling a stale shape.
+
+Return the structured verdict (one entry per lens above). Overall verdict = revise if any lens is revise; else pass. Be specific in issues[] (cite file:line from the diff).`
+}
+
+function buildCorrectivePrompt(t, worktreePath, branch, review) {
+  return `You are a coder applying a BOUNDED corrective pass to your own branch after a taste-test returned "revise".
+
+Worktree: ${worktreePath}  (the SAME worktree the implementation ran in — already checked out on ${branch} with the prior commit)
+${t.files && t.files.length ? `Scope (edit ONLY these): ${t.files.join(', ')}\n` : ''}
+Original instruction:
+${t.brief}
+
+Taste-test findings to fix:
+${JSON.stringify({ issues: review.issues, lenses: review.lenses, recommendation: review.recommendation })}
+
+## How to work
+1. \`cd ${worktreePath}\` — do NOT create a new worktree or checkout ${branch} elsewhere; it is already checked out here.
+2. Address ONLY the taste-test findings — do not re-architect, do not expand scope.
+3. Re-verify with the project's relevant gate(s). Read full output.
+4. Commit the fix on ${branch} (Conventional Commits, no flair). Do NOT push.
+5. Return the structured digest. status:fixed only if every finding is resolved; status:partial otherwise (explain what remains).`
+}
+
+// ---- run: implement -> review -> (bounded correct + re-review) per task, pipelined ----
+phase('Implement')
+log(`Fanning ${TASKS.length} task(s): ${TASKS.map((t) => t.slug).join(', ')} (correctiveRounds=${CORRECTIVE_ROUNDS})`)
+
+const results = await pipeline(
+  TASKS,
+
+  (t) => {
+    const branch = branchFor(t.slug)
+    return agent(buildCoderPrompt(t), {
+      label: `implement:${t.slug}`, phase: 'Implement', agentType: 'coder',
+      isolation: 'worktree', schema: CODER_SCHEMA,
+    }).then((impl) => ({ t, branch, impl }))
+  },
+
+  ({ t, branch, impl }) => {
+    if (!impl || impl.status !== 'done' || !impl.committed) {
+      return { t, branch, impl, review: { slug: t.slug, verdict: 'revise', lenses: [], issues: ['implement stage did not complete or did not commit'], recommendation: 'human follow-up' }, rounds: 0 }
+    }
+    return agent(buildReviewerPrompt(t, branch, impl), {
+      label: `review:${t.slug}`, phase: 'Review', agentType: 'reviewer', effort: 'high', schema: REVIEW_SCHEMA,
+    }).then((review) => ({ t, branch, impl, review, rounds: 0 }))
+  },
+
+  async ({ t, branch, impl, review, rounds }) => {
+    let corrections = []
+    let curReview = review
+    let round = rounds
+    while (curReview && curReview.verdict === 'revise' && round < CORRECTIVE_ROUNDS && impl && impl.status === 'done' && impl.committed) {
+      const correction = await agent(buildCorrectivePrompt(t, impl.worktree_path, branch, curReview), {
+        label: `correct:${t.slug}:r${round + 1}`, phase: 'Correct', agentType: 'coder',
+        schema: CORRECT_SCHEMA,
+      })
+      corrections.push(correction)
+      round++
+      if (!correction || !correction.committed) {
+        log(`${t.slug}: corrective round ${round} produced ${correction ? 'an uncommitted correction' : 'no correction'} — stopping corrective loop`)
+        break
+      }
+      curReview = await agent(buildReviewerPrompt(t, branch, correction), {
+        label: `review:${t.slug}:r${round}`, phase: 'Review', agentType: 'reviewer', effort: 'high', schema: REVIEW_SCHEMA,
+      })
+    }
+    return { t, branch, impl, review: curReview, corrections, rounds: round }
+  },
+)
+
+phase('Report')
+const tasks = results.map((r) => {
+  if (!r) return null
+  const { t, branch, impl, review, corrections, rounds } = r
+  let status
+  if (!impl || impl.status !== 'done' || !impl.committed) status = 'failed'
+  else if (!review || review.verdict === 'revise') status = 'failed'
+  else status = rounds > 0 ? 'revised-clean' : 'clean'
+  return {
+    slug: t.slug,
+    branch,
+    status,
+    corrective_rounds_used: rounds,
+    impl: impl ? { status: impl.status, summary: impl.summary, files_changed: impl.files_changed, verification: impl.verification, committed: impl.committed } : null,
+    review: review ? { verdict: review.verdict, lenses: review.lenses, issues: review.issues } : null,
+    corrections: corrections && corrections.length ? corrections : undefined,
+  }
+})
+
+const summary = { clean: 0, 'revised-clean': 0, failed: 0 }
+for (const t of tasks) if (t) summary[t.status] = (summary[t.status] || 0) + 1
+log(`Report: ${tasks.length} task(s) — clean:${summary.clean} revised-clean:${summary['revised-clean']} failed:${summary.failed}`)
+
+return { tasks, summary }

--- a/claude/workflows/curd-flock.js
+++ b/claude/workflows/curd-flock.js
@@ -23,9 +23,15 @@ export const meta = {
 // Args: { tasks: [{ slug, brief, files? }], correctiveRounds? }
 //   - tasks MUST be file-disjoint (declare `files` to get the overlap check —
 //     it's advisory: an overlap logs a warning but does not block the run).
-//   - correctiveRounds defaults to 1: on a 'revise' verdict, one corrective
-//     coder pass runs in the SAME worktree, then the reviewer re-checks once;
-//     if still 'revise' and rounds remain, repeat up to the cap.
+//   - every task needs a non-empty `slug` (/^[a-z0-9][a-z0-9._-]*$/) and a
+//     non-empty `brief` — curd/<slug> is interpolated into the coder's literal
+//     `git checkout -B` command, so an invalid slug fails the whole run fast.
+//   - re-running a slug resets curd/<slug> to origin/main — a prior run's
+//     commits on that branch are discarded (intentional retry semantics).
+//   - correctiveRounds defaults to 1, clamped to a max of 3: on a 'revise'
+//     verdict, one corrective coder pass runs in the SAME worktree, then the
+//     reviewer re-checks once; if still 'revise' and rounds remain, repeat up
+//     to the cap.
 //
 // This workflow never merges, commits to main, pushes, or opens a PR — it
 // hands back worktree paths + branch names for the orchestrator to carry
@@ -34,11 +40,33 @@ export const meta = {
 
 const input = typeof args === 'string' ? (() => { try { return JSON.parse(args) } catch (e) { log(`args was a string but not valid JSON (${e.message}) — treating as no tasks`); return {} } })() : args || {}
 const TASKS = Array.isArray(input.tasks) ? input.tasks : []
-const CORRECTIVE_ROUNDS = Number.isInteger(input.correctiveRounds) && input.correctiveRounds >= 0 ? input.correctiveRounds : 1
+const MAX_CORRECTIVE_ROUNDS = 3
+let CORRECTIVE_ROUNDS = Number.isInteger(input.correctiveRounds) && input.correctiveRounds >= 0 ? input.correctiveRounds : 1
+if (CORRECTIVE_ROUNDS > MAX_CORRECTIVE_ROUNDS) {
+  log(`Requested correctiveRounds ${CORRECTIVE_ROUNDS} exceeds max ${MAX_CORRECTIVE_ROUNDS}; clamping to ${MAX_CORRECTIVE_ROUNDS}.`)
+  CORRECTIVE_ROUNDS = MAX_CORRECTIVE_ROUNDS
+}
 
 if (!TASKS.length) {
   log('No tasks provided. Usage: /curd-flock with args = { tasks: [{ slug, brief, files? }], correctiveRounds? }')
   return { error: 'No tasks provided.' }
+}
+
+// ---- slug/brief fail-fast validation (finding 1: curd/<slug> is interpolated into a literal git checkout -B command) ----
+const SLUG_RE = /^[a-z0-9][a-z0-9._-]*$/
+function findInvalidTasks(tasks) {
+  const invalid = []
+  for (const t of tasks) {
+    const slugOk = typeof t.slug === 'string' && t.slug.length > 0 && SLUG_RE.test(t.slug)
+    const briefOk = typeof t.brief === 'string' && t.brief.length > 0
+    if (!slugOk || !briefOk) invalid.push(typeof t.slug === 'string' && t.slug ? t.slug : '(missing slug)')
+  }
+  return invalid
+}
+const invalidTasks = findInvalidTasks(TASKS)
+if (invalidTasks.length) {
+  log(`Invalid task(s): ${invalidTasks.join(', ')} — every task needs a non-empty slug matching ${SLUG_RE} and a non-empty brief`)
+  return { error: `Invalid task slug/brief for: ${invalidTasks.join(', ')}` }
 }
 
 // ---- file-disjoint check (advisory — logs, never blocks) ----
@@ -78,7 +106,7 @@ if (duplicateSlugs.length) {
 const ISO = (branch) => `
 ## Isolation contract (read first)
 - You are running in a FRESH, ISOLATED git worktree dedicated to this one task. Other tasks run concurrently in their own worktrees — never reach outside your scope.
-- First command: \`git checkout -B ${branch} origin/main\` — start from a clean origin/main base on your own branch.
+- First command: \`git checkout -B ${branch} origin/main\` — start from a clean origin/main base on your own branch. Re-running this slug resets ${branch} to origin/main; a prior run's commits on it are discarded (intentional retry semantics).
 - Work ONLY this task. Do NOT implement sibling tasks. Do NOT touch files outside the declared scope.
 - Do NOT push. Do NOT open a PR. Do NOT run \`git fetch\`/\`pull\`. Commit locally on ${branch} only.
 - Final commit: \`git add -A && git commit\` with a Conventional Commits subject. No flair, no emojis in the commit message.
@@ -197,7 +225,7 @@ Taste-test findings to fix:
 ${JSON.stringify({ issues: review.issues, lenses: review.lenses, recommendation: review.recommendation })}
 
 ## How to work
-1. \`cd ${worktreePath}\` — do NOT create a new worktree or checkout ${branch} elsewhere; it is already checked out here.
+1. \`cd ${worktreePath}\` and confirm it exists and is checked out on ${branch} (\`git rev-parse --abbrev-ref HEAD\`). If the worktree is missing (it can be reaped when a prior run made no changes), recreate it with \`git worktree add ${worktreePath} ${branch}\` — ${branch} is the durable artifact, not the worktree directory.
 2. Address ONLY the taste-test findings — do not re-architect, do not expand scope.
 3. Re-verify with the project's relevant gate(s). Read full output.
 4. Commit the fix on ${branch} (Conventional Commits, no flair). Do NOT push.
@@ -216,47 +244,70 @@ const results = await pipeline(
     return agent(buildCoderPrompt(t), {
       label: `implement:${t.slug}`, phase: 'Implement', agentType: 'coder',
       isolation: 'worktree', schema: CODER_SCHEMA,
-    }).then((impl) => ({ t, branch, impl }))
+    }).then((impl) => ({ t, branch, impl, failure: null }))
+      .catch((e) => {
+        log(`${t.slug}: implement agent crashed (${e.message}) — recording as failed, not dropping the task`)
+        return { t, branch, impl: null, failure: { stage: 'implement', message: e.message } }
+      })
   },
 
-  ({ t, branch, impl }) => {
+  ({ t, branch, impl, failure }) => {
+    if (failure) return { t, branch, impl, review: null, rounds: 0, failure }
     if (!impl || impl.status !== 'done' || !impl.committed) {
-      return { t, branch, impl, review: { slug: t.slug, verdict: 'revise', lenses: [], issues: ['implement stage did not complete or did not commit'], recommendation: 'human follow-up' }, rounds: 0 }
+      return { t, branch, impl, review: { slug: t.slug, verdict: 'revise', lenses: [], issues: ['implement stage did not complete or did not commit'], recommendation: 'human follow-up' }, rounds: 0, failure: null }
     }
     return agent(buildReviewerPrompt(t, branch, impl), {
       label: `review:${t.slug}`, phase: 'Review', agentType: 'reviewer', effort: 'high', schema: REVIEW_SCHEMA,
-    }).then((review) => ({ t, branch, impl, review, rounds: 0 }))
+    }).then((review) => ({ t, branch, impl, review, rounds: 0, failure: null }))
+      .catch((e) => {
+        log(`${t.slug}: review agent crashed (${e.message}) — recording as failed, not dropping the task`)
+        return { t, branch, impl, review: null, rounds: 0, failure: { stage: 'review', message: e.message } }
+      })
   },
 
-  async ({ t, branch, impl, review, rounds }) => {
+  async ({ t, branch, impl, review, rounds, failure }) => {
+    if (failure) return { t, branch, impl, review, corrections: [], rounds, failure }
     let corrections = []
     let curReview = review
     let round = rounds
     while (curReview && curReview.verdict === 'revise' && round < CORRECTIVE_ROUNDS && impl && impl.status === 'done' && impl.committed) {
-      const correction = await agent(buildCorrectivePrompt(t, impl.worktree_path, branch, curReview), {
-        label: `correct:${t.slug}:r${round + 1}`, phase: 'Correct', agentType: 'coder',
-        schema: CORRECT_SCHEMA,
-      })
+      let correction
+      try {
+        correction = await agent(buildCorrectivePrompt(t, impl.worktree_path, branch, curReview), {
+          label: `correct:${t.slug}:r${round + 1}`, phase: 'Correct', agentType: 'coder',
+          schema: CORRECT_SCHEMA,
+        })
+      } catch (e) {
+        log(`${t.slug}: correct agent crashed (round ${round + 1}, ${e.message}) — stopping corrective loop, recording as failed`)
+        corrections.push(null)
+        return { t, branch, impl, review: curReview, corrections, rounds: round, failure: { stage: 'correct', message: e.message } }
+      }
       corrections.push(correction)
       round++
       if (!correction || !correction.committed) {
         log(`${t.slug}: corrective round ${round} produced ${correction ? 'an uncommitted correction' : 'no correction'} — stopping corrective loop`)
         break
       }
-      curReview = await agent(buildReviewerPrompt(t, branch, correction), {
-        label: `review:${t.slug}:r${round}`, phase: 'Review', agentType: 'reviewer', effort: 'high', schema: REVIEW_SCHEMA,
-      })
+      try {
+        curReview = await agent(buildReviewerPrompt(t, branch, correction), {
+          label: `review:${t.slug}:r${round}`, phase: 'Review', agentType: 'reviewer', effort: 'high', schema: REVIEW_SCHEMA,
+        })
+      } catch (e) {
+        log(`${t.slug}: re-review agent crashed (round ${round}, ${e.message}) — stopping corrective loop, recording as failed`)
+        return { t, branch, impl, review: curReview, corrections, rounds: round, failure: { stage: 'review', message: e.message } }
+      }
     }
-    return { t, branch, impl, review: curReview, corrections, rounds: round }
+    return { t, branch, impl, review: curReview, corrections, rounds: round, failure: null }
   },
 )
 
 phase('Report')
 const tasks = results.map((r) => {
   if (!r) return null
-  const { t, branch, impl, review, corrections, rounds } = r
+  const { t, branch, impl, review, corrections, rounds, failure } = r
   let status
-  if (!impl || impl.status !== 'done' || !impl.committed) status = 'failed'
+  if (failure) status = 'failed'
+  else if (!impl || impl.status !== 'done' || !impl.committed) status = 'failed'
   else if (!review || review.verdict === 'revise') status = 'failed'
   else status = rounds > 0 ? 'revised-clean' : 'clean'
   return {
@@ -264,6 +315,7 @@ const tasks = results.map((r) => {
     branch,
     status,
     corrective_rounds_used: rounds,
+    failure: failure || undefined,
     impl: impl ? { status: impl.status, summary: impl.summary, files_changed: impl.files_changed, verification: impl.verification, committed: impl.committed } : null,
     review: review ? { verdict: review.verdict, lenses: review.lenses, issues: review.issues } : null,
     corrections: corrections && corrections.length ? corrections : undefined,

--- a/tests/workflows/curd-flock.test.mjs
+++ b/tests/workflows/curd-flock.test.mjs
@@ -1,0 +1,148 @@
+import assert from 'node:assert/strict'
+import { resolve } from 'node:path'
+import test from 'node:test'
+
+import { createRuntime, loadWorkflow } from './harness.mjs'
+
+const path = resolve(import.meta.dirname, '../../claude/workflows/curd-flock.js')
+
+function implementation(slug, status = 'done', committed = true) {
+  return {
+    slug,
+    branch: `curd/${slug}`,
+    status,
+    summary: 'implemented',
+    files_changed: ['src/example.js'],
+    verification: 'test: pass',
+    committed,
+    worktree_path: `/tmp/worktrees/${slug}`,
+  }
+}
+
+function review(slug, verdict) {
+  return {
+    slug,
+    verdict,
+    lenses: [],
+    issues: verdict === 'revise' ? ['fix this'] : [],
+    recommendation: verdict,
+  }
+}
+
+function correction(slug) {
+  return {
+    slug,
+    branch: `curd/${slug}`,
+    status: 'fixed',
+    summary: 'fixed',
+    committed: true,
+  }
+}
+
+test('curd-flock caps revise corrections and re-reviews each correction', async () => {
+  const workflow = await loadWorkflow(path)
+  const { globals, trace } = createRuntime({
+    respond: ({ opts }) => {
+      if (opts.label === 'implement:task') return implementation('task')
+      if (opts.label === 'review:task') return review('task', 'revise')
+      if (opts.label === 'correct:task:r1' || opts.label === 'correct:task:r2') return correction('task')
+      if (opts.label === 'review:task:r1') return review('task', 'revise')
+      if (opts.label === 'review:task:r2') return review('task', 'pass')
+      throw new Error(`unexpected agent ${opts.label}`)
+    },
+  })
+
+  const result = await workflow.run({ ...globals, args: { tasks: [{ slug: 'task', brief: 'do it' }], correctiveRounds: 2 } })
+
+  assert.equal(result.tasks[0].corrective_rounds_used, 2)
+  assert.equal(result.tasks[0].status, 'revised-clean')
+  assert.deepEqual(trace.agents.map(({ opts }) => opts.label), [
+    'implement:task', 'review:task', 'correct:task:r1', 'review:task:r1', 'correct:task:r2', 'review:task:r2',
+  ])
+
+  for (const call of trace.agents.filter(({ opts }) => opts.label.startsWith('implement:'))) {
+    assert.equal(call.opts.agentType, 'coder')
+    assert.equal(call.opts.isolation, 'worktree')
+  }
+  for (const call of trace.agents.filter(({ opts }) => opts.label.startsWith('correct:'))) {
+    assert.equal(call.opts.agentType, 'coder')
+    assert.equal(call.opts.isolation, undefined)
+  }
+  for (const call of trace.agents.filter(({ opts }) => opts.label.startsWith('review:'))) {
+    assert.equal(call.opts.agentType, 'reviewer')
+  }
+})
+
+test('curd-flock skips corrections after a first-pass review', async () => {
+  const workflow = await loadWorkflow(path)
+  const { globals, trace } = createRuntime({
+    respond: ({ opts }) => opts.label.startsWith('implement:') ? implementation('task') : review('task', 'pass'),
+  })
+
+  const result = await workflow.run({ ...globals, args: { tasks: [{ slug: 'task', brief: 'do it' }] } })
+
+  assert.equal(result.tasks[0].status, 'clean')
+  assert.equal(trace.agents.length, 2)
+  assert.equal(trace.agents.some(({ opts }) => opts.label.startsWith('correct:')), false)
+})
+
+for (const [name, status, committed] of [
+  ['non-done implementation', 'blocked', true],
+  ['uncommitted implementation', 'done', false],
+]) {
+  test(`curd-flock reports failed work without reviewing a ${name}`, async () => {
+    const workflow = await loadWorkflow(path)
+    const { globals, trace } = createRuntime({
+      respond: () => implementation('task', status, committed),
+    })
+
+    const result = await workflow.run({ ...globals, args: { tasks: [{ slug: 'task', brief: 'do it' }] } })
+
+    assert.equal(result.tasks[0].status, 'failed')
+    assert.equal(trace.agents.length, 1)
+    assert.equal(trace.agents[0].opts.agentType, 'coder')
+  })
+}
+
+test('curd-flock logs file overlap and gives coders/reviewers their required controls', async () => {
+  const workflow = await loadWorkflow(path)
+  const { globals, trace } = createRuntime({
+    respond: ({ opts }) => opts.label.startsWith('implement:')
+      ? implementation(opts.label.slice('implement:'.length))
+      : review(opts.label.split(':')[1], 'pass'),
+  })
+
+  await workflow.run({
+    ...globals,
+    args: {
+      tasks: [
+        { slug: 'one', brief: 'one', files: ['shared.js'] },
+        { slug: 'two', brief: 'two', files: ['shared.js'] },
+      ],
+    },
+  })
+
+  assert.match(trace.logs.join('\n'), /overlapping files/)
+  for (const call of trace.agents.filter(({ opts }) => opts.label.startsWith('implement:'))) {
+    assert.equal(call.opts.agentType, 'coder')
+    assert.equal(call.opts.isolation, 'worktree')
+  }
+  for (const call of trace.agents.filter(({ opts }) => opts.label.startsWith('review:'))) {
+    assert.equal(call.opts.agentType, 'reviewer')
+  }
+})
+
+test('curd-flock fails fast on duplicate task slugs before spawning any agent', async () => {
+  const workflow = await loadWorkflow(path)
+  const { globals, trace } = createRuntime({
+    respond: () => { throw new Error('no agent should be spawned') },
+  })
+
+  const result = await workflow.run({
+    ...globals,
+    args: { tasks: [{ slug: 'dup', brief: 'one' }, { slug: 'dup', brief: 'two' }] },
+  })
+
+  assert.match(result.error, /Duplicate task slug/)
+  assert.equal(trace.agents.length, 0)
+})

--- a/tests/workflows/curd-flock.test.mjs
+++ b/tests/workflows/curd-flock.test.mjs
@@ -146,3 +146,133 @@ test('curd-flock fails fast on duplicate task slugs before spawning any agent', 
   assert.match(result.error, /Duplicate task slug/)
   assert.equal(trace.agents.length, 0)
 })
+
+test('curd-flock keeps a task in the report when review crashes after a committed impl (finding 2)', async () => {
+  const workflow = await loadWorkflow(path)
+  const { globals, trace } = createRuntime({
+    respond: ({ opts }) => {
+      if (opts.label === 'implement:task') return implementation('task')
+      if (opts.label === 'review:task') throw new Error('reviewer crashed')
+      throw new Error(`unexpected agent ${opts.label}`)
+    },
+  })
+
+  const result = await workflow.run({ ...globals, args: { tasks: [{ slug: 'task', brief: 'do it' }] } })
+
+  // finding 2: a thrown agent() must not drop the task from the report — slug+branch and a failed status must survive.
+  assert.equal(result.tasks.length, 1)
+  assert.equal(result.tasks[0].slug, 'task')
+  assert.equal(result.tasks[0].branch, 'curd/task')
+  assert.equal(result.tasks[0].status, 'failed')
+  assert.equal(result.tasks[0].failure.stage, 'review')
+  assert.match(trace.logs.join('\n'), /review agent crashed/)
+})
+
+test('curd-flock reports failed when corrective rounds are exhausted with review still revise', async () => {
+  const workflow = await loadWorkflow(path)
+  const { globals } = createRuntime({
+    respond: ({ opts }) => {
+      if (opts.label === 'implement:task') return implementation('task')
+      if (opts.label === 'review:task') return review('task', 'revise')
+      if (opts.label === 'correct:task:r1') return correction('task')
+      if (opts.label === 'review:task:r1') return review('task', 'revise')
+      throw new Error(`unexpected agent ${opts.label}`)
+    },
+  })
+
+  // finding 6b: exhausting correctiveRounds without a clean review must land on status 'failed', not silently pass.
+  const result = await workflow.run({ ...globals, args: { tasks: [{ slug: 'task', brief: 'do it' }], correctiveRounds: 1 } })
+
+  assert.equal(result.tasks[0].status, 'failed')
+  assert.equal(result.tasks[0].corrective_rounds_used, 1)
+})
+
+test('curd-flock stops the corrective loop on an uncommitted correction', async () => {
+  const workflow = await loadWorkflow(path)
+  const { globals, trace } = createRuntime({
+    respond: ({ opts }) => {
+      if (opts.label === 'implement:task') return implementation('task')
+      if (opts.label === 'review:task') return review('task', 'revise')
+      if (opts.label === 'correct:task:r1') return { ...correction('task'), committed: false }
+      throw new Error(`unexpected agent ${opts.label}`)
+    },
+  })
+
+  // finding 6c: an uncommitted correction must break the loop immediately rather than re-reviewing nothing.
+  const result = await workflow.run({ ...globals, args: { tasks: [{ slug: 'task', brief: 'do it' }], correctiveRounds: 2 } })
+
+  assert.equal(result.tasks[0].status, 'failed')
+  assert.equal(result.tasks[0].corrective_rounds_used, 1)
+  assert.equal(trace.agents.filter(({ opts }) => opts.label.startsWith('correct:')).length, 1)
+  assert.match(trace.logs.join('\n'), /uncommitted correction/)
+})
+
+test('curd-flock accepts args as a JSON string', async () => {
+  const workflow = await loadWorkflow(path)
+  const { globals } = createRuntime({
+    respond: ({ opts }) => opts.label.startsWith('implement:') ? implementation('task') : review('task', 'pass'),
+  })
+
+  // finding 6d: args may arrive as a JSON string (some Workflow-tool invocations serialize it) rather than an object.
+  const result = await workflow.run({ ...globals, args: JSON.stringify({ tasks: [{ slug: 'task', brief: 'do it' }] }) })
+
+  assert.equal(result.tasks[0].status, 'clean')
+})
+
+for (const bad of [-1, 1.5, 'two', null]) {
+  test(`curd-flock falls back to correctiveRounds=1 for invalid value ${JSON.stringify(bad)}`, async () => {
+    const workflow = await loadWorkflow(path)
+    const { globals } = createRuntime({
+      respond: ({ opts }) => {
+        if (opts.label === 'implement:task') return implementation('task')
+        if (opts.label === 'review:task') return review('task', 'revise')
+        if (opts.label === 'correct:task:r1') return correction('task')
+        if (opts.label === 'review:task:r1') return review('task', 'pass')
+        throw new Error(`unexpected agent ${opts.label}`)
+      },
+    })
+
+    // finding 6e: a negative/non-integer correctiveRounds must fall back to the default of 1, not 0 or NaN rounds.
+    const result = await workflow.run({ ...globals, args: { tasks: [{ slug: 'task', brief: 'do it' }], correctiveRounds: bad } })
+
+    assert.equal(result.tasks[0].corrective_rounds_used, 1)
+    assert.equal(result.tasks[0].status, 'revised-clean')
+  })
+}
+
+for (const [name, tasks] of [
+  ['metachar slug', [{ slug: 'task; rm -rf', brief: 'do it' }]],
+  ['missing slug', [{ brief: 'do it' }]],
+  ['missing brief', [{ slug: 'task' }]],
+  ['empty brief', [{ slug: 'task', brief: '' }]],
+]) {
+  test(`curd-flock fails fast on ${name} before spawning any agent (finding 1)`, async () => {
+    const workflow = await loadWorkflow(path)
+    const { globals, trace } = createRuntime({
+      respond: () => { throw new Error('no agent should be spawned') },
+    })
+
+    // finding 1: curd/<slug> is interpolated into a literal `git checkout -B` command — an invalid slug must reject before any agent spawns.
+    const result = await workflow.run({ ...globals, args: { tasks } })
+
+    assert.match(result.error, /Invalid task slug\/brief/)
+    assert.equal(trace.agents.length, 0)
+  })
+}
+
+test('curd-flock clamps correctiveRounds above the max of 3 (finding 4)', async () => {
+  const workflow = await loadWorkflow(path)
+  const { globals, trace } = createRuntime({
+    respond: ({ opts }) => {
+      if (opts.label.startsWith('implement:')) return implementation('task')
+      if (opts.label.startsWith('correct:')) return correction('task')
+      return review('task', 'revise')
+    },
+  })
+
+  // finding 4: correctiveRounds must clamp to MAX_CORRECTIVE_ROUNDS (3), mirroring triage-sweep's MAX_LIMIT pattern.
+  const result = await workflow.run({ ...globals, args: { tasks: [{ slug: 'task', brief: 'do it' }], correctiveRounds: 10 } })
+
+  assert.equal(result.tasks[0].corrective_rounds_used, 3)
+  assert.match(trace.logs.join('\n'), /clamping to 3/)
+})


### PR DESCRIPTION
Stacked on #436 (offline workflow test harness). Split out of the original #436 workflow farm.

## What

`curd-flock` — worktree-isolated coder fan-out: implement → 5-lens review → bounded correction per file-disjoint task. Never pushes or merges; hands branches back to the orchestrator. Canonicalizes three ad-hoc session scripts.

Includes the affinage cure-pass fixes: corrective pass reuses the impl worktree via a required `worktree_path` schema field (no branch-collision respawn), duplicate-slug fail-fast, correction-loop exit logging, single `branchFor()` derivation, and the latest correction digest feeding the re-review.

## Verification

- `just check` green on this branch (lint, 1192 bats tests, workflow suite incl. `curd-flock.test.mjs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
