### PR TITLE
feat(omp): route work tracking through Milknado

### DIFF
--- a/.hallouminate/wiki/harnesses/omp.md
+++ b/.hallouminate/wiki/harnesses/omp.md
@@ -6,6 +6,8 @@ sources:
   - chezmoi/.chezmoidata/omp.yaml
   - chezmoi/dot_omp/private_agent/APPEND_SYSTEM.md
   - chezmoi/dot_omp/private_agent/extensions/milknado-todo-guard.ts
+  - milknado.toml
+  - tests/config-validation.bats
   - tests/omp-config.bats
   - tests/extensions/milknado-todo-guard.test.mjs
   - https://github.com/can1357/oh-my-pi/blob/39c95e5e29b1c8b082059f57421ce445c3dffdd4/docs/tools/todo.md
@@ -36,6 +38,8 @@ todo:
 ```
 
 These values live at `chezmoi/.chezmoidata/omp.yaml:68-70`. The config renderer owns both keys, so a live value of `true` is reset on the next apply. Before the cutover, OMP 17.0.5 reported both values as `true`; `prewalk.enabled` was `false` and `tools.xdev` was `true`.
+
+Milknado task completion fails closed when the project defines no quality gates. The root `milknado.toml:1-3` therefore pins `quality_gates = ["just check"]`, reusing the repository's authoritative verification recipe. Every built-in flavor inherits this gate; omitting the key would let agents claim nodes but prevent them from marking verified work done.
 
 `todo.enabled: false` removes the model-facing Todo tool. It does not unregister OMP's separately wired `/todo` command, which can still mutate native session state. Disabling reminders alone therefore does not establish single ownership.
 
@@ -86,6 +90,8 @@ Do not build that adapter unless native-looking Todo behavior becomes a requirem
 - The extension-contract test executes every extension handler test (`tests/omp-config.bats:297-310`).
 
 `tests/extensions/milknado-todo-guard.test.mjs:32-62` separately pins exact-command blocking, warning contents, the handled action, negative inputs, the continue action, and absence of spurious notifications. The implementation handoff recorded a green 15-test OMP config suite, a green two-test guard suite, and a clean prompt-policy markdown lint run.
+
+`tests/config-validation.bats:9-15` proves the project config exists, parses as TOML, and resolves the exact `just check` gate. `milknado agents check` validates base agent resolution; a direct profile probe confirmed that `implement`, `spec`, `spike`, `prototype`, and `research` all inherit `just check`.
 
 ## Remaining policy
 

--- a/.hallouminate/wiki/harnesses/omp.md
+++ b/.hallouminate/wiki/harnesses/omp.md
@@ -1,0 +1,94 @@
+---
+status: reviewed
+last_verified: 2026-07-20
+confidence: high
+sources:
+  - chezmoi/.chezmoidata/omp.yaml
+  - chezmoi/dot_omp/private_agent/APPEND_SYSTEM.md
+  - chezmoi/dot_omp/private_agent/extensions/milknado-todo-guard.ts
+  - tests/omp-config.bats
+  - tests/extensions/milknado-todo-guard.test.mjs
+  - https://github.com/can1357/oh-my-pi/blob/39c95e5e29b1c8b082059f57421ce445c3dffdd4/docs/tools/todo.md
+  - https://github.com/can1357/oh-my-pi/blob/39c95e5e29b1c8b082059f57421ce445c3dffdd4/packages/coding-agent/src/modes/controllers/input-controller.ts
+  - https://github.com/can1357/oh-my-pi/blob/39c95e5e29b1c8b082059f57421ce445c3dffdd4/packages/coding-agent/src/extensibility/extensions/types.ts
+---
+# OMP
+
+OMP uses Milknado as its sole work tracker. Native Todo and its reminders are disabled in the repo-authoritative chezmoi data, the system prompt assigns planning to Milknado MCP, and a directly discovered input extension consumes `/todo` before OMP can create a disconnected native list.
+
+## Ownership contract
+
+- Create one Milknado goal for each user request that needs a plan.
+- Add executable work as child task nodes, claim a task before starting it, and mark it done only after verification.
+- Address updates by Milknado node ID. Never mirror the same work in native Todo or another tracker.
+- Milknado is project-scoped and durable; native OMP Todo is session-scoped and reconstructed from session state. The durability difference is why two active trackers would diverge.
+
+The policy is injected through `chezmoi/dot_omp/private_agent/APPEND_SYSTEM.md:31-35`. Milknado itself was already registered as an OMP MCP server, so the cutover required no second server definition (`chezmoi/dot_omp/private_agent/mcp.json:18-20`).
+
+## Repo-authoritative configuration
+
+Disable Todo in `chezmoi/.chezmoidata/omp.yaml`, never by hand-editing the generated live OMP config:
+
+```yaml
+todo:
+  enabled: false
+  reminders: false
+```
+
+These values live at `chezmoi/.chezmoidata/omp.yaml:68-70`. The config renderer owns both keys, so a live value of `true` is reset on the next apply. Before the cutover, OMP 17.0.5 reported both values as `true`; `prewalk.enabled` was `false` and `tools.xdev` was `true`.
+
+`todo.enabled: false` removes the model-facing Todo tool. It does not unregister OMP's separately wired `/todo` command, which can still mutate native session state. Disabling reminders alone therefore does not establish single ownership.
+
+## `/todo` guard
+
+`chezmoi/dot_omp/private_agent/extensions/milknado-todo-guard.ts:3-13` handles the remaining command path. The guard:
+
+1. Matches only `/todo` followed by whitespace or end-of-input.
+2. Returns `{ action: "continue" }` for ordinary text such as `/todone` or `Use /todo later`.
+3. Warns `Native /todo is disabled. Use Milknado MCP for work tracking.` for an exact command.
+4. Returns `{ action: "handled" }`, which consumes the input before built-in slash-command dispatch.
+
+OMP still advertises the built-in `/todo` completion. An extension input handler can consume execution but cannot remove that built-in autocomplete entry. Removing the completion requires an upstream OMP change.
+
+The action shape is part of the OMP input-event protocol. `{ handled: true }` is not equivalent: a fresh-context review caught that initially incorrect shape before publication, and the implementation plus regression assertions were revised to use `action: "handled"` and `action: "continue"`.
+
+## Native Todo behavior left behind
+
+OMP's native Todo is not just a model tool. Its implementation also has slash-command edits, session custom entries, transcript reminder injection, resume-time restoration, visible Todo UI updates, and failure reminders. The public Todo documentation at the pinned source commit records those collaborators and confirms that tool availability is gated separately by `todo.enabled`.
+
+The guarded direct cutover intentionally gives up that native-looking UI and session restoration. Milknado's graph and MCP tools are the durable replacement; this repo does not emulate the native renderer or reminder loop.
+
+## Alternatives considered
+
+| Design | Decision | Reason |
+| --- | --- | --- |
+| Direct MCP only | Rejected | Lowest maintenance, but stale `/todo` could still create a second native list. |
+| Guarded direct cutover | Chosen | Keeps one durable owner with a small, explicit command guard. |
+| Todo-shaped extension adapter | Rejected | Current ExtensionAPI exposes no MCP `callTool` facade, so the adapter would need its own MCP client/process and a second stdio connection. |
+| OMP `TodoBackend` seam | Deferred upstream | A backend seam plus public MCP-call facade is the only design that can preserve the native tool, command, reminders, session state, and TUI without duplicating transport code. |
+| Native Todo plus Milknado | Rejected | Two planning systems have different persistence and status semantics and will drift. |
+
+A compatibility adapter also has unresolved semantic and loading problems:
+
+- Milknado has no exact native `abandoned` state. A Todo `drop` operation would need an explicit mapping to `blocked` with a reason, deletion, or a new Milknado status.
+- Extension tool shadowing can currently replace a built-in tool named `todo`, but that is implementation behavior rather than a stable documented contract.
+- Marketplace-installed OMP plugins do not automatically load extension modules. An adapter would need direct auto-discovery, an npm extension install, or `omp plugin link`.
+
+Do not build that adapter unless native-looking Todo behavior becomes a requirement. If it does, prefer the upstream backend/MCP facade seam over maintaining a private second MCP transport.
+
+## Verification surface
+
+`tests/omp-config.bats` protects the deployment contract:
+
+- Fresh renders assert both Todo settings are false (`tests/omp-config.bats:34-53`).
+- Drift repair starts with both settings true and verifies they are reset (`tests/omp-config.bats:76-95`).
+- The managed-file test proves chezmoi deploys the guard and system prompt (`tests/omp-config.bats:279-305`).
+- The extension-contract test executes every extension handler test (`tests/omp-config.bats:297-310`).
+
+`tests/extensions/milknado-todo-guard.test.mjs:32-62` separately pins exact-command blocking, warning contents, the handled action, negative inputs, the continue action, and absence of spurious notifications. The implementation handoff recorded a green 15-test OMP config suite, a green two-test guard suite, and a clean prompt-policy markdown lint run.
+
+## Remaining policy
+
+Completed request graphs remain durable in Milknado. This cutover does not decide whether old graphs should be retained permanently, archived, or deleted; any lifecycle policy must preserve the single-owner rule and be implemented in Milknado rather than reintroducing native Todo state.
+
+_Source: OMP Todo-to-Milknado research and guarded-cutover handoff · Updated: 2026-07-20 · Supersedes: native OMP Todo ownership_

--- a/.hallouminate/wiki/log.md
+++ b/.hallouminate/wiki/log.md
@@ -15,6 +15,8 @@
 
 2026-07-09 · a03e06a48829321c · merged · decisions/session-convergence-002-sweep-in-work-recovery.md · Added implementation note for work-recovery --wheypoint write mode (shipped 2026-07-09; git: provenance branch-only, schema-valid degradation).
 
+2026-07-20 · e89738679e9e5f1d · new-page · operations/omp-fanout-worker-models.md · Captured OMP subagent fan-out guardrails, model-role cost split, and OpenRouter worker model shortlist for cheap coder/menial workers.
+
 2026-07-20 · 79ffca5de4346cf6 · new-page · harnesses/omp.md · Curated OMP Todo behavior, extension seams, adapter constraints, and the guarded-direct-cutover decision.
 2026-07-20 · f9494484bf66a3a5 · merged · harnesses/omp.md · Added the implemented Milknado ownership contract, exact input-event protocol, verification coverage, and residual autocomplete/lifecycle limits.
 

--- a/.hallouminate/wiki/log.md
+++ b/.hallouminate/wiki/log.md
@@ -17,3 +17,5 @@
 
 2026-07-20 · 79ffca5de4346cf6 · new-page · harnesses/omp.md · Curated OMP Todo behavior, extension seams, adapter constraints, and the guarded-direct-cutover decision.
 2026-07-20 · f9494484bf66a3a5 · merged · harnesses/omp.md · Added the implemented Milknado ownership contract, exact input-event protocol, verification coverage, and residual autocomplete/lifecycle limits.
+
+2026-07-20 · fb6d1f78afb65c9f · merged · harnesses/omp.md · Recorded Milknado's fail-closed completion behavior, the repository-wide just check gate, inherited flavor resolution, and config validation coverage.

--- a/.hallouminate/wiki/log.md
+++ b/.hallouminate/wiki/log.md
@@ -14,3 +14,6 @@
 2026-07-09 · a03e06a48829321c · conflict-flagged · decisions/session-convergence-001-fixture-cli-plus-indexes.md · Reconciled disproven index sub-decision: EXPLAIN on live DB shows DuckDB does not use secondary ART indexes for base-table filter scans (SEQ_SCAN); reverted the CREATE INDEX work, superseded the "profile-derived indexes" half, kept CLI/no-MCP/no-timer.
 
 2026-07-09 · a03e06a48829321c · merged · decisions/session-convergence-002-sweep-in-work-recovery.md · Added implementation note for work-recovery --wheypoint write mode (shipped 2026-07-09; git: provenance branch-only, schema-valid degradation).
+
+2026-07-20 · 79ffca5de4346cf6 · new-page · harnesses/omp.md · Curated OMP Todo behavior, extension seams, adapter constraints, and the guarded-direct-cutover decision.
+2026-07-20 · f9494484bf66a3a5 · merged · harnesses/omp.md · Added the implemented Milknado ownership contract, exact input-event protocol, verification coverage, and residual autocomplete/lifecycle limits.

--- a/.hallouminate/wiki/operations/index.md
+++ b/.hallouminate/wiki/operations/index.md
@@ -7,3 +7,5 @@ The repo's operational plumbing — the machinery that deploys config and the lo
 - [[dev-environment]] — git tooling (difftastic, mergiraf, the conflict-resolution chain), prek pre-commit hooks, Claude marketplace plugins, and skhd.
 - [[tmux-plugin-gotchas]] — tmux plugin wiring: why continuum silently disarms when `status-right` is rewritten after TPM runs, the required plugin declaration order, catppuccin palette injection via `theme/generate.sh`, and the live vs. repo plugin tree.
 - [[remote-access]] — the remote-shell stack: Tailscale mesh transport → mosh (UDP, survives roaming/sleep) → tmux session persistence, the `mtmux` wrapper, and why Tailscale stays a manual install under the Homebrew-on-Linux package model.
+
+- [[omp-fanout-worker-models]] — OMP fan-out guardrails and evidence-dated worker-model cost research: separate parent reasoning from cheap worker roles, bound task fan-out, and treat speed rankings as provisional until measured locally.

--- a/.hallouminate/wiki/operations/omp-fanout-worker-models.md
+++ b/.hallouminate/wiki/operations/omp-fanout-worker-models.md
@@ -1,0 +1,113 @@
+---
+status: reviewed
+last_verified: 2026-07-20
+confidence: medium
+sources:
+  - omp://tools/task.md
+  - omp://settings.md
+  - omp://models.md
+  - https://openrouter.ai/api/v1/models
+  - https://openrouter.ai/api/frontend/v1/rankings/models?view=week
+---
+# OMP fan-out and worker models
+
+OMP fan-out cost is controlled by two separate levers: task runtime policy decides how many workers can spawn, and `modelRoles.task` / `modelRoles.smol` / `modelRoles.tiny` decide how expensive those workers are. Keep deep models on parent roles (`plan`, `slow`, explicit `/model`) and put cheap models on spawned-worker roles.
+
+## Current risk profile
+
+Observed on 2026-07-20 with `rtk omp config get/list` in this repo:
+
+| Setting | Observed value | Cost implication |
+| --- | ---: | --- |
+| `tools.approvalMode` | `yolo` | Tool calls do not stop for confirmation by default. |
+| `tools.approval` | `{}` | No explicit `task` approval override. |
+| `async.enabled` | `true` | Fan-outs can run in the background and become easy to miss. |
+| `task.batch` | `true` | One call can launch many subagents. |
+| `task.maxConcurrency` | `32` | Up to 32 subagents can run at once. |
+| `task.maxRecursionDepth` | `2` | Children can still spawn grandchildren. |
+| `task.softRequestBudget` | `200` | Subagents are not strongly budget-steered. |
+| `task.maxRuntimeMs` | `0` | No configured wall-clock cap. |
+
+This is the dangerous combination: `plan` or `slow` on an expensive reasoning model plus permissive task fan-out can burn a weekly subscription or OpenRouter balance without any single worker looking excessive.
+
+## Budget guardrail profile
+
+Use this shape in the managed chezmoi OMP config, not by hand-editing live generated config:
+
+```yaml
+omp:
+  config:
+    async:
+      enabled: false        # optional: background work becomes visible/blocking
+
+    tools:
+      approval:
+        task: prompt        # approve each subagent fan-out even in yolo mode
+
+    task:
+      eager: default        # lowest documented eagerness mode: default/preferred/always
+      batch: false          # prevents one Task call from launching N workers
+      maxConcurrency: 2     # hard cap live subagents
+      maxRecursionDepth: 1  # children cannot spawn grandchildren
+      softRequestBudget: 30 # steer workers to wrap up
+      maxRuntimeMs: 600000  # 10 minute hard cap per worker
+```
+
+For a hard no-fanout session, set `tools.approval.task: deny`. To keep specialist agents but remove the generic catch-all worker, add `task.disabledAgents: [task]`.
+
+## Role split
+
+Keep parent reasoning and worker execution on different price tiers:
+
+```yaml
+modelRoles:
+  default: openai-codex/gpt-5.6-terra:medium
+  plan: openai-codex/gpt-5.6-sol:xhigh
+  slow: openai-codex/gpt-5.6-sol:xhigh
+
+  # spawned-worker roles
+  task: openrouter/deepseek/deepseek-v4-flash
+  smol: openrouter/qwen/qwen3-coder-30b-a3b-instruct
+  tiny: openrouter/mistralai/mistral-nemo
+  commit: openrouter/openai/gpt-5-nano
+
+  # explicit escalation, not fan-out default
+  advisor: openrouter/moonshotai/kimi-k3
+```
+
+The invariant is simple: `plan` / `slow` may be expensive because the parent is visible; `task` / `smol` / `tiny` / `commit` must be cheap because fan-out multiplies them.
+
+## OpenRouter worker candidates
+
+Prices and capabilities below came from OpenRouter's live `/api/v1/models` on 2026-07-20. The blended price is a 10 input : 1 output token mix, which matches many code-review/search workers better than chatty assistant usage.
+
+| Worker type | Recommended model | Context | Price in/out per 1M | 10:1 blend | Signal | Caveat |
+| --- | --- | ---: | ---: | ---: | --- | --- |
+| Default coder worker | `openrouter/deepseek/deepseek-v4-flash` | 1,048,576 | `$0.098 / $0.196` | `$0.107` | Tools, structured outputs, coding 56.2, agentic 31.1, 18 endpoints. | Reasoning defaults to high where supported; use only if OMP/provider handling does not leak expensive reasoning tokens. |
+| Cheap coder worker | `openrouter/qwen/qwen3-coder-30b-a3b-instruct` | 160,000 | `$0.07 / $0.27` | `$0.088` | Coder-branded, tools, structured outputs, 5 endpoints. | No OpenRouter Artificial Analysis coding index in the model API snapshot. |
+| Long-context cheap worker | `openrouter/qwen/qwen3.5-flash-02-23` | 1,000,000 | `$0.065 / $0.26` | `$0.083` | Tools, structured outputs, very cheap 1M context. | Single provider in the endpoint snapshot. |
+| Ultra-cheap menial worker | `openrouter/mistralai/mistral-nemo` | 131,072 | `$0.019 / $0.03` | `$0.020` | Tools, structured outputs, multiple endpoints. | Use for summarization, routing, classification, and small edits, not hard debugging. |
+| Strong cheap contender | `openrouter/tencent/hy3-preview` | 262,144 | `$0.063 / $0.21` | `$0.076` | Coding 58.8, agentic 30.7, OpenRouter weekly usage leader. | No structured-output support in the model API snapshot; preview model. |
+| Strong cheap contender | `openrouter/xiaomi/mimo-v2.5` | 1,048,576 | `$0.14 / $0.28` | `$0.153` | Tools, structured outputs, coding 56.8. | Endpoint uptime snapshot was lower than DeepSeek/Qwen/Mistral. |
+| Commit / tiny fallback | `openrouter/openai/gpt-5-nano` | 400,000 | `$0.05 / $0.40` | `$0.082` | Tools, structured outputs, familiar OpenAI behavior. | Output is more expensive than Qwen/DeepSeek; reasoning is mandatory. |
+| Free disposable worker | `openrouter/google/gemma-4-31b-it:free` | 262,144 | `$0 / $0` | `$0` | Tools, structured outputs, coding 43.4. | Free pools can rate-limit or disappear; do not use for critical writes. |
+| Free coding experiment | `openrouter/qwen/qwen3-coder:free` | 1,048,576 | `$0 / $0` | `$0` | Coder-branded, tools, 1M context. | No structured-output support or benchmark fields in the snapshot. |
+| Free long-context experiment | `openrouter/nvidia/nemotron-3-ultra-550b-a55b:free` | 1,000,000 | `$0 / $0` | `$0` | Coding 49.3, agentic 27.4, tools. | Reasoning defaults high; no structured-output support in the snapshot. |
+
+## Fastest is not directly measured here
+
+OpenRouter's public model and endpoint APIs exposed price, context, supported parameters, benchmark fields, endpoint counts, and uptime for the candidates above. The endpoint records did not expose non-null latency or throughput for this shortlist at capture time, so “fastest” is an inference from `flash`/`preview` model class, endpoint count, weekly usage, and price. Treat the speed ranking as provisional until measured with the local OMP workload.
+
+Practical starting order for simple coder workers:
+
+1. `deepseek/deepseek-v4-flash` for default `task`: best cheap balance of context, tool support, structured outputs, benchmark signal, and endpoint diversity.
+2. `qwen/qwen3-coder-30b-a3b-instruct` for `smol`: cheap code-specialist worker when 160k context is enough.
+3. `mistralai/mistral-nemo` for `tiny`: cheapest useful menial agent for read-only triage, summaries, and simple mechanical edits.
+4. `tencent/hy3-preview` as a benchmark watchlist candidate: excellent cheap coding signal and weekly usage, but preview status and no structured-output support make it riskier as a default worker.
+5. `xiaomi/mimo-v2.5` as a long-context alternative: good coding signal and structured outputs, but less compelling uptime in the endpoint snapshot.
+
+## Kimi K3 placement
+
+`moonshotai/kimi-k3` is not a fan-out default. It is expensive (`$3 / $15` per 1M), has mandatory max-style reasoning in Moonshot docs, and had only one OpenRouter upstream provider in the checked snapshot. Keep it as an explicit escalation role such as `advisor` or manual `/model` for large-repo, visual, or long-horizon reasoning.
+
+_Source: 2026-07-19/20 OMP + OpenRouter model-role research · Updated: 2026-07-20 · Supersedes: none_

--- a/chezmoi/.chezmoidata/omp.yaml
+++ b/chezmoi/.chezmoidata/omp.yaml
@@ -65,6 +65,9 @@ omp:
       artifactSpillThreshold: 2
       artifactHeadBytes: 1
       artifactTailBytes: 1
+    todo:
+      enabled: false
+      reminders: false
     read:
       toolResultPreview: false
     skills:

--- a/chezmoi/dot_omp/private_agent/APPEND_SYSTEM.md
+++ b/chezmoi/dot_omp/private_agent/APPEND_SYSTEM.md
@@ -28,6 +28,12 @@ Repository instructions override generic defaults. Match local style and existin
 - Be concise: lead with the answer, add minimal support, stop. No preamble, no closing recap. One sentence beats a paragraph.
 - Calibrate every claim: `<certain>` (verified), `<speculative>` (informed guess), `<don't know>`. An absence claim ("X has no Y", "not possible") needs evidence ruling out each candidate — "didn't find it" is not "doesn't exist". When pointed at evidence, re-read the source and re-derive; don't defend a challenged claim.
 
