### PR TITLE
chore(omp): reconcile model registry and add wiki harvest

### DIFF
--- a/agents/wiki-harvest/routine.md
+++ b/agents/wiki-harvest/routine.md
@@ -1,0 +1,287 @@
+# Wiki-Harvest — scheduled routine prompt
+
+<!-- Schedule: 0 15 * * 0 UTC = Sunday 08:00 America/Los_Angeles during PDT,
+     07:00 during PST (cron is fixed UTC; the local fire time drifts one
+     hour across DST). -->
+
+You are the **orchestrator** for the dotfiles repo's weekly wiki-harvest
+routine, running in a Claude cloud environment with the dotfiles repo checked
+out. You curate the hallouminate wiki (`.hallouminate/wiki/`) of each repo
+listed in the manifest, one PR per repo, so the cheez-wiki Obsidian vault
+("the brain") stays fed with grounded, non-stale knowledge.
+
+The run has **two phases**:
+
+- **Phase A — sibling curation (parallel).** One subagent per non-parent repo
+  curates that repo's own wiki AND returns a structured **digest** (purpose,
+  wiki highlights, and action items harvested from `ROADMAP.md`, open GitHub
+  issues, and TODO markers in the wiki). Every reachable sibling returns a
+  digest even when its curation is `no-change` or `dup` — action items are
+  gathered independently of whether the wiki changed.
+- **Phase B — cheez-wiki synthesis (after A).** The `role: parent` cheez-wiki
+  subagent receives all sibling digests, curates cheez-wiki's own pages, then
+  writes the machine-managed **roll-up** pages into cheez-wiki: one
+  `corpora/<repo>.md` summary per sub-corpus and a single top-level
+  `roadmap.md` aggregating every repo's action items grouped by repo. It runs
+  last because it depends on the sibling digests.
+
+The roll-up rides entirely on the digests siblings **return** — cheez-wiki's
+subagent still touches only its own clone (file-disjoint invariant intact).
+
+## Environment
+
+`gh` auth is the environment's native GitHub OAuth. No other setup is
+required.
+
+A push notification is delivered on each run and immediately surfaces any
+issue this routine opens, so you (the human) see the question in the Claude
+app. (The push itself is configured at routine-registration time, not in
+this file.)
+
+The curation methodology this routine applies is `/wiki-curator`, defined in
+the checked-out dotfiles repo at `skills/wiki-curator/SKILL.md`. Read that
+file now, before dispatching any subagent, so this routine stays
+self-contained even in an environment where the skill isn't registered as a
+slash command. Its curation procedure, summarized:
+
+1. **Ground first.** Never author blind — list the wiki's current tree, then
+   semantically search (`ground`) or read (`read_markdown`) the page(s)
+   you're about to touch before any overwrite.
+2. **One topic per file.** The chunker splits on headings, so two unrelated
+   topics in one file degrade retrieval. Map new knowledge to a single page:
+   an existing page's subtopic becomes a new heading there; a genuinely
+   distinct topic becomes a new file under the right subdir, linked from that
+   subdir's `index.md`.
+3. **Verify before you cite.** Never fabricate a doc URL — fetch it and
+   confirm it resolves with on-topic content before adding or changing an
+   external link. Verify repo claims (file paths, module names, functions)
+   against the actual code rather than asserting unconfirmed wiring; tag
+   genuine uncertainty as speculative rather than stating it flat.
+4. **Author for rationale, not restatement.** Capture the *why* — decisions,
+   trade-offs, "this not that", gotchas — not what the code already says.
+   Use H2/H3 headings per distinct point (the retrieval unit), and link
+   related pages with `[[name]]` (the page's path-stem).
+5. **Write + reindex.** Prefer the hallouminate MCP `add_markdown`
+   (`overwrite: true` for an existing file) — it writes atomically and
+   refreshes ancestor `index.md` link trees plus the search index in one
+   step. If writing plain files instead (e.g. the MCP daemon can't resolve
+   the cloned repo's corpus path), run `hallouminate index` afterward and
+   verify with a `ground` query. Keep each subdir's `index.md` Sections list
+   pointing at the files under it.
+
+## Orchestrator steps
+
+1. **Label.** Ensure the tracking label exists before anything else — idempotent,
+   fail-fast (do not swallow real auth/permission failures, only the
+   already-exists case):
+
+       gh label list --search wiki-harvest | grep -q wiki-harvest || gh label create wiki-harvest --color 0e8a16 --description "Weekly wiki-harvest routine artifacts"
+
+2. Parse `agents/wiki-harvest/sources.yaml` with `yq` to get the repo list
+   (`sources[]`: `name`, `owner`, `clone`, `wiki_path`, `category`,
+   `seed_if_missing`, and `role` where present).
+
+3. **Phase A — dispatch one subagent per NON-parent repo, in parallel** (every
+   `sources[]` entry whose `role` is not `parent`). Each subagent clones and
+   works only its own repo (file-disjoint), following the **sibling subagent
+   brief** below, and returns a one-line status **plus a digest block**. If
+   subagent dispatch isn't available in this environment, process the siblings
+   **sequentially in this same context** instead — the per-repo logic is
+   identical. Collect every returned digest.
+
+4. **Phase B — dispatch the cheez-wiki synthesis subagent** (the single
+   `role: parent` entry), passing it the full set of Phase-A digests as input.
+   It follows the **cheez-wiki synthesis subagent brief** below. Run it only
+   after Phase A has finished, since it reads those digests. Reachable siblings
+   that produced no digest (should not happen unless `UNREACHABLE`) are simply
+   absent from the roll-up — note them.
+
+5. Collect each subagent's one-line result and print a summary table:
+
+       <repo>: PR #<n> | issue #<n> | no-change | dup | UNREACHABLE
+
+   You never clone, edit, or open artifacts yourself — the subagents do.
+
+## Sibling subagent brief
+
+You own exactly ONE non-parent repo. Inputs: `name`, `owner`, `clone`,
+`wiki_path`, `category`, `seed_if_missing`, `role`. You do two things: curate
+this repo's own wiki (steps 1–7) and return a digest that feeds the cheez-wiki
+roll-up (step 8). Gather the digest for every reachable repo — even a
+`no-change` or `dup` curation still contributes action items.
+
+1. **Dedup.** If an open PR already covers this repo's harvest — an open PR
+   titled `docs(wiki-harvest): curate <repo> wiki`, an open branch matching
+   the prefix `wiki-harvest/<repo>-*` (catches a prior week's still-open
+   dated branch — do not search for today's exact dated branch, that would
+   miss last week's open PR), or an open PR for this repo carrying the
+   `wiki-harvest` label — stop and report `dup`. Also check for an existing
+   open `wiki-harvest`-labeled issue for this repo (title/label search) —
+   if found, report `dup` and do not re-ask via the issue path in step 6.
+
+2. **Reachability pre-flight.** Before cloning, confirm write reach:
+
+       gh repo view <owner>/<name> --json viewerCanAdminister
+
+   If the call errors on a permission/auth failure, or returns
+   `viewerCanAdminister: false`, report `UNREACHABLE` and skip curation
+   entirely for this repo — do not clone or do any curation work. This
+   catches a read-reachable-but-not-write-reachable repo before wasting a
+   curation pass; it's the expected risk for the cross-org `sorensen-labs`
+   repo (`algorhythm`) reaching outside the `paulnsorensen` OAuth
+   scope.
+
+3. **Clone.** Clone `<owner>/<name>` from `<clone>`. Keep the loud
+   fail-on-push as a backstop: if the clone or a later push still fails due
+   to auth/permission, STOP for this repo and report `UNREACHABLE` loudly.
+   Never swallow the failure. Continue with the other repos regardless.
+
+4. **Wiki presence.** If `<wiki_path>` (`.hallouminate/wiki`) is absent:
+   - `seed_if_missing: true` — create a minimal starter
+     `.hallouminate/wiki/index.md` following the shape of the dotfiles repo's
+     own `.hallouminate/wiki/index.md` (a title, a short corpus description,
+     a Conventions section, and a Sections list to fill in as pages are
+     added) — then proceed to curate. If the repo's purpose is unclear
+     enough that even a minimal index would be a guess (this is the
+     expected risk for `skillz-that-grillz`), skip seeding and use the
+     ask-via-issue path in step 6 instead — propose a starter structure and
+     a recommendation in the issue rather than seeding blind.
+   - `seed_if_missing: false` — there is nothing to curate. Report
+     `no-change`, but STILL gather the digest (step 8) from `ROADMAP.md` and
+     open issues so this repo's action items roll up even without a wiki.
+
+5. **Curate.** Apply the wiki-curator procedure above to `<wiki_path>`:
+   ground the existing wiki, add or refresh pages for non-obvious decisions
+   and gotchas, fix stale content, reconcile index/Sections lists, one topic
+   per file, link related pages with `[[name]]`.
+
+6. **Ambiguous decision → ask via issue.** If curation surfaces an ambiguous
+   call the repo, wiki, and code cannot settle — e.g. whether to split a
+   large page, what structure a from-scratch seeded wiki should take, or two
+   conflicting rationales where the right one isn't determinable — do not
+   guess. Open exactly ONE GitHub issue instead of a PR for this repo:
+   - Labeled `wiki-harvest` (the tracking label from orchestrator step 1).
+   - Title: `wiki-harvest: <repo> — <question topic>`.
+   - Body: the question, the options weighed, and a clear recommendation.
+   Then skip this repo's PR this run — do not also open a PR for it — and
+   report `issue #<n>`. This is reserved for genuine ambiguity; routine
+   curation calls still go through step 7 (Act) as a normal PR.
+
+7. **Act.** If curation changed any wiki files, open exactly ONE PR on branch
+   `wiki-harvest/<repo>-<YYYYMMDD>` with the curated edits, carrying the
+   `wiki-harvest` label (`gh pr create --label wiki-harvest ...`).
+   Title: `docs(wiki-harvest): curate <repo> wiki`.
+   Body: which pages were added or changed, and why. If nothing changed, exit
+   quietly — no branch, no PR — report `no-change`.
+
+8. **Gather digest.** From this repo's clone, assemble the roll-up digest.
+   Harvest action items from three sources; tag each item with its source and
+   keep them terse (one line each):
+   - **`ROADMAP.md`** (also `ROADMAP*`, `docs/roadmap*`, `TODO.md` if present):
+     open / unchecked items and near-term planned work. Tag `[roadmap]`.
+   - **Open GitHub issues:** `gh issue list --repo <owner>/<name> --state open
+     --limit 30 --json number,title,labels`. Tag `[issue #<n>]`. If more than
+     30 are open, include the 30 most-recent and add a final line noting the
+     total count and how many were omitted — never silently truncate.
+   - **Wiki TODO markers:** scan `<wiki_path>` for `TODO` / `FIXME` /
+     `DECIDE` / `XXX` markers; tag `[todo]` with the page path. Skip if no
+     wiki.
+
+   A source that is absent contributes nothing (not an error). Also capture a
+   1–2 line **purpose** for the repo and up to ~5 **highlights** (the key
+   decisions/gotchas or what this run's curation changed) — grounded in the
+   wiki and code, never invented.
+
+9. **Return.** Emit the one-line status followed by the digest block, exactly:
+
+       <repo>: PR #<n> | issue #<n> | no-change | dup | UNREACHABLE
+
+       ### <repo>
+       - status: <the one-line status above>
+       - purpose: <1–2 lines>
+       - highlights:
+         - <highlight>            # 0–5 lines; omit the key if none
+       - action_items:
+         - [roadmap] <item>
+         - [issue #<n>] <title>
+         - [todo] <marker> (<wiki page path>)
+         # omit the key entirely if there are no action items
+
+   `UNREACHABLE` repos return the status line only — no digest block.
+
+## cheez-wiki synthesis subagent brief
+
+You own the single `role: parent` repo (`cheez-wiki`). Inputs: its manifest
+entry **plus the full set of Phase-A sibling digests** the orchestrator
+collected. You clone only cheez-wiki and touch only its clone.
+
+1. **Dedup + reachability + clone.** Same as the sibling brief steps 1–3
+   (dedup on an open `wiki-harvest/cheez-wiki-*` branch / PR / labeled issue;
+   pre-flight `viewerCanAdminister`; clone; fail loud → `UNREACHABLE`).
+
+2. **Curate own pages.** Apply the wiki-curator procedure to cheez-wiki's
+   **hand-authored** pages only — its command-center content. Do NOT copy
+   sibling wiki prose into cheez-wiki; the roll-up below summarizes, it does
+   not duplicate.
+
+3. **Write per-corpus summaries.** For each sibling digest, write
+   `<wiki_path>/corpora/<repo>.md` (create the `corpora/` subdir if absent)
+   with `add_markdown` (`overwrite: true`). Each page:
+   - Title `# <repo>` and the digest's **purpose**.
+   - A `## Highlights` section from the digest highlights.
+   - An `## Action items` section listing the digest's action_items with their
+     `[roadmap]` / `[issue #n]` / `[todo]` source tags preserved. Omit the
+     section if the digest had none.
+   - A link back to the repo and a `[[roadmap]]` link.
+   These pages are **machine-managed** — regenerated in full each run from the
+   current digests. A repo absent from the digests (e.g. `UNREACHABLE` this
+   run) keeps its existing `corpora/<repo>.md` untouched; note it in the PR
+   body rather than deleting the page.
+
+4. **Write the global roadmap.** Write `<wiki_path>/roadmap.md` with
+   `add_markdown` (`overwrite: true`): a short intro, then one `## <repo>`
+   section per repo that has action items, listing that repo's items with
+   source tags and a `[[corpora/<repo>]]` link. Repos with zero action items
+   are omitted. This is the at-a-glance triage page — also machine-managed.
+
+5. **Reconcile indexes.** Ensure `<wiki_path>/corpora/index.md` lists the
+   per-corpus pages and the top-level `index.md` Sections list references
+   `corpora/` and `roadmap.md`. Add a one-line note at the top of both
+   `roadmap.md` and each `corpora/*.md` that they are generated by
+   wiki-harvest and should not be hand-edited.
+
+6. **Act.** If anything changed (own pages, `corpora/*`, `roadmap.md`), open
+   exactly ONE PR on `wiki-harvest/cheez-wiki-<YYYYMMDD>`, label
+   `wiki-harvest`, title `docs(wiki-harvest): curate cheez-wiki wiki`, body
+   summarizing own-page edits + which corpora/roadmap pages refreshed and any
+   repos absent from the roll-up. If the git diff is empty, exit quietly →
+   `no-change`. The ambiguous-decision → issue path (sibling brief step 6)
+   applies here too.
+
+7. **Return** one line: `cheez-wiki: PR #<n> | issue #<n> | no-change | dup | UNREACHABLE`.
+
+## Invariants
+
+- **Never auto-merge.** Every PR is human-reviewed; merging and the follow-on
+  local `git pull` + `hallouminate index` into the Obsidian vault stay with
+  the human.
+- **No direct push to any default branch.** Wiki edits advance only inside a
+  PR.
+- **One PR per repo.** Honor the dedup.
+- **Subagents are file-disjoint** — each touches only its own cloned repo,
+  never another repo's clone or branch. The roll-up crosses repos only through
+  **returned digests**, never by reaching into another repo's clone.
+- **Phase B runs after Phase A.** The cheez-wiki synthesis subagent depends on
+  the sibling digests; never dispatch it before the siblings finish.
+- **The roll-up summarizes, never duplicates.** `corpora/*.md` and `roadmap.md`
+  are distilled digests, not copies of sibling wiki prose. They are
+  machine-managed — regenerated each run and marked do-not-hand-edit.
+- **Exit quietly on no-change** — an empty curation pass means no branch, no
+  PR, no noise for that repo.
+- **Fail loud on an unreachable repo.** A cross-org clone/push failure is
+  reported as `UNREACHABLE`, never silently dropped from the summary table.
+- **Ask on genuine ambiguity, never fabricate.** The routine may ask the
+  human via a labeled `wiki-harvest` issue when curation hits a call the
+  repo, wiki, and code cannot settle — and never invents a decision it
+  can't ground. This is reserved for genuine ambiguity, not routine
+  curation calls; the default remains: curate and open a PR.

--- a/agents/wiki-harvest/sources.yaml
+++ b/agents/wiki-harvest/sources.yaml
@@ -1,0 +1,106 @@
+# wiki-harvest — repos whose .hallouminate/wiki/ this routine curates.
+#
+# A weekly Claude cloud routine (agents/wiki-harvest/routine.md) runs the
+# /wiki-curator methodology over each repo's `.hallouminate/wiki/` tree and
+# opens ONE PR per repo with the curated edits. PRs are never auto-merged — a
+# human reviews and merges each one. After a merge, a local `git pull` +
+# `hallouminate index` feeds the curated knowledge into the cheez-wiki
+# Obsidian vault ("the brain").
+#
+# cheez-wiki is dual-purpose: it is BOTH the parent command-center corpus
+# (aggregates the sibling wikis below via hallouminate corpora) AND the local
+# Obsidian vault that the human reads. The routine curates cheez-wiki's own
+# hand-authored pages AND, in a synthesis phase that runs after the sibling
+# subagents finish, writes machine-managed roll-up pages into it: one
+# `corpora/<repo>.md` summary per sub-corpus (purpose + highlights + that
+# repo's action items) and a single top-level `roadmap.md` aggregating every
+# repo's open action items grouped by repo. The roll-up rides on the digests
+# the sibling subagents return — cheez-wiki still never touches another repo's
+# clone. It does NOT copy sibling wiki prose wholesale; it summarizes.
+#
+# Schema per entry:
+#   name             repo name (also the GitHub repo slug component)
+#   owner            GitHub org/user that owns the repo
+#   clone            https clone URL
+#   wiki_path        path to the hallouminate wiki tree (always .hallouminate/wiki)
+#   category         grouping used for the header comments below
+#   seed_if_missing  if true and wiki_path doesn't exist yet, the routine
+#                    seeds a starter index.md before curating; if false, a
+#                    missing wiki_path is a quiet no-change exit
+#   role             optional; "parent" marks cheez-wiki as the aggregating
+#                    corpus + Obsidian vault (see above)
+
+sources:
+  # cheese-suite — the paulnsorensen cheese-flow tool family.
+  - name: cheez-wiki
+    owner: paulnsorensen
+    clone: https://github.com/paulnsorensen/cheez-wiki
+    wiki_path: .hallouminate/wiki
+    category: cheese-suite
+    role: parent
+    seed_if_missing: false
+
+  - name: dotfiles
+    owner: paulnsorensen
+    clone: https://github.com/paulnsorensen/dotfiles
+    wiki_path: .hallouminate/wiki
+    category: cheese-suite
+    seed_if_missing: false
+
+  - name: milknado
+    owner: paulnsorensen
+    clone: https://github.com/paulnsorensen/milknado
+    wiki_path: .hallouminate/wiki
+    category: cheese-suite
+    seed_if_missing: false
+
+  - name: easy-cheese
+    owner: paulnsorensen
+    clone: https://github.com/paulnsorensen/easy-cheese
+    wiki_path: .hallouminate/wiki
+    category: cheese-suite
+    seed_if_missing: false
+
+  - name: tilth
+    owner: paulnsorensen
+    clone: https://github.com/paulnsorensen/tilth
+    wiki_path: .hallouminate/wiki
+    category: cheese-suite
+    seed_if_missing: false
+
+  - name: hallouminate
+    owner: paulnsorensen
+    clone: https://github.com/paulnsorensen/hallouminate
+    wiki_path: .hallouminate/wiki
+    category: cheese-suite
+    seed_if_missing: false
+
+  - name: skillz-that-grillz
+    owner: paulnsorensen
+    clone: https://github.com/paulnsorensen/skillz-that-grillz
+    wiki_path: .hallouminate/wiki
+    category: cheese-suite
+    # has no .hallouminate/wiki yet — the routine seeds a starter index.md
+    # then curates.
+    seed_if_missing: true
+
+  # home-labs — personal infra repos.
+  - name: crabbot
+    owner: paulnsorensen
+    clone: https://github.com/paulnsorensen/crabbot
+    wiki_path: .hallouminate/wiki
+    category: home-labs
+    # private repo.
+    seed_if_missing: false
+
+  # products — algorhythm, the sole cross-org repo under sorensen-labs. The
+  # hosted routine's gh OAuth reaching a different org from paulnsorensen is
+  # unconfirmed until the first live run; the routine must fail loud (report
+  # UNREACHABLE, never silent) if it cannot clone or push/PR to it.
+  - name: algorhythm
+    owner: sorensen-labs
+    clone: https://github.com/sorensen-labs/algorhythm
+    wiki_path: .hallouminate/wiki
+    category: products
+    # CROSS-ORG.
+    seed_if_missing: false

--- a/chezmoi/.chezmoidata/omp.yaml
+++ b/chezmoi/.chezmoidata/omp.yaml
@@ -92,6 +92,8 @@ omp:
       formatOnWrite: false
     github:
       enabled: true
+    astGrep:
+      enabled: true
     task:
       eager: default
     # Consent answer omp recorded live (autoqa prompt) — promoted to survive
@@ -117,12 +119,19 @@ omp:
       task: openai-codex/gpt-5.6-luna
       commit: openai-codex/gpt-5.6-luna
       vision: openai-codex/gpt-5.6-terra
+  # Custom model registry — always rendered to ~/.omp/agent/models.yml so
+  # non-local custom providers can be added here without enabling the local LLM
+  # stack. Keep built-in remote models in modelRoles/config.yml; do not mirror
+  # OMP's bundled catalog here.
+  models:
+    providers: {}
   # Local LLM stack — LiteLLM proxy front (~/local-llm), OpenAI-compatible.
   # Keyless: the proxy sets no master_key, so no Authorization header is sent.
   # contextWindow per model matches the backend's launched --ctx-size in
   # ~/local-llm/configs/llama-swap.yaml — do not inflate, or requests overflow
-  # the real llama.cpp n_ctx and fail.
-  models:
+  # the real llama.cpp n_ctx and fail. The models.yml template merges this
+  # provider only on hosts with localLLM = true.
+  localModels:
     providers:
       local-llm:
         baseUrl: http://127.0.0.1:4000/v1

--- a/chezmoi/.chezmoiignore
+++ b/chezmoi/.chezmoiignore
@@ -30,9 +30,10 @@ lib/
 !.omp/agent/APPEND_SYSTEM.md
 {{- /*
 Local LLM stack is per-machine, opt-in. When the localLLM flag is false,
-ignore the whole stack tree + its systemd units so non-LLM machines stay
-clean. (.chezmoiignore is rendered as a template, so this conditional works
-even though the rest of the file is static.)
+ignore the stack tree + its systemd units so non-LLM machines stay clean.
+Keep .omp/agent/models.yml managed regardless: its template renders the
+loopback local-llm provider only when localLLM is true, while still allowing
+non-local custom providers to be specified on every host.
 
 `get` (not bare `.localLLM`) is deliberate: chezmoi renders templates with
 missingkey=error, so a bare reference would fail `chezmoi apply` on any
@@ -45,8 +46,8 @@ local-llm/**
 .config/systemd/user/local-llm.target
 .config/systemd/user/llama-swap.service
 .config/systemd/user/worker-npu.service
-.omp/agent/models.yml
 {{ end }}
+
 {{ if (get . "localLLM") }}
 # Stack enabled: the global README*/*.md rules above would otherwise skip
 # local-llm/README.md, which local-llm.target's Documentation= points at.

--- a/chezmoi/dot_omp/private_agent/APPEND_SYSTEM.md
+++ b/chezmoi/dot_omp/private_agent/APPEND_SYSTEM.md
@@ -30,9 +30,9 @@ Repository instructions override generic defaults. Match local style and existin
 
 ## Work tracking
 
-- Native Todo is disabled. Use Milknado MCP when work needs a plan.
-- Create one goal for the current request, add executable work as child tasks, claim a task before starting it, and mark it done after verification.
-- Use Milknado node IDs for updates. Never mirror the same task in another tracker.
+- Native Todo is disabled. Do not create Milknado nodes for focused, single-threaded work with no coordination or durable-resume need; execute it directly.
+- Before using Milknado, decide whether persistent planning, dependencies, delegation, cross-session handoff, or user-requested tracking will materially help. If not, do not use it as a replacement TODO list.
+- When it will help, create one goal for the request, add only executable child tasks with real prerequisites or ownership boundaries, claim the active task, and mark it done after verification. Use node IDs for updates; never mirror the same task in another tracker.
 
 ## Tooling
 

--- a/chezmoi/dot_omp/private_agent/models.yml.tmpl
+++ b/chezmoi/dot_omp/private_agent/models.yml.tmpl
@@ -1,5 +1,14 @@
-# Local LLM provider config for omp (LiteLLM proxy front, keyless loopback).
-# Authored WHOLESALE from the `omp.models` subtree of .chezmoidata/omp.yaml on
-# every `chezmoi apply` — hand-edits here are WIPED. Edit the registry (which
-# carries the contextWindow/--ctx-size warning), then `dots sync`.
-{{ .omp.models | toYaml -}}
+# OMP custom model registry. Always render the file so non-local custom
+# providers can live in `.omp.models`; add the loopback local-llm provider only
+# on hosts that opted into the local stack.
+providers:
+{{ if .omp.models.providers }}
+{{ .omp.models.providers | toYaml | indent 2 }}
+{{ end }}
+{{ if get . "localLLM" }}
+  local-llm:
+{{ index .omp.localModels.providers "local-llm" | toYaml | indent 4 }}
+{{ end }}
+{{ if and (not .omp.models.providers) (not (get . "localLLM")) }}
+  {}
+{{ end }}

--- a/tests/omp-config.bats
+++ b/tests/omp-config.bats
@@ -68,6 +68,7 @@ STDIN"
     [ "$(yq '.modelRoles.smol' "$OUT")" = "openai-codex/gpt-5.6-luna" ]
     [ "$(yq '.modelRoles.task' "$OUT")" = "openai-codex/gpt-5.6-luna" ]
     [ "$(yq '.modelRoles.commit' "$OUT")" = "openai-codex/gpt-5.6-luna" ]
+    [ "$(yq '.astGrep.enabled' "$OUT")" = "true" ]
     [ "$(yq '.disabledProviders | join(",")' "$OUT")" = "claude,codex,cursor,gemini,github,opencode,agents-md" ]
     # setupVersion is machine state — never authored on a fresh machine.
     [ "$(yq 'has("setupVersion")' "$OUT")" = "false" ]
@@ -189,21 +190,45 @@ STDIN"
     fi
 }
 # --- models.yml template↔registry seam -------------------------------------
-# dot_omp/private_agent/models.yml.tmpl authors ~/.omp/agent/models.yml WHOLESALE
-# from the `omp.models` subtree via `{{ .omp.models | toYaml }}`. These lock the
-# render: it must parse as YAML and pin the local-llm provider's contextWindow
-# per model to the llama-swap --ctx-size values (inflating them overflows the
-# real llama.cpp n_ctx and breaks requests).
+# dot_omp/private_agent/models.yml.tmpl authors ~/.omp/agent/models.yml
+# WHOLESALE. `.omp.models` is the always-on custom provider map; `.omp.localModels`
+# is merged only when the host opts into the loopback local-llm stack. These lock
+# both renders: non-local custom providers remain possible on every host, and the
+# local-llm provider only appears where the proxy is expected to exist.
 
-@test "omp-models: template renders parseable YAML with the pinned local-llm provider" {
+@test "omp-models: localLLM off renders a parseable empty provider map" {
     command -v chezmoi >/dev/null 2>&1 || skip "chezmoi not installed"
+    local cfg="$TEST_HOME/cz-off.toml"
     local tmpl="$REAL_DOTFILES_DIR/chezmoi/dot_omp/private_agent/models.yml.tmpl"
-    run chezmoi execute-template --source "$REAL_DOTFILES_DIR/chezmoi" < "$tmpl"
+    cat > "$cfg" <<TOML
+sourceDir = "$REAL_DOTFILES_DIR/chezmoi"
+
+[data]
+email = "test@example.com"
+TOML
+    run chezmoi --config "$cfg" --source "$REAL_DOTFILES_DIR/chezmoi" execute-template < "$tmpl"
     [ "$status" -eq 0 ]
     printf '%s' "$output" > "$OUT"
-    # No unexpanded template syntax leaked into the rendered file.
     ! grep -qF '{{' "$OUT"
-    # Parses as a YAML map with exactly the local-llm provider.
+    [ "$(yq '.providers | length' "$OUT")" = "0" ]
+    [ "$(yq 'has("providers")' "$OUT")" = "true" ]
+}
+
+@test "omp-models: localLLM on merges the pinned local-llm provider" {
+    command -v chezmoi >/dev/null 2>&1 || skip "chezmoi not installed"
+    local cfg="$TEST_HOME/cz-on.toml"
+    local tmpl="$REAL_DOTFILES_DIR/chezmoi/dot_omp/private_agent/models.yml.tmpl"
+    cat > "$cfg" <<TOML
+sourceDir = "$REAL_DOTFILES_DIR/chezmoi"
+
+[data]
+email = "test@example.com"
+localLLM = true
+TOML
+    run chezmoi --config "$cfg" --source "$REAL_DOTFILES_DIR/chezmoi" execute-template < "$tmpl"
+    [ "$status" -eq 0 ]
+    printf '%s' "$output" > "$OUT"
+    ! grep -qF '{{' "$OUT"
     [ "$(yq '.providers | keys | .[]' "$OUT")" = "local-llm" ]
     [ "$(yq '.providers.local-llm.baseUrl' "$OUT")" = "http://127.0.0.1:4000/v1" ]
     [ "$(yq '.providers.local-llm.api' "$OUT")" = "openai-completions" ]
@@ -221,14 +246,11 @@ STDIN"
 }
 
 # --- models.yml localLLM opt-in gate ---------------------------------------
-# models.yml advertises a LiteLLM provider that only exists on machines that
-# opted into the local-llm stack. It MUST ride the same `.chezmoiignore`
-# localLLM gate as the rest of the stack, or a non-LLM box gets a models.yml
-# pointing at a proxy that isn't installed. Render .chezmoiignore as a template
-# (the gate uses `get . "localLLM"`) and assert the target path is ignored when
-# the flag is off and applied when it is on.
+# models.yml itself is always managed. Only the loopback local-llm provider is
+# conditional, so a non-LLM host can still carry future non-local custom provider
+# overrides without advertising a dead 127.0.0.1 proxy.
 
-@test "omp-models: .omp/agent/models.yml is ignored when localLLM is off" {
+@test "omp-models: .omp/agent/models.yml remains managed when localLLM is off" {
     command -v chezmoi >/dev/null 2>&1 || skip "chezmoi not installed"
     local cfg="$TEST_HOME/cz-off.toml"
     cat > "$cfg" <<TOML
@@ -240,26 +262,10 @@ TOML
     run chezmoi --config "$cfg" --source "$REAL_DOTFILES_DIR/chezmoi" \
         execute-template < "$REAL_DOTFILES_DIR/chezmoi/.chezmoiignore"
     [ "$status" -eq 0 ]
-    # localLLM absent (→ falsy): the models.yml target is ignored, never applied.
-    [[ "$output" == *".omp/agent/models.yml"* ]]
-}
-
-@test "omp-models: .omp/agent/models.yml is applied when localLLM is on" {
-    command -v chezmoi >/dev/null 2>&1 || skip "chezmoi not installed"
-    local cfg="$TEST_HOME/cz-on.toml"
-    cat > "$cfg" <<TOML
-sourceDir = "$REAL_DOTFILES_DIR/chezmoi"
-
-[data]
-email = "test@example.com"
-localLLM = true
-TOML
-    run chezmoi --config "$cfg" --source "$REAL_DOTFILES_DIR/chezmoi" \
-        execute-template < "$REAL_DOTFILES_DIR/chezmoi/.chezmoiignore"
-    [ "$status" -eq 0 ]
-    # localLLM on: the not-localLLM ignore block collapses, so the models.yml
-    # target is NOT in the ignore list (chezmoi applies it).
     [[ "$output" != *".omp/agent/models.yml"* ]]
+    run chezmoi --config "$cfg" --source "$REAL_DOTFILES_DIR/chezmoi" managed
+    [ "$status" -eq 0 ]
+    [[ "$output" == *".omp/agent/models.yml"* ]]
 }
 
 # --- .chezmoiignore negation ordering -------------------------------------


### PR DESCRIPTION
## Changes
- Keep OMP custom providers managed on every host and gate only the local loopback provider.
- Add the missing `astGrep` registry entry so `dots sync` accepts the live OMP configuration.
- Add OMP configuration coverage for both behaviors.
- Add the weekly wiki-harvest cloud-routine prompt and repository manifest.
- Keep Milknado out of focused, single-threaded work unless coordination or durable tracking is materially useful.

## Excluded
- Cursor runtime artifacts and `cursor/.gitignore` remain uncommitted.
- `.milknado/` session state remains uncommitted.

## Verification
- `rtk dots sync`
- `rtk bats tests/omp-config.bats`
- `rtk just check` (1,194 tests)