### PR TITLE
fix(doc-drift): oh-my-pi v17.0.5 — dev.autoqa.consent → dev.autoqaConsent

### DIFF
--- a/agents/doc-drift/sources.yaml
+++ b/agents/doc-drift/sources.yaml
@@ -77,4 +77,4 @@ sources:
     signal: { type: gh_release, ref: can1357/oh-my-pi }
     docs: https://github.com/can1357/oh-my-pi
     governs: [chezmoi/.chezmoidata/omp.yaml, chezmoi/dot_omp/private_agent/modify_config.yml]
-    reconciled: "v17.0.1"
+    reconciled: "v17.0.5"

--- a/chezmoi/.chezmoidata/omp.yaml
+++ b/chezmoi/.chezmoidata/omp.yaml
@@ -92,10 +92,15 @@ omp:
     task:
       eager: default
     # Consent answer omp recorded live (autoqa prompt) — promoted to survive
-    # the wholesale re-author.
+    # the wholesale re-author. Key renamed upstream (oh-my-pi v17.0.2) from
+    # nested `dev.autoqa.consent` to flat `dev.autoqaConsent`; v17.0.5 adds an
+    # automatic on-load migration that rewrites any live file still holding
+    # the old nested form. Author the new flat key here — otherwise a
+    # machine whose live config.yml gets auto-migrated by omp trips the
+    # modify_config.yml unknown-key gate (`dev.autoqaConsent` wouldn't match
+    # any path in this registry's desired document) and halts `chezmoi apply`.
     dev:
-      autoqa:
-        consent: granted
+      autoqaConsent: granted
     # Reasoning goes to the interactive session (default) and the reasoning
     # roles (plan/slow). GPT-5.6 Sol is the high-cost/deep tier; Terra is the
     # everyday Codex model; Luna covers cheap delegation and commit text.


### PR DESCRIPTION
## What changed upstream (v17.0.1 → v17.0.5)

Reviewed all four releases (`v17.0.2`, `v17.0.3`, `v17.0.4`, `v17.0.5`) between our `reconciled` marker and current:

- **v17.0.2** — `@oh-my-pi/pi-coding-agent`: renamed the `dev.autoqa.consent` config key to `dev.autoqaConsent` (and `todo.reminders.max` → `todo.remindersMax`, which we don't set).
- **v17.0.5** — `@oh-my-pi/pi-coding-agent`: *"Migrated legacy nested/quoted-dotted config keys (e.g., `dev.autoqa.consent` -> `dev.autoqaConsent`) on settings load."* — omp now auto-migrates any live `config.yml` still holding the old nested key to the new flat one, in place.
- Everything else across the four releases (`PI_CACHE_RETENTION`, `PI_CONFIG_FILES`, `ANTHROPIC_SESSION_STICKY_CACHE_WARM_MS`, `retry.fallbackChains` wildcards, `edit.enforceSeenLines`, `generate_image` provider overrides, OTel export, etc.) is either an env var or a key/flag we don't currently set in `chezmoi/.chezmoidata/omp.yaml` — no other action needed this round.

## Why this needs a config edit (not a no-op)

`chezmoi/.chezmoidata/omp.yaml` authored the *old* nested shape:

```yaml
dev:
  autoqa:
    consent: granted
```

`chezmoi/dot_omp/private_agent/modify_config.yml` authors this subtree wholesale into `~/.omp/agent/config.yml` on every `dots sync`, and separately runs an **unknown-key gate**: any live key-path not present in the registry's desired document halts `chezmoi apply` (see the script's comments, lines ~86-114).

Once a user's live omp session auto-migrates `config.yml` to the new flat `dev.autoqaConsent` key (per the v17.0.5 changelog entry above), the *next* `dots sync` would see `dev.autoqaConsent` as an "unrecognized" key path (our registry only knows the nested `dev.autoqa.consent` path) and halt with a "fold it into the registry" error — even though this is upstream's own migration, not a user-introduced key.

## The fix

Updated `chezmoi/.chezmoidata/omp.yaml` to author the new flat key:

```yaml
dev:
  autoqaConsent: granted
```

and added a comment explaining the rename/migration and why the flat form must be authored here. Bumped `agents/doc-drift/sources.yaml` `reconciled: "v17.0.1"` → `"v17.0.5"` for `oh-my-pi`.

## Verification

- Validated both edited YAML files parse correctly and the key rename round-trips (`python3 -c "import yaml; ..."`).
- Attempted to exercise `modify_config.yml` directly to simulate a live file already on the new flat key — the sandbox's `yq` is the wrong flavor (python/kislyuk `yq`, not `mikefarah/yq` the script expects: `yq -o=json` errors with `jq: Unknown option -o=json`), and `just` is not installed in this environment, so I could not run `just check` or a full `dots sync` here. This is a known sandbox limitation (see `agents/doc-drift/sources.yaml` header notes) — **CI should gate this PR** with the real toolchain.
- No other file in the repo references the old `autoqa` key path (`grep -ri autoqa` → only this file), so this is the only place the rename needs to land.

## Dedup check

Searched open PRs/issues for `doc-drift oh-my-pi v17.0.5` (none found) and checked for an existing `doc-drift/oh-my-pi-v17.0.5` branch on origin (none). There is an unrelated stale branch `doc-drift/oh-my-pi-v16.3.10` from a previous run — not a duplicate of this drift.

---

Never auto-merge — for human review + CI gate per the doc-drift routine invariants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EGvdQ8jMZ2RtTGHEyvSrnC

---
_Generated by [Claude Code](https://claude.ai/code/session_01EGvdQ8jMZ2RtTGHEyvSrnC)_