### PR TITLE
feat(omp): reconcile milknado + hallouminate as native OMP plugins

### DIFF
--- a/.hallouminate/wiki/harnesses/omp-plugins.md
+++ b/.hallouminate/wiki/harnesses/omp-plugins.md
@@ -1,0 +1,37 @@
+---
+status: reviewed
+last_verified: 2026-07-24
+confidence: high
+sources:
+  - chezmoi/.chezmoidata/omp.yaml
+  - .sync-lib.sh (sync_omp_plugins)
+  - .sync (run_sync wiring)
+  - tests/omp-plugins.bats
+  - .cheese/research/oh-my-pi-plugins/oh-my-pi-plugins.md
+---
+# OMP Native Plugins
+
+milknado and hallouminate install as **native OMP marketplace plugins**, reconciled from the `.omp.plugins` subtree of `chezmoi/.chezmoidata/omp.yaml` by `sync_omp_plugins` (`.sync-lib.sh`) on every `dots sync`. This replaced two hand-wired legs: their MCP entries in `dot_omp/private_agent/mcp.json` (now context7-only) and the `harnesses: [omp]` vendored-skill entries in `skills/_registry.yaml` (both deleted).
+
+## Why CLI reconcile, not declarative files
+
+OMP (verified at 17.0.9) has **no declarative install-list config key** — plugin state lives in imperatively-mutated files (`~/.omp/marketplaces.json`, `~/.omp/plugins/installed_plugins.json`, plus a lockfile), and marketplace payloads land in a version-stamped cache dir only the CLI can populate. chezmoi-templating those state files therefore cannot work; the reconcile must drive the CLI. It runs in `run_sync()` after `reconcile_claude_mcps`, is idempotent (converged machine → zero mutating `omp` calls), and propagates removals: de-listed registry entries are `plugin uninstall`ed and their marketplaces `marketplace remove`d. npm-installed OMP plugins (`.npm[]`) are never touched.
+
+## Why the mcp.json cutover is mandatory
+
+Plugin-owned MCP servers must NOT also appear in `dot_omp/private_agent/mcp.json` — OMP would expose both `server` and `plugin:server` namespaces (documented hazard in `omp.yaml`'s header). Going native for milknado/hallouminate therefore required removing their direct MCP entries in the same change.
+
+## OMP CLI gotchas (verified live, 17.0.9)
+
+- **Re-running `marketplace add` / `plugin install` on a present entry exits 1** ("already exists"/"already installed") — the reconcile must check current state first; it cannot lean on CLI idempotency.
+- **`--dry-run` is broken for `marketplace remove` and `uninstall`** — it actually mutates state. Never use it in the reconcile.
+- `omp plugin marketplace list --json` prints plain text (not JSON) when empty; `omp plugin list --json` is clean JSON always: `{"npm":[], "marketplace":[{"id":"name@marketplace", "scope":"user", "entries":[...]}]}`.
+- `~/.omp/marketplaces.json` schema: `{version:1, marketplaces:[{name, sourceType, sourceUri, catalogPath, addedAt, updatedAt}]}`. The reconcile guards its jq parse — a malformed file degrades to "no marketplaces" with a warning instead of aborting the whole sync under `set -e` (regression-tested in `tests/omp-plugins.bats`).
+- OMP marketplaces are **Claude-compatible**: `marketplace add` accepts `owner/repo` / git URL / local path and falls back to `.claude-plugin/marketplace.json` when `.omp-plugin/marketplace.json` is absent — so the same milknado/hallouminate repos serve claude and omp.
+- Marketplace installs load skills/agents/commands/hooks/MCP but **never `.ts` extension modules** — extensions stay chezmoi-deployed (`dot_omp/private_agent/extensions/`), unaffected by plugin installs.
+
+## Scope decisions
+
+Only milknado + hallouminate are registry-managed. cheese-flow's skills reach OMP via the easy-cheese vendor leg in `skills/_registry.yaml` (a native cheese-flow install would double them); todoist-flow and vaudeville are gated, claude-shaped, and stay out.
+
+Related: [[omp]] (Todo→Milknado cutover, extensions), [[operations/sync-and-chezmoi]] (deploy mechanics).

--- a/.sync
+++ b/.sync
@@ -61,6 +61,7 @@ run_sync() {
     install_prek_hooks
     install_tilth_claude_code
     reconcile_claude_mcps
+    sync_omp_plugins "$dir"
 
     unset DOTFILES_DEV
 

--- a/.sync-lib.sh
+++ b/.sync-lib.sh
@@ -463,6 +463,113 @@ sync_omp_chezmoi_sources() {
     return 0
 }
 
+# Reconcile native OMP marketplace plugins (milknado, hallouminate) against
+# the `.omp.plugins` subtree of chezmoi/.chezmoidata/omp.yaml. Runs after
+# chezmoi apply so the mcp.json cutover (context7 only) lands with the
+# plugin-owned MCP servers that replace it. Idempotent: a converged state
+# makes zero `omp` mutating calls. npm-installed plugins (`omp plugin list
+# --json` `.npm[]`) are never touched — only `.marketplace[]` entries whose
+# id matches `<name>@<marketplace>` for a marketplace this function owns.
+#   sync_omp_plugins <dotfiles_root>
+sync_omp_plugins() {
+    local root="$1"
+    local reg="$root/chezmoi/.chezmoidata/omp.yaml"
+
+    if ! command -v omp &>/dev/null; then
+        log_warning "omp not found — skipping OMP plugin reconcile"
+        return 0
+    fi
+    if ! command -v yq &>/dev/null; then
+        log_warning "yq not found — skipping OMP plugin reconcile"
+        return 0
+    fi
+    if ! command -v jq &>/dev/null; then
+        log_warning "jq not found — skipping OMP plugin reconcile"
+        return 0
+    fi
+    if [[ ! -f "$reg" ]]; then
+        log_error "omp registry not found: $reg"
+        return 1
+    fi
+
+    log_info "Reconciling OMP native plugins..."
+
+    # Desired: name\tmarketplace\tsource, one per registry entry.
+    local desired
+    desired=$(yq -r '.omp.plugins // {} | to_entries | .[] | [.key, .value.marketplace, .value.source] | @tsv' "$reg")
+
+    local desired_marketplaces
+    desired_marketplaces=$(printf '%s\n' "$desired" | awk -F'\t' 'NF{print $2}' | sort -u)
+
+    # Current marketplaces (empty if the file doesn't exist yet). Guarded:
+    # under the caller's `set -e`, an unguarded jq failure on a malformed
+    # file would abort the whole sync with no diagnostic.
+    local current_marketplaces=""
+    if [[ -f "$HOME/.omp/marketplaces.json" ]]; then
+        if ! current_marketplaces=$(jq -r '.marketplaces[].name' "$HOME/.omp/marketplaces.json" 2>/dev/null); then
+            log_warning "  ~/.omp/marketplaces.json malformed or missing .marketplaces — treating as none"
+            current_marketplaces=""
+        fi
+    fi
+
+    # Current marketplace-installed plugin ids (e.g. "milknado@milknado").
+    # npm-installed plugins live under `.npm` and are never read here.
+    local current_installed=""
+    current_installed=$(omp plugin list --json 2>/dev/null | jq -r '.marketplace[]?.id' 2>/dev/null) || current_installed=""
+
+    # --- Additions: marketplace add, then plugin install ---------------
+    local name marketplace source
+    while IFS=$'\t' read -r name marketplace source; do
+        [[ -z "$name" ]] && continue
+
+        if ! grep -qxF "$marketplace" <<<"$current_marketplaces"; then
+            log_info "  Adding OMP marketplace: $source"
+            if ! omp plugin marketplace add "$source" >/dev/null 2>&1; then
+                log_error "omp plugin marketplace add $source failed"
+                return 1
+            fi
+            current_marketplaces=$(printf '%s\n%s' "$current_marketplaces" "$marketplace")
+        fi
+
+        if ! grep -qxF "${name}@${marketplace}" <<<"$current_installed"; then
+            log_info "  Installing OMP plugin: ${name}@${marketplace}"
+            if ! omp plugin install "${name}@${marketplace}" >/dev/null 2>&1; then
+                log_error "omp plugin install ${name}@${marketplace} failed"
+                return 1
+            fi
+        fi
+    done <<<"$desired"
+
+    # --- Removals: uninstall plugins, then remove marketplaces no longer
+    # referenced by any registry entry. Restricted to marketplace-sourced
+    # ids (never touches `.npm`). ---------------------------------------
+    local id
+    while IFS= read -r id; do
+        [[ -z "$id" ]] && continue
+        if ! printf '%s\n' "$desired" | awk -F'\t' -v id="$id" '$1"@"$2 == id {found=1} END{exit !found}'; then
+            log_info "  Uninstalling OMP plugin no longer in registry: $id"
+            if ! omp plugin uninstall "$id" >/dev/null 2>&1; then
+                log_error "omp plugin uninstall $id failed"
+                return 1
+            fi
+        fi
+    done <<<"$current_installed"
+
+    local mp
+    while IFS= read -r mp; do
+        [[ -z "$mp" ]] && continue
+        if ! grep -qxF "$mp" <<<"$desired_marketplaces"; then
+            log_info "  Removing OMP marketplace no longer in registry: $mp"
+            if ! omp plugin marketplace remove "$mp" >/dev/null 2>&1; then
+                log_error "omp plugin marketplace remove $mp failed"
+                return 1
+            fi
+        fi
+    done <<<"$current_marketplaces"
+
+    return 0
+}
+
 # Install prek pre-commit hooks (clears conflicting core.hooksPath first)
 install_prek_hooks() {
     if ! command -v prek &>/dev/null; then

--- a/chezmoi/.chezmoidata/omp.yaml
+++ b/chezmoi/.chezmoidata/omp.yaml
@@ -129,6 +129,18 @@ omp:
   # OMP's bundled catalog here.
   models:
     providers: {}
+  # Native OMP plugin installs — reconciled by sync_omp_plugins (.sync-lib.sh)
+  # on every dots sync: marketplace add + plugin install for entries here,
+  # uninstall/remove for managed entries no longer listed. npm-installed omp
+  # plugins are NOT managed here. Plugin-owned MCPs must NOT also appear in
+  # dot_omp/private_agent/mcp.json (dual server / plugin:server namespaces).
+  plugins:
+    milknado:
+      marketplace: milknado
+      source: paulnsorensen/milknado
+    hallouminate:
+      marketplace: hallouminate
+      source: paulnsorensen/hallouminate
   # Local LLM stack — LiteLLM proxy front (~/local-llm), OpenAI-compatible.
   # Keyless: the proxy sets no master_key, so no Authorization header is sent.
   # contextWindow per model matches the backend's launched --ctx-size in

--- a/chezmoi/dot_omp/private_agent/mcp.json
+++ b/chezmoi/dot_omp/private_agent/mcp.json
@@ -10,14 +10,6 @@
       "env": {
         "CONTEXT7_API_KEY": "${CONTEXT7_API_KEY}"
       }
-    },
-    "hallouminate": {
-      "command": "hallouminate",
-      "args": ["serve"]
-    },
-    "milknado": {
-      "command": "uvx",
-      "args": ["--from", "git+https://github.com/paulnsorensen/milknado@main", "milknado-mcp"]
     }
   }
 }

