### PR TITLE
Native claude/codex/omp management + worktree symlink guard

### DIFF
--- a/.sync-lib.sh
+++ b/.sync-lib.sh
@@ -77,6 +77,22 @@ upgrade_uv_tools() {
     done
 }
 
+# True when $dir is a *linked* git worktree rather than the primary clone.
+# Home-directory symlinks (~/.zshrc, ~/.zshenv, …) must only ever point at the
+# primary clone: syncing from an ephemeral worktree (Conductor/ccw) repoints
+# them at a path that dangles the moment the worktree is removed, silently
+# breaking the shell — DOTFILES_DIR (derived from ~/.zshrc's resolved target)
+# then points at a dead path, dropping bin/ off PATH. Fails open (returns
+# non-linked) when git is unavailable or $dir is not a repo, so non-git
+# deploys and the test harness are unaffected.
+dir_is_linked_worktree() {
+    local d="${1:-$dir}" gitdir common
+    command -v git &>/dev/null || return 1
+    gitdir=$(git -C "$d" rev-parse --absolute-git-dir 2>/dev/null) || return 1
+    common=$(git -C "$d" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || return 1
+    [[ "$gitdir" != "$common" ]]
+}
+
 # Symlink a single file/dir, or dispatch to its .sync script if present
 sync_entry() {
     local file="$1"
@@ -90,6 +106,19 @@ sync_entry() {
         if ! bash "$dir/$file/.sync"; then
             log_error "sync for $file FAILED (continuing — will report at end)"
             SYNC_FAILURES+=("$file")
+        fi
+        return 0
+    fi
+
+    # Guard against the worktree-hijack: never create (or destroy) a global home
+    # symlink while syncing from a linked worktree. Removing the existing block
+    # too is deliberate — otherwise we'd delete the good primary-pointing link
+    # (line below) before bailing. Warn once, not per-file.
+    if dir_is_linked_worktree; then
+        if [[ "${_WORKTREE_SYMLINK_WARNED:-}" != "1" ]]; then
+            log_warning "Skipping home symlinks: syncing from a linked git worktree ($dir)."
+            log_warning "  Run 'dots sync' from the primary clone so ~/.zshrc etc. don't dangle when this worktree is removed."
+            _WORKTREE_SYMLINK_WARNED=1
         fi
         return 0
     fi

--- a/packages/packages.yaml
+++ b/packages/packages.yaml
@@ -68,7 +68,12 @@ packages:
   # which wires the systemd daemon. Then `tailscale up`. See operations/remote-access wiki.
   - anomalyco/tap/opencode                    # open-source AI coding agent (fresher than homebrew-core)
   - charmbracelet/tap/crush                   # Charm terminal AI coding agent (MCP via crush.json)
-  - can1357/tap/omp
+  # claude, codex, and omp are NOT brew-managed — they ship on fast-moving
+  # native channels with their own self-updaters (`claude update`, `codex
+  # update`, `omp update`). packages/sync.sh:sync_native_harnesses installs
+  # them via their official installers, self-updates in UPGRADE_MODE, and
+  # migrates any lingering brew copy off (the brew cask/formula lagged and
+  # shadow-fought the native ~/.local/bin binary on PATH).
 
   # Rust build acceleration
   - sccache                                   # rustc wrapper for compile caching
@@ -83,7 +88,6 @@ packages:
   - terminal-notifier: { platform: mac }      # macOS notifications from terminal
   - skhd: { platform: mac }                   # Hotkey daemon (from koekeishiya/formulae tap)
   - emdash: { source: cask, platform: mac }   # Desktop UI for running coding agents in parallel
-  - claude-code: { source: cask, platform: mac } # Claude Code — terminal AI coding assistant
   - cursor: { source: cask, platform: mac, greedy: false } # Cursor — AI code editor; self-updates in-app, and greedy reinstall of the root-owned .app prompts for sudo
   - cursor-cli: { source: cask, platform: mac } # Cursor CLI — command-line agent (cursor-agent)
   - obsidian: { source: cask, platform: mac }  # Obsidian — Markdown knowledge base

--- a/packages/sync.sh
+++ b/packages/sync.sh
@@ -524,28 +524,93 @@ sync_gh_extensions() {
     log_success "gh extensions sync complete"
 }
 
-########## Harness self-updaters
-# CLIs installed by their own native installers (not covered by packages.yaml).
-# Only runs in UPGRADE_MODE.
+########## Native AI-harness CLIs
+# claude, codex, and omp are managed through their own native installers and
+# self-updaters, NOT Homebrew — the brew cask/formula lag the fast-moving
+# release channels and (for claude/omp) shadow-fight the native ~/.local/bin
+# binary on PATH. Every sync: migrate off brew (uninstall a lingering copy)
+# and install the native binary when missing. In UPGRADE_MODE: self-update.
+# codex has no brew footprint and no dots-managed installer — update only.
 
-sync_harness_selfupdate() {
-    [[ "${UPGRADE_MODE:-false}" == "true" ]] || return 0
+# Brew package to migrate off, per harness ("" = none; "cask:NAME" = cask).
+native_harness_brew_pkg() {
+    case "$1" in
+        claude) echo "cask:claude-code" ;;
+        omp)    echo "omp" ;;
+        *)      echo "" ;;
+    esac
+}
 
-    log_info "Upgrading AI harness CLIs..."
+# Harnesses with a dots-managed native installer (codex is installed elsewhere).
+native_harness_has_installer() {
+    case "$1" in claude|omp) return 0 ;; *) return 1 ;; esac
+}
+
+native_harness_install() {
+    case "$1" in
+        claude) curl -fsSL https://claude.ai/install.sh | bash ;;
+        omp)    curl -fsSL https://omp.sh/install | sh ;;
+    esac
+}
+
+# Uninstall a lingering Homebrew copy so it stops shadowing the native binary.
+migrate_harness_off_brew() {
+    local harness="$1" spec cask_flag=""
+    spec="$(native_harness_brew_pkg "$harness")"
+    [[ -z "$spec" ]] && return 0
+    command -v brew &>/dev/null || return 0
+
+    # Capture the list first, then match the here-string. A `brew list | grep
+    # -qx` pipeline is unsafe under `set -o pipefail`: grep -q closes the pipe
+    # on first match and the still-producing brew gets SIGPIPE (141), so the
+    # pipeline reports failure even on a match — silently skipping migration.
+    local installed
+    if [[ "$spec" == cask:* ]]; then
+        cask_flag="--cask"
+        spec="${spec#cask:}"
+        installed=$(brew list --cask 2>/dev/null || true)
+    else
+        installed=$(brew list --formulae 2>/dev/null || true)
+    fi
+    grep -qxF "$spec" <<<"$installed" || return 0
+
+    log_info "  Removing Homebrew $spec (now native-managed)..."
+    # shellcheck disable=SC2086  # cask_flag intentionally unquoted (may be empty)
+    if ! brew uninstall $cask_flag "$spec" </dev/null; then
+        log_warning "brew uninstall $spec failed — continuing"
+    fi
+}
+
+sync_native_harnesses() {
+    log_info "Syncing native AI-harness CLIs..."
 
     local harness
-    for harness in claude codex; do
+    for harness in claude codex omp; do
+        migrate_harness_off_brew "$harness"
+
         if ! command -v "$harness" &>/dev/null; then
-            log_info "  $harness not found — skipping"
-            continue
+            if native_harness_has_installer "$harness"; then
+                echo "  Installing $harness (native)..."
+                if native_harness_install "$harness"; then
+                    hash -r 2>/dev/null || true
+                    log_success "  Installed $harness"
+                else
+                    log_warning "  $harness native install failed — continuing"
+                fi
+            else
+                log_info "  $harness not found — no native installer, skipping"
+            fi
         fi
+
+        [[ "${UPGRADE_MODE:-false}" == "true" ]] || continue
+        command -v "$harness" &>/dev/null || continue
         echo "  Updating $harness..."
         if ! "$harness" update </dev/null; then
             log_warning "$harness update failed — continuing"
         fi
     done
 
-    log_success "Harness CLI update complete"
+    log_success "Native harness sync complete"
 }
 ########## Main
 
