### PR TITLE
fix(rectangle): skip keymap rewrite and restart when config unchanged

### DIFF
--- a/.hallouminate/wiki/operations/rectangle-sync.md
+++ b/.hallouminate/wiki/operations/rectangle-sync.md
@@ -1,0 +1,21 @@
+# Rectangle Pro sync — idempotence via hash stamp
+
+`rectangle/.sync` runs unconditionally on every `dots sync` (like every dir `.sync`). Before 2026-07-20 it always rewrote the shortcut defaults, `killall cfprefsd`, and hard-restarted Rectangle Pro (`pkill -9` + `open`) — so every sync (i.e. every commit, per repo convention) SIGKILLed the app. The user experienced this as Rectangle Pro "continually crashing".
+
+## Why diagnosis was tricky
+
+SIGKILL produces **no crash report** — zero `Rectangle Pro-*.ips` under `~/Library/Logs/DiagnosticReports/` despite constant "crashes". Absence of crash reports for a repeatedly-dying app is the signature of an external `kill -9`, not an app bug.
+
+## The fix
+
+`rectangle_sync` stamps a SHA-256 of the desired config (shortcut table + the three QoL defaults) into `defaults write <bundle> dotfilesKeymapHash`. On later runs a matching stamp skips all writes, the `cfprefsd` kill, and the restart. Restart only fires when the keymap actually changed.
+
+Deliberate choice: hash stamp, **not** live `defaults read` comparison of shortcut leaves — float-vs-int number printing makes text comparison of leaf values fragile (could mis-compare in either direction: perpetual restarts or never reapplying).
+
+## Gotchas
+
+- Don't delete the `dotfilesKeymapHash` key from `com.knollsoft.Hookshot` — the next sync would kill/restart the app once to re-stamp.
+- The stamp write must land **before** `killall cfprefsd` (see comment in `rectangle/lib.sh`).
+- `bash .sync` from inside `rectangle/` fails (`BASH_SOURCE` has no dir component to strip) — invoke by full path, as the orchestrator does.
+
+Related: [[operations/sync-and-chezmoi]]

--- a/rectangle/lib.sh
+++ b/rectangle/lib.sh
@@ -40,6 +40,19 @@ previousDisplay|33|$ctrl_opt_cmd
 EOF
 }
 
+# Hash the full desired config (shortcut table + QoL values) so rectangle_sync
+# can skip re-applying when nothing changed. Text comparison of live `defaults
+# read` output is fragile (NSNumber float-vs-int printing) -- a hash of our own
+# desired inputs sidesteps that entirely.
+rectangle_config_hash() {
+    {
+        rectangle_shortcuts
+        echo "subsequentExecutionMode=0"
+        echo "launchOnLogin=true"
+        echo "hideMenubarIcon=false"
+    } | shasum -a 256 | awk '{print $1}'
+}
+
 # Write every shortcut plus quality-of-life defaults to $bundle. Idempotent --
 # every keyCode/modifierFlags leaf is rewritten each run.
 #
