### PR TITLE
Add routine-env skill and env definitions for Claude Cloud provisioning

### DIFF
--- a/chezmoi/.chezmoidata/claude.yaml
+++ b/chezmoi/.chezmoidata/claude.yaml
@@ -267,6 +267,7 @@ claude:
     - nih-audit
     - prompt-analytics
     - rennet
+    - routine-env
     - routine-scaffold
     - serena-project-config
     - session-analytics

--- a/envs/README.md
+++ b/envs/README.md
@@ -1,0 +1,65 @@
+# envs/
+
+A **routine env** is a named bundle of Claude Code plugins + MCP servers + skill packs, defined once
+as data and rendered into a setup-script body by the `routine-env` skill (`skills/routine-env/`).
+
+This directory is consumed **only** by that skill. It is not wired into `ap`, `profiles/base`, the
+`agents/` registries, or `dots sync` — an env defn is not a rendered artifact.
+
+## Why a routine env, not just committed `.claude/`
+
+A "routine env" targets **Claude Cloud** (Claude Code on the web, `claude.ai/code`), a different
+product from Managed Agents (`ant beta:environments`). Per
+`.cheese/research/routine-env-provisioning/routine-env-provisioning.md`:
+
+- Claude Cloud's per-environment setup script is **UI-configured** — plain bash typed into the
+  environment dialog, not a repo-committed file, and there is **no CLI to push it from git**
+  (`<certain>`, addendum A1/A5). It runs once per build cache-miss and persists into every session
+  from that cached container until invalidated (addendum A2).
+- Separately, a repo's committed `.claude/settings.json` (`enabledPlugins`/`extraKnownMarketplaces`)
+  auto-installs at cloud session start, and `.claude/skills/` loads with the clone — zero install step
+  (addendum A1). That is the git-native alternative path when you don't need the setup-script route.
+
+Because there is no push API for the Claude Cloud setup script, `envs/*.yaml` is the source of truth
+and the `routine-env` skill **renders** an idempotent bash body from it — the user pastes that body
+into the Claude Cloud environment dialog (or runs it locally via `apply-local`).
+
+## Schema
+
+```yaml
+name: cheese-core
+description: <one line>
+marketplaces:                 # → claude plugin marketplace add <ref>
+  - ref: paulnsorensen/hallouminate     # owner/repo or URL the CLI accepts
+plugins:                      # → claude plugin install <id>
+  - id: hallouminate@hallouminate       # <plugin>@<marketplace-id>; CONFIRM id via `claude plugin marketplace list`
+mcp:                          # npx-launched MCP servers (NOT plugins)
+  - name: tilth
+    package: "@paulnsorensen/tilth-nightly"
+skills:                       # skill packs via the skills CLI
+  - pack: paulnsorensen/easy-cheese
+    args: "--all --global"    # per easy-cheese README: npx skills@latest add paulnsorensen/easy-cheese --all --global
+```
+
+`plugins[].id` marketplace coordinates come from `agents/plugins/registry.yaml` (the cross-harness
+plugin registry) — do not invent new coordinates here; that registry is the source of truth for which
+plugin lives at which marketplace. Every `plugins[].id` carries an inline comment that the exact id
+must be confirmed via `claude plugin marketplace list` before use, since the marketplace's `.name`
+field in its `marketplace.json` is not assumed by this file.
+
+## Env defns
+
+- `cheese-core.yaml` — hallouminate wiki MCP/plugin + tilth-nightly MCP + easy-cheese review skills.
+- `milknado.yaml` — milknado Mikado execution plugin + easy-cheese review skills (skills list has an
+  open `TODO(confirm)` for additional packs).
+
+## Consumption
+
+The `routine-env` skill (`skills/routine-env/SKILL.md`) reads an `envs/<name>.yaml` and:
+
+- `render <env>` — emits one idempotent bash setup-script body to paste into the Claude Cloud UI.
+- `apply-local <env>` — runs the same commands on the current machine.
+- `update <env>` — re-renders after bumping plugin/skill versions.
+- `new <name>` — scaffolds a fresh `envs/<name>.yaml` from this schema.
+
+See that skill for the full flow and the "what it never does" boundary.

