### PR TITLE
chore(doc-drift): bump serena to v1.6.1 (no-op)

### DIFF
--- a/agents/doc-drift/sources.yaml
+++ b/agents/doc-drift/sources.yaml
@@ -71,7 +71,7 @@ sources:
     # --prerelease=allow), so a schema change can land a release ahead — fine
     # for triage, we reconcile on stable.
     governs: [chezmoi/dot_serena/modify_serena_config.yml, packages/packages.yaml]
-    reconciled: "v1.6.0"
+    reconciled: "v1.6.1"
 
   - id: oh-my-pi
     signal: { type: gh_release, ref: can1357/oh-my-pi }


### PR DESCRIPTION
## Drift

`serena` (`oraios/serena`, gh_release) reconciled `v1.6.0` -> current `v1.6.1` (released 2026-07-21).

## Change reviewed

Fetched the `CHANGELOG.md` delta between the `v1.6.0` and `v1.6.1` headers (both releases point at the same `main`-branch changelog, no per-release body). The `v1.6.1` section:

- **General**: `FileUtils.read_file`'s `charset_normalizer` fallback now normalizes line endings to LF (was skipping universal-newline translation); `SymbolBody.get_text` fix for a symbol range ending exactly one line past EOF.
- **Language Servers**: raw/high-level symbol-cache fingerprint fix; a file-system polling mechanism to catch external changes; ignore-pattern ordering fix; `uv tool run` replaces `uv x` for launching *language servers* (internal to serena, not how we install `serena-agent` itself); Java JDT-LS gets a new `ls_specific_settings.java.runtimes` key; gopls `replace_symbol_body` duplicate-keyword fix; TypeScript no longer blanket-ignores `coverage/` dirs; PHP `.phtml` + `file_filter` support; LSP `ContentModified` retry fix.
- **Tools**: `search_for_pattern` line-matching + overflow-shortening fixes; `safe_delete` empty-line heuristic.
- **JetBrains**: external dependency files become readable/searchable.
- **Dashboard**: version-available indicator; "Last Execution" empty-state fix.
- **Dependencies**: `mcp` 1.27.0→1.28.1, `anthropic` 0.59.0→0.117.0.

Compared against our two `governs` files:

- `chezmoi/dot_serena/modify_serena_config.yml` — patches `web_dashboard`, `web_dashboard_open_on_launch`, and `excluded_tools` (memory tools, `onboarding`, `initial_instructions`, `find_declaration`, `find_implementations`, `get_diagnostics_for_file`).
- `packages/packages.yaml` — installs `serena-agent` via `uv tool install --python 3.13 --prerelease=allow`.

None of the `v1.6.1` delta touches our config surface:
- No change to `web_dashboard` / `web_dashboard_open_on_launch` semantics (the dashboard-related fixes are UI-only and moot with the dashboard disabled).
- No rename/removal of any tool in our `excluded_tools` list — `search_for_pattern` and `safe_delete` (the only tools with changes this release) aren't in that list.
- The `uv x` → `uv tool run` change is serena's *internal* mechanism for launching per-language-server processes, not the `uv tool install --prerelease=allow` command we use to install `serena-agent` itself — no impact on our pin/flags.
- No install-method, package-name, or Python-pin change.

## Classification: no-op

This PR only bumps `reconciled: "v1.6.1"` for `serena` in `agents/doc-drift/sources.yaml`. No config edits.

## Test plan

- [x] Diff limited to the single `reconciled` line bump — no functional change to gate.
- Sandbox lacks `just`/`ruff` etc. for this session; nothing here should trip `just check` since no config/behavior changed, but CI is the authority.

---
Never auto-merge invariant note: this is the no-op class, which per the doc-drift routine spec for this run is self-merged via auto-merge (or direct merge as fallback) after opening.

---
_Generated by [Claude Code](https://claude.ai/code/session_01USudGamMEpiTNrSx63CxsR)_