### PR TITLE
docs(envs): unblock tilth marketplace/plugin in routine envs

### DIFF
--- a/envs/README.md
+++ b/envs/README.md
@@ -45,8 +45,8 @@ skills:                       # skill packs via the skills CLI
 plugin registry) where an entry exists — do not invent new coordinates here when it does; that registry
 is the source of truth for which plugin lives at which marketplace. **Exception:** `tilth` has no entry
 in `agents/plugins/registry.yaml` (only `hallouminate` and `milknado` are registered there), so its
-`ref`/`id` are sourced directly from the `paulnsorensen/tilth` repo instead — see "Known gaps" below for
-why that repo isn't registry-eligible yet. Every `plugins[].id` carries an inline comment that the exact
+`ref`/`id` are sourced directly from the `paulnsorensen/tilth` repo's root `.claude-plugin/marketplace.json`
+instead. Every `plugins[].id` carries an inline comment that the exact
 id must be confirmed via `claude plugin marketplace list` before use, since the marketplace's `.name`
 field in its `marketplace.json` is not assumed by this file.
 
@@ -59,15 +59,6 @@ field in its `marketplace.json` is not assumed by this file.
 
 ## Known gaps
 
-- **`tilth-cwd-inject@tilth` is currently non-installable.** `<certain>` (verified via
-  `gh api repos/paulnsorensen/tilth/git/trees/main?recursive=true` on 2026-07-18): the `paulnsorensen/tilth`
-  repo has no root `.claude-plugin/marketplace.json` — only `plugin/claude/.claude-plugin/plugin.json`
-  (a bare plugin payload named `tilth-cwd-inject`, not a marketplace). Compare `paulnsorensen/hallouminate`
-  and `paulnsorensen/milknado`, both of which have a root `.claude-plugin/marketplace.json`. Until tilth's
-  upstream adds one (mirroring hallouminate's `{name, plugins: [{name, source}]}` shape),
-  `claude plugin marketplace add paulnsorensen/tilth` will fail, and `tilth-cwd-inject@tilth` is a
-  placeholder id — same as the existing `CONFIRM via claude plugin marketplace list` caveat on every
-  other `plugins[].id`, just with a stronger, verified-broken severity rather than merely-unconfirmed.
 - The `tilth-cwd-inject` plugin only bundles the PreToolUse hook that auto-injects `cwd` into tilth MCP
   calls (mirrors the hand-wired hook in this repo's own `chezmoi/.chezmoidata/claude.yaml`) — it does
   **not** bundle an `.mcp.json`, so it cannot replace the `mcp:` entry that actually launches the tilth

--- a/envs/cheese-core.yaml
+++ b/envs/cheese-core.yaml
@@ -2,10 +2,10 @@ name: cheese-core
 description: Core hallouminate wiki + tilth-nightly MCP + tilth-cwd-inject plugin + easy-cheese review skills for a general Claude Cloud session
 marketplaces:                 # → claude plugin marketplace add <ref>
   - ref: paulnsorensen/hallouminate     # owner/repo the CLI accepts (source: agents/plugins/registry.yaml)
-  - ref: paulnsorensen/tilth            # BLOCKED — no root marketplace.json yet; see envs/README.md#known-gaps
+  - ref: paulnsorensen/tilth            # owner/repo the CLI accepts (source: paulnsorensen/tilth root marketplace.json)
 plugins:                      # → claude plugin install <id>
   - id: hallouminate@hallouminate       # <plugin>@<marketplace-id>; CONFIRM id via `claude plugin marketplace list`
-  - id: tilth-cwd-inject@tilth          # cwd-injects tilth MCP calls; NOT the MCP server itself (see mcp: below); BLOCKED, see envs/README.md#known-gaps
+  - id: tilth-cwd-inject@tilth          # cwd-injects tilth MCP calls; NOT the MCP server itself (see mcp: below)
 mcp:                          # npx-launched MCP servers (NOT plugins)
   - name: tilth
     package: "@paulnsorensen/tilth-nightly"

--- a/envs/milknado.yaml
+++ b/envs/milknado.yaml
@@ -2,11 +2,11 @@ name: milknado
 description: Same as cheese-core (hallouminate wiki + tilth-nightly MCP + tilth-cwd-inject plugin + easy-cheese review skills), plus the Milknado Mikado execution engine, for goal-graph-driven Claude Cloud sessions
 marketplaces:                 # → claude plugin marketplace add <ref>
   - ref: paulnsorensen/hallouminate     # owner/repo the CLI accepts (source: agents/plugins/registry.yaml)
-  - ref: paulnsorensen/tilth            # BLOCKED — no root marketplace.json yet; see envs/README.md#known-gaps
+  - ref: paulnsorensen/tilth            # owner/repo the CLI accepts (source: paulnsorensen/tilth root marketplace.json)
   - ref: paulnsorensen/milknado         # owner/repo the CLI accepts (source: agents/plugins/registry.yaml)
 plugins:                      # → claude plugin install <id>
   - id: hallouminate@hallouminate       # <plugin>@<marketplace-id>; CONFIRM id via `claude plugin marketplace list`
-  - id: tilth-cwd-inject@tilth          # cwd-injects tilth MCP calls; NOT the MCP server itself (see mcp: below); BLOCKED, see envs/README.md#known-gaps
+  - id: tilth-cwd-inject@tilth          # cwd-injects tilth MCP calls; NOT the MCP server itself (see mcp: below)
   - id: milknado@milknado               # <plugin>@<marketplace-id>; CONFIRM id via `claude plugin marketplace list`
 mcp:                          # npx-launched MCP servers (NOT plugins)
   - name: tilth


### PR DESCRIPTION
`paulnsorensen/tilth` now has a root `.claude-plugin/marketplace.json` (fixed via [tilth#140](https://github.com/paulnsorensen/tilth/pull/140)), so the tilth marketplace/plugin are no longer non-installable.

- `envs/cheese-core.yaml`, `envs/milknado.yaml` — drop the stale `BLOCKED` comments on the `paulnsorensen/tilth` marketplace ref and `tilth-cwd-inject@tilth` plugin id.
- `envs/README.md` — remove the resolved 'no root marketplace.json' entry from Known gaps (keeping the hook-vs-MCP caveat) and update the Schema-section note.

Depends on tilth#140 merging for the coordinates to actually resolve; the id `tilth-cwd-inject@tilth` and marketplace `tilth` are confirmed against the repo's marketplace.json.

🤖 Generated with [Claude Code](https://claude.com/claude-code)