--- a/envs/README.md
+++ b/envs/README.md
@@ -42,16 +42,38 @@ skills:                       # skill packs via the skills CLI
 ```
 
 `plugins[].id` marketplace coordinates come from `agents/plugins/registry.yaml` (the cross-harness
-plugin registry) — do not invent new coordinates here; that registry is the source of truth for which
-plugin lives at which marketplace. Every `plugins[].id` carries an inline comment that the exact id
-must be confirmed via `claude plugin marketplace list` before use, since the marketplace's `.name`
+plugin registry) where an entry exists — do not invent new coordinates here when it does; that registry
+is the source of truth for which plugin lives at which marketplace. **Exception:** `tilth` has no entry
+in `agents/plugins/registry.yaml` (only `hallouminate` and `milknado` are registered there), so its
+`ref`/`id` are sourced directly from the `paulnsorensen/tilth` repo instead — see "Known gaps" below for
+why that repo isn't registry-eligible yet. Every `plugins[].id` carries an inline comment that the exact
+id must be confirmed via `claude plugin marketplace list` before use, since the marketplace's `.name`
 field in its `marketplace.json` is not assumed by this file.
 
 ## Env defns
 
-- `cheese-core.yaml` — hallouminate wiki MCP/plugin + tilth-nightly MCP + easy-cheese review skills.
-- `milknado.yaml` — milknado Mikado execution plugin + easy-cheese review skills (skills list has an
-  open `TODO(confirm)` for additional packs).
+- `cheese-core.yaml` — hallouminate wiki MCP/plugin + tilth-nightly MCP + tilth-cwd-inject plugin +
+  easy-cheese review skills.
+- `milknado.yaml` — same bundle as `cheese-core.yaml`, plus the milknado Mikado execution plugin
+  (skills list has an open `TODO(confirm)` for additional packs).
+
+## Known gaps
+
+- **`tilth-cwd-inject@tilth` is currently non-installable.** `<certain>` (verified via
+  `gh api repos/paulnsorensen/tilth/git/trees/main?recursive=true` on 2026-07-18): the `paulnsorensen/tilth`
+  repo has no root `.claude-plugin/marketplace.json` — only `plugin/claude/.claude-plugin/plugin.json`
+  (a bare plugin payload named `tilth-cwd-inject`, not a marketplace). Compare `paulnsorensen/hallouminate`
+  and `paulnsorensen/milknado`, both of which have a root `.claude-plugin/marketplace.json`. Until tilth's
+  upstream adds one (mirroring hallouminate's `{name, plugins: [{name, source}]}` shape),
+  `claude plugin marketplace add paulnsorensen/tilth` will fail, and `tilth-cwd-inject@tilth` is a
+  placeholder id — same as the existing `CONFIRM via claude plugin marketplace list` caveat on every
+  other `plugins[].id`, just with a stronger, verified-broken severity rather than merely-unconfirmed.
+- The `tilth-cwd-inject` plugin only bundles the PreToolUse hook that auto-injects `cwd` into tilth MCP
+  calls (mirrors the hand-wired hook in this repo's own `chezmoi/.chezmoidata/claude.yaml`) — it does
+  **not** bundle an `.mcp.json`, so it cannot replace the `mcp:` entry that actually launches the tilth
+  MCP server. Both entries are required; removing `mcp:` would drop tilth entirely. `<don't know>`
+  whether tilth MCP calls still function without the hook (e.g. by passing `cwd` explicitly) or error
+  outright — not tested.
 
 ## Consumption
 

--- a/envs/cheese-core.yaml
+++ b/envs/cheese-core.yaml
@@ -1,9 +1,11 @@
 name: cheese-core
-description: Core hallouminate wiki + tilth-nightly MCP + easy-cheese review skills for a general Claude Cloud session
+description: Core hallouminate wiki + tilth-nightly MCP + tilth-cwd-inject plugin + easy-cheese review skills for a general Claude Cloud session
 marketplaces:                 # → claude plugin marketplace add <ref>
   - ref: paulnsorensen/hallouminate     # owner/repo the CLI accepts (source: agents/plugins/registry.yaml)
+  - ref: paulnsorensen/tilth            # BLOCKED — no root marketplace.json yet; see envs/README.md#known-gaps
 plugins:                      # → claude plugin install <id>
   - id: hallouminate@hallouminate       # <plugin>@<marketplace-id>; CONFIRM id via `claude plugin marketplace list`
+  - id: tilth-cwd-inject@tilth          # cwd-injects tilth MCP calls; NOT the MCP server itself (see mcp: below); BLOCKED, see envs/README.md#known-gaps
 mcp:                          # npx-launched MCP servers (NOT plugins)
   - name: tilth
     package: "@paulnsorensen/tilth-nightly"

