### PR TITLE
chore(doc-drift): bump opencode to 1.18.3 (no-op)

### DIFF
--- a/agents/doc-drift/sources.yaml
+++ b/agents/doc-drift/sources.yaml
@@ -37,7 +37,7 @@ sources:
     signal: { type: npm, ref: opencode-ai }
     docs: https://opencode.ai/docs
     governs: [harnesses/opencode.md]
-    reconciled: "1.18.2"
+    reconciled: "1.18.3"
 
   - id: copilot-cli
     signal: { type: npm, ref: "@github/copilot" }


### PR DESCRIPTION
## What changed upstream (opencode-ai 1.18.2 → 1.18.3)

Full release notes ([anomalyco/opencode v1.18.3](https://github.com/anomalyco/opencode/releases/tag/v1.18.3)):

**Core**
- Improvement: Up Arrow now closes the subagent picker when the first item is selected.

**Desktop**
- Bugfix: home page scrolling (sticky headers / session list behavior)
- Bugfix: startup readiness now waits for WSL server loading before reporting ready
- Removed the inactive help button from the app layout
- Fixed custom agent selector visibility when custom agents are available

## Why this is a no-op for us

`harnesses/opencode.md` (`.hallouminate/wiki/harnesses/opencode.md`) documents our CLI/config surface: hooks (none — plugin-API only), sub-agents (`agents/registry.yaml` → `agents/<n>.md`), MCP (isolated-profile injection, live `opencode.json` untouched by `ap`), system prompt (`agents/preamble.md` → `build.md`, `AGENTS.md`/`instructions` rules), settings/config (`opencode.json`, `tui.json`, themes), skills, and the local-LLM provider/`opencode-lean` launcher.

None of the 1.18.3 changes touch that surface:
- The subagent-picker keyboard tweak is a TUI UX nicety, not a config/schema/behavior change.
- Everything else is Desktop-app-only (a separate GUI product we don't reference anywhere in our wiring).

## Change

Bumps `reconciled: "1.18.2"` → `"1.18.3"` for the `opencode` entry in `agents/doc-drift/sources.yaml`. No other files touched.

## Testing

Docs/manifest-only change (single YAML field). Did not run `just check` in this sandbox (isolated worktree without the full toolchain) — relying on CI to gate.

---
Automated by the weekly doc-drift routine (`agents/doc-drift/routine.md`). Never auto-merged — please review and merge manually, then run `dots sync` if applicable (not needed here, manifest-only).


---
_Generated by [Claude Code](https://claude.ai/code/session_01EGvdQ8jMZ2RtTGHEyvSrnC)_