--- a/skills/_registry.yaml
+++ b/skills/_registry.yaml
@@ -36,12 +36,3 @@ sources:
   paulnsorensen/skillz-that-grillz:
     description: Other useful skills
     harnesses: [claude]
-  paulnsorensen/hallouminate:
-    description: hallouminate plugin-bundled wiki skills (vendored for omp; claude/codex get them via the native plugin)
-    skills_path: plugins/hallouminate/skills
-    harnesses: [omp]
-    skills: [wiki-ingest, wiki-init, wiki-query, wiki-reindex, wiki-roadmap]
-  paulnsorensen/milknado:
-    description: milknado plugin-bundled skills (vendored for omp; claude gets them via the native plugin)
-    skills_path: plugins/milknado/skills
-    harnesses: [omp]

--- a/tests/omp-config.bats
+++ b/tests/omp-config.bats
@@ -160,31 +160,28 @@ STDIN"
     [[ "$output" == *".chezmoidata/omp.yaml"* ]]      # registry path named
 }
 
-@test "omp-mcp: native user config keeps direct MCP servers, no omp-scoped plugin duplicates" {
+@test "omp-mcp: native user config keeps context7 only; hallouminate/milknado are native OMP plugins" {
     local cfg="$REAL_DOTFILES_DIR/chezmoi/dot_omp/private_agent/mcp.json"
-    local plugin_registry="$REAL_DOTFILES_DIR/agents/plugins/registry.yaml"
+    local omp_reg="$REAL_DOTFILES_DIR/chezmoi/.chezmoidata/omp.yaml"
     jq -e '.mcpServers.context7.command == "npx"' "$cfg"
     jq -e '.mcpServers.context7.args == ["-y", "@upstash/context7-mcp"]' "$cfg"
     jq -e '.mcpServers.context7.env.CONTEXT7_API_KEY == "${CONTEXT7_API_KEY}"' "$cfg"
-    jq -e '.mcpServers.hallouminate.command == "hallouminate"' "$cfg"
-    jq -e '.mcpServers.hallouminate.args == ["serve"]' "$cfg"
-    jq -e '.mcpServers.milknado.command == "uvx"' "$cfg"
-    jq -e '.mcpServers.milknado.args == ["--from", "git+https://github.com/paulnsorensen/milknado@main", "milknado-mcp"]' "$cfg"
 
-    # hallouminate/milknado are vendored here directly: neither lists `omp` in
-    # agents/plugins/registry.yaml `harnesses:`, so OMP never gets them via
-    # plugin decomposition (that mechanism is claude/codex/opencode/cursor/
-    # copilot/crush only). Listing a server here only duplicates a
-    # plugin-owned MCP for a harness the plugin registry actually decomposes
-    # onto.
+    # hallouminate/milknado are now installed as native OMP marketplace
+    # plugins (chezmoi/.chezmoidata/omp.yaml `.omp.plugins`), which supply
+    # their own MCP servers. Listing them here too would duplicate the
+    # server under both the bare name and OMP's plugin-scoped namespace.
+    jq -e 'has("hallouminate") | not' <<<"$(jq '.mcpServers' "$cfg")"
+    jq -e 'has("milknado") | not' <<<"$(jq '.mcpServers' "$cfg")"
+
     local duplicates
     duplicates=$(
         comm -12 \
             <(jq -r '.mcpServers | keys[]' "$cfg" | sort) \
-            <(yq -r '.plugins | to_entries | map(select(.value.harnesses // [] | index("omp"))) | .[].key' "$plugin_registry" | sort)
+            <(yq -r '.omp.plugins // {} | keys[]' "$omp_reg" | sort)
     )
     if [ -n "$duplicates" ]; then
-        echo "dot_omp/private_agent/mcp.json duplicates omp-scoped plugin-owned MCP server(s):"
+        echo "dot_omp/private_agent/mcp.json duplicates a native OMP plugin MCP server:"
         printf '%s\n' "$duplicates"
         return 1
     fi

--- a/tests/omp-plugins.bats
+++ b/tests/omp-plugins.bats
@@ -1,0 +1,190 @@
+#!/usr/bin/env bats
+# Behavioural tests for sync_omp_plugins() in .sync-lib.sh — the reconcile
+# that installs milknado + hallouminate as native OMP marketplace plugins from
+# the `.omp.plugins` subtree of chezmoi/.chezmoidata/omp.yaml. Idempotent: a
+# converged machine makes zero mutating `omp` calls. `.npm[]`-installed
+# plugins are never touched — only `.marketplace[]` entries this function owns.
+#
+# The `omp` CLI is mocked with a recorder that also applies marketplace
+# add/remove and install/uninstall to fixture state (~/.omp/marketplaces.json
+# and an installed-ids file feeding `omp plugin list --json`), so the
+# reconcile flow behaves like the real CLI (same pattern as
+# tests/reconcile-claude-mcps.bats).
+
+load test_helper
+
+setup() {
+    setup_test_env
+    command -v jq >/dev/null 2>&1 || skip "jq not installed"
+    command -v yq >/dev/null 2>&1 || skip "yq not installed"
+
+    export LIB="$REAL_DOTFILES_DIR/.sync-lib.sh"
+    export CALLS="$TEST_HOME/omp-calls.log"
+    export MP_JSON="$TEST_HOME/.omp/marketplaces.json"
+    export INSTALLED="$TEST_HOME/omp-installed.txt"
+    export NPM_JSON="$TEST_HOME/omp-npm.json"
+    mkdir -p "$TEST_HOME/.omp"
+    : > "$INSTALLED"
+    printf '[]' > "$NPM_JSON"
+
+    # Mock omp CLI: records argv; applies marketplace add/remove and plugin
+    # install/uninstall to fixture state; plugin list --json reads it back.
+    local fake_bin="$TEST_HOME/fake-bin"
+    mkdir -p "$fake_bin"
+    cat > "$fake_bin/omp" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$CALLS"
+case "$1 $2 $3" in
+    "plugin marketplace add")
+        source="$4"
+        mp_name="${source##*/}"
+        jq --arg n "$mp_name" --arg s "$source" \
+            '.marketplaces += [{name:$n, sourceType:"github", sourceUri:$s, catalogPath:"", addedAt:"", updatedAt:""}]' \
+            "$MP_JSON" > "$MP_JSON.tmp" && mv "$MP_JSON.tmp" "$MP_JSON"
+        exit 0
+        ;;
+    "plugin marketplace remove")
+        mp_name="$4"
+        jq --arg n "$mp_name" '.marketplaces |= map(select(.name != $n))' "$MP_JSON" > "$MP_JSON.tmp" && mv "$MP_JSON.tmp" "$MP_JSON"
+        exit 0
+        ;;
+esac
+case "$1 $2" in
+    "plugin install")
+        printf '%s\n' "$3" >> "$INSTALLED"
+        exit 0
+        ;;
+    "plugin uninstall")
+        grep -vxF "$3" "$INSTALLED" > "$INSTALLED.tmp" 2>/dev/null
+        mv "$INSTALLED.tmp" "$INSTALLED"
+        exit 0
+        ;;
+    "plugin list")
+        mp_json=$(jq -Rn '[inputs | select(length>0) | {id: ., scope: "user", entries: [{}]}]' < "$INSTALLED")
+        npm_json=$(cat "$NPM_JSON")
+        jq -n --argjson mp "$mp_json" --argjson npm "$npm_json" '{npm: $npm, marketplace: $mp}'
+        exit 0
+        ;;
+esac
+exit 1
+SH
+    chmod +x "$fake_bin/omp"
+    export PATH="$fake_bin:$PATH"
+
+    # Fixture dotfiles root: minimal omp registry with the two plugins this
+    # function owns.
+    export FIX="$TEST_HOME/fixture-dotfiles"
+    mkdir -p "$FIX/chezmoi/.chezmoidata"
+    cat > "$FIX/chezmoi/.chezmoidata/omp.yaml" <<'YAML'
+omp:
+  plugins:
+    milknado:
+      marketplace: milknado
+      source: paulnsorensen/milknado
+    hallouminate:
+      marketplace: hallouminate
+      source: paulnsorensen/hallouminate
+YAML
+
+    seed_marketplaces() {
+        printf '{"version":1,"marketplaces":[%s]}' "$1" > "$MP_JSON"
+    }
+}
+
+teardown() { teardown_test_env; }
+
+mp_entry() {
+    local name="$1"
+    printf '{"name":"%s","sourceType":"github","sourceUri":"paulnsorensen/%s","catalogPath":"","addedAt":"","updatedAt":""}' "$name" "$name"
+}
+
+@test "sync_omp_plugins: converged state makes zero mutating omp calls" {
+    seed_marketplaces "$(mp_entry milknado),$(mp_entry hallouminate)"
+    printf 'milknado@milknado\nhallouminate@hallouminate\n' > "$INSTALLED"
+
+    run bash -c "source '$LIB'; sync_omp_plugins '$FIX'"
+    [ "$status" -eq 0 ]
+    ! grep -qE 'marketplace add|marketplace remove| install | uninstall ' "$CALLS"
+}
+
+@test "sync_omp_plugins: missing marketplace triggers add then install" {
+    seed_marketplaces "$(mp_entry hallouminate)"
+    printf 'hallouminate@hallouminate\n' > "$INSTALLED"
+
+    run bash -c "source '$LIB'; sync_omp_plugins '$FIX'"
+    [ "$status" -eq 0 ]
+    grep -qF "plugin marketplace add paulnsorensen/milknado" "$CALLS"
+    grep -qF "plugin install milknado@milknado" "$CALLS"
+    jq -e '.marketplaces[] | select(.name == "milknado")' "$MP_JSON" >/dev/null
+    grep -qxF "milknado@milknado" "$INSTALLED"
+}
+
+@test "sync_omp_plugins: missing plugin (marketplace present) triggers install only" {
+    seed_marketplaces "$(mp_entry milknado),$(mp_entry hallouminate)"
+    printf 'hallouminate@hallouminate\n' > "$INSTALLED"
+
+    run bash -c "source '$LIB'; sync_omp_plugins '$FIX'"
+    [ "$status" -eq 0 ]
+    ! grep -q "plugin marketplace add" "$CALLS"
+    grep -qF "plugin install milknado@milknado" "$CALLS"
+}
+
+@test "sync_omp_plugins: de-listed entry triggers uninstall then marketplace remove" {
+    # Registry only lists hallouminate; live machine still has milknado.
+    cat > "$FIX/chezmoi/.chezmoidata/omp.yaml" <<'YAML'
+omp:
+  plugins:
+    hallouminate:
+      marketplace: hallouminate
+      source: paulnsorensen/hallouminate
+YAML
+    seed_marketplaces "$(mp_entry milknado),$(mp_entry hallouminate)"
+    printf 'milknado@milknado\nhallouminate@hallouminate\n' > "$INSTALLED"
+
+    run bash -c "source '$LIB'; sync_omp_plugins '$FIX'"
+    [ "$status" -eq 0 ]
+    grep -qF "plugin uninstall milknado@milknado" "$CALLS"
+    grep -qF "plugin marketplace remove milknado" "$CALLS"
+    ! grep -qxF "milknado@milknado" "$INSTALLED"
+    ! jq -e '.marketplaces[] | select(.name == "milknado")' "$MP_JSON" >/dev/null
+}
+
+@test "sync_omp_plugins: npm-installed plugins are never touched" {
+    seed_marketplaces "$(mp_entry milknado),$(mp_entry hallouminate)"
+    printf 'milknado@milknado\nhallouminate@hallouminate\n' > "$INSTALLED"
+    printf '[{"id":"some-npm-plugin","scope":"user"}]' > "$NPM_JSON"
+
+    run bash -c "source '$LIB'; sync_omp_plugins '$FIX'"
+    [ "$status" -eq 0 ]
+    ! grep -qF "some-npm-plugin" "$CALLS"
+}
+
+@test "sync_omp_plugins: malformed marketplaces.json degrades to empty instead of aborting under set -e" {
+    # No .marketplaces key → jq exits non-zero. Unguarded, that killed the
+    # whole sync under the caller's `set -e` with no diagnostic; guarded, it
+    # warns, treats the file as empty, and re-adds the marketplaces.
+    printf '{"version":1}' > "$MP_JSON"
+    printf 'milknado@milknado\nhallouminate@hallouminate\n' > "$INSTALLED"
+
+    run bash -ec "source '$LIB'; sync_omp_plugins '$FIX'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"marketplaces.json malformed"* ]]
+    grep -qF "plugin marketplace add paulnsorensen/milknado" "$CALLS"
+    grep -qF "plugin marketplace add paulnsorensen/hallouminate" "$CALLS"
+}
+
+@test "sync_omp_plugins: omp absent from PATH skips cleanly (returns 0)" {
+    seed_marketplaces "$(mp_entry milknado),$(mp_entry hallouminate)"
+    printf 'milknado@milknado\nhallouminate@hallouminate\n' > "$INSTALLED"
+
+    local minimal="$TEST_HOME/minimal-bin"
+    mkdir -p "$minimal"
+    for t in bash yq jq sed grep mv cat mkdir printf; do
+        [ -e "$minimal/$t" ] && continue
+        cmd_path=$(command -v "$t") && ln -s "$cmd_path" "$minimal/$t"
+    done
+
+    run bash -c "PATH='$minimal' source '$LIB'; PATH='$minimal' sync_omp_plugins '$FIX'"
+    [ "$status" -eq 0 ]
+    [ ! -s "$CALLS" ]
+}

