### PR TITLE
chore(doc-drift): bump oh-my-pi to v17.0.9 (no-op)

### DIFF
--- a/agents/doc-drift/sources.yaml
+++ b/agents/doc-drift/sources.yaml
@@ -77,4 +77,4 @@ sources:
     signal: { type: gh_release, ref: can1357/oh-my-pi }
     docs: https://github.com/can1357/oh-my-pi
     governs: [chezmoi/.chezmoidata/omp.yaml, chezmoi/dot_omp/private_agent/modify_config.yml]
-    reconciled: "v17.0.5"
+    reconciled: "v17.0.9"


### PR DESCRIPTION
## Drift

`oh-my-pi` (can1357/oh-my-pi) `v17.0.5` → `v17.0.9`, spanning four releases: v17.0.6, v17.0.7, v17.0.8, v17.0.9.

## Changelog reviewed (full span, not just the last hop)

**v17.0.6**
- Migrated legacy nested/dotted keys (`dev.autoqa.consent` → `dev.autoqaConsent`, `todo.reminders.max` → `todo.remindersMax`) on settings load — matches what our registry comment already documents ("canonical since v17.0.0").
- Changed the default `astGrep.enabled` to `false` — irrelevant, we set it explicitly (`true`).
- Various TUI/session/transcript/browser-tool fixes, no config-surface impact.

**v17.0.7**
- Single fix: Portkey/gateway custom model id (`@...`) rewriting bug. Not applicable — we don't use Portkey.

**v17.0.8**
- Model catalog changes: removed GPT-5 through GPT-5.3 Codex variants and GPT-5.4-nano from the openai-codex catalog; removed several deprecated Devin models; new models added (MiniMax M3, Gemini 3.5/3.6 Flash, etc.); context-window/pricing updates. None of these touch our `modelRoles`, which reference the `gpt-5.6-terra/luna/sol` family exclusively.
- Various provider auth/discovery bug fixes (OpenAI-compat `auth: none`, Alibaba Coding Plan, LM Studio context reporting) — no config-surface impact.

**v17.0.9**
- **Breaking:** `getAutoQaDbDir` renamed to `getAutoQaDbPath` (pi-utils). This is an internal upstream API function, not a config key — `modify_config.yml` only authors `omp.config` by key path and never calls omp's internal helpers. No impact.
- **Model catalog:** `codex-auto-review` renamed to `GPT-5.3 Codex Spark`, context window 272K→128K, thinking-effort tiers changed, image input removed. We don't reference this model name anywhere in `omp.yaml` or `modify_config.yml` (grepped the repo — no hits). No impact.
- New features/settings: Synthetic usage provider, `UsageWindow.resetLabel`, GitHub Copilot OpenAI-compat priority-tier fix, SuperGrok usage tracking, per-call `model` on the `task` tool, Firecrawl keyless mode, new `mcp.renderMarkdownResults` setting (opt-out, default-on), Auto QA consent-flow restoration (`dev.autoqa` defaults back to `true`, distinct from our `dev.autoqaConsent: granted` which already records the resolved consent), setup-wizard short-terminal fix, RPC protocol v2. None of these are keys/behaviors our two governs files set, reference, or depend on.

## Conclusion

**No-op.** Nothing in the v17.0.5→v17.0.9 span touches the config surface `chezmoi/.chezmoidata/omp.yaml` or `chezmoi/dot_omp/private_agent/modify_config.yml` depend on — the two potentially scary items (the breaking rename and the model-catalog rename) are both internal/upstream-only and not referenced by our config.

Only the `oh-my-pi` `reconciled` marker is bumped to `"v17.0.9"` in `agents/doc-drift/sources.yaml`. No other line touched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01USudGamMEpiTNrSx63CxsR)_