### PR TITLE
chore(doc-drift): bump codex-cli to 0.144.6 (no-op)

### DIFF
--- a/agents/doc-drift/sources.yaml
+++ b/agents/doc-drift/sources.yaml
@@ -31,7 +31,7 @@ sources:
     signal: { type: npm, ref: "@openai/codex" }
     docs: https://developers.openai.com/codex
     governs: [harnesses/codex.md, agents/hooks/registry.yaml, agents/registry.yaml]
-    reconciled: "0.144.5"
+    reconciled: "0.144.6"
 
   - id: opencode
     signal: { type: npm, ref: opencode-ai }


### PR DESCRIPTION
## What changed upstream

`@openai/codex` 0.144.5 → 0.144.6 (rust-v0.144.6, 2026-07-18). Per the GitHub release changelog:

> Refreshed bundled instructions for GPT-5.6 Sol, Terra, and Luna, and corrected their context windows to 272,000 tokens. (openai/codex#33972, openai/codex#34009)

This is an upstream-internal hotfix: Codex's own bundled model instructions and a context-window value correction for the GPT-5.6 model family. It is not a CLI flag, config-schema, hook-surface, or sub-agent-format change.

## Why this is a no-op

Checked against all three `governs` files for `codex-cli` in `agents/doc-drift/sources.yaml`:

- `harnesses/codex.md` (wiki page — hooks/sub-agents/MCP/system-prompt/settings/skills wiring): none of that surface is touched by this release.
- `agents/hooks/registry.yaml`: unrelated (hooks event/matcher/timeout schema unchanged).
- `agents/registry.yaml`: this file only references Codex model *names* per sub-agent (e.g. `codex: gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`) — it doesn't encode context-window sizes or anything else this release adjusts. Those model-name strings remain valid.

So no config/doc edits are needed — only the `reconciled` marker bump.

## Change

Bumps `reconciled: "0.144.5"` → `"0.144.6"` for the `codex-cli` entry in `agents/doc-drift/sources.yaml`. No other files touched.

Sources consulted: GitHub `openai/codex` releases page (via Tavily), SourceForge mirror README for `rust-v0.144.6` (has the full changelog text quoted above).

🤖 Generated by the doc-drift weekly routine (per-item subagent for `codex-cli`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01EGvdQ8jMZ2RtTGHEyvSrnC)_