### PR TITLE
feat(workflows): add nih-scanner report-only NIH-audit workflow

### DIFF
--- a/chezmoi/dot_omp/private_agent/extensions/nih-scanner.ts
+++ b/chezmoi/dot_omp/private_agent/extensions/nih-scanner.ts
@@ -1,0 +1,90 @@
+// NIH (Not-Invented-Here) scanner audit command. It sends a structured user
+// prompt whose standalone `workflowz` routing token activates OMP's native
+// task-graph mode. Report only — never files issues or mutates code.
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+
+type Options = {
+  scope: string
+  minUsage: number
+  maxCandidates: number
+  workers: number
+  languages?: string[]
+}
+
+const DEFAULT_OPTIONS: Options = {
+  scope: ".",
+  minUsage: 0,
+  maxCandidates: 25,
+  workers: 4,
+}
+
+function usage(reason?: string): string {
+  const prefix = reason ? `${reason}\n\n` : ""
+  return `${prefix}Usage: /nih-scanner [scope] [--min-usage=N] [--max-candidates=1..100] [--workers=1..16] [--languages=ts,py,...]`
+}
+
+function parseOptions(raw: string): Options | string {
+  const options: Options = { ...DEFAULT_OPTIONS }
+  const positionals: string[] = []
+
+  for (const token of raw.trim().split(/\s+/).filter(Boolean)) {
+    if (token.startsWith("--min-usage=")) {
+      const value = Number(token.slice("--min-usage=".length))
+      if (!Number.isInteger(value) || value < 0) return usage("min-usage must be an integer >= 0")
+      options.minUsage = value
+    } else if (token.startsWith("--max-candidates=")) {
+      const value = Number(token.slice("--max-candidates=".length))
+      if (!Number.isInteger(value) || value < 1 || value > 100) return usage("max-candidates must be an integer from 1 to 100")
+      options.maxCandidates = value
+    } else if (token.startsWith("--workers=")) {
+      const value = Number(token.slice("--workers=".length))
+      if (!Number.isInteger(value) || value < 1 || value > 16) return usage("workers must be an integer from 1 to 16")
+      options.workers = value
+    } else if (token.startsWith("--languages=")) {
+      const languages = token.slice("--languages=".length).split(",").map((l) => l.trim()).filter(Boolean)
+      if (!languages.length) return usage("languages must be a non-empty comma-separated list")
+      options.languages = languages
+    } else if (token.startsWith("-")) {
+      return usage(`Unknown option: ${token}`)
+    } else {
+      positionals.push(token)
+    }
+  }
+
+  if (positionals.length > 1) return usage("Pass one scope path only")
+  if (positionals[0]) options.scope = positionals[0]
+  return options
+}
+
+export default function (pi: ExtensionAPI) {
+  pi.registerCommand("nih-scanner", {
+    description: "Run an evidence-ranked NIH (Not-Invented-Here) build-vs-buy audit through OMP's native workflow runner",
+    handler: async (args, ctx) => {
+      const options = parseOptions(String(args ?? ""))
+      if (typeof options === "string") {
+        ctx.ui.notify(options, "error")
+        return
+      }
+
+      await pi.sendUserMessage(`workflowz
+
+Run a Not-Invented-Here (NIH) build-vs-buy audit.
+
+Scope: ${options.scope}
+Minimum usage count: ${options.minUsage}
+Maximum candidates: ${options.maxCandidates}
+Scan workers: ${options.workers}
+Languages: ${options.languages ? options.languages.join(", ") : "auto-detect"}
+
+Build this as a deterministic task graph, not as a single review. First run one cheap detection pass over the scope to identify languages, dependency manifests, and file count. Split the scope into up to ${options.workers} chunks and fan out an nih-scanner agent per chunk to find candidate code that reinvents well-supported library functionality. Dedupe overlapping candidates by file, line, and function, drop candidates below the minimum usage count, and cap the surviving set at ${options.maxCandidates} candidates.
+
+Then run an independent adversarial-skeptic verification task against every candidate, default-refute: a confirmation must name the specific replacement library and cite why the local code duplicates it, or it is refuted. A crashed verification keeps the candidate flagged low-confidence and needs-human, never silently confirmed.
+
+Finally, synthesize a ranked findings table from only the confirmed candidates: category, file:line, function, usage count, replacement library, migration effort, confidence, and recommendation, plus a summary of counts by category and the single highest-leverage action. Never file issues, post comments, or modify production code during this audit — report only.
+
+Return the ranked findings report, refuted candidates, and needs-human candidates.`)
+      ctx.ui.notify("NIH scanner audit workflow queued.", "info")
+    },
+  })
+}

