### PR TITLE
Wire mise into zsh

### DIFF
--- a/tests/zsh-config.bats
+++ b/tests/zsh-config.bats
@@ -283,3 +283,78 @@ SH
     fi
     [[ $failed -eq 0 ]]
 }
+
+@test "core.zsh activates mise, guarded so a missing binary can't break shell startup" {
+    local core_file="$REAL_DOTFILES_DIR/zsh/core.zsh"
+
+    grep -q 'command -v mise' "$core_file"
+    local mise_activation="eval \"\$(mise activate zsh)\""
+    grep -Fq "$mise_activation" "$core_file"
+
+    # mise activation must come after the pyenv block so its shims win PATH
+    # over any stale pyenv shim of the same tool name.
+    local pyenv_line mise_line
+    pyenv_line=$(grep -n 'pyenv init' "$core_file" | cut -d: -f1)
+    mise_line=$(grep -n 'mise activate zsh' "$core_file" | cut -d: -f1)
+    [ -n "$pyenv_line" ]
+    [ -n "$mise_line" ]
+    [ "$mise_line" -gt "$pyenv_line" ]
+}
+
+@test "core.zsh sources cleanly in zsh even when mise is not on PATH" {
+    command -v zsh &>/dev/null || skip "zsh not installed"
+    run zsh -c "PATH=/usr/bin:/bin; source '$REAL_DOTFILES_DIR/zsh/core.zsh'" 2>&1
+    assert_success
+}
+
+@test "zshenv prepends the mise shims dir ahead of stale PATH entries" {
+    local zshenv_file="$REAL_DOTFILES_DIR/zshenv"
+
+    grep -q 'mise/shims' "$zshenv_file"
+    local mise_shims_guard="if [[ -d \"\$MISE_SHIMS_DIR\""
+    grep -Fq "$mise_shims_guard" "$zshenv_file"
+}
+
+@test "zshenv's mise shims guard resolves ahead of a stale native PATH entry" {
+    command -v zsh &>/dev/null || skip "zsh not installed"
+    local fake_xdg="$TEST_HOME/xdg-data"
+    mkdir -p "$fake_xdg/mise/shims"
+    # A stale native copy of a mise-managed tool sits earlier on PATH.
+    local stale_bin="$TEST_HOME/stale-bin"
+    mkdir -p "$stale_bin"
+    cat > "$stale_bin/claude" <<'SH'
+#!/bin/sh
+echo stale
+SH
+    chmod +x "$stale_bin/claude"
+    cat > "$fake_xdg/mise/shims/claude" <<'SH'
+#!/bin/sh
+echo shimmed
+SH
+    chmod +x "$fake_xdg/mise/shims/claude"
+
+    run zsh -c "XDG_DATA_HOME='$fake_xdg'; PATH='$stale_bin':/usr/bin:/bin; source '$REAL_DOTFILES_DIR/zshenv'; claude"
+
+    assert_success
+    [ "$output" = "shimmed" ]
+}
+
+@test "zshenv sources cleanly with no XDG_DATA_HOME and no mise shims dir present" {
+    command -v zsh &>/dev/null || skip "zsh not installed"
+    run zsh -c "unset XDG_DATA_HOME; HOME='$TEST_HOME'; PATH=/usr/bin:/bin; source '$REAL_DOTFILES_DIR/zshenv'" 2>&1
+    assert_success
+}
+
+@test "zshenv's mise shims guard is idempotent — double-sourcing doesn't grow PATH" {
+    command -v zsh &>/dev/null || skip "zsh not installed"
+    local fake_xdg="$TEST_HOME/xdg-data-idempotent"
+    mkdir -p "$fake_xdg/mise/shims"
+
+    run zsh -c "XDG_DATA_HOME='$fake_xdg'; PATH=/usr/bin:/bin; source '$REAL_DOTFILES_DIR/zshenv'; source '$REAL_DOTFILES_DIR/zshenv'; echo \$PATH"
+
+    assert_success
+    local shims_dir="$fake_xdg/mise/shims"
+    local occurrences
+    occurrences=$(grep -o "$shims_dir" <<< "$output" | wc -l | tr -d ' ')
+    [ "$occurrences" -eq 1 ]
+}

--- a/zsh/core.zsh
+++ b/zsh/core.zsh
@@ -85,6 +85,13 @@ if command -v pyenv 1>/dev/null 2>&1; then
   export PATH="$DOTFILES_DIR/bin:$PATH"
 fi
 
+# init mise if it exists — re-prepend its shims dir ahead of pyenv/native
+# copies so a mise-managed tool (e.g. claude, codex) resolves before any
+# stale native/brew install still on PATH from before migration.
+if command -v mise 1>/dev/null 2>&1; then
+  eval "$(mise activate zsh)"
+fi
+
 # Source .env file if it exists (key=value only, no command execution)
 if [[ -f "$DOTFILES_DIR/.env" ]]; then
     while IFS='=' read -r key val; do

--- a/zshenv
+++ b/zshenv
@@ -25,6 +25,15 @@ if [[ "$OSTYPE" == darwin* && -d /opt/homebrew/bin && ":$PATH:" != *":/opt/homeb
   export PATH="/opt/homebrew/bin:$PATH"
 fi
 
+# mise shims dir ahead of stale native/brew copies for non-interactive shells
+# (e.g. agent Bash tools, ssh/mosh). Plain PATH-prepend, not `mise activate` —
+# that's for interactive shells only (zsh/core.zsh). Idempotent guard.
+MISE_SHIMS_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/mise/shims"
+if [[ -d "$MISE_SHIMS_DIR" && ":$PATH:" != *":$MISE_SHIMS_DIR:"* ]]; then
+  export PATH="$MISE_SHIMS_DIR:$PATH"
+fi
+unset MISE_SHIMS_DIR
+
 # rustup proxy dir + cargo bin on PATH for non-interactive shells (e.g. agent
 # Bash tools). cargo/config.toml sets rustc-wrapper=sccache unconditionally;
 # without rustc on PATH here, sccache fails with "cannot find binary path".


### PR DESCRIPTION
## Layer 6/11 — Zsh mise wiring

Activates mise and wires its shims into interactive and non-interactive shells.

Review this PR against `stack/05-installer-convergence`.

Verification: `just check`.
