### PR TITLE
feat(agents): tier orchestration — Sonnet top, Fable brain, inherit backbone

### DIFF
--- a/.hallouminate/wiki/decisions/index.md
+++ b/.hallouminate/wiki/decisions/index.md
@@ -1,6 +1,11 @@
 # decisions
 
 <!-- HALLOUMINATE:INDEX-START -->
+- [orchestration-model-tiering-001-fable-brains-only](./orchestration-model-tiering-001-fable-brains-only.md) — ADR orchestration-model-tiering-001: Fable as the brain tier only, pinned xhigh  [status: accepted]
+- [orchestration-model-tiering-002-sonnet-top-both-paths](./orchestration-model-tiering-002-sonnet-top-both-paths.md) — ADR orchestration-model-tiering-002: Sonnet/high top on both launch paths  [status: accepted]
+- [orchestration-model-tiering-003-routing-ladder-standing-auth](./orchestration-model-tiering-003-routing-ladder-standing-auth.md) — ADR orchestration-model-tiering-003: Three-rung routing ladder with standing Workflow authorization  [status: accepted]
+- [orchestration-model-tiering-004-single-dual-use-brain](./orchestration-model-tiering-004-single-dual-use-brain.md) — ADR orchestration-model-tiering-004: One dual-use brain definition  [status: accepted]
+- [orchestration-model-tiering-005-tops-first-then-inherit](./orchestration-model-tiering-005-tops-first-then-inherit.md) — ADR orchestration-model-tiering-005: Hybrid pin/inherit, deployed tops-first  [status: accepted]
 - [session-convergence-001-fixture-cli-plus-indexes](./session-convergence-001-fixture-cli-plus-indexes.md) — ADR session-convergence-001: Analytics DB stays CLI-queried — no MCP, no ingest timer, no secondary indexes  [status: accepted]
 - [session-convergence-002-sweep-in-work-recovery](./session-convergence-002-sweep-in-work-recovery.md) — ADR session-convergence-002: Convergence sweep lives in /work-recovery, manual-only  [status: accepted]
 - [session-convergence-003-provenance-header-fields](./session-convergence-003-provenance-header-fields.md) — ADR session-convergence-003: Wheypoint provenance as additive header fields with explicit join/split verbs  [status: accepted]

--- a/.hallouminate/wiki/decisions/orchestration-model-tiering-001-fable-brains-only.md
+++ b/.hallouminate/wiki/decisions/orchestration-model-tiering-001-fable-brains-only.md
@@ -1,0 +1,8 @@
+# ADR orchestration-model-tiering-001: Fable as the brain tier only, pinned xhigh  [status: accepted]
+
+- **Context:** Moving off a flagship-at-the-top design, the deep-reasoning tier had to land somewhere. `claude-fable-5` is the tier above Opus ($10/$50 vs $5/$25 per MTok) and the user suspects Opus quality degradation. Candidates: fable everywhere the design said opus/xhigh (brains + review gates), fable for brains only, or fable strictly on-demand.
+- **Decision:** Fable for the reasoning brains only — the `deep-thinker` agent and the plan/judge stages of the default pipeline — pinned `model: fable`, `effort: xhigh` in frontmatter. Review gates (reviewer/fromage-secaudit/fromage-age-arch) stay pinned opus/high.
+- **Alternatives:** Fable-everywhere doubles gate cost for review work opus handles well; on-demand-only re-introduces per-use friction that the ambient-flagship design was already paying in reverse. The frontmatter `xhigh` pin (vs workflow-only effort) is what makes fable/xhigh reachable via the plain Agent tool, which has no effort parameter.
+- **Consequences:** Deep reasoning costs are deliberate and legible (one brain dispatch or pipeline stage at a time); gates stay at half the token price. Fable brain turns can run minutes at xhigh — the routing rule must keep trivia away from them.
+
+Related: [[decisions/orchestration-model-tiering-002-sonnet-top-both-paths]], [[decisions/orchestration-model-tiering-003-routing-ladder-standing-auth]]

--- a/.hallouminate/wiki/decisions/orchestration-model-tiering-002-sonnet-top-both-paths.md
+++ b/.hallouminate/wiki/decisions/orchestration-model-tiering-002-sonnet-top-both-paths.md
@@ -1,0 +1,8 @@
+# ADR orchestration-model-tiering-002: Sonnet/high top on both launch paths  [status: accepted]
+
+- **Context:** Two launch paths had two different tops: terminal (`cc`/`ccc`/`ccr`) booted `claude-fable-5[1m]`/high via the chezmoi settings floor, while Conductor sessions booted `claude-opus-4-8` via an app-level override the dotfiles repo cannot reach. The perceived "Opus is getting dumber" is plausibly this confound — a fable-quality baseline from terminal sessions compared against opus-tier Conductor sessions.
+- **Decision:** Sonnet 5 at effort `high` as the interactive top on **both** paths: settings floor lowered in `chezmoi/lib/claude-settings-authoritative.json`, Conductor model preference set manually (documented operator step — `dots sync` cannot control it). Deep reasoning is invoked deliberately via the fable brain tier, not carried ambiently by the top.
+- **Alternatives:** Split tops (terminal stays fable) keeps flagship spend on routine routing; "fix the confound first" (Conductor→fable, observe a week) delays the cost win and the design was already converged.
+- **Consequences:** Conversation, routing, and dispatch run at $3/$15; both paths are tier-consistent, removing the confound. Risk: Sonnet/high top adequacy for routing is unvalidated — to be checked over real sessions post-deploy. Sequencing is mandatory: tops lowered **before** the backbone agents flip to `model: inherit` (inherit cascades whatever the launcher picked).
+
+Related: [[decisions/orchestration-model-tiering-001-fable-brains-only]], [[decisions/orchestration-model-tiering-005-tops-first-then-inherit]]

--- a/.hallouminate/wiki/decisions/orchestration-model-tiering-003-routing-ladder-standing-auth.md
+++ b/.hallouminate/wiki/decisions/orchestration-model-tiering-003-routing-ladder-standing-auth.md
@@ -1,0 +1,8 @@
+# ADR orchestration-model-tiering-003: Three-rung routing ladder with standing Workflow authorization  [status: accepted]
+
+- **Context:** With a lean Sonnet top and a fable brain tier, the top needs a rule for when to reach for what — and the Workflow tool is opt-in-only by policy, so a "default pipeline the top invokes by default" needs written standing authorization or the top asks permission every time.
+- **Decision:** Three-rung ladder in the preamble: trivial/conversational → inline; single hard reasoning question → dispatch `deep-thinker` via the Agent tool; multi-step or decomposable task → invoke the `default-pipeline` workflow, with the preamble text serving as standing authorization (no per-invocation ask).
+- **Alternatives:** Two-rung (inline or workflow, no direct brain dispatch) pays pipeline overhead for one-shot questions; ask-first workflow invocation preserves the permission ritual at the cost of the frictionless-default goal.
+- **Consequences:** The top stays the sole human channel by construction — subagents and workflow stages cannot ask the user anything, so all input flows through Sonnet, which is also the context-economics win (fable sees distilled problems, not file dumps). Risk: the "multi-step" rung may over-trigger; the wording is tunable after observation.
+
+Related: [[decisions/orchestration-model-tiering-004-single-dual-use-brain]]