--- a/tests/sync-rollback.bats
+++ b/tests/sync-rollback.bats
@@ -33,8 +33,8 @@ esac
 MOCK
     chmod +x "$MOCK_BIN/git"
 
-    # Mock brew, prek, uv, tmux, yq — no-ops
-    for cmd in brew prek uv tmux yq; do
+    # Mock brew, prek, uv, tmux, yq, omp — no-ops
+    for cmd in brew prek uv tmux yq omp; do
         printf '#!/bin/bash\nexit 0\n' > "$MOCK_BIN/$cmd"
         chmod +x "$MOCK_BIN/$cmd"
     done
@@ -43,6 +43,10 @@ MOCK
     mkdir -p "$FAKE_DOTFILES/packages"
     printf '#!/bin/bash\nexit 0\n' > "$FAKE_DOTFILES/packages/sync.sh"
     chmod +x "$FAKE_DOTFILES/packages/sync.sh"
+
+    # Mock chezmoi/.chezmoidata/omp.yaml registry — empty plugin set
+    mkdir -p "$FAKE_DOTFILES/chezmoi/.chezmoidata"
+    printf 'omp:\n  plugins: {}\n' > "$FAKE_DOTFILES/chezmoi/.chezmoidata/omp.yaml"
 
     export PATH="$MOCK_BIN:$PATH"
 


