### PR TITLE
feat(zsh): add .NET SDK env + PATH to shell profiles

### DIFF
--- a/zsh/core.zsh
+++ b/zsh/core.zsh
@@ -42,6 +42,12 @@ export PATH="$HOME/.local/bin:$PATH"
 # cargo install puts binaries in ~/.cargo/bin
 [[ -d "$HOME/.cargo/bin" ]] && export PATH="$HOME/.cargo/bin:$PATH"
 
+# .NET SDK + global tools (dotnet tool install, e.g. godotenv) live under ~/.dotnet
+if [[ -d "$HOME/.dotnet" ]]; then
+  export DOTNET_ROOT="$HOME/.dotnet"
+  export PATH="$DOTNET_ROOT:$DOTNET_ROOT/tools:$PATH"
+fi
+
 # prek cache/logs — persistent location writable by Claude sandbox
 export PREK_HOME="$HOME/Dev/.prek"
 

--- a/zshenv
+++ b/zshenv
@@ -36,3 +36,10 @@ fi
 if [[ -d "$HOME/.cargo/bin" && ":$PATH:" != *":$HOME/.cargo/bin:"* ]]; then
   export PATH="$HOME/.cargo/bin:$PATH"
 fi
+
+# .NET SDK + global tools (e.g. godotenv) for non-interactive shells. Interactive
+# shells get these via zsh/core.zsh; mirrored here for the non-interactive path.
+if [[ -d "$HOME/.dotnet" ]]; then
+  export DOTNET_ROOT="$HOME/.dotnet"
+  [[ ":$PATH:" != *":$DOTNET_ROOT:"* ]] && export PATH="$DOTNET_ROOT:$DOTNET_ROOT/tools:$PATH"
+fi


### PR DESCRIPTION
Adds the .NET SDK to the shell environment so `dotnet` global tools (e.g. `godotenv`) resolve. Exports `DOTNET_ROOT="$HOME/.dotnet"` and prepends `$DOTNET_ROOT` plus its `tools/` dir to `PATH`. Added to `zsh/core.zsh` for interactive shells and mirrored into `zshenv` for non-interactive/agent shells, both guarded on `~/.dotnet` existence following the existing cargo/rustup convention.