--- a/envs/cheese-core.yaml
+++ b/envs/cheese-core.yaml
@@ -1,0 +1,12 @@
+name: cheese-core
+description: Core hallouminate wiki + tilth-nightly MCP + easy-cheese review skills for a general Claude Cloud session
+marketplaces:                 # → claude plugin marketplace add <ref>
+  - ref: paulnsorensen/hallouminate     # owner/repo the CLI accepts (source: agents/plugins/registry.yaml)
+plugins:                      # → claude plugin install <id>
+  - id: hallouminate@hallouminate       # <plugin>@<marketplace-id>; CONFIRM id via `claude plugin marketplace list`
+mcp:                          # npx-launched MCP servers (NOT plugins)
+  - name: tilth
+    package: "@paulnsorensen/tilth-nightly"
+skills:                       # skill packs via the skills CLI
+  - pack: paulnsorensen/easy-cheese
+    args: "--all --global"    # per easy-cheese README: npx skills@latest add paulnsorensen/easy-cheese --all --global

--- a/envs/milknado.yaml
+++ b/envs/milknado.yaml
@@ -1,0 +1,10 @@
+name: milknado
+description: Milknado Mikado execution engine for goal-graph-driven Claude Cloud sessions
+marketplaces:                 # → claude plugin marketplace add <ref>
+  - ref: paulnsorensen/milknado         # owner/repo the CLI accepts (source: agents/plugins/registry.yaml)
+plugins:                      # → claude plugin install <id>
+  - id: milknado@milknado               # <plugin>@<marketplace-id>; CONFIRM id via `claude plugin marketplace list`
+skills:                       # skill packs via the skills CLI
+  # TODO(confirm): "the recent" packs — user to name which additional packs belong here
+  - pack: paulnsorensen/easy-cheese
+    args: "--all --global"    # per easy-cheese README: npx skills@latest add paulnsorensen/easy-cheese --all --global

--- a/envs/milknado.yaml
+++ b/envs/milknado.yaml
@@ -1,9 +1,16 @@
 name: milknado
-description: Milknado Mikado execution engine for goal-graph-driven Claude Cloud sessions
+description: Same as cheese-core (hallouminate wiki + tilth-nightly MCP + tilth-cwd-inject plugin + easy-cheese review skills), plus the Milknado Mikado execution engine, for goal-graph-driven Claude Cloud sessions
 marketplaces:                 # → claude plugin marketplace add <ref>
+  - ref: paulnsorensen/hallouminate     # owner/repo the CLI accepts (source: agents/plugins/registry.yaml)
+  - ref: paulnsorensen/tilth            # BLOCKED — no root marketplace.json yet; see envs/README.md#known-gaps
   - ref: paulnsorensen/milknado         # owner/repo the CLI accepts (source: agents/plugins/registry.yaml)
 plugins:                      # → claude plugin install <id>
+  - id: hallouminate@hallouminate       # <plugin>@<marketplace-id>; CONFIRM id via `claude plugin marketplace list`
+  - id: tilth-cwd-inject@tilth          # cwd-injects tilth MCP calls; NOT the MCP server itself (see mcp: below); BLOCKED, see envs/README.md#known-gaps
   - id: milknado@milknado               # <plugin>@<marketplace-id>; CONFIRM id via `claude plugin marketplace list`
+mcp:                          # npx-launched MCP servers (NOT plugins)
+  - name: tilth
+    package: "@paulnsorensen/tilth-nightly"
 skills:                       # skill packs via the skills CLI
   # TODO(confirm): "the recent" packs — user to name which additional packs belong here
   - pack: paulnsorensen/easy-cheese

