### PR TITLE
Pin remaining package sources

### DIFF
--- a/packages/packages.yaml
+++ b/packages/packages.yaml
@@ -111,29 +111,47 @@ packages:
   - pyright
   - gopls: { dev: true }
   - rust-analyzer
-  - vtsls: { source: npm, pkg: "@vtsls/language-server" }
+  # renovate: datasource=npm depName=@vtsls/language-server
+  - vtsls: { source: npm, pkg: "@vtsls/language-server", version: "0.3.0" }
 
   # Linters
-  - eslint: { source: npm, pkg: "eslint@8" }
-  - markdownlint-cli2: { source: npm }
-  - ccusage: { source: npm }
-  - agent-skills: { source: npm, pkg: "@govcraft/agent-skills" }
-  - graphite: { source: npm, pkg: "@withgraphite/graphite-cli", platform: linux } # `gt` — stacked-diff PR workflow (mac uses the withgraphite/tap brew formula)
+  # renovate: datasource=npm depName=eslint
+  - eslint: { source: npm, version: "8.57.1" }
+  # renovate: datasource=npm depName=markdownlint-cli2
+  - markdownlint-cli2: { source: npm, version: "0.23.1" }
+  # renovate: datasource=npm depName=ccusage
+  - ccusage: { source: npm, version: "20.0.18" }
+  # renovate: datasource=npm depName=@govcraft/agent-skills
+  - agent-skills: { source: npm, pkg: "@govcraft/agent-skills", version: "0.4.4" }
+  # renovate: datasource=npm depName=@withgraphite/graphite-cli
+  - graphite: { source: npm, pkg: "@withgraphite/graphite-cli", platform: linux, version: "1.8.6" } # `gt` — stacked-diff PR workflow (mac uses the withgraphite/tap brew formula)
 
   # uv tools (Python)
-  - ralphify: { source: uv }
-  - ruff: { source: uv }                      # Python linter (just lint-python)
-  - check-jsonschema: { source: uv }
-  - skills-ref: { source: uv, pkg: "git+https://github.com/agentskills/agentskills@main#subdirectory=skills-ref" }
-  - tavily-cli: { source: uv }                # provides `tvly` CLI for Tavily API
+  # renovate: datasource=pypi depName=ralphify
+  - ralphify: { source: uv, version: "0.3.0" }
+  # renovate: datasource=pypi depName=ruff
+  - ruff: { source: uv, version: "0.16.0" }                      # Python linter (just lint-python)
+  # renovate: datasource=pypi depName=check-jsonschema
+  - check-jsonschema: { source: uv, version: "0.37.4" }
+  # renovate: datasource=git-refs depName=agentskills/agentskills
+  - skills-ref: { source: uv, pkg: "git+https://github.com/agentskills/agentskills@main#subdirectory=skills-ref", rev: "38a2ff82958afee88dadf4831509e6f7e9d8ef4e" }
+  # renovate: datasource=pypi depName=tavily-cli
+  - tavily-cli: { source: uv, version: "0.1.5" }                # provides `tvly` CLI for Tavily API
   - milknado: { source: uv, pkg: "git+https://github.com/paulnsorensen/milknado@main" }  # Mikado execution engine; exposes `milknado-mcp` for the MCP registry
+  # Serena pins Python 3.13 and ships pre-release builds on PyPI; the `flags`
+  # array is passed through to `uv tool install` verbatim. Exposes the `serena`
+  # binary, which the MCP registry invokes per harness via --context.
+  # renovate: datasource=pypi depName=serena-agent
+  - serena-agent: { source: uv, version: "1.6.1", flags: ["--python", "3.13", "--prerelease=allow"] }
 
   # gh CLI extensions
-  - gh-stack: { source: gh-extension, pkg: github/gh-stack }   # native PR-stack management (used by /pr-stack)
+  # renovate: datasource=github-releases depName=github/gh-stack
+  - gh-stack: { source: gh-extension, pkg: github/gh-stack, version: "v0.0.8" }   # native PR-stack management (used by /pr-stack)
 
   # Cargo
   - cargo-llvm-cov: { source: cargo }