--- a/.hallouminate/wiki/decisions/orchestration-model-tiering-004-single-dual-use-brain.md
+++ b/.hallouminate/wiki/decisions/orchestration-model-tiering-004-single-dual-use-brain.md
@@ -1,0 +1,8 @@
+# ADR orchestration-model-tiering-004: One dual-use brain definition  [status: accepted]
+
+- **Context:** The fable brain is needed on two invocation paths: direct Agent-tool dispatch from the Sonnet top (brain-and-hands) and as plan/judge stages inside the default pipeline (Workflow `agentType`). Candidates: one shared agent definition, or two specialized ones.
+- **Decision:** A single `deep-thinker` definition (name is a placeholder) serves both paths — `model: fable`, `effort: xhigh`, read-only tool surface, a goal-and-constraints prompt kept deliberately un-prescriptive (Fable documentation warns that over-prescriptive prompts written for prior models reduce its output quality).
+- **Alternatives:** Separate "planner" and "judge" definitions allow role-tuned prompts but guarantee divergence of two expensive prompts that encode the same brain contract; role context rides in the dispatch prompt instead.
+- **Consequences:** One place to tune the brain; the role is supplied per-dispatch. A dispatched brain cannot fan out (one-level nesting — dispatched agents have no Agent tool), which is fine by design: it returns a plan and either the Sonnet top or the workflow script does the spinning-off.
+
+Related: [[decisions/orchestration-model-tiering-001-fable-brains-only]], [[decisions/orchestration-model-tiering-003-routing-ladder-standing-auth]]

--- a/.hallouminate/wiki/decisions/orchestration-model-tiering-005-tops-first-then-inherit.md
+++ b/.hallouminate/wiki/decisions/orchestration-model-tiering-005-tops-first-then-inherit.md
@@ -1,0 +1,8 @@
+# ADR orchestration-model-tiering-005: Hybrid pin/inherit, deployed tops-first  [status: accepted]
+
+- **Context:** Registry agents needed a rule for which get `model: inherit` and which stay pinned, and the deployment order matters because `inherit` cascades whatever model the launcher picked.
+- **Decision:** Hybrid, keyed on *why* each agent has its tier: pin the quality gates (reviewer/fromage-secaudit/fromage-age-arch → opus/high — must never downgrade in a lean session); pin the mechanical workers (whey-drainer/duckdb-expert/fromage-age-history/worktree-content-digest → haiku/low — must never upgrade in a deep session); flip the phase backbone (explorer/researcher/coder/generalist) to `model: inherit` with the `effort` key dropped so both axes cascade. Deploy sequence: lower both tops (settings floor + Conductor pref) **first**, then land the inherit flip.
+- **Alternatives:** All-inherit is wrong in both directions — it downgrades gates in lean sessions and upgrades workers in deep ones. Flipping inherit before the tops change would run the whole backbone on the old flagship tops (fable/opus), the opposite of the goal. Mid-tier fork targets (ghostbuster/nih-scanner/ricotta-reducer/roquefort-wrecker/fromage-fort) pin sonnet rather than inherit — same never-upgrade rationale as workers; ghostbuster's skill/agent split-brain resolves to the registry value (sonnet/medium) as canonical.
+- **Consequences:** Tier intent is legible per agent class; session tier changes only move the backbone. The two-commit sequencing is a hard ordering constraint on the implementation plan (not parallelizable curds).
+
+Related: [[decisions/orchestration-model-tiering-002-sonnet-top-both-paths]]