@@ -591,7 +656,7 @@ sync_rustup_proxies
 sync_npm
 sync_uv
 sync_gh_extensions
-sync_harness_selfupdate
+sync_native_harnesses
 
 if ((${#FAILED[@]})); then
     echo ""

--- a/tests/packages.bats
+++ b/tests/packages.bats
@@ -24,6 +24,9 @@ setup() {
     export GH_LOG="$TEST_HOME/gh.log"
     export NPM_LOG="$TEST_HOME/npm.log"
     export SUDO_LOG="$TEST_HOME/sudo.log"
+    export CLAUDE_LOG="$TEST_HOME/claude.log"
+    export CODEX_LOG="$TEST_HOME/codex.log"
+    export OMP_LOG="$TEST_HOME/omp.log"
 
     write_mock_brew
     write_mock_cargo
@@ -32,6 +35,12 @@ setup() {
     # Mock sudo records its args and no-ops — guarantees the Linux brew-deps
     # bootstrap can never run a real `sudo apt-get` against the test machine.
     write_mock_sudo
+    # Mock the native AI harnesses as present-and-recording, so no test ever
+    # shells out to the real claude/codex/omp (self-update hits the network /
+    # mutates the real install). Install/absence tests override these.
+    write_mock_harness claude
+    write_mock_harness codex
+    write_mock_harness omp
     export PATH="$MOCK_BIN:$PATH"
 }
 
@@ -42,6 +51,34 @@ echo "sudo $*" >> "$SUDO_LOG"
 exit 0
 MOCKSUDO
     chmod +x "$MOCK_BIN/sudo"
+}
+
+# Mock an AI-harness CLI (claude/codex/omp): record args to its log, exit 0.
+write_mock_harness() {
+    local name="$1" log
+    case "$name" in
+        claude) log="$CLAUDE_LOG" ;;
+        codex)  log="$CODEX_LOG" ;;
+        omp)    log="$OMP_LOG" ;;
+    esac
+    cat > "$MOCK_BIN/$name" << MOCKHARNESS
+#!/bin/bash
+echo "$name \$*" >> "$log"
+exit 0
+MOCKHARNESS
+    chmod +x "$MOCK_BIN/$name"
+}
+
+# Mock curl for native-installer tests: record the URL, emit nothing so the
+# downstream `| bash` / `| sh` runs an empty (no-op) script.
+write_mock_curl() {
+    export CURL_LOG="$TEST_HOME/curl.log"
+    cat > "$MOCK_BIN/curl" << 'MOCKCURL'
+#!/bin/bash
+echo "curl $*" >> "$CURL_LOG"
+exit 0
+MOCKCURL
+    chmod +x "$MOCK_BIN/curl"
 }
 
 write_mock_uv() {
@@ -810,47 +847,23 @@ MOCKCARGO
     ! grep -q "cargo install --force cargo-llvm-cov" "$CARGO_LOG"
 }
 
