### PR TITLE
chore(doc-drift): bump context7-mcp to 3.2.4 (no-op)

### DIFF
--- a/agents/doc-drift/sources.yaml
+++ b/agents/doc-drift/sources.yaml
@@ -49,7 +49,7 @@ sources:
     signal: { type: npm, ref: "@upstash/context7-mcp" }
     docs: https://github.com/upstash/context7
     governs: [chezmoi/.chezmoidata/claude.yaml, agents/mcp/registry.yaml]
-    reconciled: "3.2.3"
+    reconciled: "3.2.4"
 
   - id: tavily-mcp
     signal: { type: npm, ref: tavily-mcp }


### PR DESCRIPTION
## What
Bumps `reconciled` for `context7-mcp` from `3.2.3` → `3.2.4` in `agents/doc-drift/sources.yaml`. No config edits.

## Why (no-op)
Checked the upstream release for `@upstash/context7-mcp@3.2.4` (https://github.com/upstash/context7/releases):

> Patch Changes: Bump jose from 6.1.3 to 6.2.3.

That's the entire delta between 3.2.3 and 3.2.4 for the `context7-mcp` package itself — a transitive dependency bump with no change to CLI args, env vars, tool schema, or transport. Our `governs` surface (`chezmoi/.chezmoidata/claude.yaml`'s `context7` MCP entry — `npx -y @upstash/context7-mcp` with `CONTEXT7_API_KEY`, and the matching entry in `agents/mcp/registry.yaml`) needs no change.

(Note: since we invoke via `npx -y @upstash/context7-mcp` unpinned, this bump doesn't even require a code change on our end to pick up — it's purely bookkeeping so the doc-drift scanner stops flagging it.)

## Testing
Docs/manifest-only change; no `just check` needed (no code/config touched).

---
🤖 Generated by the doc-drift routine subagent.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EGvdQ8jMZ2RtTGHEyvSrnC)_