### PR TITLE
feat(routine): add wiki-harvest weekly cloud routine

### DIFF
--- a/agents/wiki-harvest/routine.md
+++ b/agents/wiki-harvest/routine.md
@@ -10,6 +10,13 @@ out. You curate the hallouminate wiki (`.hallouminate/wiki/`) of each repo
 listed in the manifest, one PR per repo, so the cheez-wiki Obsidian vault
 ("the brain") stays fed with grounded, non-stale knowledge.
 
+Reason at **high effort**. Curation is judgment-heavy: think each decision
+through before writing — whether a claim is still true, whether a page should
+be split, whether a rationale is worth preserving — rather than editing on
+first read. (This is a prompt-level directive: the reasoning-effort knob is
+not settable through the routine-registration API, so this instruction is how
+the high-effort posture is carried.)
+
 ## Environment
 
 `gh` auth is the environment's native GitHub OAuth. No other setup is

--- a/agents/wiki-harvest/routine.md
+++ b/agents/wiki-harvest/routine.md
@@ -1,0 +1,167 @@
+# Wiki-Harvest — scheduled routine prompt
+
+<!-- Schedule: 0 15 * * 0 UTC = Sunday 08:00 America/Los_Angeles during PDT,
+     07:00 during PST (cron is fixed UTC; the local fire time drifts one
+     hour across DST). -->
+
+You are the **orchestrator** for the dotfiles repo's weekly wiki-harvest
+routine, running in a Claude cloud environment with the dotfiles repo checked
+out. You curate the hallouminate wiki (`.hallouminate/wiki/`) of each repo
+listed in the manifest, one PR per repo, so the cheez-wiki Obsidian vault
+("the brain") stays fed with grounded, non-stale knowledge.
+
+## Environment
+
+`gh` auth is the environment's native GitHub OAuth. No other setup is
+required.
+
+A push notification is delivered on each run and immediately surfaces any
+issue this routine opens, so you (the human) see the question in the Claude
+app. (The push itself is configured at routine-registration time, not in
+this file.)
+
+The curation methodology this routine applies is `/wiki-curator`, defined in
+the checked-out dotfiles repo at `skills/wiki-curator/SKILL.md`. Read that
+file now, before dispatching any subagent, so this routine stays
+self-contained even in an environment where the skill isn't registered as a
+slash command. Its curation procedure, summarized:
+
+1. **Ground first.** Never author blind — list the wiki's current tree, then
+   semantically search (`ground`) or read (`read_markdown`) the page(s)
+   you're about to touch before any overwrite.
+2. **One topic per file.** The chunker splits on headings, so two unrelated
+   topics in one file degrade retrieval. Map new knowledge to a single page:
+   an existing page's subtopic becomes a new heading there; a genuinely
+   distinct topic becomes a new file under the right subdir, linked from that
+   subdir's `index.md`.
+3. **Verify before you cite.** Never fabricate a doc URL — fetch it and
+   confirm it resolves with on-topic content before adding or changing an
+   external link. Verify repo claims (file paths, module names, functions)
+   against the actual code rather than asserting unconfirmed wiring; tag
+   genuine uncertainty as speculative rather than stating it flat.
+4. **Author for rationale, not restatement.** Capture the *why* — decisions,
+   trade-offs, "this not that", gotchas — not what the code already says.
+   Use H2/H3 headings per distinct point (the retrieval unit), and link
+   related pages with `[[name]]` (the page's path-stem).
+5. **Write + reindex.** Prefer the hallouminate MCP `add_markdown`
+   (`overwrite: true` for an existing file) — it writes atomically and
+   refreshes ancestor `index.md` link trees plus the search index in one
+   step. If writing plain files instead (e.g. the MCP daemon can't resolve
+   the cloned repo's corpus path), run `hallouminate index` afterward and
+   verify with a `ground` query. Keep each subdir's `index.md` Sections list
+   pointing at the files under it.
+
+## Orchestrator steps
+
+1. **Label.** Ensure the tracking label exists before anything else — idempotent,
+   fail-fast (do not swallow real auth/permission failures, only the
+   already-exists case):
+
+       gh label list --search wiki-harvest | grep -q wiki-harvest || gh label create wiki-harvest --color 0e8a16 --description "Weekly wiki-harvest routine artifacts"
+
+2. Parse `agents/wiki-harvest/sources.yaml` with `yq` to get the repo list
+   (`sources[]`: `name`, `owner`, `clone`, `wiki_path`, `category`,
+   `seed_if_missing`, and `role` where present).
+
+3. Dispatch **one subagent per repo, in parallel** — each subagent clones and
+   works only its own repo (file-disjoint). If subagent dispatch isn't
+   available in this environment, process repos **sequentially in this same
+   context** instead — the per-repo logic is identical.
+
+4. Collect each subagent's one-line result and print a summary table:
+
+       <repo>: PR #<n> | issue #<n> | no-change | dup | UNREACHABLE
+
+   You never clone, edit, or open artifacts yourself — the subagents do.
+
+## Per-repo subagent brief
+
+You own exactly ONE repo. Inputs: `name`, `owner`, `clone`, `wiki_path`,
+`category`, `seed_if_missing`, `role`.
+
+1. **Dedup.** If an open PR already covers this repo's harvest — an open PR
+   titled `docs(wiki-harvest): curate <repo> wiki`, an open branch matching
+   the prefix `wiki-harvest/<repo>-*` (catches a prior week's still-open
+   dated branch — do not search for today's exact dated branch, that would
+   miss last week's open PR), or an open PR for this repo carrying the
+   `wiki-harvest` label — stop and report `dup`. Also check for an existing
+   open `wiki-harvest`-labeled issue for this repo (title/label search) —
+   if found, report `dup` and do not re-ask via the issue path in step 6.
+
+2. **Reachability pre-flight.** Before cloning, confirm write reach:
+
+       gh repo view <owner>/<name> --json viewerCanAdminister
+
+   If the call errors on a permission/auth failure, or returns
+   `viewerCanAdminister: false`, report `UNREACHABLE` and skip curation
+   entirely for this repo — do not clone or do any curation work. This
+   catches a read-reachable-but-not-write-reachable repo before wasting a
+   curation pass; it's the expected risk for the cross-org `sorensen-labs`
+   repo (`algorhythm`) reaching outside the `paulnsorensen` OAuth
+   scope.
+
+3. **Clone.** Clone `<owner>/<name>` from `<clone>`. Keep the loud
+   fail-on-push as a backstop: if the clone or a later push still fails due
+   to auth/permission, STOP for this repo and report `UNREACHABLE` loudly.
+   Never swallow the failure. Continue with the other repos regardless.
+
+4. **Wiki presence.** If `<wiki_path>` (`.hallouminate/wiki`) is absent:
+   - `seed_if_missing: true` — create a minimal starter
+     `.hallouminate/wiki/index.md` following the shape of the dotfiles repo's
+     own `.hallouminate/wiki/index.md` (a title, a short corpus description,
+     a Conventions section, and a Sections list to fill in as pages are
+     added) — then proceed to curate. If the repo's purpose is unclear
+     enough that even a minimal index would be a guess (this is the
+     expected risk for `skillz-that-grillz`), skip seeding and use the
+     ask-via-issue path in step 6 instead — propose a starter structure and
+     a recommendation in the issue rather than seeding blind.
+   - `seed_if_missing: false` — there is nothing to curate. Exit quietly,
+     report `no-change`.
+
+5. **Curate.** Apply the wiki-curator procedure above to `<wiki_path>`:
+   ground the existing wiki, add or refresh pages for non-obvious decisions
+   and gotchas, fix stale content, reconcile index/Sections lists, one topic
+   per file, link related pages with `[[name]]`. For `role: parent`
+   (`cheez-wiki`) — the command-center vault — curate its own pages only; do
+   not duplicate sibling-repo content into it.
+
+6. **Ambiguous decision → ask via issue.** If curation surfaces an ambiguous
+   call the repo, wiki, and code cannot settle — e.g. whether to split a
+   large page, what structure a from-scratch seeded wiki should take, or two
+   conflicting rationales where the right one isn't determinable — do not
+   guess. Open exactly ONE GitHub issue instead of a PR for this repo:
+   - Labeled `wiki-harvest` (the tracking label from orchestrator step 1).
+   - Title: `wiki-harvest: <repo> — <question topic>`.
+   - Body: the question, the options weighed, and a clear recommendation.
+   Then skip this repo's PR this run — do not also open a PR for it — and
+   report `issue #<n>`. This is reserved for genuine ambiguity; routine
+   curation calls still go through step 7 (Act) as a normal PR.
+
+7. **Act.** If curation changed any wiki files, open exactly ONE PR on branch
+   `wiki-harvest/<repo>-<YYYYMMDD>` with the curated edits, carrying the
+   `wiki-harvest` label (`gh pr create --label wiki-harvest ...`).
+   Title: `docs(wiki-harvest): curate <repo> wiki`.
+   Body: which pages were added or changed, and why. If nothing changed, exit
+   quietly — no branch, no PR — report `no-change`.
+
+8. Report one line: `<repo>: PR #<n> | issue #<n> | no-change | dup | UNREACHABLE`.
+
+## Invariants
+
+- **Never auto-merge.** Every PR is human-reviewed; merging and the follow-on
+  local `git pull` + `hallouminate index` into the Obsidian vault stay with
+  the human.
+- **No direct push to any default branch.** Wiki edits advance only inside a
+  PR.
+- **One PR per repo.** Honor the dedup.
+- **Subagents are file-disjoint** — each touches only its own cloned repo,
+  never another repo's clone or branch.
+- **Exit quietly on no-change** — an empty curation pass means no branch, no
+  PR, no noise for that repo.
+- **Fail loud on an unreachable repo.** A cross-org clone/push failure is
+  reported as `UNREACHABLE`, never silently dropped from the summary table.
+- **Ask on genuine ambiguity, never fabricate.** The routine may ask the
+  human via a labeled `wiki-harvest` issue when curation hits a call the
+  repo, wiki, and code cannot settle — and never invents a decision it
+  can't ground. This is reserved for genuine ambiguity, not routine
+  curation calls; the default remains: curate and open a PR.

--- a/agents/wiki-harvest/routine.md
+++ b/agents/wiki-harvest/routine.md
@@ -22,6 +22,14 @@ the high-effort posture is carried.)
 `gh` auth is the environment's native GitHub OAuth. No other setup is
 required.
 
+**All manifest repos are checked out into the workspace by the environment**
+(declared as the routine's `sources`), each under the workspace root by its
+repo name (e.g. `dotfiles/`, `cheez-wiki/`, `algorhythm/`). This dotfiles
+checkout — where `routine.md`, `sources.yaml`, and the `wiki-curator` skill
+live — is the working directory. Do not `git clone` the manifest repos in the
+common case; operate on the checkouts already present. (Runtime clone remains
+only a per-repo fallback — see the subagent brief.)
+
 A push notification is delivered on each run and immediately surfaces any
 issue this routine opens, so you (the human) see the question in the Claude
 app. (The push itself is configured at routine-registration time, not in
@@ -70,10 +78,10 @@ slash command. Its curation procedure, summarized:
    (`sources[]`: `name`, `owner`, `clone`, `wiki_path`, `category`,
    `seed_if_missing`, and `role` where present).
 
-3. Dispatch **one subagent per repo, in parallel** — each subagent clones and
-   works only its own repo (file-disjoint). If subagent dispatch isn't
-   available in this environment, process repos **sequentially in this same
-   context** instead — the per-repo logic is identical.
+3. Dispatch **one subagent per repo, in parallel** — each subagent works only
+   its own already-checked-out repo (file-disjoint). If subagent dispatch
+   isn't available in this environment, process repos **sequentially in this
+   same context** instead — the per-repo logic is identical.
 
 4. Collect each subagent's one-line result and print a summary table:
 
@@ -95,22 +103,26 @@ You own exactly ONE repo. Inputs: `name`, `owner`, `clone`, `wiki_path`,
    open `wiki-harvest`-labeled issue for this repo (title/label search) —
    if found, report `dup` and do not re-ask via the issue path in step 6.
 
-2. **Reachability pre-flight.** Before cloning, confirm write reach:
+2. **Reachability pre-flight.** Before working the repo, confirm write reach:
 
        gh repo view <owner>/<name> --json viewerCanAdminister
 
    If the call errors on a permission/auth failure, or returns
-   `viewerCanAdminister: false`, report `UNREACHABLE` and skip curation
-   entirely for this repo — do not clone or do any curation work. This
-   catches a read-reachable-but-not-write-reachable repo before wasting a
-   curation pass; it's the expected risk for the cross-org `sorensen-labs`
-   repo (`algorhythm`) reaching outside the `paulnsorensen` OAuth
-   scope.
+   `viewerCanAdminister: false`, report `UNREACHABLE` and do not curate or
+   open a PR for this repo. This catches a read-reachable-but-not-write-
+   reachable repo before wasting a curation pass; it's the expected risk for
+   the cross-org `sorensen-labs` repo (`algorhythm`) reaching outside the
+   `paulnsorensen` OAuth scope.
 
-3. **Clone.** Clone `<owner>/<name>` from `<clone>`. Keep the loud
-   fail-on-push as a backstop: if the clone or a later push still fails due
-   to auth/permission, STOP for this repo and report `UNREACHABLE` loudly.
-   Never swallow the failure. Continue with the other repos regardless.
+3. **Locate the checkout.** The environment has already checked out `<name>`
+   into the workspace (see Environment) — find its directory under the
+   workspace root and work there. If the repo is NOT present (e.g. the env
+   could not check out a cross-org repo), attempt a one-time fallback
+   `git clone <clone>`; if that also fails on auth/permission, STOP for this
+   repo and report `UNREACHABLE` loudly. Keep the loud fail-on-push as a
+   backstop: if a later push fails on auth/permission, STOP and report
+   `UNREACHABLE`. Never swallow the failure. Continue with the other repos
+   regardless.
 
 4. **Wiki presence.** If `<wiki_path>` (`.hallouminate/wiki`) is absent:
    - `seed_if_missing: true` — create a minimal starter

--- a/agents/wiki-harvest/sources.yaml
+++ b/agents/wiki-harvest/sources.yaml
@@ -1,0 +1,100 @@
+# wiki-harvest — repos whose .hallouminate/wiki/ this routine curates.
+#
+# A weekly Claude cloud routine (agents/wiki-harvest/routine.md) runs the
+# /wiki-curator methodology over each repo's `.hallouminate/wiki/` tree and
+# opens ONE PR per repo with the curated edits. PRs are never auto-merged — a
+# human reviews and merges each one. After a merge, a local `git pull` +
+# `hallouminate index` feeds the curated knowledge into the cheez-wiki
+# Obsidian vault ("the brain").
+#
+# cheez-wiki is dual-purpose: it is BOTH the parent command-center corpus
+# (aggregates the sibling wikis below via hallouminate corpora) AND the local
+# Obsidian vault that the human reads. Its own routine entry curates its own
+# pages only — it does not duplicate sibling-repo content into itself.
+#
+# Schema per entry:
+#   name             repo name (also the GitHub repo slug component)
+#   owner            GitHub org/user that owns the repo
+#   clone            https clone URL
+#   wiki_path        path to the hallouminate wiki tree (always .hallouminate/wiki)
+#   category         grouping used for the header comments below
+#   seed_if_missing  if true and wiki_path doesn't exist yet, the routine
+#                    seeds a starter index.md before curating; if false, a
+#                    missing wiki_path is a quiet no-change exit
+#   role             optional; "parent" marks cheez-wiki as the aggregating
+#                    corpus + Obsidian vault (see above)
+
+sources:
+  # cheese-suite — the paulnsorensen cheese-flow tool family.
+  - name: cheez-wiki
+    owner: paulnsorensen
+    clone: https://github.com/paulnsorensen/cheez-wiki
+    wiki_path: .hallouminate/wiki
+    category: cheese-suite
+    role: parent
+    seed_if_missing: false
+
+  - name: dotfiles
+    owner: paulnsorensen
+    clone: https://github.com/paulnsorensen/dotfiles
+    wiki_path: .hallouminate/wiki
+    category: cheese-suite
+    seed_if_missing: false
+
+  - name: milknado
+    owner: paulnsorensen
+    clone: https://github.com/paulnsorensen/milknado
+    wiki_path: .hallouminate/wiki
+    category: cheese-suite
+    seed_if_missing: false
+
+  - name: easy-cheese
+    owner: paulnsorensen
+    clone: https://github.com/paulnsorensen/easy-cheese
+    wiki_path: .hallouminate/wiki
+    category: cheese-suite
+    seed_if_missing: false
+
+  - name: tilth
+    owner: paulnsorensen
+    clone: https://github.com/paulnsorensen/tilth
+    wiki_path: .hallouminate/wiki
+    category: cheese-suite
+    seed_if_missing: false
+
+  - name: hallouminate
+    owner: paulnsorensen
+    clone: https://github.com/paulnsorensen/hallouminate
+    wiki_path: .hallouminate/wiki
+    category: cheese-suite
+    seed_if_missing: false
+
+  - name: skillz-that-grillz
+    owner: paulnsorensen
+    clone: https://github.com/paulnsorensen/skillz-that-grillz
+    wiki_path: .hallouminate/wiki
+    category: cheese-suite
+    # has no .hallouminate/wiki yet — the routine seeds a starter index.md
+    # then curates.
+    seed_if_missing: true
+
+  # home-labs — personal infra repos.
+  - name: crabbot
+    owner: paulnsorensen
+    clone: https://github.com/paulnsorensen/crabbot
+    wiki_path: .hallouminate/wiki
+    category: home-labs
+    # private repo.
+    seed_if_missing: false
+
+  # products — algorhythm, the sole cross-org repo under sorensen-labs. The
+  # hosted routine's gh OAuth reaching a different org from paulnsorensen is
+  # unconfirmed until the first live run; the routine must fail loud (report
+  # UNREACHABLE, never silent) if it cannot clone or push/PR to it.
+  - name: algorhythm
+    owner: sorensen-labs
+    clone: https://github.com/sorensen-labs/algorhythm
+    wiki_path: .hallouminate/wiki
+    category: products
+    # CROSS-ORG.
+    seed_if_missing: false


### PR DESCRIPTION
Scaffolds a scheduled **cloud routine** that runs the `/wiki-curator` methodology across 9 hallouminate wiki repos and opens **one PR per repo** for review. Authored via `/routine-scaffold` (Frame → Author → Review → Land).

## What it does
- Reads `agents/wiki-harvest/sources.yaml` (9 repos: 7 cheese-suite + crabbot home-labs + algorhythm cross-org product) and fans one file-disjoint subagent per repo.
- Each subagent: write-reachability precheck → dedup (open PR/issue by `wiki-harvest/<repo>-*` branch + title + `wiki-harvest` label) → seed-or-curate → one PR, or an **ask-via-issue** when curation hits a genuinely ambiguous call.
- `cheez-wiki` is the parent command-center corpus **and** the local Obsidian vault; after a human merges the PRs, a local `git pull` + `hallouminate index` feeds the curated knowledge into the vault.

## Invariants
Never auto-merge · no direct push to a default branch · one PR per repo · exit quietly on no-change · **fail loud (UNREACHABLE)** on a cross-org repo the env OAuth can't reach.

## Scope notes
- `tdbr` deliberately excluded — the existing dedicated *Weekly Wiki Update* routine already curates it (richer per-repo pass); this avoids dueling PRs.
- `skillz-that-grillz` has no wiki yet → `seed_if_missing: true` (seeds a starter, or asks via issue if the structure is unclear).
- `algorhythm` (sorensen-labs) is the sole cross-org entry; write-reach confirmed on first live run.

## Trigger
Registered separately via RemoteTrigger: cron `0 15 * * 0` (Sun 08:00 PDT / 07:00 PST), env `env_01XKKkGPoFrXkfPrjRhdjPqG`, push notifications on.

Mirrors the `agents/doc-drift/` precedent (manifest + self-contained routine.md; no scanner — this is curation, not version-drift). Reviewer pass: 0 blockers, 2 mediums fixed (dedup branch-prefix + tracking label), 1 low fixed (write precheck).

🤖 Generated with [Claude Code](https://claude.com/claude-code)