--- a/chezmoi/dot_omp/private_agent/extensions/nih-scanner.ts
+++ b/chezmoi/dot_omp/private_agent/extensions/nih-scanner.ts
@@ -30,8 +30,9 @@ function parseOptions(raw: string): Options | string {
 
   for (const token of raw.trim().split(/\s+/).filter(Boolean)) {
     if (token.startsWith("--min-usage=")) {
-      const value = Number(token.slice("--min-usage=".length))
-      if (!Number.isInteger(value) || value < 0) return usage("min-usage must be an integer >= 0")
+      const rawValue = token.slice("--min-usage=".length)
+      const value = Number(rawValue)
+      if (!rawValue.trim() || !Number.isInteger(value) || value < 0) return usage("min-usage must be an integer >= 0")
       options.minUsage = value
     } else if (token.startsWith("--max-candidates=")) {
       const value = Number(token.slice("--max-candidates=".length))

--- a/claude/workflows/nih-scanner.js
+++ b/claude/workflows/nih-scanner.js
@@ -213,7 +213,7 @@ function verifyPrompt(candidate) {
     '',
     'Known false positives to rule out: stdlib usage (structuredClone, crypto.randomUUID, Intl, http.Client, logging.basicConfig, timedelta), intentional/domain logic, code that already delegates to an installed dependency, or code too trivial to matter.',
     'Rule 12: an NIH confirmation is a positive claim that a specific library supplies this functionality — you must NAME the replacement library and explain why the local code duplicates it. If you cannot, set refuted=true.',
-    'If not refuted, also return library (the specific replacement), effort (S = 1-3 callers, M = 4-10, L = 10+, based on the usage count above), and a citation backing your claim.',
+    'If not refuted, also return library (the specific replacement), effort (S = 1-3 callers, M = 4-9, L = 10+, based on the usage count above), and a citation backing your claim.',
   ].join('\n')
 }
 
@@ -257,6 +257,25 @@ const scanResults = await parallel(
 const validScans = scanResults.filter(Boolean)
 const rawCandidates = validScans.flatMap((r) => r.candidates || [])
 
+// scanMeta is aggregated across every chunk (not just the last one) so a
+// self-truncated fan-out (each nih-scanner agent has a bounded tool-call
+// budget) is visible instead of silently reading as "clean". serenaAvailable
+// is AND-reduced: the aggregate is only true when every chunk had it.
+const scannedMetas = validScans.map((r) => r.scanMeta).filter(Boolean)
+const filesScanned = scannedMetas.reduce((sum, m) => sum + (typeof m.filesScanned === 'number' ? m.filesScanned : 0), 0)
+const serenaAvailable = scannedMetas.length > 0 && scannedMetas.every((m) => m.serenaAvailable === true)
+const underScanned = filesScanned < detected.fileCount
+if (underScanned) {
+  log(`Under-scanned: scanned ${filesScanned} of ${detected.fileCount} detected file(s) — a scan agent may have self-truncated; results could be incomplete.`)
+}
+const scanMeta = {
+  ...detected,
+  filesScanned,
+  serenaAvailable,
+  underScanned,
+  ...(underScanned ? { underScanNote: `Only ${filesScanned} of ${detected.fileCount} detected file(s) were scanned; findings may be incomplete.` } : {}),
+}
+
 const seen = new Set()
 const deduped = []
 for (const candidate of rawCandidates) {
@@ -280,6 +299,11 @@ if (meetsUsage.length > maxCandidates) {
 }
 log(`Scan produced ${capped.length} candidate(s) to verify.`)
 
+if (budget.total != null && budget.remaining() <= 0) {
+  log(`Budget exhausted (remaining ${budget.remaining()}) — skipping Verify/Rank for ${capped.length} scanned candidate(s).`)
+  return { scanMeta, candidates: capped, confirmed: [], report: null }
+}
+
 phase('Verify')
 const verified = await pipeline(
   capped,
@@ -293,15 +317,20 @@ const verified = await pipeline(
 )
 
 // candidates carries every verified survivor, flagged with its verify outcome
-// (confirmed / refuted / crashed) — a crashed verify is KEPT here, never
-// silently dropped or silently confirmed. confirmed narrows to the subset
-// that survived adversarial verification.
+// (confirmed / refuted / crashed / unnamed-library). A crashed verify, and a
+// non-refuted verify that names no replacement library (Rule 12 requires
+// naming one to count as a confirmation), are both KEPT here flagged
+// needs-human — never silently dropped or silently confirmed. confirmed
+// narrows to the subset that survived adversarial verification.
 const candidates = verified.filter(Boolean).map((v) => {
   if (v.verifyFailed) {
     return { ...v.candidate, confidence: 'low', verifyFailed: true, note: 'verify crashed — needs human review' }
   }
   if (v.verify && v.verify.refuted) {
     return { ...v.candidate, refuted: true }
+  }
+  if (!v.verify || typeof v.verify.library !== 'string' || !v.verify.library.trim()) {
+    return { ...v.candidate, confidence: 'low', verifyFailed: true, note: 'verify confirmed without naming a replacement library — needs human review' }
   }
   return {
     ...v.candidate,
@@ -315,9 +344,15 @@ const candidates = verified.filter(Boolean).map((v) => {
 const confirmed = candidates.filter((c) => c.confirmed === true)
 const refutedCount = candidates.filter((c) => c.refuted === true).length
 const needsHumanCount = candidates.filter((c) => c.verifyFailed === true).length
-log(`Verified ${capped.length} candidate(s): ${confirmed.length} confirmed, ${refutedCount} refuted, ${needsHumanCount} crashed (flagged needs-human).`)
+log(`Verified ${capped.length} candidate(s): ${confirmed.length} confirmed, ${refutedCount} refuted, ${needsHumanCount} flagged needs-human.`)
+
+if (budget.total != null && budget.remaining() <= 0) {
+  log(`Budget exhausted (remaining ${budget.remaining()}) — skipping Rank for ${confirmed.length} confirmed candidate(s).`)
+  return { scanMeta, candidates, confirmed, report: null }
+}
 
 phase('Rank')
-const report = await agent(reportPrompt(confirmed), { schema: REPORT_SCHEMA, phase: 'Rank', label: 'rank', effort: 'high' })
+const report = await agent(reportPrompt(confirmed), { schema: REPORT_SCHEMA, phase: 'Rank', label: 'rank', effort: 'high' }).catch(() => null)
+if (!report) log('Rank agent crashed — returning candidates and confirmed findings without a synthesized report.')
 
-return { scanMeta: detected, candidates, confirmed, report }
+return { scanMeta, candidates, confirmed, report }

--- a/claude/workflows/nih-scanner.js
+++ b/claude/workflows/nih-scanner.js
@@ -1,0 +1,323 @@
+export const meta = {
+  name: 'nih-scanner',
+  description: 'Fan the nih-scanner sub-agent across a codebase, adversarially verify each Not-Invented-Here candidate, and emit a ranked build-vs-buy findings table',
+  whenToUse: 'A codebase you suspect reinvents library functionality and you want an evidence-ranked build-vs-buy audit — report only, never mutates.',
+  phases: [
+    { title: 'Detect', detail: 'one cheap agent detects primary language(s), dependency manifests, and file count' },
+    { title: 'Scan', detail: 'nih-scanner agents fan out over scope chunks; results are deduped and capped' },
+    { title: 'Verify', detail: 'one skeptic agent per candidate, default-refute, names the replacement library' },
+    { title: 'Rank', detail: 'barrier synthesis agent produces a ranked findings table' },
+  ],
+}
+
+// Canonicalizes an evidence-grounded NIH ("not invented here") audit: fan the
+// nih-scanner sub-agent (agents/agent_definitions/nih-scanner.md) across a
+// codebase, adversarially verify every candidate before it counts as
+// confirmed, and hand back a ranked report. Read-only — Detect/Scan/Verify
+// only inspect code; Rank only synthesizes a report; nothing in this file
+// ever writes a file, opens a PR, or calls `gh`.
+//
+// Invoked as `/nih-scanner [args]`; args is a bare scope-path string, or an
+// object {scope?, languages?, minUsage?, maxCandidates?, workers?}.
+
+const DETECT_SCHEMA = {
+  type: 'object',
+  required: ['languages', 'depManifest', 'fileCount', 'scope'],
+  properties: {
+    languages: { type: 'array', items: { type: 'string' } },
+    depManifest: { type: 'array', items: { type: 'string' } },
+    fileCount: { type: 'integer' },
+    scope: { type: 'string' },
+  },
+}
+
+const SCAN_SCHEMA = {
+  type: 'object',
+  required: ['scanMeta', 'candidates'],
+  properties: {
+    scanMeta: {
+      type: 'object',
+      required: ['languages', 'filesScanned', 'serenaAvailable', 'scope'],
+      properties: {
+        languages: { type: 'array', items: { type: 'string' } },
+        filesScanned: { type: 'integer' },
+        serenaAvailable: { type: 'boolean' },
+        scope: { type: 'string' },
+      },
+    },
+    candidates: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: [
+          'id', 'filePath', 'lineRange', 'category', 'pattern', 'snippet',
+          'usageCount', 'functionName', 'linesOfCode',
+        ],
+        properties: {
+          id: { type: 'integer' },
+          filePath: { type: 'string' },
+          lineRange: { type: 'array', items: { type: 'integer' } },
+          category: { type: 'string' },
+          pattern: { type: 'string' },
+          snippet: { type: 'string' },
+          usageCount: { type: 'integer' },
+          functionName: { type: 'string' },
+          linesOfCode: { type: 'integer' },
+        },
+      },
+    },
+  },
+}
+
+const VERIFY_SCHEMA = {
+  type: 'object',
+  required: ['refuted', 'reasoning'],
+  properties: {
+    refuted: { type: 'boolean' },
+    library: { type: 'string', description: 'the specific replacement library, when not refuted' },
+    effort: { type: 'string', enum: ['S', 'M', 'L'] },
+    reasoning: { type: 'string' },
+    citation: { type: 'string' },
+  },
+}
+
+const REPORT_SCHEMA = {
+  type: 'object',
+  required: ['findings', 'summary'],
+  properties: {
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: [
+          'category', 'location', 'functionName', 'usageCount', 'library',
+          'effort', 'confidence', 'recommendation',
+        ],
+        properties: {
+          category: { type: 'string' },
+          location: { type: 'string', description: 'file:line' },
+          functionName: { type: 'string' },
+          usageCount: { type: 'integer' },
+          library: { type: 'string' },
+          effort: { type: 'string', enum: ['S', 'M', 'L'] },
+          confidence: { type: 'string' },
+          recommendation: { type: 'string' },
+        },
+      },
+    },
+    summary: { type: 'string' },
+  },
+}
+
+// ── args ─────────────────────────────────────────────────────────────────
+
+const UNSAFE_REPO_CHARS = /[\s;&|`$(){}<>"'\\]/
+const MAX_CANDIDATES = 100
+const MAX_WORKERS = 16
+
+function coerceArgs(a) {
+  if (a == null) return {}
+  if (typeof a === 'string') return { scope: a }
+  if (typeof a === 'object') return a
+  return {}
+}
+
+function clampInt(value, min, max, fallback, name) {
+  if (!Number.isInteger(value)) return fallback
+  if (value < min) {
+    log(`${name} ${value} below minimum ${min}; clamping to ${min}.`)
+    return min
+  }
+  if (value > max) {
+    log(`${name} ${value} exceeds maximum ${max}; clamping to ${max}.`)
+    return max
+  }
+  return value
+}
+
+const opts = coerceArgs(args)
+
+let scope = typeof opts.scope === 'string' && opts.scope.trim() ? opts.scope.trim() : '.'
+if (UNSAFE_REPO_CHARS.test(scope)) {
+  log(`scope "${scope}" contains unsafe characters; falling back to "."`)
+  scope = '.'
+}
+
+const argLanguages = Array.isArray(opts.languages) ? opts.languages.filter((l) => typeof l === 'string') : []
+const minUsage = clampInt(opts.minUsage, 0, Number.MAX_SAFE_INTEGER, 0, 'minUsage')
+const maxCandidates = clampInt(opts.maxCandidates, 1, MAX_CANDIDATES, 25, 'maxCandidates')
+const workers = clampInt(opts.workers, 1, MAX_WORKERS, 4, 'workers')
+
+// ── helpers ──────────────────────────────────────────────────────────────
+
+// The workflow sandbox has no filesystem access, so a real top-level
+// directory listing is not available in plain code — chunking only has
+// something to split when the caller already encodes multiple top-level
+// paths as a comma-separated scope (e.g. "src/a,src/b,src/c"). Otherwise it
+// falls back to a single chunk covering the whole scope, per spec.
+function chunkScope(scopeValue, count) {
+  const parts = scopeValue.split(',').map((p) => p.trim()).filter(Boolean)
+  if (parts.length <= 1) return [scopeValue]
+  const groups = Array.from({ length: Math.min(count, parts.length) }, () => [])
+  parts.forEach((part, i) => groups[i % groups.length].push(part))
+  return groups.map((g) => g.join(','))
+}
+
+function slugify(text) {
+  return String(text).toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') || 'scope'
+}
+
+function candidateKey(c) {
+  return `${c.filePath}:${c.lineRange ? c.lineRange[0] : ''}:${c.functionName || c.category}`
+}
+
+// ── prompts ──────────────────────────────────────────────────────────────
+
+function detectPrompt() {
+  return [
+    `Detect the primary language(s), dependency manifest(s), and source file count under scope \`${scope}\`. This is a CHEAP detection pass — no deep code reading.`,
+    '',
+    'Steps:',
+    '1. Identify the primary programming language(s) present under the scope.',
+    '2. Locate and read dependency manifest(s) (package.json, Cargo.toml, pyproject.toml, go.mod) into a flat list of installed dependency names.',
+    '3. Count the source files under scope (excluding tests, vendored deps, build output, .git/).',
+    '',
+    `Return languages (array), depManifest (array of dependency names), fileCount (integer), and scope="${scope}".`,
+  ].join('\n')
+}
+
+function scanPrompt(chunk, detected) {
+  const languages = argLanguages.length ? argLanguages : detected.languages
+  return [
+    'You are the NIH Scanner. Follow your protocol exactly: Serena first, ast-grep fallback, never Grep for pattern detection.',
+    '',
+    `Languages: ${JSON.stringify(languages)}`,
+    `Scope: ${chunk}`,
+    `depManifest: ${JSON.stringify(detected.depManifest)}`,
+    `Slug: nih-scan-${slugify(chunk)}`,
+  ].join('\n')
+}
+
+function verifyPrompt(candidate) {
+  return [
+    `You are a SKEPTIC verifying whether this candidate is a REAL reinvention of a well-supported library, or a false positive. Default to refuted=true — a confirmation is the expensive mistake here.`,
+    '',
+    `Category: ${candidate.category}`,
+    `Location: ${candidate.filePath}:${candidate.lineRange ? candidate.lineRange.join('-') : '?'}`,
+    `Function: ${candidate.functionName}`,
+    `Pattern: ${candidate.pattern}`,
+    `Usage count: ${candidate.usageCount}`,
+    `Lines of code: ${candidate.linesOfCode}`,
+    'Snippet:',
+    candidate.snippet,
+    '',
+    'Known false positives to rule out: stdlib usage (structuredClone, crypto.randomUUID, Intl, http.Client, logging.basicConfig, timedelta), intentional/domain logic, code that already delegates to an installed dependency, or code too trivial to matter.',
+    'Rule 12: an NIH confirmation is a positive claim that a specific library supplies this functionality — you must NAME the replacement library and explain why the local code duplicates it. If you cannot, set refuted=true.',
+    'If not refuted, also return library (the specific replacement), effort (S = 1-3 callers, M = 4-10, L = 10+, based on the usage count above), and a citation backing your claim.',
+  ].join('\n')
+}
+
+function reportPrompt(confirmed) {
+  return [
+    'You are producing the final ranked NIH (Not-Invented-Here) findings report. Below is every candidate confirmed by an independent skeptic verification pass.',
+    '',
+    'DATA (JSON):',
+    JSON.stringify(confirmed, null, 2),
+    '',
+    'Produce a ranked findings table. For each finding include: category, location (file:line), functionName, usageCount, library, effort (S/M/L), confidence, and recommendation.',
+    'Rank by leverage: highest usageCount and lowest effort first.',
+    'summary: counts by category, and the single highest-leverage action to take next.',
+    '',
+    'REPORT ONLY: do not call gh, do not post anywhere, do not write files, do not mutate anything.',
+  ].join('\n')
+}
+
+// ── run ──────────────────────────────────────────────────────────────────
+
+phase('Detect')
+log(`Detecting languages, dependency manifests, and file count in scope "${scope}"...`)
+const detected = await agent(detectPrompt(), { agentType: 'explorer', schema: DETECT_SCHEMA, phase: 'Detect', label: 'detect' }).catch(() => null)
+
+if (!detected || detected.fileCount === 0) {
+  log(detected ? `No source files found in scope "${scope}" — nothing to scan.` : 'Detect agent returned no result — nothing to scan.')
+  return { scanMeta: null, candidates: [], confirmed: [], report: null }
+}
+
+if (budget.total != null && budget.remaining() <= 0) {
+  log(`Budget exhausted (remaining ${budget.remaining()}) — skipping Scan/Verify/Rank.`)
+  return { scanMeta: detected, candidates: [], confirmed: [], report: null }
+}
+
+phase('Scan')
+const chunks = chunkScope(scope, workers)
+log(`Scanning ${chunks.length} chunk(s) of scope "${scope}" (up to ${workers} worker(s))...`)
+const scanResults = await parallel(
+  chunks.map((chunk) => () => agent(scanPrompt(chunk, detected), { agentType: 'nih-scanner', schema: SCAN_SCHEMA, phase: 'Scan', label: `scan:${chunk}` }))
+)
+const validScans = scanResults.filter(Boolean)
+const rawCandidates = validScans.flatMap((r) => r.candidates || [])
+
+const seen = new Set()
+const deduped = []
+for (const candidate of rawCandidates) {
+  const key = candidateKey(candidate)
+  if (seen.has(key)) continue
+  seen.add(key)
+  deduped.push(candidate)
+}
+if (rawCandidates.length !== deduped.length) {
+  log(`Deduped ${rawCandidates.length - deduped.length} overlapping candidate(s).`)
+}
+
+const meetsUsage = deduped.filter((c) => (typeof c.usageCount === 'number' ? c.usageCount : 0) >= minUsage)
+if (meetsUsage.length !== deduped.length) {
+  log(`${deduped.length - meetsUsage.length} candidate(s) dropped below minUsage=${minUsage}.`)
+}
+
+const capped = meetsUsage.slice(0, maxCandidates)
+if (meetsUsage.length > maxCandidates) {
+  log(`${meetsUsage.length - maxCandidates} candidate(s) dropped by the maxCandidates cap (${maxCandidates}).`)
+}
+log(`Scan produced ${capped.length} candidate(s) to verify.`)
+
+phase('Verify')
+const verified = await pipeline(
+  capped,
+  (candidate) => agent(verifyPrompt(candidate), { agentType: 'explorer', schema: VERIFY_SCHEMA, phase: 'Verify', label: `verify:${candidate.functionName}` })
+    .catch(() => null)
+    .then((verify) => {
+      const verifyFailed = verify == null
+      if (verifyFailed) log(`Verify crashed for ${candidate.functionName} (${candidate.filePath}) — flagging low-confidence, needs-human.`)
+      return { candidate, verify, verifyFailed }
+    })
+)
+
+// candidates carries every verified survivor, flagged with its verify outcome
+// (confirmed / refuted / crashed) — a crashed verify is KEPT here, never
+// silently dropped or silently confirmed. confirmed narrows to the subset
+// that survived adversarial verification.
+const candidates = verified.filter(Boolean).map((v) => {
+  if (v.verifyFailed) {
+    return { ...v.candidate, confidence: 'low', verifyFailed: true, note: 'verify crashed — needs human review' }
+  }
+  if (v.verify && v.verify.refuted) {
+    return { ...v.candidate, refuted: true }
+  }
+  return {
+    ...v.candidate,
+    confirmed: true,
+    library: v.verify.library,
+    effort: v.verify.effort,
+    reasoning: v.verify.reasoning,
+    citation: v.verify.citation,
+  }
+})
+const confirmed = candidates.filter((c) => c.confirmed === true)
+const refutedCount = candidates.filter((c) => c.refuted === true).length
+const needsHumanCount = candidates.filter((c) => c.verifyFailed === true).length
+log(`Verified ${capped.length} candidate(s): ${confirmed.length} confirmed, ${refutedCount} refuted, ${needsHumanCount} crashed (flagged needs-human).`)
+
+phase('Rank')
+const report = await agent(reportPrompt(confirmed), { schema: REPORT_SCHEMA, phase: 'Rank', label: 'rank', effort: 'high' })
+
+return { scanMeta: detected, candidates, confirmed, report }

--- a/tests/extensions/nih-scanner.test.mjs
+++ b/tests/extensions/nih-scanner.test.mjs
@@ -1,0 +1,151 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import nihScanner from '../../chezmoi/dot_omp/private_agent/extensions/nih-scanner.ts'
+
+const description = "Run an evidence-ranked NIH (Not-Invented-Here) build-vs-buy audit through OMP's native workflow runner"
+const usage = 'Usage: /nih-scanner [scope] [--min-usage=N] [--max-candidates=1..100] [--workers=1..16] [--languages=ts,py,...]'
+
+function expectedPrompt({
+  scope = '.',
+  minUsage = 0,
+  maxCandidates = 25,
+  workers = 4,
+  languages,
+} = {}) {
+  return `workflowz
+
+Run a Not-Invented-Here (NIH) build-vs-buy audit.
+
+Scope: ${scope}
+Minimum usage count: ${minUsage}
+Maximum candidates: ${maxCandidates}
+Scan workers: ${workers}
+Languages: ${languages ? languages.join(', ') : 'auto-detect'}
+
+Build this as a deterministic task graph, not as a single review. First run one cheap detection pass over the scope to identify languages, dependency manifests, and file count. Split the scope into up to ${workers} chunks and fan out an nih-scanner agent per chunk to find candidate code that reinvents well-supported library functionality. Dedupe overlapping candidates by file, line, and function, drop candidates below the minimum usage count, and cap the surviving set at ${maxCandidates} candidates.
+
+Then run an independent adversarial-skeptic verification task against every candidate, default-refute: a confirmation must name the specific replacement library and cite why the local code duplicates it, or it is refuted. A crashed verification keeps the candidate flagged low-confidence and needs-human, never silently confirmed.
+
+Finally, synthesize a ranked findings table from only the confirmed candidates: category, file:line, function, usage count, replacement library, migration effort, confidence, and recommendation, plus a summary of counts by category and the single highest-leverage action. Never file issues, post comments, or modify production code during this audit — report only.
+
+Return the ranked findings report, refuted candidates, and needs-human candidates.`
+}
+
+function loadExtension({ dispatch = async () => {} } = {}) {
+  const sent = []
+  const notifications = []
+  let registered
+
+  const api = {
+    registerCommand(name, command) {
+      registered = { name, command }
+    },
+    sendUserMessage(message) {
+      sent.push(message)
+      return dispatch(message)
+    },
+  }
+
+  nihScanner(api)
+  assert.deepEqual(
+    { name: registered?.name, description: registered?.command.description },
+    { name: 'nih-scanner', description },
+  )
+
+  const ctx = {
+    ui: {
+      notify(message, level) {
+        notifications.push({ message, level })
+      },
+    },
+  }
+
+  return { handler: registered.command.handler, ctx, sent, notifications }
+}
+
+test('registers the command and dispatches the exact default workflow contract', async () => {
+  const harness = loadExtension()
+
+  await harness.handler('', harness.ctx)
+
+  assert.deepEqual(harness.sent, [expectedPrompt()])
+  assert.deepEqual(harness.notifications, [
+    { message: 'NIH scanner audit workflow queued.', level: 'info' },
+  ])
+})
+
+for (const { name, args, options } of [
+  { name: 'scope', args: 'src/domain', options: { scope: 'src/domain' } },
+  { name: 'minimum min-usage', args: '--min-usage=0', options: { minUsage: 0 } },
+  { name: 'positive min-usage', args: '--min-usage=5', options: { minUsage: 5 } },
+  { name: 'minimum max-candidates', args: '--max-candidates=1', options: { maxCandidates: 1 } },
+  { name: 'maximum max-candidates', args: '--max-candidates=100', options: { maxCandidates: 100 } },
+  { name: 'minimum workers', args: '--workers=1', options: { workers: 1 } },
+  { name: 'maximum workers', args: '--workers=16', options: { workers: 16 } },
+  { name: 'languages', args: '--languages=ts,py', options: { languages: ['ts', 'py'] } },
+]) {
+  test(`${name} produces the exact dispatch prompt`, async () => {
+    const harness = loadExtension()
+
+    await harness.handler(args, harness.ctx)
+
+    assert.deepEqual(harness.sent, [expectedPrompt(options)])
+    assert.deepEqual(harness.notifications, [
+      { message: 'NIH scanner audit workflow queued.', level: 'info' },
+    ])
+  })
+}
+
+for (const { args, reason } of [
+  { args: '--unknown', reason: 'Unknown option: --unknown' },
+  { args: '--min-usage=-1', reason: 'min-usage must be an integer >= 0' },
+  { args: '--min-usage=1.5', reason: 'min-usage must be an integer >= 0' },
+  { args: '--max-candidates=0', reason: 'max-candidates must be an integer from 1 to 100' },
+  { args: '--max-candidates=101', reason: 'max-candidates must be an integer from 1 to 100' },
+  { args: '--max-candidates=1.5', reason: 'max-candidates must be an integer from 1 to 100' },
+  { args: '--workers=0', reason: 'workers must be an integer from 1 to 16' },
+  { args: '--workers=17', reason: 'workers must be an integer from 1 to 16' },
+  { args: '--workers=1.5', reason: 'workers must be an integer from 1 to 16' },
+  { args: '--languages=', reason: 'languages must be a non-empty comma-separated list' },
+  { args: 'src/a src/b', reason: 'Pass one scope path only' },
+]) {
+  test(`rejects ${args} without dispatching`, async () => {
+    const harness = loadExtension()
+
+    await harness.handler(args, harness.ctx)
+
+    assert.deepEqual(harness.sent, [])
+    assert.deepEqual(harness.notifications, [
+      { message: `${reason}\n\n${usage}`, level: 'error' },
+    ])
+  })
+}
+
+test('notifies queued only after dispatch resolves', async () => {
+  let resolveDispatch
+  const dispatch = new Promise((resolve) => {
+    resolveDispatch = resolve
+  })
+  const harness = loadExtension({ dispatch: () => dispatch })
+
+  const pending = harness.handler('--workers=2', harness.ctx)
+  assert.deepEqual(harness.sent, [expectedPrompt({ workers: 2 })])
+  assert.deepEqual(harness.notifications, [])
+
+  resolveDispatch()
+  await pending
+
+  assert.deepEqual(harness.notifications, [
+    { message: 'NIH scanner audit workflow queued.', level: 'info' },
+  ])
+})
+
+test('dispatch rejection propagates without reporting success', async () => {
+  const failure = new Error('dispatch failed')
+  const harness = loadExtension({ dispatch: async () => { throw failure } })
+
+  await assert.rejects(harness.handler('', harness.ctx), (error) => error === failure)
+  assert.deepEqual(harness.sent, [expectedPrompt()])
+  assert.deepEqual(harness.notifications, [])
+})

--- a/tests/extensions/nih-scanner.test.mjs
+++ b/tests/extensions/nih-scanner.test.mjs
@@ -101,6 +101,7 @@ for (const { args, reason } of [
   { args: '--unknown', reason: 'Unknown option: --unknown' },
   { args: '--min-usage=-1', reason: 'min-usage must be an integer >= 0' },
   { args: '--min-usage=1.5', reason: 'min-usage must be an integer >= 0' },
+  { args: '--min-usage=', reason: 'min-usage must be an integer >= 0' },
   { args: '--max-candidates=0', reason: 'max-candidates must be an integer from 1 to 100' },
   { args: '--max-candidates=101', reason: 'max-candidates must be an integer from 1 to 100' },
   { args: '--max-candidates=1.5', reason: 'max-candidates must be an integer from 1 to 100' },

--- a/tests/omp-config.bats
+++ b/tests/omp-config.bats
@@ -272,7 +272,7 @@ TOML
 }
 
 # --- omp extension modules are chezmoi-managed -----------------------------
-# rtk.ts, cheese-flair.ts, and sliced-bread-audit.ts under dot_omp/private_agent/
+# rtk.ts, cheese-flair.ts, sliced-bread-audit.ts, and nih-scanner.ts under
 # extensions deploy to ~/.omp/agent/extensions/ (auto-discovered by omp's extension
 # loader). Nothing in .chezmoiignore may exclude them, or the extensions silently
 # never deploy.
@@ -290,11 +290,18 @@ TOML
     [[ "$output" == *".omp/agent/extensions/rtk.ts"* ]]
     [[ "$output" == *".omp/agent/extensions/cheese-flair.ts"* ]]
     [[ "$output" == *".omp/agent/extensions/sliced-bread-audit.ts"* ]]
+    [[ "$output" == *".omp/agent/extensions/nih-scanner.ts"* ]]
     [[ "$output" == *".omp/agent/APPEND_SYSTEM.md"* ]]
 }
 
 @test "omp-ext: sliced bread audit command handler contract" {
     command -v node >/dev/null 2>&1 || skip "node not installed"
     run node --test "$REAL_DOTFILES_DIR/tests/extensions/sliced-bread-audit.test.mjs"
+    [ "$status" -eq 0 ]
+}
+
+@test "omp-ext: nih scanner command handler contract" {
+    command -v node >/dev/null 2>&1 || skip "node not installed"
+    run node --test "$REAL_DOTFILES_DIR/tests/extensions/nih-scanner.test.mjs"
     [ "$status" -eq 0 ]
 }

--- a/tests/workflows/nih-scanner.test.mjs
+++ b/tests/workflows/nih-scanner.test.mjs
@@ -1,0 +1,219 @@
+import assert from 'node:assert/strict'
+import { resolve } from 'node:path'
+import test from 'node:test'
+
+import { createRuntime, loadWorkflow } from './harness.mjs'
+
+const path = resolve(import.meta.dirname, '../../claude/workflows/nih-scanner.js')
+
+const detected = (overrides = {}) => ({
+  languages: ['typescript'],
+  depManifest: ['lodash'],
+  fileCount: 10,
+  scope: '.',
+  ...overrides,
+})
+
+const candidate = (overrides = {}) => ({
+  id: 1,
+  filePath: 'src/utils/uuid.ts',
+  lineRange: [12, 28],
+  category: 'UUID',
+  pattern: 'Hand-rolled UUID v4',
+  snippet: 'export function generateUUID() {...}',
+  usageCount: 3,
+  functionName: 'generateUUID',
+  linesOfCode: 16,
+  ...overrides,
+})
+
+const refuteVerdict = (overrides = {}) => ({ refuted: true, reasoning: 'stdlib usage', ...overrides })
+const confirmVerdict = (overrides = {}) => ({
+  refuted: false,
+  reasoning: 'hand-rolled UUID generator duplicates crypto.randomUUID',
+  library: 'crypto.randomUUID',
+  effort: 'S',
+  citation: 'src/utils/uuid.ts:12',
+  ...overrides,
+})
+
+function baseRespond(overrides) {
+  return ({ opts, prompt }) => {
+    if (overrides[opts.label]) return overrides[opts.label]({ opts: { ...opts, prompt } })
+    if (opts.label === 'detect') return detected()
+    if (opts.label && opts.label.startsWith('scan:')) return { scanMeta: { languages: ['typescript'], filesScanned: 10, serenaAvailable: true, scope: '.' }, candidates: [] }
+    if (opts.label && opts.label.startsWith('verify:')) return refuteVerdict()
+    if (opts.label === 'rank') return { findings: [], summary: 'nothing found' }
+    throw new Error(`unexpected agent ${opts.label}`)
+  }
+}
+
+test('nih-scanner coerces a bare string arg into scope', async () => {
+  const workflow = await loadWorkflow(path)
+  const { globals, trace } = createRuntime({ respond: baseRespond({}) })
+
+  await workflow.run({ ...globals, args: 'src/pkg' })
+
+  assert.match(trace.agents[0].prompt, /scope `src\/pkg`/)
+})
+
+test('nih-scanner falls back to "." scope when given unsafe shell characters and logs it', async () => {
+  const workflow = await loadWorkflow(path)
+  const { globals, trace } = createRuntime({ respond: baseRespond({}) })
+
+  await workflow.run({ ...globals, args: { scope: 'src; rm -rf /' } })
+
+  assert.match(trace.agents[0].prompt, /scope `\.`/)
+  assert.match(trace.logs.join('\n'), /unsafe characters/)
+})
+
+test('nih-scanner clamps maxCandidates, workers, and minUsage and logs each clamp', async () => {
+  const workflow = await loadWorkflow(path)
+  const { globals, trace } = createRuntime({
+    respond: baseRespond({
+      detect: () => detected({ fileCount: 0 }),
+    }),
+  })
+
+  await workflow.run({ ...globals, args: { scope: '.', maxCandidates: 500, workers: 99, minUsage: -3 } })
+
+  const logs = trace.logs.join('\n')
+  assert.match(logs, /maxCandidates 500 exceeds maximum 100; clamping to 100/)
+  assert.match(logs, /workers 99 exceeds maximum 16; clamping to 16/)
+  // minUsage is not an integer >= 0 here (it's negative, but still an
+  // integer) so it clamps to its floor of 0.
+  assert.match(logs, /minUsage -3 below minimum 0; clamping to 0/)
+})
+
+test('nih-scanner short-circuits on fileCount 0 with no Scan/Verify/Rank dispatch', async () => {
+  const workflow = await loadWorkflow(path)
+  const { globals, trace } = createRuntime({
+    respond: baseRespond({ detect: () => detected({ fileCount: 0 }) }),
+  })
+
+  const result = await workflow.run({ ...globals, args: '.' })
+
+  assert.deepEqual({ ...result, candidates: Array.from(result.candidates), confirmed: Array.from(result.confirmed) }, { scanMeta: null, candidates: [], confirmed: [], report: null })
+  assert.deepEqual(trace.agents.map(({ opts }) => opts.label), ['detect'])
+  assert.match(trace.logs.join('\n'), /nothing to scan/)
+})
+
+test('nih-scanner short-circuits when Detect returns null', async () => {
+  const workflow = await loadWorkflow(path)
+  const { globals, trace } = createRuntime({
+    respond: baseRespond({ detect: () => null }),
+  })
+
+  const result = await workflow.run({ ...globals, args: '.' })
+
+  assert.deepEqual({ ...result, candidates: Array.from(result.candidates), confirmed: Array.from(result.confirmed) }, { scanMeta: null, candidates: [], confirmed: [], report: null })
+  assert.deepEqual(trace.agents.map(({ opts }) => opts.label), ['detect'])
+})
+
+test('nih-scanner dedupes overlapping candidates by filePath:lineRange[0]:functionName', async () => {
+  const workflow = await loadWorkflow(path)
+  const dupe = candidate()
+  const { globals, trace } = createRuntime({
+    respond: baseRespond({
+      'scan:.': () => ({
+        scanMeta: { languages: ['typescript'], filesScanned: 10, serenaAvailable: true, scope: '.' },
+        candidates: [dupe, { ...dupe, id: 2, snippet: 'different snippet, same location' }],
+      }),
+      'verify:generateUUID': () => confirmVerdict(),
+    }),
+  })
+
+  const result = await workflow.run({ ...globals, args: '.' })
+
+  assert.equal(result.candidates.length, 1)
+  assert.match(trace.logs.join('\n'), /Deduped 1 overlapping candidate/)
+})
+
+test('nih-scanner caps at maxCandidates and logs the drop', async () => {
+  const workflow = await loadWorkflow(path)
+  const many = Array.from({ length: 3 }, (_, i) => candidate({ id: i + 1, filePath: `src/f${i}.ts`, functionName: `fn${i}` }))
+  const { globals, trace } = createRuntime({
+    respond: baseRespond({
+      'scan:.': () => ({
+        scanMeta: { languages: ['typescript'], filesScanned: 10, serenaAvailable: true, scope: '.' },
+        candidates: many,
+      }),
+      'verify:fn0': () => confirmVerdict(),
+    }),
+  })
+
+  const result = await workflow.run({ ...globals, args: { scope: '.', maxCandidates: 1 } })
+
+  assert.equal(result.candidates.length, 1)
+  assert.match(trace.logs.join('\n'), /2 candidate\(s\) dropped by the maxCandidates cap \(1\)/)
+})
+
+test('nih-scanner drops refuted candidates from confirmed and from the report data', async () => {
+  const workflow = await loadWorkflow(path)
+  const { globals, trace } = createRuntime({
+    respond: baseRespond({
+      'scan:.': () => ({
+        scanMeta: { languages: ['typescript'], filesScanned: 10, serenaAvailable: true, scope: '.' },
+        candidates: [candidate()],
+      }),
+      'verify:generateUUID': () => refuteVerdict({ reasoning: 'this is crypto.randomUUID usage, not NIH' }),
+    }),
+  })
+
+  const result = await workflow.run({ ...globals, args: '.' })
+
+  assert.equal(result.confirmed.length, 0)
+  assert.equal(result.candidates.length, 1)
+  assert.equal(result.candidates[0].refuted, true)
+  const rankPrompt = trace.agents.find(({ opts }) => opts.label === 'rank').prompt
+  assert.match(rankPrompt, /"candidates":\s*\[\]|DATA \(JSON\):\n\[\]/)
+})
+
+test('a crashed verify keeps the candidate flagged low-confidence and never confirms it', async () => {
+  const workflow = await loadWorkflow(path)
+  const { globals, trace } = createRuntime({
+    respond: baseRespond({
+      'scan:.': () => ({
+        scanMeta: { languages: ['typescript'], filesScanned: 10, serenaAvailable: true, scope: '.' },
+        candidates: [candidate()],
+      }),
+      'verify:generateUUID': () => { throw new Error('verify agent crashed') },
+    }),
+  })
+
+  const result = await workflow.run({ ...globals, args: '.' })
+
+  assert.equal(result.confirmed.length, 0)
+  assert.equal(result.candidates.length, 1)
+  assert.equal(result.candidates[0].verifyFailed, true)
+  assert.equal(result.candidates[0].confidence, 'low')
+  assert.match(trace.logs.join('\n'), /Verify crashed for generateUUID/)
+})
+
+test('the report is built only from confirmed findings', async () => {
+  const workflow = await loadWorkflow(path)
+  const confirmedCandidate = candidate()
+  const refutedCandidate = candidate({ id: 2, filePath: 'src/other.ts', functionName: 'otherFn' })
+  const { globals, trace } = createRuntime({
+    respond: baseRespond({
+      'scan:.': () => ({
+        scanMeta: { languages: ['typescript'], filesScanned: 10, serenaAvailable: true, scope: '.' },
+        candidates: [confirmedCandidate, refutedCandidate],
+      }),
+      'verify:generateUUID': () => confirmVerdict(),
+      'verify:otherFn': () => refuteVerdict(),
+      rank: ({ opts }) => {
+        assert.doesNotMatch(opts.prompt, /otherFn/)
+        return { findings: [{ category: 'UUID', location: 'src/utils/uuid.ts:12', functionName: 'generateUUID', usageCount: 3, library: 'crypto.randomUUID', effort: 'S', confidence: 'high', recommendation: 'replace with crypto.randomUUID' }], summary: '1 finding' }
+      },
+    }),
+  })
+
+  const result = await workflow.run({ ...globals, args: '.' })
+
+  assert.equal(result.confirmed.length, 1)
+  assert.equal(result.confirmed[0].functionName, 'generateUUID')
+  assert.equal(result.report.findings.length, 1)
+  const rankPrompt = trace.agents.find(({ opts }) => opts.label === 'rank').prompt
+  assert.doesNotMatch(rankPrompt, /otherFn/)
+})

--- a/tests/workflows/nih-scanner.test.mjs
+++ b/tests/workflows/nih-scanner.test.mjs
@@ -217,3 +217,157 @@ test('the report is built only from confirmed findings', async () => {
   const rankPrompt = trace.agents.find(({ opts }) => opts.label === 'rank').prompt
   assert.doesNotMatch(rankPrompt, /otherFn/)
 })
+
+test('a non-refuted verify without a named library is not confirmed (needs-human, low confidence)', async () => {
+  const workflow = await loadWorkflow(path)
+  const { globals, trace } = createRuntime({
+    respond: baseRespond({
+      'scan:.': () => ({
+        scanMeta: { languages: ['typescript'], filesScanned: 10, serenaAvailable: true, scope: '.' },
+        candidates: [candidate()],
+      }),
+      'verify:generateUUID': () => ({ refuted: false, reasoning: 'plausible but no concrete library named', effort: 'S' }),
+    }),
+  })
+
+  const result = await workflow.run({ ...globals, args: '.' })
+
+  assert.equal(result.confirmed.length, 0)
+  assert.equal(result.candidates[0].verifyFailed, true)
+  assert.equal(result.candidates[0].confidence, 'low')
+  assert.match(result.candidates[0].note, /without naming a replacement library/)
+})
+
+test('a non-refuted verify with a whitespace-only library is not confirmed', async () => {
+  const workflow = await loadWorkflow(path)
+  const { globals, trace } = createRuntime({
+    respond: baseRespond({
+      'scan:.': () => ({
+        scanMeta: { languages: ['typescript'], filesScanned: 10, serenaAvailable: true, scope: '.' },
+        candidates: [candidate()],
+      }),
+      'verify:generateUUID': () => confirmVerdict({ library: '   ' }),
+    }),
+  })
+
+  const result = await workflow.run({ ...globals, args: '.' })
+
+  assert.equal(result.confirmed.length, 0)
+  assert.equal(result.candidates[0].verifyFailed, true)
+  assert.equal(result.candidates[0].confidence, 'low')
+})
+
+test('scanMeta flags underScanned when aggregated filesScanned is less than detected fileCount', async () => {
+  const workflow = await loadWorkflow(path)
+  const { globals, trace } = createRuntime({
+    respond: baseRespond({
+      detect: () => detected({ fileCount: 50 }),
+      'scan:.': () => ({
+        scanMeta: { languages: ['typescript'], filesScanned: 12, serenaAvailable: true, scope: '.' },
+        candidates: [],
+      }),
+    }),
+  })
+
+  const result = await workflow.run({ ...globals, args: '.' })
+
+  assert.equal(result.scanMeta.underScanned, true)
+  assert.equal(result.scanMeta.filesScanned, 12)
+  assert.match(trace.logs.join('\n'), /Under-scanned: scanned 12 of 50/)
+})
+
+test('scanMeta does not flag underScanned when filesScanned covers detected fileCount', async () => {
+  const workflow = await loadWorkflow(path)
+  const { globals, trace } = createRuntime({ respond: baseRespond({}) })
+
+  const result = await workflow.run({ ...globals, args: '.' })
+
+  assert.equal(result.scanMeta.underScanned, false)
+  assert.doesNotMatch(trace.logs.join('\n'), /Under-scanned/)
+})
+
+test('a crashed Rank agent returns report:null while keeping candidates and confirmed', async () => {
+  const workflow = await loadWorkflow(path)
+  const { globals, trace } = createRuntime({
+    respond: baseRespond({
+      'scan:.': () => ({
+        scanMeta: { languages: ['typescript'], filesScanned: 10, serenaAvailable: true, scope: '.' },
+        candidates: [candidate()],
+      }),
+      'verify:generateUUID': () => confirmVerdict(),
+      rank: () => { throw new Error('rank agent crashed') },
+    }),
+  })
+
+  const result = await workflow.run({ ...globals, args: '.' })
+
+  assert.equal(result.report, null)
+  assert.equal(result.confirmed.length, 1)
+  assert.equal(result.candidates.length, 1)
+  assert.match(trace.logs.join('\n'), /Rank agent crashed/)
+})
+
+test('budget exhaustion before Verify skips Verify/Rank and returns the capped candidates unverified', async () => {
+  const workflow = await loadWorkflow(path)
+  let spent = 0
+  const budget = { total: 10, spent: () => spent, remaining: () => Math.max(0, 10 - spent) }
+  const { globals, trace } = createRuntime({
+    respond: baseRespond({
+      'scan:.': () => {
+        spent = 10
+        return { scanMeta: { languages: ['typescript'], filesScanned: 10, serenaAvailable: true, scope: '.' }, candidates: [candidate()] }
+      },
+    }),
+  })
+
+  const result = await workflow.run({ ...globals, args: '.', budget })
+
+  assert.equal(result.confirmed.length, 0)
+  assert.equal(result.candidates.length, 1)
+  assert.equal(result.report, null)
+  assert.deepEqual(trace.agents.map(({ opts }) => opts.label), ['detect', 'scan:.'])
+  assert.match(trace.logs.join('\n'), /skipping Verify\/Rank/)
+})
+
+test('budget exhaustion before Rank skips Rank and returns confirmed candidates without a report', async () => {
+  const workflow = await loadWorkflow(path)
+  let spent = 0
+  const budget = { total: 10, spent: () => spent, remaining: () => Math.max(0, 10 - spent) }
+  const { globals, trace } = createRuntime({
+    respond: baseRespond({
+      'scan:.': () => ({
+        scanMeta: { languages: ['typescript'], filesScanned: 10, serenaAvailable: true, scope: '.' },
+        candidates: [candidate()],
+      }),
+      'verify:generateUUID': () => {
+        spent = 10
+        return confirmVerdict()
+      },
+    }),
+  })
+
+  const result = await workflow.run({ ...globals, args: '.', budget })
+
+  assert.equal(result.confirmed.length, 1)
+  assert.equal(result.report, null)
+  assert.deepEqual(trace.agents.map(({ opts }) => opts.label), ['detect', 'scan:.', 'verify:generateUUID'])
+  assert.match(trace.logs.join('\n'), /skipping Rank/)
+})
+
+test('verifyPrompt uses disjoint effort buckets S=1-3, M=4-9, L=10+', async () => {
+  const workflow = await loadWorkflow(path)
+  const { globals, trace } = createRuntime({
+    respond: baseRespond({
+      'scan:.': () => ({
+        scanMeta: { languages: ['typescript'], filesScanned: 10, serenaAvailable: true, scope: '.' },
+        candidates: [candidate()],
+      }),
+      'verify:generateUUID': () => confirmVerdict(),
+    }),
+  })
+
+  await workflow.run({ ...globals, args: '.' })
+
+  const verifyPrompt = trace.agents.find(({ opts }) => opts.label === 'verify:generateUUID').prompt
+  assert.match(verifyPrompt, /S = 1-3 callers, M = 4-9, L = 10\+/)
+})


### PR DESCRIPTION
Adds a report-only multi-agent saved workflow that fans out the existing `nih-scanner` sub-agent across a codebase, adversarially verifies each NIH candidate, and emits a ranked findings table — on both surfaces (Claude saved workflow + OMP extension), the way sliced-bread-audit shipped (#457 + #463).

## What it does
`/nih-scanner [scope] [--min-usage] [--max-candidates] [--workers] [--languages]`

- **Detect** — one explorer agent detects language(s), reads dependency manifests, counts source files.
- **Scan** — fans out the `nih-scanner` agent (Serena/ast-grep) per scope chunk; dedupes candidates; applies `minUsage` filter + `maxCandidates` cap (logged, never silent).
- **Verify** — adversarial default-refute pass; a candidate is confirmed only if a replacement **library is named** (Rule 12), else dropped/needs-human; a crashed verify is kept + flagged, never silently confirmed.
- **Rank** — ranked table (category, file:line, usage, library, effort S/M/L, confidence) + summary.

**Report-only**: never calls `gh`, posts, or writes files. Surfaces an `underScanned` note when the scan under-covers the detected file count.

## Files
- `claude/workflows/nih-scanner.js` + `tests/workflows/nih-scanner.test.mjs`
- `chezmoi/dot_omp/private_agent/extensions/nih-scanner.ts` + `tests/extensions/nih-scanner.test.mjs`
- `tests/omp-config.bats` — managed-extension assertion + handler-contract test

## Verification
`just check` green (lint clean, shellcheck ok, full suite). Reviewed via a fresh-context taste-test (all lenses pass); the 2 medium + 3 low findings from that pass are fixed in the final commit.

Stacked on #458 → #459 → #460.