### PR TITLE
refactor(workflows): rename ultracook-fleet to milknado-fleet

### DIFF
--- a/claude/workflows/milknado-fleet-worker.toml
+++ b/claude/workflows/milknado-fleet-worker.toml
@@ -1,4 +1,4 @@
-# milknado.toml — ultracook-fleet partition worker config
+# milknado.toml — milknado-fleet partition worker config
 #
 # This file is copied into each partition worktree by the Partition phase.
 # It configures the claude -p execution agent and empty quality_gates

--- a/claude/workflows/milknado-fleet.js
+++ b/claude/workflows/milknado-fleet.js
@@ -1,5 +1,5 @@
 export const meta = {
-  name: 'ultracook-fleet',
+  name: 'milknado-fleet',
   description:
     'Parallelize the easy-cheese pipeline (cook→press→age→cure→age→cure→age) across an entire hallouminate roadmap. Each roadmap goal becomes a git branch + PR, driven by milknado as the execution engine.',
   whenToUse:
@@ -13,11 +13,11 @@ export const meta = {
   ],
 }
 
-// Tracked source: claude/workflows/ultracook-fleet.js in the dotfiles repo.
+// Tracked source: claude/workflows/milknado-fleet.js in the dotfiles repo.
 // Deployed to ~/.claude/workflows/ as a symlink by claude/.sync (the `configs`
-// array). Invoked as `/ultracook-fleet <roadmap-slug>`; `args` is the slug.
+// array). Invoked as `/milknado-fleet <roadmap-slug>`; `args` is the slug.
 //
-// Architecture (spec: ultracook-fleet):
+// Architecture (spec: milknado-fleet):
 //   - MCP calls (milknado MCP tools) live INSIDE agent() calls — MCP is
 //     undefined in Workflow script scope (node-runner.js:9-14).
 //   - The .js script owns deterministic fan-out, sequencing, and schema.
