### PR TITLE
chore(doc-drift): bump chezmoi to v2.71.1 (no-op)

### DIFF
--- a/agents/doc-drift/sources.yaml
+++ b/agents/doc-drift/sources.yaml
@@ -61,7 +61,7 @@ sources:
     signal: { type: gh_release, ref: twpayne/chezmoi }
     docs: https://www.chezmoi.io/reference/
     governs: [chezmoi/]
-    reconciled: "v2.71.0"
+    reconciled: "v2.71.1"
 
 
   - id: serena


### PR DESCRIPTION
## What changed upstream

[twpayne/chezmoi v2.71.1](https://github.com/twpayne/chezmoi/releases/tag/v2.71.1) (2026-07-20):

**Features**
- `feat: Add --verbose flag to upgrade command`
- `feat: Add --skip-secrets flag`

**Fixes**
- `fix: Ensure that external target paths are in target dir`

## Impact assessment

None of this touches our config surface (`chezmoi/`):

- We never invoke `chezmoi upgrade` anywhere in this repo — `chezmoi` itself is installed/updated via `packages/packages.yaml` (the package manager), not chezmoi's self-upgrade command. The new `--verbose`/`--skip-secrets` flags on `upgrade` are moot for us.
- We have no `.chezmoiexternal.*` sources anywhere under `chezmoi/`, so the external-target-path containment fix doesn't apply to anything we configure.

This is a pure version-marker bump.

## Change

- `agents/doc-drift/sources.yaml`: `chezmoi.reconciled` `v2.71.0` → `v2.71.1`


---
_Generated by [Claude Code](https://claude.ai/code/session_01USudGamMEpiTNrSx63CxsR)_