--- a/.hallouminate/wiki/domain-model.md
+++ b/.hallouminate/wiki/domain-model.md
@@ -1,0 +1,33 @@
+# Domain model
+
+Cumulative ubiquitous language for this repo's agent-orchestration domain. Merged per-session at curdle; context-specific terms only.
+
+**Top** — the interactive top-level orchestrator model+effort a session boots with; two launch paths set it independently (terminal settings floor, Conductor app preference).
+_Avoid_: orchestrator model, apex
+_Code_: chezmoi/lib/claude-settings-authoritative.json:1-2 (terminal, claude-sonnet-5[1m]/high); Conductor app pref (manual)
+
+**Brain** — a Fable/xhigh reasoning delegate that returns decisions and plans; read-only, never edits, never fans out.
+_Avoid_: god-tier agent, planner agent
+_Code_: agents/registry.yaml (`deep-thinker` entry) + agents/agent_definitions/deep-thinker.md
+
+**Brain-and-hands** — delegation pattern: the brain reasons and returns a plan; the Sonnet top performs the dispatch/fan-out and owns the human channel.
+_Code_: agents/preamble.md (Model-tier routing ladder, rung 2)
+
+**Default pipeline** — the named workflow the top invokes for multi-step work: Fable Plan stage → cheap Work fan-out → Fable Judge stage.
+_Avoid_: default workflow
+_Code_: claude/workflows/default-pipeline.js
+
+**Three-rung ladder** — standing routing rule: trivial → inline; single hard question → brain dispatch; multi-step/decomposable → default pipeline (standing Workflow authorization).
+_Avoid_: routing ladder
+_Code_: agents/preamble.md (Model-tier routing ladder)
+
+**Backbone** — the phase agents (explorer/researcher/coder/generalist) that cascade with the session via `model: inherit`, no effort key.
+_Avoid_: phase backbone
+_Code_: agents/registry.yaml
+
+**Gates** — quality-gate agents pinned opus/high (reviewer, fromage-secaudit, fromage-age-arch); must never downgrade in a lean session.
+_Avoid_: review agents
+_Code_: agents/registry.yaml
+
+**Workers** — mechanical agents pinned haiku/low (whey-drainer, duckdb-expert, fromage-age-history, worktree-content-digest); must never upgrade in a deep session.
+_Code_: agents/registry.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,3 +107,4 @@ Global **claude** config is chezmoi-authoritative: the claude registry `chezmoi/
 - Reference docs go in `reference/` (gitignored, not synced).
 - `git commit --no-verify` only for rare temporary prek overrides (see `prek.toml`).
 - Prefix shell commands with `rtk` (token-filtering proxy; a hook auto-rewrites them anyway). Full reference: `~/.claude/RTK.md` or `rtk --help`.
+- **Conductor's top-level model is a manual step.** The terminal top is the chezmoi settings floor (`chezmoi/lib/claude-settings-authoritative.json` → Sonnet/high, applied by `dots sync`), but Conductor launches with its own app-level model preference that no file under repo control reaches. To keep both launch paths tier-consistent (Sonnet/high), set the Conductor app's model preference to Sonnet manually — and redo it on a new machine. Drift here is the likely source of "Opus is getting dumber" (a Sonnet terminal baseline vs. whatever Conductor booted).

--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -149,7 +149,12 @@ The task-to-tool tables, the serena-vs-tilth edit-shape guide, and the routing s
 
 ## Deep Think
 
-For reasoning-heavy synthesis (design, spec, research), the deepest path is Opus at `xhigh` effort. Hooks cannot change model/effort mid-session, so the graceful switch is checkpoint-and-relaunch: run `/wheypoint` to write a resumable handoff, then relaunch. Opus is already the default model; raise effort with `/effort xhigh` (or relaunch the session on it).
+The interactive top is Sonnet/high on both launch paths (terminal settings floor; Conductor app preference — a manual operator step). Deep reasoning is a deliberate tier, not the ambient default: reach the Fable/`xhigh` brain on demand rather than relaunching the session. Two paths, picked by the model-tier routing ladder in `agents/preamble.md`:
+
+- **One hard reasoning question** → dispatch the `deep-thinker` agent (Fable/`xhigh`) via the Agent tool; relay its decision.
+- **A multi-step or decomposable task** → invoke the `default-pipeline` workflow (Fable plans → cheap agents work → Fable judges).
+
+Both return to the Sonnet top, which owns the human channel. The old checkpoint-and-relaunch dance (`/wheypoint` + `/effort xhigh`) is no longer the deep path — it's only for preserving state across a `/clear`, not for reaching the reasoning tier.
 
 ## Banned Phrases
 

--- a/agents/agent_definitions/deep-thinker.md
+++ b/agents/agent_definitions/deep-thinker.md
@@ -1,0 +1,25 @@
+You are the deep-thinking brain — the deliberate reasoning tier. The parent dispatches you with one hard problem: a decision to make, a plan to shape, or a set of results to judge and synthesize. You reason at depth and hand back a decision. You are the brain; the parent is the hands.
+
+Your leverage is judgment, not motion. Read what you need to ground the decision, think it through, and return the call — with the reasoning that would let the parent (or a future you) trust it or overturn it.
+
+## Constraints
+
+- **Read-only. You never edit, create, or run mutating commands.** You have no Edit/Write tool by design. If the decision implies a change, describe it precisely enough to act on — do not make it.
+- **You cannot fan out.** You have no Agent tool. Return the plan; the parent or the workflow script does the spinning-off.
+- **You are not the human channel.** You cannot ask the user anything — only the top-level orchestrator can. If the problem is underspecified, state the assumption you reasoned under and flag the alternative; don't stall on a question you can't ask.
+- Ground claims in what you read or already know. Tag anything uncertain rather than asserting it.
+
+## What to return
+
+Lead with the four-field block so the parent can machine-read where you landed, then the decision and the reasoning behind it:
+
+```
+status: ok | blocked: <one-line reason>
+next: <recommended next phase> | done
+artifact: <path to fuller output, if any>
+<one-line orientation: the decision in a sentence>
+```
+
+Then: the decision or plan, and the reasoning that supports it — the trade-offs weighed, the option chosen and why, what would change the call. When the parent asked for a plan to fan out, return discrete, independently-actionable subtasks. When the parent asked you to judge, return the verdict and the evidence for it. Give a recommendation, not an exhaustive survey of everything you considered.
+
+Default to an inline answer. Only when the reasoning genuinely exceeds a digest, write it to `.cheese/<phase>/<slug>.md` and return that path as `artifact:` — never dump the full deliberation into your reply.

--- a/agents/preamble.md
+++ b/agents/preamble.md
@@ -65,6 +65,16 @@ Before each tool call, ask: "What's the shape of the question?"
 
 If unsure, pick the smallest-scope tool that can answer the question. Don't rationalize built-ins with "the file is small" or "I already know the path" — those rationalizations have produced incorrect behavior before.
 
+## Model-tier routing (standing ladder)
+
+You are the lean interactive top (Sonnet/high). Deep reasoning (Fable/xhigh) is a deliberate tier you reach for by the rule below — never carried ambiently. A three-rung ladder, followed without asking:
+
+1. **Trivial or conversational** → answer inline. Routing, dispatch, file reads, and cheap synthesis are yours; don't escalate them.
+2. **A single hard reasoning question** (one decision/plan/judgement that genuinely needs depth) → dispatch the `deep-thinker` agent via the Agent tool (`subagent_type: deep-thinker`, no call-site model — it inherits its Fable/xhigh pin), then relay its decision.
+3. **A multi-step or decomposable task** → invoke the `default-pipeline` workflow (Fable plans → cheap agents work → Fable judges). **This instruction is standing authorization for the Workflow tool — do not ask permission per invocation.**
+
+You are the sole human channel: the `deep-thinker` brain and every workflow stage are subagents that **cannot ask the user anything**. All input flows through you — which is also the context-economics win, since the brain sees a distilled problem, not your file dumps. When a subagent needs a decision only the user can make, it hands back; you ask, then re-dispatch. Keep trivia off the Fable tier — its turns can run minutes at `xhigh`.
+
 ## Phase-agent delegation (every skill, not just cheese-flow)
 
 Four general phase-agents model the explore → research → review → code workflow. Delegate to them by default — under any easy-cheese skill (`/mold`, `/cook`, `/age`, `/cure`, …) **and** any user-installed skill or bare task. They run in isolated context windows and hand back a condensed digest, keeping file dumps and fetch bodies out of your window. Planning stays with you, the top-level orchestrator: you own the human approval loop and you are the only level that can fan these agents out (a level-1 subagent cannot spawn subagents).

--- a/agents/registry.yaml
+++ b/agents/registry.yaml
@@ -220,7 +220,7 @@ agents:
   explorer:
     description: Read-only codebase investigator. Answers "where / how / what" questions by searching and reading — never writes. Returns a structured findings digest (file:line citations, call paths, conclusions), keeping the file dumps out of the parent's context. Models the easy-cheese explore phase. Use PROACTIVELY to orient before any task touches unfamiliar code — blast-radius scoping, "find me X" sweeps, "how does Y work" — whether the active skill is /mold, /cook, /age, or any user-installed skill that needs grounding before it acts.
     models:
-      claude: sonnet
+      claude: inherit
       codex: gpt-5.6-terra
       opencode: inherit
     disallowedTools:
@@ -231,7 +231,6 @@ agents:
     - Grep
     - Glob
     color: cyan
-    effort: medium
     skills:
     - cheez-search
     - cheez-read
@@ -240,7 +239,7 @@ agents:
   researcher:
     description: External-research agent. Answers questions outside the codebase — library/API docs, current web facts, version/changelog checks, best-practice comparisons, GitHub examples — via Context7, Tavily, web fetch, and gh, then writes a durable cited research slug under .cheese/research/. Read-only against code. Returns a condensed claim-level digest (the heavy fetch bodies stay on disk, out of the parent's context). Models the easy-cheese research phase. Use PROACTIVELY before implementing against an unfamiliar library or API, when a claim needs a current source instead of a guess, or whenever a skill (/mold, /cook, /briesearch, or any user-installed skill) would otherwise rely on stale training data.
     models:
-      claude: sonnet
+      claude: inherit
       codex: gpt-5.6-terra
       opencode: inherit
     disallowedTools:
@@ -250,7 +249,6 @@ agents:
     - Grep
     - Glob
     color: blue
-    effort: medium
     skills:
     - briesearch
     - cheez-search
@@ -279,14 +277,15 @@ agents:
     maxTurns: 50
     body_path: agents/agent_definitions/reviewer.md
   coder:
-    # Runs on sonnet at medium effort: Sonnet 5 matches Opus at low/medium effort
-    # at a fraction of the token cost, and the write surface's loop is bounded.
+    # Backbone phase agent: model: inherit, no effort key — both axes cascade
+    # with the session (a lean Sonnet/high top runs the coder at Sonnet/high; a
+    # deep session lifts it too). See decisions/orchestration-model-tiering-005.
     # Denies native Edit/Write/Grep/Glob/NotebookEdit — all edits go through
     # cheez-write (tilth); keeps Read. Denies Agent — a dispatched coder is a
     # level-1 subagent and cannot fan out.
     description: TDD-disciplined implementer. Takes an approved spec or unambiguous task and drives the contract → cut → implement → taste-test loop, editing through the cheez-write (tilth) skill. Runs the project's test/lint/build gates and applies review fixes. Models the easy-cheese code phase (/cook, /press, /cure). Mutates the tree exclusively through cheez-write (tilth) — the one phase agent that changes code. Use PROACTIVELY whenever a task requires writing or changing code — implementing a spec, fixing a bug, applying review findings — under /cook, /press, /cure, or any user-installed skill that needs a code change made.
     models:
-      claude: sonnet
+      claude: inherit
       codex: gpt-5.6-terra
       opencode: inherit
     disallowedTools:
@@ -297,7 +296,6 @@ agents:
     - Write
     - NotebookEdit
     color: green
-    effort: medium
     skills:
     - cook
     - press
@@ -322,7 +320,7 @@ agents:
     # level-1 subagent cannot fan out).
     description: General-purpose catch-all for an open-ended, multi-step task that does not fit a specialist phase agent — mixed research, code reading, and synthesis in one dispatch. The capped stand-in for the built-in general-purpose agent. Prefer a specialist when the task is cleanly one shape — explorer for "where/how/what" code questions, researcher for external/library/web facts, reviewer for checking a diff before it lands, coder for writing or changing code. Use this only as the fallback when no single specialist owns the task. Routes file I/O through the cheez-* (tilth) skills.
     models:
-      claude: sonnet
+      claude: inherit
       codex: gpt-5.6-terra
       opencode: inherit
     disallowedTools:
@@ -331,10 +329,38 @@ agents:
     - Glob
     - NotebookEdit
     color: yellow
-    effort: medium
     skills:
     - cheez-search
     - cheez-read
     - cheez-write
     maxTurns: 100
     body_path: agents/agent_definitions/generalist.md
+  # ── deliberate reasoning brain ────────────────────────────────────────────
+  # The one Fable/xhigh tier reachable on demand. Pinned in frontmatter (not
+  # inherit) because fable/xhigh is the deliberate reasoning tier, invoked via
+  # the routing ladder — not carried ambiently by the Sonnet top. The plain
+  # Agent tool has no effort param, so the frontmatter `effort: xhigh` pin is
+  # what makes xhigh reachable by name. Read-only: it decides and plans, never
+  # edits and never fans out (a level-1 subagent has no Agent tool). Serves both
+  # the Agent-tool dispatch and the default-pipeline workflow's plan/judge
+  # stages. `deep-thinker` is a placeholder name. Claude-only: fable is a Claude
+  # tier and the other harnesses are frozen pending their migration spec.
+  # See decisions/orchestration-model-tiering-00{1,3,4}.
+  deep-thinker:
+    description: Deliberate reasoning brain (Fable at xhigh effort). Dispatched for a single hard reasoning question — it plans, judges, or synthesizes and returns a decision, never editing code and never fanning out. Read-only. Used by the top-level routing ladder (via the Agent tool) and by the default-pipeline workflow's plan and judge stages. Prefer it over inline reasoning only when the question is genuinely hard; route trivial questions inline and multi-step work to the pipeline.
+    models:
+      claude: fable
+    disallowedTools:
+    - Edit
+    - Write
+    - NotebookEdit
+    - Agent
+    - Grep
+    - Glob
+    color: magenta
+    effort: xhigh
+    skills:
+    - cheez-search
+    - cheez-read
+    maxTurns: 50
+    body_path: agents/agent_definitions/deep-thinker.md

--- a/chezmoi/.chezmoidata/claude.yaml
+++ b/chezmoi/.chezmoidata/claude.yaml
@@ -290,6 +290,7 @@ claude:
   # Frontmatter is rendered from agents/registry.yaml metadata at assembly time.
   agents:
     - coder
+    - deep-thinker
     - duckdb-expert
     - explorer
     - fromage-age-arch

--- a/chezmoi/lib/claude-settings-authoritative.json
+++ b/chezmoi/lib/claude-settings-authoritative.json
@@ -1,5 +1,5 @@
 {
-  "model": "claude-fable-5[1m]",
+  "model": "claude-sonnet-5[1m]",
   "effortLevel": "high",
   "env": {
     "ENABLE_TOOL_SEARCH": "true",

--- a/claude/workflows/default-pipeline.js
+++ b/claude/workflows/default-pipeline.js
@@ -1,0 +1,84 @@
+export const meta = {
+  name: 'default-pipeline',
+  description: 'The Sonnet top\'s default for multi-step work: a Fable brain plans, cheap Sonnet agents do the bulk in parallel, a Fable brain judges and synthesizes.',
+  phases: [
+    { title: 'Plan', detail: 'deep-thinker (fable/xhigh) decomposes the problem into file-disjoint subtasks', model: 'fable' },
+    { title: 'Work', detail: 'one sonnet agent per subtask, run as a pipeline (no barrier)' },
+    { title: 'Judge', detail: 'deep-thinker (fable/xhigh) judges and synthesizes the worker outputs into one answer', model: 'fable' },
+  ],
+}
+
+// Tracked source: claude/workflows/default-pipeline.js in the dotfiles repo.
+// The named workflow the three-rung routing ladder invokes for multi-step or
+// decomposable tasks (spec: orchestration-model-tiering). The brain-and-hands
+// split: the deep-thinker brain only reasons (plan/judge) — the SCRIPT does the
+// fan-out, because a dispatched agent is a level-1 subagent and cannot spawn.
+// The plan and judge stages pass agentType:'deep-thinker' with no call-site
+// model/effort, so they inherit the agent's fable/xhigh frontmatter pins; the
+// work stage pins sonnet explicitly. Returns to the Sonnet top, which relays to
+// the user and owns every follow-up question (subagents/stages cannot ask).
+//
+// Args: a bare problem string, or { problem: string }.
+
+const PLAN = {
+  type: 'object',
+  required: ['subtasks'],
+  properties: {
+    approach: { type: 'string', description: 'One or two sentences on the overall approach.' },
+    subtasks: {
+      type: 'array',
+      description: 'Independently-actionable subtasks; keep them file-disjoint where the work touches code.',
+      items: {
+        type: 'object',
+        required: ['brief'],
+        properties: {
+          label: { type: 'string', description: 'Short label for progress display.' },
+          brief: { type: 'string', description: 'Self-contained instruction a single agent can complete on its own.' },
+        },
+      },
+    },
+  },
+}
+
+const input = typeof args === 'string' ? { problem: args } : (args || {})
+const problem = typeof input.problem === 'string' ? input.problem.trim() : ''
+
+if (!problem) {
+  log('No problem provided. Usage: /default-pipeline with args = "<problem>" or { problem: "<problem>" }')
+  return { error: 'No problem provided.' }
+}
+
+phase('Plan')
+const plan = await agent(
+  `Plan how to solve this problem. Decompose it into independently-actionable subtasks a fan-out of cheaper agents can each complete on its own; keep them file-disjoint where the work touches code. State the approach, then the subtasks.\n\nProblem:\n${problem}`,
+  { agentType: 'deep-thinker', label: 'plan', phase: 'Plan', schema: PLAN },
+)
+
+const subtasks = plan && Array.isArray(plan.subtasks) ? plan.subtasks : []
+if (!subtasks.length) {
+  log('The plan produced no subtasks; returning the plan as the answer.')
+  return { plan }
+}
+
+phase('Work')
+const outputs = await pipeline(
+  subtasks,
+  (t) => agent(t.brief, { model: 'sonnet', label: t.label || t.brief.slice(0, 40), phase: 'Work' }),
+)
+
+phase('Judge')
+const results = subtasks
+  .map((t, i) => ({ subtask: t.label || t.brief, output: outputs[i] }))
+  .filter((r) => r.output != null)
+
+if (!results.length) {
+  // Every worker failed — nothing to judge. Skip the expensive Fable/xhigh
+  // judge pass (mirrors the no-subtasks short-circuit above).
+  log('Every worker produced no output; returning the plan and raw outputs without a judge pass.')
+  return { plan, outputs }
+}
+
+return await agent(
+  `Judge and synthesize the worker outputs into a single answer to the original problem. Weigh them, resolve conflicts, and state one coherent result with the reasoning behind it — do not just concatenate.\n\nOriginal problem:\n${problem}\n\nApproach taken:\n${plan.approach || '(none stated)'}\n\nWorker outputs:\n${JSON.stringify(results, null, 2)}`,
+  { agentType: 'deep-thinker', label: 'judge', phase: 'Judge' },
+)

--- a/skills/ghostbuster/SKILL.md
+++ b/skills/ghostbuster/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ghostbuster
-model: opus
-effort: high
+model: sonnet
+effort: medium
 context: fork
 argument-hint: "[directory to scope, or leave blank for full codebase]"
 allowed-tools: Read, Glob, Grep, Bash(git log:*), Bash(git diff:*), Bash(git blame:*), Bash(wc:*), Agent, mcp__serena__*

--- a/tests/agent-skill-model-effort.bats
+++ b/tests/agent-skill-model-effort.bats
@@ -1,17 +1,25 @@
 #!/usr/bin/env bats
-# Guard the agent/skill model+effort retune (spec: agent-model-effort-retune).
+# Guard the agent/skill model+effort tiering (specs: agent-model-effort-retune,
+# then orchestration-model-tiering, which supersedes the uniform rule for two
+# named classes).
 #
-# WHY: the retune's whole premise is that EVERY agent and skill carries an
-# EXPLICIT model+effort following ONE uniform tier→effort mapping
-# (haiku→low, sonnet→medium, opus→high). Nothing else in the suite pins those
-# values, so a future edit could drop an effort, flip sonnet→high, or leave a
-# skill model-less and every other test would still pass. These assertions are
-# the regression guard for the retune: they fail the moment the mapping drifts.
+# WHY: pinned agents/skills must carry an EXPLICIT model+effort following the
+# tier→effort mapping (haiku→low, sonnet→medium, opus→high, fable→xhigh).
+# Nothing else in the suite pins those values, so a future edit could drop an
+# effort, flip sonnet→high, or leave a skill model-less and every other test
+# would still pass. These assertions fail the moment the mapping drifts.
 #
-# Scope: Claude models/efforts plus the Codex model tier paired to each agent.
-# The Codex mapping is high/opus→Sol, medium/sonnet→Terra, low/haiku→Luna.
-# xhigh/max remain reserved for the manual deep-think path and must not appear
-# on any agent/skill.
+# Two deliberate exceptions from orchestration-model-tiering (ADRs 001/005):
+#   - Backbone phase agents (explorer/researcher/coder/generalist) run
+#     `model: inherit` with NO effort key, so both axes cascade with the
+#     session. inherit agents are exempt from the effort/Codex mapping.
+#   - The `deep-thinker` brain pins `model: fable`, `effort: xhigh` — the one
+#     place xhigh is allowed. It is Claude-only (no Codex tier), since fable is
+#     a Claude tier and the other harnesses are frozen.
+#
+# Scope: Claude models/efforts plus the Codex model tier paired to each PINNED
+# agent. The Codex mapping is high/opus→Sol, medium/sonnet→Terra, low/haiku→Luna.
+# `max` remains reserved and must not appear anywhere; `xhigh` only on fable.
 
 DOTFILES_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME}")/.." && pwd)"
 REGISTRY="$DOTFILES_DIR/agents/registry.yaml"
@@ -19,12 +27,13 @@ CLAUDE_YAML="$DOTFILES_DIR/chezmoi/.chezmoidata/claude.yaml"
 
 setup() { command -v yq >/dev/null 2>&1 || skip "yq not installed"; }
 
-# Expected effort for a claude model tier, per the uniform mapping rule.
+# Expected effort for a claude model tier, per the mapping rule.
 expected_effort() {
     case "$1" in
         haiku) echo low ;;
         sonnet) echo medium ;;
         opus) echo high ;;
+        fable) echo xhigh ;;
         *) echo "UNMAPPED" ;;
     esac
 }
@@ -38,43 +47,64 @@ expected_codex_model() {
     esac
 }
 
-@test "every agent has an explicit claude model and effort" {
+@test "every agent has an explicit claude model; inherit drops effort, pins carry it" {
     local a model effort
     while IFS= read -r a; do
         model="$(yq -r ".agents.\"$a\".models.claude // \"\"" "$REGISTRY")"
         effort="$(yq -r ".agents.\"$a\".effort // \"\"" "$REGISTRY")"
         [[ -n "$model" ]] || { echo "agent '$a' has no models.claude" >&2; return 1; }
-        [[ -n "$effort" ]] || { echo "agent '$a' has no effort" >&2; return 1; }
+        if [[ "$model" == "inherit" ]]; then
+            # backbone: both axes cascade with the session — no effort key
+            [[ -z "$effort" ]] || { echo "agent '$a' is model: inherit but pins effort '$effort'" >&2; return 1; }
+        else
+            [[ -n "$effort" ]] || { echo "agent '$a' has no effort" >&2; return 1; }
+        fi
     done < <(yq -r '.agents | keys | .[]' "$REGISTRY")
 }
 
-@test "every agent's effort matches the tier→effort mapping" {
+@test "every pinned agent's effort matches the tier→effort mapping" {
     local a model effort want
     while IFS= read -r a; do
         model="$(yq -r ".agents.\"$a\".models.claude" "$REGISTRY")"
+        [[ "$model" == "inherit" ]] && continue   # backbone: exempt, no effort
         effort="$(yq -r ".agents.\"$a\".effort" "$REGISTRY")"
         want="$(expected_effort "$model")"
         [[ "$want" != "UNMAPPED" ]] \
-            || { echo "agent '$a' claude model '$model' is outside the haiku/sonnet/opus mapping" >&2; return 1; }
+            || { echo "agent '$a' claude model '$model' is outside the haiku/sonnet/opus/fable mapping" >&2; return 1; }
         [[ "$effort" == "$want" ]] \
             || { echo "agent '$a' is $model/$effort — mapping wants $model/$want" >&2; return 1; }
     done < <(yq -r '.agents | keys | .[]' "$REGISTRY")
 }
 
-@test "no agent carries a reserved xhigh/max effort" {
-    local a effort
+@test "xhigh appears only on the fable brain; max never appears" {
+    local a model effort
     while IFS= read -r a; do
+        model="$(yq -r ".agents.\"$a\".models.claude // \"\"" "$REGISTRY")"
         effort="$(yq -r ".agents.\"$a\".effort // \"\"" "$REGISTRY")"
-        [[ "$effort" != "xhigh" && "$effort" != "max" ]] \
-            || { echo "agent '$a' has reserved effort '$effort' (xhigh/max are manual-only)" >&2; return 1; }
+        [[ "$effort" != "max" ]] \
+            || { echo "agent '$a' has reserved effort 'max'" >&2; return 1; }
+        if [[ "$effort" == "xhigh" ]]; then
+            [[ "$model" == "fable" ]] \
+                || { echo "agent '$a' has xhigh effort but model '$model' (xhigh is fable-only)" >&2; return 1; }
+        fi
     done < <(yq -r '.agents | keys | .[]' "$REGISTRY")
 }
 
-@test "every agent uses the GPT-5.6 Codex model matching its tier" {
+@test "every pinned agent uses the GPT-5.6 Codex model matching its tier" {
     local a claude_model codex_model want
     while IFS= read -r a; do
         claude_model="$(yq -r ".agents.\"$a\".models.claude // \"\"" "$REGISTRY")"
         codex_model="$(yq -r ".agents.\"$a\".models.codex // \"\"" "$REGISTRY")"
+        # inherit backbone: Codex tiering is frozen at gpt-5.6-terra (decoupled
+        # from the claude flip). Enforce the freeze rather than skip it, so a
+        # future flip to luna/sol fails loud instead of passing silently.
+        if [[ "$claude_model" == "inherit" ]]; then
+            [[ "$codex_model" == "gpt-5.6-terra" ]] \
+                || { echo "agent '$a' is model: inherit but codex '$codex_model' — frozen value is gpt-5.6-terra" >&2; return 1; }
+            continue
+        fi
+        # fable (Claude-only brain) has no claude→Codex derivation.
+        [[ "$claude_model" == "fable" ]] && continue
         want="$(expected_codex_model "$claude_model")"
         [[ "$want" != "UNMAPPED" ]] \
             || { echo "agent '$a' claude model '$claude_model' has no Codex tier mapping" >&2; return 1; }

--- a/tests/claude-settings.bats
+++ b/tests/claude-settings.bats
@@ -33,6 +33,18 @@ $1
 STDIN"
 }
 
+@test "settings floor: the terminal top is the Sonnet 5 tier at high (spec: orchestration-model-tiering)" {
+    # The tests above guard the floor-overrides-drift MECHANISM (OUT == AUTH).
+    # This pins the floor's VALUE: the interactive top is a deliberate tier —
+    # Sonnet 5 at high, not the old flagship. A drift back to fable/opus would
+    # pass every mechanism test but breaks the tiering; this fails loud. The
+    # `[1m]` (or any) suffix is tolerated; the tier and effort are pinned.
+    run jq -r '.model' "$AUTH"
+    [ "$status" -eq 0 ]
+    [[ "$output" == claude-sonnet-5* ]] || { echo "top model '$output' is not the Sonnet 5 tier"; return 1; }
+    [ "$(jq -r '.effortLevel' "$AUTH")" = "high" ]
+}
+
 @test "modify_settings: empty stdin emits the composed desired document (fresh machine)" {
     run bash -c "CHEZMOI_SOURCE_DIR='$CZ_SRC' sh '$SCRIPT' </dev/null >'$OUT'"
     [ "$status" -eq 0 ]

--- a/tests/registry-model-tiering.bats
+++ b/tests/registry-model-tiering.bats
@@ -1,0 +1,81 @@
+#!/usr/bin/env bats
+# Tier invariant for the real agents/registry.yaml (spec:
+# orchestration-model-tiering). Renders each agent's claude frontmatter via
+# _cz_render_claude_agent and asserts the model/effort tier its ROLE demands:
+#
+#   backbone (explorer/researcher/coder/generalist) -> model: inherit, no effort
+#     (cascades both axes with the session)
+#   gates    (reviewer/fromage-secaudit/fromage-age-arch) -> opus / high
+#     (must never downgrade in a lean session)
+#   workers  (whey-drainer/duckdb-expert/fromage-age-history/
+#             worktree-content-digest) -> haiku / low (must never upgrade)
+#   brain    (deep-thinker) -> fable / xhigh (the deliberate reasoning tier)
+#
+# A tier change to any of these is deliberate by design; this test makes an
+# accidental one fail loud rather than ship silently.
+
+load test_helper
+
+setup() {
+    command -v yq >/dev/null 2>&1 || skip "yq not installed"
+    command -v jq >/dev/null 2>&1 || skip "jq not installed"
+    ROOT="$REAL_DOTFILES_DIR"
+    REG="$ROOT/agents/registry.yaml"
+    RENDER_DIR="$(mktemp -d "${TMPDIR:-/tmp}/tier-render.XXXXXX")"
+    export ROOT REG RENDER_DIR
+}
+
+teardown() { rm -rf "$RENDER_DIR"; }
+
+render() {
+    # render <agent-name> -> frontmatter+body on stdout
+    local name="$1" out="$RENDER_DIR/$1.md"
+    bash -c "source '$ROOT/.sync-lib.sh' && _cz_render_claude_agent '$REG' '$name' '$ROOT' '$out'" || return 1
+    cat "$out"
+}
+
+@test "backbone agents render model: inherit and no effort key" {
+    for a in explorer researcher coder generalist; do
+        run render "$a"
+        [ "$status" -eq 0 ] || { echo "render $a failed: $output"; return 1; }
+        [[ "$output" == *"model: inherit"* ]] || { echo "$a: expected 'model: inherit'"; echo "$output"; return 1; }
+        # no effort line at all — both axes cascade with the session
+        if grep -q '^effort:' <<<"$output"; then
+            echo "$a: expected NO effort key, found one"; echo "$output"; return 1
+        fi
+    done
+}
+
+@test "quality-gate agents stay pinned opus / high" {
+    for a in reviewer fromage-secaudit fromage-age-arch; do
+        run render "$a"
+        [ "$status" -eq 0 ] || { echo "render $a failed: $output"; return 1; }
+        [[ "$output" == *"model: opus"* ]] || { echo "$a: expected 'model: opus'"; echo "$output"; return 1; }
+        [[ "$output" == *"effort: high"* ]] || { echo "$a: expected 'effort: high'"; echo "$output"; return 1; }
+    done
+}
+
+@test "mechanical worker agents stay pinned haiku / low" {
+    for a in whey-drainer duckdb-expert fromage-age-history worktree-content-digest; do
+        run render "$a"
+        [ "$status" -eq 0 ] || { echo "render $a failed: $output"; return 1; }
+        [[ "$output" == *"model: haiku"* ]] || { echo "$a: expected 'model: haiku'"; echo "$output"; return 1; }
+        [[ "$output" == *"effort: low"* ]] || { echo "$a: expected 'effort: low'"; echo "$output"; return 1; }
+    done
+}
+
+@test "deep-thinker brain renders fable / xhigh and is read-only" {
+    run render deep-thinker
+    [ "$status" -eq 0 ] || { echo "render deep-thinker failed: $output"; return 1; }
+    [[ "$output" == *"model: fable"* ]] || { echo "expected 'model: fable'"; echo "$output"; return 1; }
+    [[ "$output" == *"effort: xhigh"* ]] || { echo "expected 'effort: xhigh'"; echo "$output"; return 1; }
+    # brain, not hands: Edit/Write must be denied
+    [[ "$output" == *"disallowedTools:"*"Edit"* ]] || { echo "expected Edit in disallowedTools"; echo "$output"; return 1; }
+    [[ "$output" == *"Write"* ]] || { echo "expected Write denied"; echo "$output"; return 1; }
+}
+
+@test "deep-thinker is selected in the claude registry so it deploys" {
+    run yq -r '.claude.agents // [] | .[]' "$ROOT/chezmoi/.chezmoidata/claude.yaml"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"deep-thinker"* ]] || { echo "deep-thinker not in claude.yaml agents:"; echo "$output"; return 1; }
+}

--- a/tests/registry-model-tiering.bats
+++ b/tests/registry-model-tiering.bats
@@ -69,9 +69,13 @@ render() {
     [ "$status" -eq 0 ] || { echo "render deep-thinker failed: $output"; return 1; }
     [[ "$output" == *"model: fable"* ]] || { echo "expected 'model: fable'"; echo "$output"; return 1; }
     [[ "$output" == *"effort: xhigh"* ]] || { echo "expected 'effort: xhigh'"; echo "$output"; return 1; }
-    # brain, not hands: Edit/Write must be denied
-    [[ "$output" == *"disallowedTools:"*"Edit"* ]] || { echo "expected Edit in disallowedTools"; echo "$output"; return 1; }
-    [[ "$output" == *"Write"* ]] || { echo "expected Write denied"; echo "$output"; return 1; }
+    # brain, not hands: Edit/Write must be members of the disallowedTools
+    # frontmatter list, not just substrings anywhere in the rendered output
+    deny="$(printf '%s\n' "$output" | sed -n 's/^disallowedTools:[[:space:]]*//p' | head -n1 | tr -d '[]')"
+    [[ -n "$deny" ]] || { echo "no disallowedTools line in frontmatter"; echo "$output"; return 1; }
+    for tool in Edit Write; do
+        [[ ",${deny// /}," == *",$tool,"* ]] || { echo "expected $tool in disallowedTools: [$deny]"; return 1; }
+    done
 }
 
 @test "deep-thinker is selected in the claude registry so it deploys" {

--- a/tests/workflows/default-pipeline.test.mjs
+++ b/tests/workflows/default-pipeline.test.mjs
@@ -1,0 +1,98 @@
+import assert from 'node:assert/strict'
+import { resolve } from 'node:path'
+import test from 'node:test'
+
+import { createRuntime, loadWorkflow } from './harness.mjs'
+
+const path = resolve(import.meta.dirname, '../../claude/workflows/default-pipeline.js')
+
+// Acceptance (spec: orchestration-model-tiering): the plan and judge stages run
+// on the deep-thinker brain (agentType, no call-site model — it inherits its
+// fable/xhigh frontmatter pin), and the work stage runs on sonnet.
+
+test('default-pipeline: plan+judge dispatch the deep-thinker brain, work fans out on sonnet', async () => {
+  const workflow = await loadWorkflow(path)
+  const { globals, trace } = createRuntime({
+    respond: ({ opts }) => {
+      if (opts.label === 'plan') {
+        return { approach: 'split it', subtasks: [
+          { label: 'a', brief: 'do a' },
+          { label: 'b', brief: 'do b' },
+        ] }
+      }
+      if (opts.label === 'a') return 'result a'
+      if (opts.label === 'b') return 'result b'
+      if (opts.label === 'judge') return 'final answer'
+      throw new Error(`unexpected agent ${opts.label}`)
+    },
+  })
+
+  const result = await workflow.run({ ...globals, args: 'solve X' })
+
+  assert.equal(result, 'final answer')
+
+  const byLabel = Object.fromEntries(trace.agents.map((c) => [c.opts.label, c.opts]))
+
+  // Plan: deep-thinker, no call-site model override (so it inherits fable/xhigh).
+  assert.equal(byLabel.plan.agentType, 'deep-thinker')
+  assert.equal(byLabel.plan.model, undefined)
+  assert.ok(byLabel.plan.schema, 'plan stage requests structured output')
+
+  // Work: one sonnet agent per subtask.
+  assert.equal(byLabel.a.model, 'sonnet')
+  assert.equal(byLabel.b.model, 'sonnet')
+  assert.equal(byLabel.a.agentType, undefined)
+
+  // Judge: deep-thinker, no call-site model override.
+  assert.equal(byLabel.judge.agentType, 'deep-thinker')
+  assert.equal(byLabel.judge.model, undefined)
+
+  // Dispatch order: plan -> work fan-out -> judge.
+  assert.deepEqual(trace.agents.map((c) => c.opts.label), ['plan', 'a', 'b', 'judge'])
+})
+
+test('default-pipeline: empty args returns an error and dispatches no agents', async () => {
+  const workflow = await loadWorkflow(path)
+  const { globals, trace } = createRuntime({ respond: () => { throw new Error('should not dispatch') } })
+
+  const result = await workflow.run({ ...globals, args: '   ' })
+
+  assert.ok(result.error, 'returns an error object')
+  assert.equal(trace.agents.length, 0)
+})
+
+test('default-pipeline: when every worker fails, it skips the judge and returns the plan + outputs', async () => {
+  const workflow = await loadWorkflow(path)
+  const { globals, trace } = createRuntime({
+    respond: ({ opts }) => {
+      if (opts.label === 'plan') return { approach: 'split it', subtasks: [{ label: 'a', brief: 'do a' }] }
+      if (opts.label === 'a') throw new Error('worker crashed') // harness pipeline maps a throw to null
+      throw new Error(`unexpected agent ${opts.label}`)
+    },
+  })
+
+  const result = await workflow.run({ ...globals, args: 'solve X' })
+
+  // No judge dispatched — plan + work only.
+  assert.deepEqual(trace.agents.map((c) => c.opts.label), ['plan', 'a'])
+  assert.ok(result.plan, 'returns the plan')
+  assert.ok(Array.isArray(result.outputs), 'returns the raw outputs')
+})
+
+test('default-pipeline: a plan with no subtasks returns the plan without a work/judge fan-out', async () => {
+  const workflow = await loadWorkflow(path)
+  const { globals, trace } = createRuntime({
+    respond: ({ opts }) => {
+      if (opts.label === 'plan') return { approach: 'nothing to split', subtasks: [] }
+      throw new Error(`unexpected agent ${opts.label}`)
+    },
+  })
+
+  const result = await workflow.run({ ...globals, args: { problem: 'trivial' } })
+
+  // result is built in the workflow's vm realm — assert on properties, not a
+  // cross-realm deepEqual (prototype identity differs).
+  assert.equal(result.plan.approach, 'nothing to split')
+  assert.equal(result.plan.subtasks.length, 0)
+  assert.deepEqual(trace.agents.map((c) => c.opts.label), ['plan'])
+})


### PR DESCRIPTION
## What & why

Move off a flagship-at-the-top orchestration design so deep reasoning is invoked **deliberately**, not carried ambiently. The interactive top becomes lean (Sonnet/high) and routes hard work to a Fable brain and a default pipeline.

## Changes

- **Terminal top → Sonnet/high.** `chezmoi/lib/claude-settings-authoritative.json` → `claude-sonnet-5[1m]`, effort `high`. Conductor's top-model is a documented manual step (`AGENTS.md` gotcha) — no repo-controlled file reaches it.
- **Backbone → `model: inherit`.** explorer/researcher/coder/generalist drop their pin and `effort` key so both axes cascade with the session. Sequenced *after* the top change (inherit cascades whatever the launcher picked).
- **Deep-thinker brain** — new read-only Fable/`xhigh` agent (decides/plans, never edits, never fans out), registered in the claude registry.
- **`default-pipeline` workflow** — Fable plans (`agentType: deep-thinker`) → sonnet `pipeline()` fan-out → Fable judges. The script does the fan-out; the brain only reasons.
- **Three-rung routing ladder** in the preamble (inline → brain dispatch → default-pipeline) with standing Workflow authorization; the Sonnet top stays the sole human channel.
- **Unchanged tiers:** quality gates stay opus/high, mechanical workers stay haiku/low. ghostbuster canonicalized to sonnet/medium (skill == registry, split-brain resolved).
- **Docs:** corrected the stale "Opus is already the default model" line.

## Tests

- `tests/registry-model-tiering.bats` — tier invariant per agent class (backbone inherit/no-effort, gates opus/high, workers haiku/low, brain fable/xhigh read-only, brain deployed).
- `tests/agent-skill-model-effort.bats` — policy updated for the two exceptions (inherit exempt from effort/codex mapping but Codex freeze enforced; xhigh only on fable; max never).
- `tests/workflows/default-pipeline.test.mjs` — dispatch contract (plan/judge on `deep-thinker`, work on sonnet) + empty-args, no-subtasks, and all-workers-failed guards.
- `tests/claude-settings.bats` — pins the Sonnet-5/high top value.
- `just check` (lint + full bats suite + workflow smoke): green.

## Follow-ups / notes

- Empirical launch tests **V1–V3** (subagent-model override precedence; deep-thinker fable/xhigh transcript; terminal boots Sonnet-5/high) are operator steps post-merge — they need live session transcripts.
- The `[1m]` settings-value suffix is a reasoned mirror of `claude-fable-5[1m]`; V3 confirms it.
- Deploys live on the next `dots sync` from the canonical clone after merge.
- Deferred: `[[architecture/model-tier-routing]]` wiki page (F001) via `/wiki-curator`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