@@ -48,7 +61,7 @@ EOF
 # (TerminalCommands.md). An ASCII plist-dict string "{ keyCode = N; ... }"
 # lands the leaves as NSString, which Rectangle's shortcut parser ignores.
 rectangle_write_shortcuts() {
-    local bundle="$1" cmd keycode mods
+    local bundle="$1" hash="$2" cmd keycode mods
     while IFS='|' read -r cmd keycode mods; do
         [[ -z "$cmd" ]] && continue
         defaults write "$bundle" "$cmd" -dict-add keyCode -float "$keycode" modifierFlags -float "$mods"
@@ -57,6 +70,7 @@ rectangle_write_shortcuts() {
     defaults write "$bundle" subsequentExecutionMode -int 0  # cycle 1/2 -> 2/3 -> 1/3 on repeat
     defaults write "$bundle" launchOnLogin -bool true
     defaults write "$bundle" hideMenubarIcon -bool false
+    defaults write "$bundle" dotfilesKeymapHash -string "$hash"
 
     # Flush the prefs cache so a running Rectangle Pro doesn't overwrite these
     # external writes with its in-memory copy when it next quits.
@@ -84,7 +98,15 @@ rectangle_sync() {
         return 0
     fi
 
-    rectangle_write_shortcuts "$RECTANGLE_BUNDLE"
+    local hash stamp
+    hash="$(rectangle_config_hash)"
+    stamp="$(defaults read "$RECTANGLE_BUNDLE" dotfilesKeymapHash 2>/dev/null || true)"
+    if [[ "$stamp" == "$hash" ]]; then
+        echo "rectangle/.sync: keymap already applied to $RECTANGLE_BUNDLE - skipping (no restart)"
+        return 0
+    fi
+
+    rectangle_write_shortcuts "$RECTANGLE_BUNDLE" "$hash"
     rectangle_restart
 
     echo "rectangle/.sync: wrote SizeUp keymap to $RECTANGLE_BUNDLE and reloaded Rectangle Pro"

--- a/tests/rectangle.bats
+++ b/tests/rectangle.bats
@@ -57,6 +57,21 @@ EOF
     chmod +x "$MOCK_BIN/pkill"
 }
 
+# Make `defaults read $bundle dotfilesKeymapHash` return a given stamp, while
+# every other `defaults` call still logs to $MOCK_LOG like the base mock.
+_mock_defaults_stamp() {
+    cat > "$MOCK_BIN/defaults" <<EOF
+#!/usr/bin/env bash
+if [[ "\$1" == "read" && "\$3" == "dotfilesKeymapHash" ]]; then
+    echo "$1"
+    exit 0
+fi
+printf 'defaults %s\n' "\$*" >> "$MOCK_LOG"
+exit 0
+EOF
+    chmod +x "$MOCK_BIN/defaults"
+}
+
 # ── rectangle_restart ──
 
 @test "rectangle_restart hard-kills with pkill -9 then relaunches" {
@@ -94,13 +109,31 @@ EOF
 
 @test "rectangle_write_shortcuts writes numeric-typed dict leaves, not an ASCII plist string" {
     source "$LIB"
-    run rectangle_write_shortcuts com.knollsoft.Hookshot
+    run rectangle_write_shortcuts com.knollsoft.Hookshot deadbeef
     [ "$status" -eq 0 ]
     # Rectangle's documented schema: -dict-add with -float leaves (NSNumber),
     # so keyCode/modifierFlags land as numbers the shortcut parser honors.
     grep -qF 'defaults write com.knollsoft.Hookshot leftHalf -dict-add keyCode -float 123 modifierFlags -float 1835008' "$MOCK_LOG"
     # the old ASCII plist-dict string form (lands leaves as NSString) must be gone
     ! grep -qF '{ keyCode =' "$MOCK_LOG"
+    # the stamp is written with the given hash
+    grep -qF 'defaults write com.knollsoft.Hookshot dotfilesKeymapHash -string deadbeef' "$MOCK_LOG"
+}
+
+# ── rectangle_config_hash ──
+
+@test "rectangle_config_hash hashes the shortcut table plus the three QoL values" {
+    source "$LIB"
+    expected="$( { rectangle_shortcuts; echo "subsequentExecutionMode=0"; echo "launchOnLogin=true"; echo "hideMenubarIcon=false"; } | shasum -a 256 | awk '{print $1}')"
+    [ "$(rectangle_config_hash)" = "$expected" ]
+}
+
+@test "rectangle_config_hash changes when the shortcut table changes" {
+    source "$LIB"
+    before="$(rectangle_config_hash)"
+    rectangle_shortcuts() { echo "leftHalf|999|1835008"; }
+    after="$(rectangle_config_hash)"
+    [ "$before" != "$after" ]
 }
 
 # ── rectangle_sync guards ──
@@ -143,4 +176,40 @@ EOF
     source "$LIB"
     run rectangle_sync
     [[ "$output" != *"restart Rectangle Pro to load"* ]]
+}
+
+# ── rectangle_sync idempotent stamp ──
+
+@test "rectangle_sync skips (no writes, no restart) when the stamp matches the desired hash" {
+    source "$LIB"
+    hash="$(rectangle_config_hash)"
+    _mock_defaults_stamp "$hash"
+    run rectangle_sync
+    [ "$status" -eq 0 ]
+    ! grep -q '^defaults write' "$MOCK_LOG"
+    ! grep -q '^pkill' "$MOCK_LOG"
+    ! grep -q '^killall' "$MOCK_LOG"
+    [[ "$output" == *"already applied"* ]]
+    [[ "$output" == *"skipping"* ]]
+}
+
+@test "rectangle_sync writes, restarts, and stamps the new hash when the stamp is missing" {
+    source "$LIB"
+    hash="$(rectangle_config_hash)"
+    run rectangle_sync
+    [ "$status" -eq 0 ]
+    grep -q 'defaults write com.knollsoft.Hookshot leftHalf' "$MOCK_LOG"
+    grep -qF "defaults write com.knollsoft.Hookshot dotfilesKeymapHash -string $hash" "$MOCK_LOG"
+    grep -q 'pkill -9 -f Rectangle Pro' "$MOCK_LOG"
+}
+
+@test "rectangle_sync writes, restarts, and stamps the new hash when the stamp is stale" {
+    source "$LIB"
+    _mock_defaults_stamp "stale-hash-does-not-match"
+    hash="$(rectangle_config_hash)"
+    run rectangle_sync
+    [ "$status" -eq 0 ]
+    grep -q 'defaults write com.knollsoft.Hookshot leftHalf' "$MOCK_LOG"
+    grep -qF "defaults write com.knollsoft.Hookshot dotfilesKeymapHash -string $hash" "$MOCK_LOG"
+    grep -q 'pkill -9 -f Rectangle Pro' "$MOCK_LOG"
 }

--- a/tests/window-mgmt.bats
+++ b/tests/window-mgmt.bats
@@ -83,11 +83,11 @@ MOCK
     assert_output_contains "write com.test topLeft -dict-add keyCode -float 123 modifierFlags -float 917504"
 }
 
-@test "rectangle_write_shortcuts: writes all 19 shortcuts plus 3 quality-of-life defaults" {
+@test "rectangle_write_shortcuts: writes all 19 shortcuts plus 3 quality-of-life defaults plus the hash stamp" {
     source "$RECT_LIB"
-    rectangle_write_shortcuts com.test
+    rectangle_write_shortcuts com.test deadbeef
     count=$(grep -c '^write com.test' "$DEFAULTS_LOG")
-    [ "$count" -eq 22 ]
+    [ "$count" -eq 23 ]
 }
 
 @test "rectangle_sync: skips on non-Darwin without writing defaults" {


### PR DESCRIPTION
## Problem

Every `dots sync` runs `rectangle/.sync` unconditionally, which always rewrote Rectangle Pro's shortcut defaults, killed `cfprefsd`, and hard-restarted the app (`pkill -9` + `open`). Since sync runs before every commit, Rectangle Pro was SIGKILLed constantly — perceived as the app "continually crashing", with zero crash reports (SIGKILL writes none, which is also what made it confusing to diagnose).

## Fix

`rectangle_sync` now computes a SHA-256 of the desired config (shortcut table + the three QoL defaults) and stamps it into `defaults` as `dotfilesKeymapHash`. On later runs a matching stamp skips all writes, the `cfprefsd` flush, and the restart — the kill/relaunch only fires when the keymap actually changed.

Hash-stamp over live `defaults read` comparison is deliberate: NSNumber float-vs-int printing makes text comparison of leaf values fragile in both directions (perpetual restarts, or never reapplying).

## Verification

- `bats tests/rectangle.bats` — 13/13 (new: stamp-match skips with zero writes/pkill/killall; missing/stale stamp writes + stamps + restarts; hash sensitivity tests)
- `just check` — green (1206/1206 bats, 92/92 workflow tests)
- Live: first `.sync` run wrote + stamped + restarted once; second run printed `keymap already applied … skipping (no restart)` with the app untouched
- Wiki gotcha page added: `operations/rectangle-sync.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