--- a/skills/routine-env/SKILL.md
+++ b/skills/routine-env/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: routine-env
+model: sonnet
+effort: medium
+allowed-tools: Read, Write, Edit, Bash(claude:*), Bash(npx:*), Bash(jq:*), Bash(yq:*), mcp__tilth__*
+description: >
+  Render or apply a "routine env" — a named bundle of Claude Code plugins + MCP
+  servers + skill packs defined in `envs/<name>.yaml` — into a setup-script body
+  for Claude Cloud (Claude Code on the web), or apply it to the local machine.
+  Use when the user says "set up a routine env", "provision my Claude Cloud
+  environment", "install my cheese env", "render the setup script for <env>",
+  "update my env", "scaffold a new env", or invokes "/routine-env". Do NOT use
+  for cloud cron/scheduled agents that open PRs (that is `routine-scaffold`) or
+  for a personal CLAUDE.md preferences overlay in a contributed repo (that is
+  `claude-local`) — routine-env is about plugin/MCP/skill provisioning only.
+---
+
+# routine-env
+
+Turns an `envs/<name>.yaml` bundle definition into the commands that actually
+install it — either as a setup-script body to paste into the Claude Cloud UI,
+or run directly on the local machine.
+
+## What a routine env is
+
+A **routine env** = a named, versioned bundle of:
+
+- **marketplaces** — `claude plugin marketplace add <ref>` sources
+- **plugins** — `claude plugin install <id>` targets (`<plugin>@<marketplace-id>`)
+- **mcp** — npx-launched MCP servers (not plugins)
+- **skills** — skill packs installed via the `npx skills@latest` CLI
+
+Definitions live in `envs/<name>.yaml` at the repo root (see `envs/README.md`
+for the full schema and field-by-field rationale). This skill is the only
+consumer of `envs/` — the directory is standalone data, not wired into `ap`,
+`profiles/base`, the `agents/` registries, or `dots sync`.
+
+## The Claude Cloud reality
+
+"Claude Cloud" here means **Claude Code on the web** (`claude.ai/code`), a
+different product from Managed Agents (`ant beta:environments`). Ground facts
+from `.cheese/research/routine-env-provisioning/routine-env-provisioning.md`
+(addendum, A1/A2/A5):
+
+- The environment's setup script is **UI-configured plain bash** — typed into
+  the Claude Cloud environment dialog's "setup script" field. It is **not** a
+  repo-committed file, and `<certain>` there is **no CLI/API to push it from
+  git**. This skill cannot write directly to that dialog — it can only render
+  the bash body for the user to paste in.
+- The setup script runs **once per build cache-miss** (first run, or after an
+  invalidating change) and then persists into every session reusing that
+  cached container — it is not re-run per session.
+- **A3 caveat — the setup-script install path is unverified.** Whether
+  `claude`/`node`/`npx` are even available inside the setup-script shell, and
+  whether a plugin or skill installed there survives into the booted session,
+  is graded `<don't know>` in the research (A3): every official setup-script
+  example is plain OS commands (`apt install`, `docker compose`); none invoke
+  `claude`, `npx`, or `node`. Spike this empirically on a real Claude Cloud
+  environment before relying on the rendered setup script for plugins/skills.
+- **The confirmed (`<certain>`) path for plugins/skills-only envs is
+  git-native, not the setup script.** A repo's committed
+  `.claude/settings.json` (`enabledPlugins`/`extraKnownMarketplaces`)
+  auto-installs at cloud session start with zero setup-script involvement,
+  and `.claude/skills/` loads with the clone — no install step, no A3
+  uncertainty. When an env only needs plugins/skills (no OS packages, no
+  services), committing to `.claude/` is the confirmed default, and
+  `render`ing a setup-script body is the fallback for what that path can't
+  cover (OS packages, background services) — not the default over a
+  confirmed path. Mention the `.claude/` alternative to the user before
+  reaching for `render` on a plugins/skills-only env.
+
+## Modes
+
+### `render <env>`
+
+1. Read `envs/<env>.yaml`.
+2. Emit **one** idempotent bash setup-script body, in this order:
+   - `claude plugin marketplace add <ref>` for each `marketplaces[]` entry
+   - `claude plugin install <id>` for each `plugins[]` entry
+   - `claude mcp add <name> -- npx -y <package>` for each `mcp[]` entry
+     (e.g. `claude mcp add tilth -- npx -y @paulnsorensen/tilth-nightly`)
+   - `npx skills@latest add <pack> <args>` for each `skills[]` entry
+3. Every command must be safe to re-run (idempotent) — rely on each CLI's own
+   already-installed/already-added no-op behavior; do not add custom existence
+   checks that duplicate what the CLI already handles.
+4. Print the rendered body as a single fenced bash block the user can paste
+   verbatim into the Claude Cloud environment dialog's setup-script field.
+
+### `apply-local <env>`
+
+Run the same rendered commands directly on the current machine via `Bash`, in
+the same order as `render`. Report each command's outcome.
+
+### `update <env>`
+
+Bump plugin/skill versions or ids in `envs/<env>.yaml` (e.g. after confirming
+a new marketplace id or skill pack revision), then re-run `render <env>` so
+the user has the refreshed setup-script body to re-paste.
+
+### `new <name>`
+
+Scaffold a fresh `envs/<name>.yaml` from the locked schema in `envs/README.md`
+(`name`, `description`, `marketplaces`, `plugins`, `mcp`, `skills`), with the
+same inline confirm-comment on every `plugins[].id`. Leave placeholder values
+for the user to fill in — do not fabricate marketplace ids or skill packs.
+
+## Verification
+
+- Confirm every `plugins[].id` marketplace segment against `claude plugin
+  marketplace list` before treating it as final — a marketplace's actual
+  `.name` in its `marketplace.json` is not assumed by `envs/*.yaml`.
+- Reuse plugin coordinates from `agents/plugins/registry.yaml` (the
+  cross-harness plugin registry) — that file is the source of truth for which
+  plugin lives at which marketplace; do not invent new coordinates in
+  `envs/*.yaml`.
+
+## What it never does
+
+- **Not cloud cron/scheduled agents.** A routine env provisions plugins/MCP/
+  skills for a session to boot with; it never authors a recurring watcher that
+  opens PRs — that is `routine-scaffold`.
+- **Not a CLAUDE.md preferences overlay.** It does not distill or write a
+  `CLAUDE.local.md` — that is `claude-local`.
+- **Does not wire into `ap`, `profiles/base`, the `agents/` registries, or
+  `dots sync`.** `envs/` is standalone data consumed only by this skill.
+- **Does not push the rendered setup script into the Claude Cloud UI
+  programmatically** — no such CLI/API exists (see "The Claude Cloud reality"
+  above); the user pastes the rendered body in manually.
+- **Does not fabricate marketplace ids or skill packs** — every id traces to
+  `agents/plugins/registry.yaml` or an explicit user-confirmed source, with the
+  `claude plugin marketplace list` confirmation step called out above.