-# --- Integration: sync_harness_selfupdate ---
+# --- Integration: sync_native_harnesses ---
+# claude/codex/omp are mocked present in setup(); each test overrides as needed.
 
-@test "UPGRADE_MODE runs claude update and codex update when both present" {
+@test "UPGRADE_MODE runs native update for claude, codex, and omp when present" {
     write_test_yaml
-
-    export CLAUDE_LOG="$TEST_HOME/claude.log"
-    export CODEX_LOG="$TEST_HOME/codex.log"
-
-    cat > "$MOCK_BIN/claude" << MOCKCLAUDE
-#!/bin/bash
-echo "claude \$*" >> "$CLAUDE_LOG"
-exit 0
-MOCKCLAUDE
-    chmod +x "$MOCK_BIN/claude"
-
-    cat > "$MOCK_BIN/codex" << MOCKCODEX
-#!/bin/bash
-echo "codex \$*" >> "$CODEX_LOG"
-exit 0
-MOCKCODEX
-    chmod +x "$MOCK_BIN/codex"
 
     UPGRADE_MODE=true run bash "$SYNC_SCRIPT"
     assert_success
 
     grep -q "claude update" "$CLAUDE_LOG"
     grep -q "codex update" "$CODEX_LOG"
+    grep -q "omp update" "$OMP_LOG"
 }
 
-@test "UPGRADE_MODE skips codex update when codex absent but still runs claude update" {
+@test "UPGRADE_MODE skips codex when absent but still updates claude and omp" {
     write_test_yaml
-
-    export CLAUDE_LOG="$TEST_HOME/claude.log"
-
-    cat > "$MOCK_BIN/claude" << MOCKCLAUDE
-#!/bin/bash
-echo "claude \$*" >> "$CLAUDE_LOG"
-exit 0
-MOCKCLAUDE
-    chmod +x "$MOCK_BIN/claude"
-    # No codex mock — intentionally absent
+    rm -f "$MOCK_BIN/codex"   # intentionally absent; codex has no installer
 
     local clean_path
     clean_path=$(scrub_toolchain_path | tr ':' '\n' | while IFS= read -r d; do [[ -x "$d/codex" ]] || printf '%s:' "$d"; done)
@@ -858,42 +871,24 @@ MOCKCLAUDE
     assert_success
 
     grep -q "claude update" "$CLAUDE_LOG"
-    assert_output_contains "codex not found"
+    grep -q "omp update" "$OMP_LOG"
+    assert_output_contains "codex not found — no native installer, skipping"
 }
 
-@test "non-UPGRADE_MODE does not invoke claude or codex update" {
+@test "non-UPGRADE_MODE does not invoke any harness update" {
     write_test_yaml
-
-    export CLAUDE_LOG="$TEST_HOME/claude.log"
-    export CODEX_LOG="$TEST_HOME/codex.log"
-
-    cat > "$MOCK_BIN/claude" << MOCKCLAUDE
-#!/bin/bash
-echo "claude \$*" >> "$CLAUDE_LOG"
-exit 0
-MOCKCLAUDE
-    chmod +x "$MOCK_BIN/claude"
-
-    cat > "$MOCK_BIN/codex" << MOCKCODEX
-#!/bin/bash
-echo "codex \$*" >> "$CODEX_LOG"
-exit 0
-MOCKCODEX
-    chmod +x "$MOCK_BIN/codex"
 
     run_sync
     assert_success
 
     [[ ! -f "$CLAUDE_LOG" ]] || ! grep -q "claude update" "$CLAUDE_LOG"
     [[ ! -f "$CODEX_LOG" ]] || ! grep -q "codex update" "$CODEX_LOG"
+    [[ ! -f "$OMP_LOG" ]] || ! grep -q "omp update" "$OMP_LOG"
 }
 
 @test "UPGRADE_MODE continues and exits 0 when one harness updater fails" {
     write_test_yaml
-
-    export CLAUDE_LOG="$TEST_HOME/claude.log"
-    export CODEX_LOG="$TEST_HOME/codex.log"
-
+    # Make claude update fail; codex + omp still succeed.
     cat > "$MOCK_BIN/claude" << MOCKCLAUDE
 #!/bin/bash
 echo "claude \$*" >> "$CLAUDE_LOG"
@@ -901,16 +896,72 @@ exit 1
 MOCKCLAUDE
     chmod +x "$MOCK_BIN/claude"
 
-    cat > "$MOCK_BIN/codex" << MOCKCODEX
-#!/bin/bash
-echo "codex \$*" >> "$CODEX_LOG"
-exit 0
-MOCKCODEX
-    chmod +x "$MOCK_BIN/codex"
-
     UPGRADE_MODE=true run bash "$SYNC_SCRIPT"
     assert_success
 
     assert_output_contains "claude update failed"
     grep -q "codex update" "$CODEX_LOG"
+    grep -q "omp update" "$OMP_LOG"
+}
+
+@test "native install: claude and omp installed via official installer when missing" {
+    write_test_yaml
+    rm -f "$MOCK_BIN/claude" "$MOCK_BIN/omp"
+    write_mock_curl
+
+    # Absent from PATH entirely so the native installer path fires.
+    local clean_path
+    clean_path=$(scrub_toolchain_path | tr ':' '\n' | while IFS= read -r d; do [[ -x "$d/claude" || -x "$d/omp" ]] || printf '%s:' "$d"; done)
+    PATH="$MOCK_BIN:${clean_path%:}" run bash "$SYNC_SCRIPT"
+    assert_success
+
+    grep -q "claude.ai/install.sh" "$CURL_LOG"
+    grep -q "omp.sh/install" "$CURL_LOG"
+    assert_output_contains "Installing claude (native)"
+    assert_output_contains "Installing omp (native)"
+}
+
+@test "native install: codex is skipped (no dots-managed installer)" {
+    write_test_yaml
+    rm -f "$MOCK_BIN/codex"
+    write_mock_curl
+
+    local clean_path
+    clean_path=$(scrub_toolchain_path | tr ':' '\n' | while IFS= read -r d; do [[ -x "$d/codex" ]] || printf '%s:' "$d"; done)
+    PATH="$MOCK_BIN:${clean_path%:}" run bash "$SYNC_SCRIPT"
+    assert_success
+
+    assert_output_contains "codex not found — no native installer, skipping"
+    [[ ! -f "$CURL_LOG" ]] || ! grep -q "codex" "$CURL_LOG"
+}
+
+@test "migration: lingering brew claude-code cask and omp formula are uninstalled" {
+    write_test_yaml
+    # Long lists with the target at the FRONT: grep -qx matches immediately and
+    # closes the pipe while the mock is still producing, so a `brew list | grep
+    # -qx` pipeline SIGPIPEs the producer and — under set -o pipefail — reports
+    # failure on a real match, silently skipping the uninstall. Regression guard
+    # for that bug; the migration must fire regardless of list length/position.
+    local formulae cask i
+    formulae="omp"
+    for i in $(seq 1 200); do formulae+=$'\n'"filler-formula-$i"; done
+    cask="claude-code"
+    for i in $(seq 1 200); do cask+=$'\n'"filler-cask-$i"; done
+    write_mock_brew "$formulae" "$cask"
+
+    run_sync
+    assert_success
+
+    grep -q "uninstall --cask claude-code" "$BREW_LOG"
+    grep -q "uninstall omp" "$BREW_LOG"
+}
+
+@test "migration: no brew uninstall when neither brew copy is present" {
+    write_test_yaml
+    # Default mock brew reports no formulae/casks installed.
+
+    run_sync
+    assert_success
+
+    ! grep -q "uninstall" "$BREW_LOG"
 }

--- a/tests/sync-worktree-guard.bats
+++ b/tests/sync-worktree-guard.bats
@@ -1,0 +1,75 @@
+#!/usr/bin/env bats
+# Guard: sync_entry must never repoint global home symlinks (~/.zshrc, …) when
+# run from a *linked* git worktree. Syncing from an ephemeral Conductor/ccw
+# worktree otherwise hijacks the home symlink to a path that dangles the moment
+# the worktree is removed, silently breaking the shell (DOTFILES_DIR resolves
+# to a dead path → bin/ off PATH). Covers dir_is_linked_worktree + sync_entry.
+
+load test_helper
+
+setup() {
+    setup_test_env
+    command -v git >/dev/null 2>&1 || skip "git not installed"
+
+    # Primary clone with a tracked home-dotfile source.
+    PRIMARY="$TEST_HOME/dotfiles"
+    mkdir -p "$PRIMARY"
+    echo "export FROM=primary" > "$PRIMARY/zshrc"
+    git -C "$PRIMARY" init -q
+    git -C "$PRIMARY" -c user.email=t@t -c user.name=t add -A
+    git -C "$PRIMARY" -c user.email=t@t -c user.name=t commit -qm init
+
+    # Linked worktree of the same repo (the Conductor/ccw case).
+    WORKTREE="$TEST_HOME/wt"
+    git -C "$PRIMARY" worktree add --detach -q "$WORKTREE" >/dev/null 2>&1
+    echo "export FROM=worktree" > "$WORKTREE/zshrc"
+
+    OLDDIR="$TEST_HOME/bak"
+    mkdir -p "$OLDDIR"
+    export PRIMARY WORKTREE OLDDIR
+}
+
+teardown() { teardown_test_env; }
+
+# Run sync_entry with the sync globals it depends on ($dir, $olddir).
+run_sync_entry() {
+    local d="$1" file="$2"
+    run bash -c "source '$REAL_DOTFILES_DIR/.sync-lib.sh'; dir='$d'; olddir='$OLDDIR'; SYNC_FAILURES=(); sync_entry '$file'"
+}
+
+@test "sync_entry creates the home symlink when run from the primary clone" {
+    run_sync_entry "$PRIMARY" zshrc
+    assert_success
+    [[ -L "$TEST_HOME/.zshrc" ]]
+    [[ "$(readlink "$TEST_HOME/.zshrc")" == "$PRIMARY/zshrc" ]]
+}
+
+@test "sync_entry refuses to create a home symlink from a linked worktree" {
+    run_sync_entry "$WORKTREE" zshrc
+    assert_success
+    [[ ! -e "$TEST_HOME/.zshrc" ]]
+    assert_output_contains "linked git worktree"
+}
+
+@test "sync_entry from a worktree leaves an existing primary-pointing link intact" {
+    ln -s "$PRIMARY/zshrc" "$TEST_HOME/.zshrc"   # the good, primary-pointing link
+    run_sync_entry "$WORKTREE" zshrc
+    assert_success
+    # Not removed, not repointed at the worktree.
+    [[ -L "$TEST_HOME/.zshrc" ]]
+    [[ "$(readlink "$TEST_HOME/.zshrc")" == "$PRIMARY/zshrc" ]]
+}
+
+@test "dir_is_linked_worktree: true for a linked worktree, false for the primary clone" {
+    run bash -c "source '$REAL_DOTFILES_DIR/.sync-lib.sh'; dir_is_linked_worktree '$WORKTREE'"
+    assert_success
+    run bash -c "source '$REAL_DOTFILES_DIR/.sync-lib.sh'; dir_is_linked_worktree '$PRIMARY'"
+    assert_failure
+}
+
+@test "dir_is_linked_worktree: false (fails open) outside any git repo" {
+    local nonrepo="$TEST_HOME/plain"
+    mkdir -p "$nonrepo"
+    run bash -c "source '$REAL_DOTFILES_DIR/.sync-lib.sh'; dir_is_linked_worktree '$nonrepo'"
+    assert_failure
+}


### PR DESCRIPTION
## Why

Two independent fixes from one debugging session.

### 1. Worktree symlink hijack (`dots: command not found`)
`sync_entry` symlinks top-level files into `$HOME` (`~/.zshrc`, `~/.zshenv`, …) using `$dir` = the clone it runs from. Running `dots sync` from a linked git worktree (Conductor/ccw) repointed those home symlinks at the worktree — which **dangles the moment the worktree is deleted**. `DOTFILES_DIR` (derived from `~/.zshrc`'s resolved target) then resolves to a dead path and `bin/` drops off PATH.

Adds `dir_is_linked_worktree` and skips the home-symlink create/destroy block when syncing from a linked worktree (warns once, fails open outside git). Package install + directory `.sync` dispatch unchanged.

### 2. claude/codex/omp → native, off Homebrew
These CLIs ship on fast native channels with their own self-updaters; the brew cask/formula lagged and (claude/omp) shadow-fought the native `~/.local/bin` binary on PATH. Removes the `claude-code` cask + `can1357/tap/omp` formula and drives all three through `sync_native_harnesses`: migrate off brew, native-install claude/omp when missing, self-update all three in `UPGRADE_MODE`. codex = update-only (no brew footprint).

**Bug caught + fixed mid-migration:** the brew-list check piped to `grep -qx` under `set -o pipefail` — grep closes the pipe on first match, the still-producing `brew` gets SIGPIPE (141), the pipeline reports failure on a real match, and the uninstall is silently skipped (reproduced live: omp at list position 106 was skipped). Now captures `brew list` to a variable first. Regression-tested with a front-loaded 200-line list.

## Verification
- `just check` green: 1237 bats + 151 JS tests pass, lint + smoke clean.
- Ran live on this machine: `brew uninstall`'d claude-code cask + omp formula, native omp installed (`~/.bun/bin/omp`), all three resolve and self-update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)