+## Work tracking
+
+- Native Todo is disabled. Use Milknado MCP when work needs a plan.
+- Create one goal for the current request, add executable work as child tasks, claim a task before starting it, and mark it done after verification.
+- Use Milknado node IDs for updates. Never mirror the same task in another tracker.
+
 ## Tooling
 
 - Prefer OMP-native file, search, edit, and code-intelligence tools over shell; use shell for tests, builds, and non-file operations.

--- a/chezmoi/dot_omp/private_agent/extensions/milknado-todo-guard.ts
+++ b/chezmoi/dot_omp/private_agent/extensions/milknado-todo-guard.ts
@@ -1,0 +1,14 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+
+const TODO_COMMAND = /^\/todo(?:\s|$)/
+const MESSAGE = "Native /todo is disabled. Use Milknado MCP for work tracking."
+
+export default function (pi: ExtensionAPI) {
+  // `todo.enabled` removes the model tool, but OMP still registers `/todo`.
+  pi.on("input", (event, ctx) => {
+    if (!TODO_COMMAND.test(event.text)) return { action: "continue" }
+
+    ctx.ui.notify(MESSAGE, "warning")
+    return { action: "handled" }
+  })
+}

--- a/milknado.toml
+++ b/milknado.toml
@@ -1,0 +1,3 @@
+[milknado]
+# Native task completion fails closed without an explicit project gate.
+quality_gates = ["just check"]