@@ -136,7 +136,7 @@ function partitionPrompt(goal, roadmapSlug, projectRoot, mainBranch) {
   const branch = `uf/${goal.slug}`
   const wt = `${projectRoot}/.worktrees/uf-${goal.slug}`
   return [
-    'You are building one partition for an ultracook-fleet run.',
+    'You are building one partition for a milknado-fleet run.',
     '',
     `Goal id: ${goal.id}`,
     `Goal slug: ${goal.slug}`,
@@ -153,7 +153,7 @@ function partitionPrompt(goal, roadmapSlug, projectRoot, mainBranch) {
     '   If the worktree already exists (branch already exists or path exists), skip creation.',
     '',
     '2. Copy the milknado.toml worker config into the partition worktree:',
-    `   cp ${projectRoot}/claude/workflows/ultracook-fleet-worker.toml ${wt}/milknado.toml`,
+    `   cp ${projectRoot}/claude/workflows/milknado-fleet-worker.toml ${wt}/milknado.toml`,
     '   (This sets execution_agent and quality_gates for the partition.)',
     '',
     '3. Initialize milknado db in the partition worktree:',
@@ -282,8 +282,8 @@ function harvestPrompt(partition, roadmapSlug, projectRoot, mainBranch, isWip) {
     '',
     '3. Open a PR for this partition:',
     `   gh pr create --base ${mainBranch} --head ${partition.branch}${isWip ? ' --draft' : ''}`,
-    `     --title "${titlePrefix}feat(${partition.goal_slug}): easy-cheese pipeline via ultracook-fleet"`,
-    `     --body "Automated by /ultracook-fleet roadmap=${roadmapSlug} goal=${partition.goal_slug}.`,
+    `     --title "${titlePrefix}feat(${partition.goal_slug}): easy-cheese pipeline via milknado-fleet"`,
+    `     --body "Automated by /milknado-fleet roadmap=${roadmapSlug} goal=${partition.goal_slug}.`,
     `            Phases: cook→press→age→cure→age→cure→age (all run as milknado tasks)."`,
     '   Capture the PR URL from the output.',
     '',
@@ -314,8 +314,8 @@ const rawArg =
 const roadmapSlug = rawArg.trim()
 
 if (!roadmapSlug) {
-  log('No roadmap slug provided. Usage: /ultracook-fleet <roadmap-slug>')
-  return { error: 'No roadmap slug provided. Usage: /ultracook-fleet <roadmap-slug>' }
+  log('No roadmap slug provided. Usage: /milknado-fleet <roadmap-slug>')
+  return { error: 'No roadmap slug provided. Usage: /milknado-fleet <roadmap-slug>' }
 }
 
 // Resolve project root: this workflow runs in the primary checkout.

--- a/docs/adr/workflow-test-harness-003.md
+++ b/docs/adr/workflow-test-harness-003.md
@@ -4,3 +4,5 @@
 - **Decision:** Delete `tests/workflows-parse.sh`; port its parse check (as `all-parse.test.mjs` over all shipped workflow scripts) and `ultracook-fleet-worker.toml` key checks into the node:test suite; repoint `just smoke` at `tests/workflows-test.sh`; update the justfile `lint-shell` file list; add `just smoke` to the CI `test` job.
 - **Alternatives:** (a) Keep both scripts side by side — rejected: split-brain guard, the grep-based one keeps producing false green. (b) Leave workflow tests local-only — rejected: a guard that never runs on PRs cannot gate regressions.
 - **Consequences:** One guard, CI-enforced. Cost: CI `test` job now needs node (preinstalled on ubuntu-latest runners) and the smoke leg's runtime (~seconds).
+
+(2026-07: `ultracook-fleet*` renamed to `milknado-fleet*`; the checks now target the renamed files.)

--- a/tests/workflows/all-parse.test.mjs
+++ b/tests/workflows/all-parse.test.mjs
@@ -89,8 +89,8 @@ test('every workflow declares the meta fields the runtime requires', async () =>
   }
 })
 
-test('ultracook worker config retains its required execution keys', async () => {
-  const source = await readFile(resolve(root, 'claude/workflows/ultracook-fleet-worker.toml'), 'utf8')
+test('milknado worker config retains its required execution keys', async () => {
+  const source = await readFile(resolve(root, 'claude/workflows/milknado-fleet-worker.toml'), 'utf8')
 
   for (const key of ['execution_agent', 'quality_gates', 'concurrency_limit', 'db_path', 'worktree_pattern']) {
     assert.match(source, new RegExp(`^${key}\\s*=`, 'm'), key)

--- a/tests/workflows/milknado-fleet.test.mjs
+++ b/tests/workflows/milknado-fleet.test.mjs
@@ -4,10 +4,10 @@ import test from 'node:test'
 
 import { createRuntime, loadWorkflow } from './harness.mjs'
 
-const path = resolve(import.meta.dirname, '../../claude/workflows/ultracook-fleet.js')
+const path = resolve(import.meta.dirname, '../../claude/workflows/milknado-fleet.js')
 
 for (const args of [undefined, '', {}, { roadmap_slug: '   ' }]) {
-  test(`ultracook-fleet rejects an empty roadmap slug before dispatching agents: ${JSON.stringify(args)}`, async () => {
+  test(`milknado-fleet rejects an empty roadmap slug before dispatching agents: ${JSON.stringify(args)}`, async () => {
     const workflow = await loadWorkflow(path)
     const { globals, trace } = createRuntime()
 


### PR DESCRIPTION
## What

Mechanical rename of the saved workflow `ultracook-fleet` → `milknado-fleet`: the workflow is the dotfiles-authored orchestration layer over the external milknado execution engine, so the name should reflect the engine. `ultracook` is freed up for the Claude-native full-pipeline workflow (curd-flock v2, upcoming).

- `claude/workflows/milknado-fleet.js` + `milknado-fleet-worker.toml` + test file renamed; meta.name, comments, prompt literals, usage errors updated
- `all-parse.test.mjs` repointed; dated appendix line on ADR workflow-test-harness-003
- Zero behavior change: schemas, phase logic, `uf/` branch/worktree prefixes untouched; `/ultracook` skill references untouched

## Verification

- `just check` green on this branch (prek lint, 1192 bats tests, workflow suite 34/34 incl. renamed `milknado-fleet` cases)
- Fresh-context taste-test: 5/5 lenses pass; grep confirms only historical ADR text still says `ultracook-fleet`

🤖 Generated with [Claude Code](https://claude.com/claude-code)