### PR TITLE
feat(cheese-flair): add Dr. Gorgonzola to Big hitters pool

### DIFF
--- a/agents/reference/cheese-flair.md
+++ b/agents/reference/cheese-flair.md
@@ -18,6 +18,7 @@ these, 25% pull from the wider bank.
 - Cheddar King
 - The Cheesiah
 - Don Curdleone
+- Dr. Gorgonzola
 
 ## Curated names
 


### PR DESCRIPTION
## Summary
- Add "Dr. Gorgonzola" to the Big hitters pool in `agents/reference/cheese-flair.md`, weighted ~25% alongside Big Cheese, Cheddar King, The Cheesiah, and Don Curdleone.

## Test plan
- [x] `bats tests/cheese-flair.bats` passes (dynamic section-read tests cover the new entry with no hardcoding needed)