### PR TITLE
docs(skills): document two-leg external-skill flow; fix nested node_modules lint gap

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -9,7 +9,9 @@ config:
   no-emphasis-as-heading: false
 
 ignores:
-  - node_modules/**
+  # Match node_modules at any depth — skills that npm-install (e.g.
+  # skills/roadmap/scripts) create nested trees the root glob misses.
+  - "**/node_modules/**"
   - .worktrees/**
   - reference/**
   - tmux/plugins/**

--- a/skills/_registry.yaml
+++ b/skills/_registry.yaml
@@ -1,4 +1,8 @@
-# Skill Install Registry — source repos to sync via `npx skills add`
+# Skill Install Registry — external skill source repos, consumed by two legs:
+#   1. chezmoi assembly (_cz_vendor_external_skills in .sync-lib.sh): vendors
+#      skills for claude + omp on every `dots sync`.
+#   2. npx `skills add` (chezmoi/lib/install-external.sh): installs into the
+#      non-claude harnesses (SKILL_HARNESSES); run by `dots upgrade`.
 #
 # Each entry is a GitHub repo in OWNER/REPO format. Skills are auto-discovered
 # by the `skills` CLI (`--skill '*'`) from `skills/<name>/SKILL.md` per the
@@ -22,7 +26,8 @@
 # Harnesses are configured in .env via SKILL_HARNESSES (space-separated).
 #
 # Usage:
-#   skill-sync           Install/update all skills for each configured harness
+#   dots sync            Vendor + deploy for claude/omp (chezmoi leg)
+#   dots upgrade         Also refresh non-claude harnesses (npx leg, --force)
 #   skill-ls             List installed global skills (npx skills list --global)
 
 sources:


### PR DESCRIPTION
## What

Two small fixes from an audit of the external-skill install system:

1. **`skills/_registry.yaml` header** — the Usage block referenced `skill-sync`, a command that no longer exists. Rewritten to document the real two-leg flow:
   - **chezmoi assembly leg** (`_cz_vendor_external_skills` in `.sync-lib.sh`): vendors external skills for claude + omp on every `dots sync`.
   - **npx `skills add` leg** (`chezmoi/lib/install-external.sh`): installs into the non-claude harnesses (`SKILL_HARNESSES`); run by `dots upgrade` with `SKILL_EXCLUDE_AGENTS=claude-code` (`bin/dots:439`).

2. **`.markdownlint-cli2.yaml`** — `node_modules/**` only excludes a root-level tree. Skills that npm-install (e.g. `skills/roadmap/scripts` on the in-flight roadmap branch) create nested `node_modules` trees, and `just check` then fails with ~90 MD* errors on vendored READMEs. Now `**/node_modules/**`.

## Verification

- `just check` exits 0 on this branch.
- Both install legs verified working: 121/121 bats tests across `skills-external.bats`, `chezmoi-wiring.bats`, `dots.bats`; `install-external.sh --dry-run` targets the right harnesses and skips omp-only sources; `dots sync` deploys skills byte-identical to the vendor cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)