### PR TITLE
chore(doc-drift): bump serena to v1.6.0 (no-op)

### DIFF
--- a/agents/doc-drift/sources.yaml
+++ b/agents/doc-drift/sources.yaml
@@ -71,7 +71,7 @@ sources:
     # --prerelease=allow), so a schema change can land a release ahead — fine
     # for triage, we reconcile on stable.
     governs: [chezmoi/dot_serena/modify_serena_config.yml, packages/packages.yaml]
-    reconciled: "v1.5.3"
+    reconciled: "v1.6.0"
 
   - id: oh-my-pi
     signal: { type: gh_release, ref: can1357/oh-my-pi }


### PR DESCRIPTION
## Drift

`serena` (`oraios/serena`, gh_release) reconciled `v1.5.3` -> current `v1.6.0`.

## Change reviewed

Compared the `CHANGELOG.md` delta (the "Unreleased (main)" section at the time of triage, released as `v1.6.0` on 2026-07-16) against our two `governs` files:

- `chezmoi/dot_serena/modify_serena_config.yml` — patches `web_dashboard`, `web_dashboard_open_on_launch`, and `excluded_tools` (memory tools, `onboarding`, `initial_instructions`, `find_declaration`, `find_implementations`, `get_diagnostics_for_file`) into `~/.serena/serena_config.yml`.
- `packages/packages.yaml` — installs `serena-agent` via `uv tool install --python 3.13 --prerelease=allow`.

Notable items in the v1.6.0 delta: new `trusted_project_path_patterns` global setting, a CLI fix for `--project-from-cwd` under nested git worktrees, a new `replace_in_files` tool, several language-server additions (C/C++, TypeScript vts, C#, Svelte, Julia, Java, LaTeX, PHP), a per-context structured-tool-output toggle for Claude Code, and dashboard/hooks polish (trusted-hosts config, tool_input-as-string handling).

None of it touches our config surface:
- No change to the `web_dashboard` / `web_dashboard_open_on_launch` keys or their semantics.
- No rename/removal of any tool in our `excluded_tools` list; the new `replace_in_files` tool is additive and not one we exclude.
- No change to the install method, Python pin, or the `--prerelease=allow` flag we pass in `packages.yaml`.

## Classification: no-op

This PR only bumps `reconciled: "v1.6.0"` for `serena` in `agents/doc-drift/sources.yaml`. No config edits.

## Test plan

- [x] Diff limited to the single `reconciled` line bump — no functional change to gate.
- Note: sandbox lacks `just`/`ruff` etc. for this session; nothing here should trip `just check` since no config/behavior changed, but CI is the authority.

---
Never auto-merge — human review + merge per the doc-drift routine invariants.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EGvdQ8jMZ2RtTGHEyvSrnC)_