### PR TITLE
chore(doc-drift): bump claude-code to 2.1.215 (no-op)

### DIFF
--- a/agents/doc-drift/sources.yaml
+++ b/agents/doc-drift/sources.yaml
@@ -25,7 +25,7 @@ sources:
     signal: { type: npm, ref: "@anthropic-ai/claude-code" }
     docs: https://code.claude.com/docs
     governs: [harnesses/claude.md, chezmoi/.chezmoidata/claude.yaml]
-    reconciled: "2.1.211"
+    reconciled: "2.1.215"
 
   - id: codex-cli
     signal: { type: npm, ref: "@openai/codex" }


### PR DESCRIPTION
## Summary

Weekly doc-drift routine: `claude-code` (npm `@anthropic-ai/claude-code`) moved `2.1.211` → `2.1.215`. Classified **no-op** — bumping `reconciled` only, no config edits.

## Changelog reviewed (2.1.212 → 2.1.215)

- **2.1.212**: `/fork` reworked to spawn a background session; `claude auto-mode reset`; new session-wide caps `CLAUDE_CODE_MAX_WEB_SEARCHES_PER_SESSION` / `CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION`; MCP calls >2min auto-background (`CLAUDE_CODE_MCP_AUTO_BACKGROUND_MS`); `/resume` picker changes; Task tool `mode` parameter deprecated (subagents now inherit parent permission mode); large batch of bug fixes (plan-mode Bash guard, worktree symlink escape, hook `continue:false` handling, OTel export fixes, etc).
- **2.1.213**: minor — Edit tool's system-prompt description now documents exact string replacement / `replace_all` guidance (prompt-only change, no schema/flag change).
- **2.1.214**: internal — removed an internal model id reference (`claude-code-github-actionj`) and reduced default system-prompt token footprint; no user-facing config surface.
- **2.1.215**: Claude no longer auto-invokes the built-in `/verify` and `/code-review` skills on its own initiative — they now only run when explicitly invoked.

## Why no-op

Checked both `governs` files for this source — `harnesses/claude.md` (the wiki page, `.hallouminate/wiki/harnesses/claude.md`) and `chezmoi/.chezmoidata/claude.yaml`:

- No CLI flags we wire in `zsh/claude.zsh` / `ap` isolated-launch overlay changed.
- No `settings.json` schema keys we author (`hooks`, `enabledPlugins`, `extraKnownMarketplaces`, `permissions`) changed.
- No sub-agent frontmatter field we render (`agents/registry.yaml` → `agent_definitions/`) uses the deprecated Task `mode` param — confirmed via repo-wide grep, no hits.
- The 2.1.215 `/verify`/`/code-review` auto-invoke change is a built-in-skill behavior change, not something either governed file documents or depends on.
- None of the new env vars (`CLAUDE_CODE_MAX_WEB_SEARCHES_PER_SESSION`, `CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION`, `CLAUDE_CODE_MCP_AUTO_BACKGROUND_MS`, `CLAUDE_CODE_FORWARD_SUBAGENT_TEXT`) are referenced anywhere in the repo.

## Change

- `agents/doc-drift/sources.yaml`: `claude-code.reconciled` `"2.1.211"` → `"2.1.215"`.

## Test plan

- [ ] CI (`just check` equivalent) — sandbox this PR was authored in lacks a usable `gh`/`yq`, so `just check` was not run locally; this is a single-line YAML value change with no code/doc-content edits, so risk is minimal. CI should gate as usual.

🤖 Generated with the doc-drift routine.

https://claude.ai/code/session_01EGvdQ8jMZ2RtTGHEyvSrnC

---
_Generated by [Claude Code](https://claude.ai/code/session_01EGvdQ8jMZ2RtTGHEyvSrnC)_