--- a/tests/config-validation.bats
+++ b/tests/config-validation.bats
@@ -4,6 +4,16 @@
 
 DOTFILES_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME}")/.." && pwd)"
 
+# ── Milknado ─────────────────────────────────────────────────────────────────
+
+@test "milknado config pins the repository verification gate" {
+    local config="$DOTFILES_DIR/milknado.toml"
+    [[ -f "$config" ]]
+    run yq -p=toml -o=json '.' "$config"
+    [[ $status -eq 0 ]]
+    [[ "$(yq -p=toml '.milknado.quality_gates | join(",")' "$config")" == "just check" ]]
+}
+
 # ── Atuin ─────────────────────────────────────────────────────────────────────
 
 @test "atuin config is valid TOML" {

--- a/tests/extensions/milknado-todo-guard.test.mjs
+++ b/tests/extensions/milknado-todo-guard.test.mjs
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import milknadoTodoGuard from '../../chezmoi/dot_omp/private_agent/extensions/milknado-todo-guard.ts'
+
+const message = 'Native /todo is disabled. Use Milknado MCP for work tracking.'
+
+function loadExtension() {
+  const notifications = []
+  let inputHandler
+
+  milknadoTodoGuard({
+    on(event, handler) {
+      assert.equal(event, 'input')
+      inputHandler = handler
+    },
+  })
+
+  assert.equal(typeof inputHandler, 'function')
+
+  const ctx = {
+    ui: {
+      notify(text, level) {
+        notifications.push({ text, level })
+      },
+    },
+  }
+
+  return { inputHandler, ctx, notifications }
+}
+
+test('blocks native todo commands and identifies Milknado as the owner', async () => {
+  const harness = loadExtension()
+
+  for (const text of ['/todo', '/todo append Implementation\nWrite guard', '/todo\tview']) {
+    const result = await harness.inputHandler(
+      { type: 'input', text, source: 'interactive' },
+      harness.ctx,
+    )
+    assert.deepEqual(result, { action: 'handled' })
+  }
+
+  assert.deepEqual(harness.notifications, [
+    { text: message, level: 'warning' },
+    { text: message, level: 'warning' },
+    { text: message, level: 'warning' },
+  ])
+})
+
+test('leaves non-command input untouched', async () => {
+  const harness = loadExtension()
+
+  for (const text of ['Use /todo later', '/todone', ' /todo', 'plain input']) {
+    const result = await harness.inputHandler(
+      { type: 'input', text, source: 'interactive' },
+      harness.ctx,
+    )
+    assert.deepEqual(result, { action: 'continue' })
+  }
+
+  assert.deepEqual(harness.notifications, [])
+})

--- a/tests/omp-config.bats
+++ b/tests/omp-config.bats
@@ -49,6 +49,8 @@ STDIN"
     [ "$(yq '.tools.artifactSpillThreshold' "$OUT")" = "2" ]
     [ "$(yq '.tools.artifactHeadBytes' "$OUT")" = "1" ]
     [ "$(yq '.tools.artifactTailBytes' "$OUT")" = "1" ]
+    [ "$(yq '.todo.enabled' "$OUT")" = "false" ]
+    [ "$(yq '.todo.reminders' "$OUT")" = "false" ]
     [ "$(yq '.read.toolResultPreview' "$OUT")" = "false" ]
     [ "$(yq '.skills.enableSkillCommands' "$OUT")" = "true" ]
     [ "$(yq '.tui.tight' "$OUT")" = "true" ]
@@ -79,12 +81,17 @@ theme:
   dark: titanium
   light: dark
 disabledProviders: []
+todo:
+  enabled: true
+  reminders: true
 setupVersion: 1'
     [ "$status" -eq 0 ]
     [ "$(yq '.symbolPreset' "$OUT")" = "nerd" ]
     [ "$(yq '.theme.dark' "$OUT")" = "chocolate-donut" ]
     [ "$(yq '.theme.light' "$OUT")" = "light" ]
     [ "$(yq '.disabledProviders | join(",")' "$OUT")" = "claude,codex,cursor,gemini,github,opencode,agents-md" ]
+    [ "$(yq '.todo.enabled' "$OUT")" = "false" ]
+    [ "$(yq '.todo.reminders' "$OUT")" = "false" ]
     [ "$(yq '.setupVersion' "$OUT")" = "1" ]
 }
 
