### PR TITLE
Add self-hosted Renovate workflow

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,31 @@
+# Renovate — self-hosted dependency updates driven by renovate.json5.
+# See: https://github.com/renovatebot/github-action
+name: renovate
+
+on:
+  schedule:
+    - cron: "0 4 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run (no PRs/branches created)"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      RENOVATE_TOKEN: ${{ secrets.RENOVATE_TOKEN }}
+      RENOVATE_DRY_RUN: ${{ (github.event_name == 'workflow_dispatch' && inputs.dry_run) && 'full' || '' }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: renovatebot/github-action@3064367f740a1a91cca218698a63902689cce200 # v46.1.20


### PR DESCRIPTION
## Layer 8/11 — Renovate execution

Adds the SHA-pinned self-hosted Renovate workflow.

Review this PR against `stack/07-zsh-path-fix`.

Verification: `just check`; `uvx zizmor .github/workflows`.
