### PR TITLE
fix(omp): match omp's nested dev.autoqa.consent registry shape

### DIFF
--- a/chezmoi/.chezmoidata/omp.yaml
+++ b/chezmoi/.chezmoidata/omp.yaml
@@ -97,11 +97,12 @@ omp:
     task:
       eager: default
     # Consent answer omp recorded live (autoqa prompt) — promoted to survive
-    # the wholesale re-author. omp stores this as a flat `dev.autoqaConsent`
-    # key, not a nested `dev.autoqa.consent` object — match the live shape or
-    # the unknown-key gate in modify_config.yml trips on both paths.
+    # the wholesale re-author. omp migrated this from flat `dev.autoqaConsent`
+    # to nested `dev.autoqa.consent` — match the live shape or the unknown-key
+    # gate in modify_config.yml trips.
     dev:
-      autoqaConsent: granted
+      autoqa:
+        consent: granted
     # omp-introduced toggle (hides the model's thinking block in the TUI),
     # promoted to survive the wholesale re-author.
     hideThinkingBlock: true


### PR DESCRIPTION
## Changes
- Fold omp's migrated `dev.autoqa.consent` (nested) key shape into `chezmoi/.chezmoidata/omp.yaml`, replacing the stale flat `dev.autoqaConsent` entry that tripped the unknown-key gate in `modify_config.yml` and halted `chezmoi apply` during `dots sync`.

## Verification
- `rtk dots sync` — clean, no unknown key-paths
- `rtk just check` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)