### PR TITLE
fix(dots): stop cursor sudo prompts in dots up; document omp config-shape drift

### DIFF
--- a/.hallouminate/wiki/operations/index.md
+++ b/.hallouminate/wiki/operations/index.md
@@ -10,4 +10,5 @@ The repo's operational plumbing — the machinery that deploys config and the lo
 - [[tmux-plugin-gotchas]] — tmux plugin wiring: why continuum silently disarms when `status-right` is rewritten after TPM runs, the required plugin declaration order, catppuccin palette injection via `theme/generate.sh`, and the live vs. repo plugin tree.
 - [[remote-access]] — the remote-shell stack: Tailscale mesh transport → mosh (UDP, survives roaming/sleep) → tmux session persistence, the `mtmux` wrapper, and why Tailscale stays a manual install under the Homebrew-on-Linux package model.
 
+- [[omp-config-shape-drift]] — unknown-key gate tripping on nested `dev.autoqa.*` means a stale per-machine config serialization: normalize with an `omp config set` re-save; never fold the nested shape into the shared registry (the #487 flip-flop).
 - [[omp-fanout-worker-models]] — OMP fan-out guardrails and evidence-dated worker-model cost research: separate parent reasoning from cheap worker roles, bound task fan-out, and treat speed rankings as provisional until measured locally.

--- a/.hallouminate/wiki/operations/omp-config-shape-drift.md
+++ b/.hallouminate/wiki/operations/omp-config-shape-drift.md
@@ -1,0 +1,53 @@
+---
+status: reviewed
+last_verified: 2026-07-21
+confidence: high
+sources:
+  - chezmoi/.chezmoidata/omp.yaml
+  - chezmoi/dot_omp/private_agent/modify_config.yml.tmpl
+  - https://github.com/can1357/oh-my-pi/commit/46ad908
+  - https://github.com/can1357/oh-my-pi/commit/ec65115
+  - .cheese/research/omp-autoqa-consent-shape/omp-autoqa-consent-shape.md
+---
+# OMP config-shape drift: normalize the machine, never fold into the registry
+
+When `dots sync` halts with the unknown-key gate on nested `dev.autoqa` /
+`dev.autoqa.consent` paths in `~/.omp/agent/config.yml`, the cause is a
+**stale per-machine file serialization**, not an omp version or platform
+difference.
+
+## Why
+
+- omp's canonical file shape is **flat** `dev.autoqaConsent` since v17.0.0
+  (oh-my-pi `46ad908`, 2026-07-15, "renamed settings keys to avoid
+  nested-value lookup collisions"). The nested `dev.autoqa.consent` object is
+  the *pre-rename legacy* shape, accepted only as read-migration (`ec65115`)
+  and normalized on omp's next settings save.
+- omp only re-saves settings when something writes them — a machine whose
+  config predates the rename keeps the nested shape indefinitely, so
+  different machines legitimately show different file shapes at the same omp
+  version. The write path has zero platform conditionals (settings.ts is
+  byte-identical across 17.0.5/17.0.6; verified in the research slug above).
+
+## The trap (history: #487 → revert b27ab75)
+
+The unknown-key gate compares **live file key-paths** against the registry
+(`chezmoi/.chezmoidata/omp.yaml`). Folding the nested shape into the shared
+registry makes sync pass on the stale machine and **halt on every normalized
+machine** — that is exactly the #487 (authored on the Mac, nested live file)
+→ revert (authored on the UTC/Linux box, flat live file) flip-flop. Both
+commits were "right" for the machine they were written on.
+
+## The fix
+
+Normalize the stale machine's file instead — force an omp settings save:
+
+```sh
+omp config set dev.autoqaConsent granted   # re-save normalizes legacy keys
+```
+
+then re-run `dots sync`. The registry stays flat everywhere. (If a shell
+wrapper injects flags into `omp`, call the raw binary:
+`$(which -a omp | tail -1)`.)
+
+Related: [[sync-and-chezmoi]], [[../harnesses/omp]].

--- a/chezmoi/.chezmoidata/omp.yaml
+++ b/chezmoi/.chezmoidata/omp.yaml
@@ -97,9 +97,13 @@ omp:
     task:
       eager: default
     # Consent answer omp recorded live (autoqa prompt) — promoted to survive
-    # the wholesale re-author. omp stores this as a flat `dev.autoqaConsent`
-    # key, not a nested `dev.autoqa.consent` object — match the live shape or
-    # the unknown-key gate in modify_config.yml trips on both paths.
+    # the wholesale re-author. Flat `dev.autoqaConsent` is omp's canonical
+    # file shape since v17.0.0 (oh-my-pi 46ad908 renamed away from nested
+    # `dev.autoqa.consent`; nested survives only as legacy read-migration).
+    # If the unknown-key gate trips on nested `dev.autoqa.*` paths, that
+    # machine's config.yml is a stale pre-rename serialization — normalize it
+    # with `omp config set dev.autoqaConsent granted` (forces a re-save);
+    # do NOT fold nested into this registry, it breaks every other machine.
     dev:
       autoqaConsent: granted
     # omp-introduced toggle (hides the model's thinking block in the TUI),

--- a/packages/packages.yaml
+++ b/packages/packages.yaml
@@ -82,7 +82,7 @@ packages:
   - skhd: { platform: mac }                   # Hotkey daemon (from koekeishiya/formulae tap)
   - emdash: { source: cask, platform: mac }   # Desktop UI for running coding agents in parallel
   - claude-code: { source: cask, platform: mac } # Claude Code — terminal AI coding assistant
-  - cursor: { source: cask, platform: mac }    # Cursor — AI code editor
+  - cursor: { source: cask, platform: mac, greedy: false } # Cursor — AI code editor; self-updates in-app, and greedy reinstall of the root-owned .app prompts for sudo
   - cursor-cli: { source: cask, platform: mac } # Cursor CLI — command-line agent (cursor-agent)
   - obsidian: { source: cask, platform: mac }  # Obsidian — Markdown knowledge base
   - alt-tab: { source: cask, platform: mac }   # AltTab — window switcher (prefs restored by alttab/.sync)


### PR DESCRIPTION
## Why

`dots up` blocked on a terminal `Password:` prompt, and `dots sync` halted in the chezmoi leg. Two independent root causes from one debugging session:

**Sudo prompt (`dots up`)** — `/Applications/Cursor.app` is root-owned, so the greedy pass's reinstall of the auto-updating `cursor` cask shelled out to `sudo` every time its installed version lagged. Cursor self-updates in-app, so it gets the existing `greedy: false` treatment (the docker-desktop pattern).

**Chezmoi halt (`dots sync`)** — the unknown-key gate tripped on nested `dev.autoqa.*` paths in `~/.omp/agent/config.yml`. Research against oh-my-pi source (cited in the wiki page): flat `dev.autoqaConsent` is omp's canonical file shape since v17.0.0 (`46ad908`); nested is a stale pre-rename serialization that omp only normalizes on its next settings save. That per-machine staleness is what drove the #487 → b27ab75 flip-flop — each fix matched the file on the machine it was authored on. The durable repair is normalizing the stale machine (`omp config set dev.autoqaConsent granted`), never folding nested into the shared registry; this PR records that in the registry comment and a new wiki page (`operations/omp-config-shape-drift.md`). No registry value changes.

## Verification

- `just check` green (1206 bats tests) on the final tree
- `dots sync` exits 0 twice on the affected Mac (flat registry + normalized flat live file)
- `dots up` full run with zero password prompts
- greedy exclusion list verified to emit `cursor` + `docker-desktop`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