### PR DESCRIPTION
## What

Introduces a **routine env** mechanism: named, versioned bundles of Claude Code plugins + MCP servers + skill packs that provision a **Claude Cloud** (Claude Code on the web) environment before an agent boots.

- **`envs/`** — standalone data dir (consumed only by the skill; *not* wired into `ap`, `profiles/`, the registries, or `dots sync`):
  - `envs/README.md` — the env-defn schema + Claude Cloud provisioning mechanics.
  - `envs/cheese-core.yaml` — hallouminate plugin, tilth MCP, easy-cheese skills.
  - `envs/milknado.yaml` — milknado plugin + easy-cheese (with a `TODO(confirm)` for "the recent" packs).
- **`skills/routine-env/SKILL.md`** — renders an env defn into a setup-script body to paste into the Claude Cloud UI (or applies it locally). Modes: `render` / `apply-local` / `update` / `new`.
- Registers `routine-env` in `chezmoi/.chezmoidata/claude.yaml` skills.

## Why it looks like this

Research (`.cheese/research/routine-env-provisioning/`) established:
- Claude Cloud = Claude Code on the web, distinct from Managed Agents (`ant beta:environments`).
- Its setup script is UI-configured plain bash — no CLI/API to push it from git — so the skill renders a body to paste, it can't write the dialog.
- **A3 caveat:** whether `claude`/`npx` run inside the setup-script shell and persist into the session is `<don't know>`; the skill flags this and points at the confirmed git-native `.claude/settings.json` + `.claude/skills/` path for plugins/skills-only envs.

## Verification

- `just check` — exit 0 (shellcheck, ruff, eslint, markdownlint, bats 1192/1192, workflows 69/69).
- Reviewer taste-test: all locked decisions hold; two revises (A3 caveat + least-privilege tool grants + concrete `claude mcp add` command) applied.

## Follow-ups

- Plugin marketplace ids (`hallouminate@hallouminate`, `milknado@milknado`) carry inline "confirm via `claude plugin marketplace list`" comments — verify against a live `claude` CLI at first use.
- `milknado.yaml` "recent" packs left as a `TODO(confirm)` for you to name.
- The SKILL.md cites the research slug under gitignored `.cheese/` — provenance only, resolves locally, not in a fresh clone.
- Run `dots sync` to deploy the new skill into `~/.claude`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)