### PR DESCRIPTION
## Summary

Install **milknado** and **hallouminate** as native oh-my-pi plugins, reconciled declaratively from the repo registry on every `dots sync`.

OMP 17.0.9's marketplace format is Claude-compatible (falls back to `.claude-plugin/marketplace.json`), so the existing plugin repos work unmodified — but OMP has **no declarative install key**: plugin state is imperatively mutated (`~/.omp/marketplaces.json`, `installed_plugins.json`) and payloads land in a CLI-managed cache. The reconcile therefore drives the CLI, not templated state files.

## Changes

- **`chezmoi/.chezmoidata/omp.yaml`** — new `.omp.plugins` registry block (single source of truth)
- **`.sync-lib.sh`** — `sync_omp_plugins`: idempotent reconcile (add missing marketplaces, install missing plugins, uninstall/remove de-listed entries; `.npm[]` never touched; clean skip when omp/yq/jq absent; guarded jq parse so a malformed `marketplaces.json` degrades with a warning instead of aborting the whole sync under `set -e`)
- **`.sync`** — wired into `run_sync()` after `reconcile_claude_mcps`
- **Cutover** — hallouminate/milknado removed from `dot_omp/private_agent/mcp.json` (dual `server`/`plugin:server` namespace hazard) and their `harnesses: [omp]` vendor entries removed from `skills/_registry.yaml`; native installs supply both
- **Tests** — new `tests/omp-plugins.bats` (7 cases, recorder-mock omp incl. the set -e regression); `omp-config.bats` mcp assertions updated; `sync-rollback.bats` gains an omp mock + fixture registry
- **Wiki** — `harnesses/omp-plugins.md`: design rationale + live-verified omp CLI gotchas (re-add/re-install exit 1, so state-check-first is required; `--dry-run` actually mutates on remove/uninstall)

## Verification

- `just check` green (lint + 1227 bats + 151 smoke)
- Live on this machine: both plugins installed via the new path; re-run converges with **zero mutating omp calls**; `omp plugin doctor` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
