### PR TITLE
Add glow — terminal markdown renderer

### DIFF
--- a/packages/packages.yaml
+++ b/packages/packages.yaml
@@ -28,6 +28,7 @@ packages:
   - fd
   - eza
   - bat
+  - glow                                         # Terminal markdown renderer
   - ast-grep
   - git-delta
   - git-lfs                                  # gitconfig.tmpl declares filter "lfs"; this installs the binary


### PR DESCRIPTION
## Summary
Adds `glow` to packages, a dedicated terminal markdown renderer with syntax highlighting, proper formatting, and color support.

Complements existing readers:
- `bat` — syntax-highlighted cat (code-first)
- `less`/`more` — Unix pagers
- **`glow`** — markdown-first rendering

## Test plan
- `dots sync` to install
- `glow <markdown-file>` to render with proper formatting
- `glow` interactive mode to browse markdown files

🧀 Generated with [Claude Code](https://claude.com/claude-code)