### PR TITLE
fix(omp): switch to shake compaction

### DIFF
--- a/chezmoi/.chezmoidata/omp.yaml
+++ b/chezmoi/.chezmoidata/omp.yaml
@@ -76,7 +76,7 @@ omp:
     advisor:
       enabled: false
     compaction:
-      strategy: snapcompact
+      strategy: shake
       thresholdTokens: 120000
       keepRecentTokens: 20000
       midTurnEnabled: true

--- a/tests/omp-config.bats
+++ b/tests/omp-config.bats
@@ -54,7 +54,7 @@ STDIN"
     [ "$(yq '.tui.tight' "$OUT")" = "true" ]
     [ "$(yq '.startup.quiet' "$OUT")" = "true" ]
     [ "$(yq '.compaction.thresholdTokens' "$OUT")" = "120000" ]
-    [ "$(yq '.compaction.strategy' "$OUT")" = "snapcompact" ]
+    [ "$(yq '.compaction.strategy' "$OUT")" = "shake" ]
     [ "$(yq '.compaction.keepRecentTokens' "$OUT")" = "20000" ]
     [ "$(yq '.compaction.midTurnEnabled' "$OUT")" = "true" ]
     [ "$(yq '.compaction.autoContinue' "$OUT")" = "true" ]


### PR DESCRIPTION
## Purpose

Use OMP's provider-agnostic `shake` maintenance for Codex instead of `snapcompact`. Shake drops heavy tool results and fenced blocks before rebuilding provider state, avoiding snapcompact's persistent image-frame payload on subsequent requests.

## Changes

- set `compaction.strategy` to `shake` in the repo-authoritative OMP config
- update the generated-config contract test
- retain the existing 120,000-token threshold, 20,000 recent-token budget, mid-turn checks, and auto-continue behavior

## Verification

- `bats tests/omp-config.bats` — 15/15 passed
- `just check` — passed in a clean checkout
- generated config smoke check emitted `strategy: shake`
- applied the config with chezmoi and confirmed live `~/.omp/agent/config.yml` reports `strategy: shake`
- `omp models --json` succeeded after rollout

## Artifacts

| Artifact | Backend | Verified |
| --- | --- | --- |
| OMP strategy research | durable Cheese research corpus | yes |
| Authoritative OMP config and contract test | this branch | yes |

## Risk

Shake may reclaim too little when the most recent turn alone exceeds the context budget; OMP then warns and pauses automatic maintenance rather than looping. Existing thresholds are intentionally unchanged so this PR isolates the algorithm change.