### PR TITLE
chore(doc-drift): bump opencode to 1.18.4 (no-op)

### DIFF
--- a/agents/doc-drift/sources.yaml
+++ b/agents/doc-drift/sources.yaml
@@ -37,7 +37,7 @@ sources:
     signal: { type: npm, ref: opencode-ai }
     docs: https://opencode.ai/docs
     governs: [harnesses/opencode.md]
-    reconciled: "1.18.3"
+    reconciled: "1.18.4"
 
   - id: copilot-cli
     signal: { type: npm, ref: "@github/copilot" }


### PR DESCRIPTION
## What
Bumps the `opencode` doc-drift `reconciled` marker from `1.18.3` to `1.18.4`. No other changes.

## Why no-op
Release notes for [v1.18.4](https://github.com/anomalyco/opencode/releases/tag/v1.18.4) (npm `opencode-ai@1.18.4`), covering `1.18.3 → 1.18.4`:

**Core**
- Improvement: adaptive thinking controls for Kimi models on Anthropic-compatible providers
- Bugfixes: reduced OpenAI provider header timeouts on slow connection setup, respect provider-defined reasoning options, restore Azure Cognitive Services endpoint support

**Desktop**
- Improvements: terminal theme sync with app theme, review panel/tab alignment, rewritten v2 prompt input, review panel resizing
- Bugfixes: various desktop-app UI fixes (command drafts, session view, model variant selection, diff summary dedup, etc.)

None of this touches the config surface `harnesses/opencode.md` mirrors (hooks/plugin API, sub-agents, MCP config, system prompt/rules, `opencode.json`/`tui.json` settings, skills, local-LLM provider wiring, or the `.json` vs `.jsonc` quirk). All changes are provider-reasoning/timeout fixes and desktop-app-only UI work — nothing in the CLI config schema or docs we mirror.

## Checks
Marker-only YAML edit; not code, so `just check` wasn't run for this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01USudGamMEpiTNrSx63CxsR)_