@@ -272,7 +279,7 @@ TOML
 }
 
 # --- omp extension modules are chezmoi-managed -----------------------------
-# rtk.ts, cheese-flair.ts, and sliced-bread-audit.ts under dot_omp/private_agent/
+# rtk.ts, cheese-flair.ts, sliced-bread-audit.ts, and milknado-todo-guard.ts
 # extensions deploy to ~/.omp/agent/extensions/ (auto-discovered by omp's extension
 # loader). Nothing in .chezmoiignore may exclude them, or the extensions silently
 # never deploy.
@@ -290,11 +297,14 @@ TOML
     [[ "$output" == *".omp/agent/extensions/rtk.ts"* ]]
     [[ "$output" == *".omp/agent/extensions/cheese-flair.ts"* ]]
     [[ "$output" == *".omp/agent/extensions/sliced-bread-audit.ts"* ]]
+    [[ "$output" == *".omp/agent/extensions/milknado-todo-guard.ts"* ]]
     [[ "$output" == *".omp/agent/APPEND_SYSTEM.md"* ]]
 }
 
-@test "omp-ext: sliced bread audit command handler contract" {
+@test "omp-ext: extension handler contracts" {
     command -v node >/dev/null 2>&1 || skip "node not installed"
-    run node --test "$REAL_DOTFILES_DIR/tests/extensions/sliced-bread-audit.test.mjs"
+    run node --test "$REAL_DOTFILES_DIR"/tests/extensions/*.test.mjs
     [ "$status" -eq 0 ]
+    [[ "$output" == *"registers the command and dispatches the exact default workflow contract"* ]]
+    [[ "$output" == *"blocks native todo commands and identifies Milknado as the owner"* ]]
 }


### PR DESCRIPTION
## Purpose

Make Milknado the sole OMP work tracker. Native Todo was session-scoped and could diverge from Milknado's durable project graph.

## Changes

- Disable OMP's native Todo tool and reminders in repo-authoritative chezmoi data.
- Add a directly discovered input extension that consumes exact `/todo` commands and redirects users to Milknado while leaving ordinary text untouched.
- Add the Milknado ownership protocol to OMP's appended system prompt.
- Add `milknado.toml` with the repository's `just check` quality gate so claimed nodes can complete instead of failing closed.
- Add focused configuration and extension contract tests.
- Curate the implemented OMP/Milknado cutover research in the Hallouminate OMP page: rejected adapter designs, protocol details, verification, and residual policy questions.
- Add separate OMP fan-out guardrail and worker-model research, linked from the operations index. It distinguishes durable Milknado tracking from OMP worker-cost policy and marks time-sensitive model data as evidence-dated.

## Verification

- `just check` — 1,194/1,194 tests passed; lint, shellcheck, markdownlint, and workflow checks passed.
- `bats tests/config-validation.bats` — 19/19 passed.
- `bats tests/omp-config.bats` — 15/15 passed.
- `node --test tests/extensions/milknado-todo-guard.test.mjs` — 2/2 passed.
- `milknado agents check` — base planning and execution commands resolved.
- Direct flavor probe — `implement`, `spec`, `spike`, `prototype`, and `research` all inherit `just check`.

## Durable artifacts

| Target | Backend | Verified |
| --- | --- | --- |
| `.hallouminate/wiki/harnesses/omp.md` | Hallouminate | Read back and ranked first for the OMP Todo/Milknado policy query |
| `.hallouminate/wiki/operations/omp-fanout-worker-models.md` | Hallouminate | External OpenRouter source URLs resolved; page and operations-index link were read back and ranked for the fan-out query |
| `.hallouminate/wiki/log.md` | Hallouminate | Append-only research, handoff, and completion-gate decisions read back |

## Known constraints

- OMP still advertises the built-in `/todo` autocomplete entry; the extension can consume execution but cannot remove built-in completion metadata.
- Completed Milknado graph retention versus archival remains an explicit policy decision.
