### PR TITLE
chore(doc-drift): bump copilot-cli to 1.0.73 (no-op)

### DIFF
--- a/agents/doc-drift/sources.yaml
+++ b/agents/doc-drift/sources.yaml
@@ -43,7 +43,7 @@ sources:
     signal: { type: npm, ref: "@github/copilot" }
     docs: https://docs.github.com/en/copilot/how-tos/copilot-cli
     governs: [harnesses/copilot.md]
-    reconciled: "1.0.71"
+    reconciled: "1.0.73"
 
   - id: context7-mcp
     signal: { type: npm, ref: "@upstash/context7-mcp" }


### PR DESCRIPTION
## What

Bumps `copilot-cli`'s `reconciled` marker in `agents/doc-drift/sources.yaml` from `1.0.71` to `1.0.73` (current `@github/copilot` npm version). No other changes.

## Why no-op

Read the upstream release notes (`github/copilot-cli` GitHub Releases) for `1.0.72` and `1.0.73` against what `.hallouminate/wiki/harnesses/copilot.md` (governs file) actually documents/mirrors:

**1.0.72 (2026-07-20) highlights:** an `agentStop` hook that always blocks no longer loops indefinitely (ends the turn after 8 consecutive blocks; `agentStop` hooks now receive a `stop_hook_active` flag); opt-in git/gh auth inside the OS sandbox; sandbox macOS keychain access now defaults off; `/mcp delete` stops the server's background process; `/worktree` and `/move` reliability fixes; `update`/`uninstall` verbs and `--plugin`/`--mcp`/`--skill` flags added to the interactive `/plugins` command for skill/MCP/marketplace parity with `/plugin`; `copilot skill list` now strips terminal control characters from names/descriptions (ANSI-injection hardening); various `/settings` UX additions (mask secrets in `/settings show`, show defaults, SSO enforcement for remote control); multi-turn subagents always enabled.

**1.0.73 (2026-07-20) highlights:** Anthropic subagents continue working when additional directories are configured; relative links in custom-agent instructions now resolve from the agent file's own location.

None of this touches our governed surface:
- Our two Copilot hooks (`chezmoi/private_dot_copilot/hooks/{git-guard,sensitive-file-guard}.json.tmpl`) are both `preToolUse` hooks — we don't use `agentStop` hooks, so the loop-fix / `stop_hook_active` flag doesn't apply to us.
- We don't use the interactive `/plugins`/`/settings`/`/worktree`/`/mcp` slash commands ourselves; our renderer (`agent-profile/agent_profile/renderers/copilot.py`) drives the CLI non-interactively via `copilot plugin marketplace add/remove` and `copilot plugin install/uninstall` (the `copilot plugin` singular subcommand family), which are unchanged and unaffected by the `/plugins` (interactive) parity additions.
- Sandbox git/gh auth and macOS keychain defaults are runtime behavior we don't configure or depend on.
- The sub-agent (`.agent.md`) relative-link fix and multi-turn-subagent behavior are additive/bugfix runtime changes, not a schema change to the `.github/agents/<n>.agent.md` format our renderer emits.
- MCP (`~/.copilot/mcp-config.json` `mcpServers` schema), skills (`.github/skills/*`), instructions precedence, and "isolated settings: not available" all remain accurate — nothing in 1.0.72/1.0.73 changes those schemas/flags/precedence.

## Verification

Doc-only/no-op change (single YAML value). `just check` was not run — no `just` binary in this environment; CI gates it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01USudGamMEpiTNrSx63CxsR)_