### PR TITLE
Keep mise shims first in PATH

### DIFF
--- a/tests/zsh-config.bats
+++ b/tests/zsh-config.bats
@@ -339,6 +339,29 @@ SH
     [ "$output" = "shimmed" ]
 }
 
+@test "zshenv moves existing mise shims ahead of a stale native PATH entry" {
+    command -v zsh &>/dev/null || skip "zsh not installed"
+    local fake_xdg="$TEST_HOME/xdg-data-existing"
+    mkdir -p "$fake_xdg/mise/shims"
+    local stale_bin="$TEST_HOME/stale-bin-existing"
+    mkdir -p "$stale_bin"
+    cat > "$stale_bin/claude" <<'SH'
+#!/bin/sh
+echo stale
+SH
+    chmod +x "$stale_bin/claude"
+    cat > "$fake_xdg/mise/shims/claude" <<'SH'
+#!/bin/sh
+echo shimmed
+SH
+    chmod +x "$fake_xdg/mise/shims/claude"
+
+    run zsh -c "XDG_DATA_HOME='$fake_xdg'; PATH='$stale_bin:$fake_xdg/mise/shims':/usr/bin:/bin; source '$REAL_DOTFILES_DIR/zshenv'; claude"
+
+    assert_success
+    [ "$output" = "shimmed" ]
+}
+
 @test "zshenv sources cleanly with no XDG_DATA_HOME and no mise shims dir present" {
     command -v zsh &>/dev/null || skip "zsh not installed"
     run zsh -c "unset XDG_DATA_HOME; HOME='$TEST_HOME'; PATH=/usr/bin:/bin; source '$REAL_DOTFILES_DIR/zshenv'" 2>&1

--- a/zshenv
+++ b/zshenv
@@ -27,13 +27,13 @@ fi
 
 # mise shims dir ahead of stale native/brew copies for non-interactive shells
 # (e.g. agent Bash tools, ssh/mosh). Plain PATH-prepend, not `mise activate` —
-# that's for interactive shells only (zsh/core.zsh). Idempotent guard.
+# that's for interactive shells only (zsh/core.zsh). `path` is unique, so this
+# also moves an existing later copy ahead of stale earlier PATH entries.
 MISE_SHIMS_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/mise/shims"
-if [[ -d "$MISE_SHIMS_DIR" && ":$PATH:" != *":$MISE_SHIMS_DIR:"* ]]; then
-  export PATH="$MISE_SHIMS_DIR:$PATH"
+if [[ -d "$MISE_SHIMS_DIR" ]]; then
+  path=("$MISE_SHIMS_DIR" "${path[@]}")
 fi
 unset MISE_SHIMS_DIR
-
 # rustup proxy dir + cargo bin on PATH for non-interactive shells (e.g. agent
 # Bash tools). cargo/config.toml sets rustc-wrapper=sccache unconditionally;
 # without rustc on PATH here, sccache fails with "cannot find binary path".


### PR DESCRIPTION
## Layer 7/11 — Zsh path precedence

Keeps mise shims ahead of stale later PATH entries.

Review this PR against `stack/06-zsh-wiring`.

Verification: `just check`.