-  - cargo-update: { source: cargo }            # provides `cargo install-update` for idempotent `dots up`
+  # renovate: datasource=crate depName=cargo-update
+  - cargo-update: { source: cargo, version: "22.1.0" }            # provides `cargo install-update` for idempotent `dots up`
   # tilth and hallouminate are installed from their npm nightly channels
   # (@paulnsorensen/{tilth,hallouminate}-nightly) by the run_onchange_after_
   # install-{tilth,hallouminate}.sh.tmpl scripts — a cargo build here would

--- a/tests/packages-yaml-pins.bats
+++ b/tests/packages-yaml-pins.bats
@@ -1,0 +1,144 @@
+#!/usr/bin/env bats
+# Validate packages.yaml manifest pins: every npm/uv/cargo/gh-extension entry
+# that stays outside mise carries an exact version:/rev: pin plus a Renovate
+# custom-regex-manager annotation, exempting milknado by design.
+
+DOTFILES_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME}")/.." && pwd)"
+PACKAGES_YAML="$DOTFILES_DIR/packages/packages.yaml"
+
+# entry_name:datasource — the 14 pinned entries and their expected Renovate datasource
+PINNED_ENTRIES=(
+    "vtsls:npm"
+    "eslint:npm"
+    "markdownlint-cli2:npm"
+    "ccusage:npm"
+    "agent-skills:npm"
+    "graphite:npm"
+    "ralphify:pypi"
+    "ruff:pypi"
+    "check-jsonschema:pypi"
+    "skills-ref:git-refs"
+    "tavily-cli:pypi"
+    "serena-agent:pypi"
+    "gh-stack:github-releases"
+    "cargo-update:crate"
+)
+
+@test "packages.yaml is valid YAML after adding pins" {
+    run yq eval '.' "$PACKAGES_YAML"
+    [[ $status -eq 0 ]]
+}
+
+@test "each of the 14 pinned entries has a version or rev key" {
+    for pair in "${PINNED_ENTRIES[@]}"; do
+        local name="${pair%%:*}"
+        local version rev
+        version=$(yq -r ".packages[] | select(kind == \"map\") | select(has(\"$name\")) | .\"$name\".version // \"\"" "$PACKAGES_YAML")
+        rev=$(yq -r ".packages[] | select(kind == \"map\") | select(has(\"$name\")) | .\"$name\".rev // \"\"" "$PACKAGES_YAML")
+        if [[ -z "$version" && -z "$rev" ]]; then
+            echo "$name has neither a version: nor a rev: key" >&2
+            return 1
+        fi
+    done
+}
+
+@test "pinned version/rev values are exact — no latest, no bare partial, no range" {
+    for pair in "${PINNED_ENTRIES[@]}"; do
+        local name="${pair%%:*}"
+        local value
+        value=$(yq -r ".packages[] | select(kind == \"map\") | select(has(\"$name\")) | (.\"$name\".version // .\"$name\".rev)" "$PACKAGES_YAML")
+        if [[ -z "$value" ]]; then
+            echo "$name has an empty version/rev value" >&2
+            return 1
+        fi
+        if [[ "$value" == "latest" ]]; then
+            echo "$name pin '$value' is 'latest', not exact" >&2
+            return 1
+        fi
+        if [[ "$value" == *'^'* ]]; then
+            echo "$name pin '$value' is a caret range, not exact" >&2
+            return 1
+        fi
+        if [[ "$value" == *'~'* ]]; then
+            echo "$name pin '$value' is a tilde range, not exact" >&2
+            return 1
+        fi
+        # a bare partial like "8" (no dot) is a floating major, not exact
+        if [[ "$value" != v* && "$value" != *.* && "$value" =~ ^[0-9]+$ ]]; then
+            echo "$name pin '$value' looks like a bare floating partial, not an exact version" >&2
+            return 1
+        fi
+    done
+}
+
+@test "skills-ref rev is a full 40-character git commit SHA, not a branch or ref name" {
+    local rev
+    rev=$(yq -r '.packages[] | select(kind == "map") | select(has("skills-ref")) | ."skills-ref".rev // ""' "$PACKAGES_YAML")
+    if [[ ! "$rev" =~ ^[0-9a-f]{40}$ ]]; then
+        echo "skills-ref rev '$rev' is not a full 40-character commit SHA (e.g. a branch name like 'main' would slip past a generic exactness check)" >&2
+        return 1
+    fi
+}
+
+@test "eslint's pkg field stays bare — version pin lives only in version:" {
+    local pkg
+    pkg=$(yq -r '.packages[] | select(kind == "map") | select(has("eslint")) | .eslint.pkg // ""' "$PACKAGES_YAML")
+    [[ -z "$pkg" ]]
+}
+
+@test "each of the 14 pinned entries has an adjacent renovate annotation with a valid datasource" {
+    for pair in "${PINNED_ENTRIES[@]}"; do
+        local name="${pair%%:*}"
+        local expected_ds="${pair##*:}"
+        # the line above the entry's `- name:` line must carry the renovate annotation
+        local entry_line annotation
+        entry_line=$(grep -n "^  - ${name}:" "$PACKAGES_YAML" | head -1 | cut -d: -f1)
+        if [[ -z "$entry_line" ]]; then
+            echo "$name: entry line not found" >&2
+            return 1
+        fi
+        annotation=$(sed -n "$((entry_line - 1))p" "$PACKAGES_YAML")
+        if [[ "$annotation" != *"# renovate: datasource=${expected_ds} depName="* ]]; then
+            echo "$name: expected line above '- ${name}:' to carry '# renovate: datasource=${expected_ds} depName=...', got: $annotation" >&2
+            return 1
+        fi
+    done
+}
+
+@test "milknado stays exempt — no version, no rev, no renovate annotation" {
+    local version rev entry_line annotation
+    version=$(yq -r '.packages[] | select(kind == "map") | select(has("milknado")) | .milknado.version // ""' "$PACKAGES_YAML")
+    rev=$(yq -r '.packages[] | select(kind == "map") | select(has("milknado")) | .milknado.rev // ""' "$PACKAGES_YAML")
+    if [[ -n "$version" ]]; then
+        echo "milknado unexpectedly has a version: $version" >&2
+        return 1
+    fi
+    if [[ -n "$rev" ]]; then
+        echo "milknado unexpectedly has a rev: $rev" >&2
+        return 1
+    fi
+    entry_line=$(grep -n "^  - milknado:" "$PACKAGES_YAML" | head -1 | cut -d: -f1)
+    if [[ -z "$entry_line" ]]; then
+        echo "milknado entry not found" >&2
+        return 1
+    fi
+    annotation=$(sed -n "$((entry_line - 1))p" "$PACKAGES_YAML")
+    if [[ "$annotation" == *"# renovate:"* ]]; then
+        echo "milknado unexpectedly has a renovate annotation: $annotation" >&2
+        return 1
+    fi
+}
+
+@test "rtk and cargo-llvm-cov are untouched (out of this curd's scope)" {
+    local rtk_map cargo_llvm_cov_map
+    rtk_map=$(yq -o=json -I=0 '.packages[] | select(kind == "map") | select(has("rtk")) | .rtk' "$PACKAGES_YAML")
+    if [[ "$rtk_map" != '{"source":"cargo","git":"https://github.com/rtk-ai/rtk","branch":"master"}' ]]; then
+        echo "rtk map changed: $rtk_map" >&2
+        return 1
+    fi
+    cargo_llvm_cov_map=$(yq -o=json -I=0 '.packages[] | select(kind == "map") | select(has("cargo-llvm-cov")) | ."cargo-llvm-cov"' "$PACKAGES_YAML")
+    if [[ "$cargo_llvm_cov_map" != '{"source":"cargo"}' ]]; then
+        echo "cargo-llvm-cov map changed: $cargo_llvm_cov_map" >&2
+        return 1
+    fi
+}


### PR DESCRIPTION
## Layer 3/11 — Package pins

Pins the remaining npm, uv, cargo, and gh-extension package entries with Renovate annotations.

Review this PR against `stack/02-mise-manifest`.

Verification: `just check`.
