### PR TITLE
Close supply-chain review gaps

### DIFF
--- a/.hallouminate/wiki/adr/manifest-pinned-packages.md
+++ b/.hallouminate/wiki/adr/manifest-pinned-packages.md
@@ -45,3 +45,13 @@ Rationale record for the `manifest-pinned-packages` spec (durable spec: `~/.loca
 - **Decision:** Leave them floating; the `run_onchange_after_install-*.sh.tmpl` nightly scripts stay untouched. Third-party moving refs (skills-ref@main, rtk@master) DO get pinned (rtk via aqua).
 - **Alternatives:** Pin everything — rejected: daily nightly-bump PR noise with no trust gain (author == user).
 - **Consequences:** A trusted-author boundary exists in the manifest; documented, deliberate.
+
+### ADR-007: Apply the manifest before package convergence  [status: accepted]
+
+- **Context:** A mise pin can change in the chezmoi source without changing packages.yaml; running package sync before chezmoi apply leaves the machine on the old tool version. A failed install must also remain retryable rather than becoming a cache hit.
+- **Decision:** On a configured machine, .sync applies the dotfiles/chezmoi entries first, then runs packages/sync.sh. On a fresh machine, it invokes package sync in bootstrap-only mode against the repository's mise manifest, verifies chezmoi became available, applies chezmoi, then performs normal package convergence. The package cache hashes packages.yaml, the selected mise config, and the OMP pin; it is written only after all installers succeed.
+- **Consequences:** A manifest-only bump converges in the same sync; bootstrap failures stop before partial convergence is reported as complete; dots up can pull the bump and run pin-aware upgrade mode without floating pinned channels.
+
+Sources: .sync:47-73, packages/sync.sh:44-63, 291-329, 667-689, and bin/dots:205-224.[^1]
+
+[^1]: .sync:47-73; packages/sync.sh:44-63, 291-329, 667-689; bin/dots:205-224

--- a/bin/gh-stack-rebase
+++ b/bin/gh-stack-rebase
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Wrapper around `gh stack rebase` that works around a gh-stack bug: its
+# local trunk-tracking branch (stack-trunk/origin-<default>) is documented
+# to fast-forward to match the remote before the cascade rebase, but when
+# it can't compare cleanly it silently skips the update and rebases the
+# whole stack onto the STALE trunk instead ("Could not compare trunk ...
+# skipping trunk update"). That drops any commits merged into the real
+# default branch since the trunk ref last advanced, surfacing as spurious
+# file-deletion conflicts further up the stack.
+#
+# Usage: gh-stack-rebase [gh stack rebase flags...]
+set -euo pipefail
+
+remote="origin"
+args=("$@")
+for i in "${!args[@]}"; do
+    if [[ "${args[$i]}" == "--remote" && -n "${args[$((i + 1))]:-}" ]]; then
+        remote="${args[$((i + 1))]}"
+    fi
+done
+
+default_branch="$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')"
+git fetch "$remote" "$default_branch"
+
+trunk_branch="$(git for-each-ref --format='%(refname:short)' 'refs/heads/stack-trunk/*' | head -1)"
+
+if [[ -z "$trunk_branch" ]]; then
+    echo "gh-stack-rebase: no stack-trunk/* branch found — nothing to fast-forward, delegating as-is" >&2
+elif git worktree list --porcelain | grep -qx "branch refs/heads/$trunk_branch"; then
+    echo "gh-stack-rebase: $trunk_branch is checked out in another worktree — skipping fast-forward, fix manually if the rebase warns about a stale trunk" >&2
+else
+    git fetch . "$remote/$default_branch:$trunk_branch"
+fi
+
+exec gh stack rebase "$@"

--- a/packages/sync.sh
+++ b/packages/sync.sh
@@ -262,7 +262,19 @@ sync_brew() {
         # upgrades through upgrade_casks_greedy instead, which honors the
         # exclusion list. `brew outdated --cask --greedy-auto-updates` is a
         # superset of the plain outdated set, so nothing is missed.
-        brew upgrade --formula </dev/null || log_warning "brew upgrade failed"
+        local -a upgrade_formulae=()
+        local formula
+        while IFS= read -r formula; do
+            [[ -n "$formula" ]] && upgrade_formulae+=( "$formula" )
+        done < <(get_platform_pkgs)
+        if [[ "${DOTFILES_DEV:-false}" == "true" ]]; then
+            while IFS= read -r formula; do
+                [[ -n "$formula" ]] && upgrade_formulae+=( "$formula" )
+            done < <(get_platform_pkgs "--dev")
+        fi
+        if ((${#upgrade_formulae[@]})); then
+            brew upgrade --formula "${upgrade_formulae[@]}" </dev/null || log_warning "brew upgrade failed"
+        fi
         # Casks flagged `auto_updates true` (e.g. Cursor) are skipped by a plain
         # `brew upgrade`; --greedy-auto-updates version-checks them and reinstalls
         # only on a diff. Excludes `version :latest` casks (no version to compare,
@@ -539,7 +551,7 @@ sync_gh_extensions() {
 
         if [[ -n "$version" ]]; then
             echo "  Installing $pkg --pin $version..."
-            if ! gh extension install "$pkg" --pin "$version" </dev/null; then
+            if ! gh extension install "$pkg" --pin "$version" --force </dev/null; then
                 log_error "Failed to install $pkg"
                 FAILED+=("$pkg")
             fi

--- a/packages/sync.sh
+++ b/packages/sync.sh
@@ -671,7 +671,18 @@ if [[ "$PLATFORM" == "Darwin" || "$PLATFORM" == "Linux" ]]; then
     sync_brew
 fi
 
+failures_before_mise=${#FAILED[@]}
 sync_mise
+if ((${#FAILED[@]} > failures_before_mise)); then
+    if [[ "${PACKAGES_BOOTSTRAP_ONLY:-false}" == "true" ]]; then
+        log_error "package bootstrap failed: ${FAILED[*]}"
+    else
+        echo ""
+        log_error "failed to install ${#FAILED[@]} package(s): ${FAILED[*]}"
+        log_warning "cache NOT saved due to install failures"
+    fi
+    exit 1
+fi
 
 if [[ "${PACKAGES_BOOTSTRAP_ONLY:-false}" == "true" ]]; then
     if ((${#FAILED[@]})); then

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "enabledManagers": ["mise", "custom.regex"],
 
   "mise": {
     "managerFilePatterns": [

--- a/tests/claude-mcp-pins.bats
+++ b/tests/claude-mcp-pins.bats
@@ -20,13 +20,13 @@ tavily_arg() { yq eval '.claude.mcps.tavily.args[1]' "$CLAUDE_YAML"; }
 @test "context7 args pin an exact version, not @latest or bare" {
     run context7_arg
     [ "$status" -eq 0 ]
-    [ "$output" = "@upstash/context7-mcp@3.2.4" ]
+    [[ "$output" =~ ^@upstash/context7-mcp@[0-9]+\.[0-9]+\.[0-9]+$ ]]
 }
 
 @test "tavily args pin an exact version, not @latest or bare" {
     run tavily_arg
     [ "$status" -eq 0 ]
-    [ "$output" = "tavily-mcp@0.2.21" ]
+    [[ "$output" =~ ^tavily-mcp@[0-9]+\.[0-9]+\.[0-9]+$ ]]
 }
 
 @test "context7 pin is not a float (@latest or bare package name)" {
@@ -40,13 +40,13 @@ tavily_arg() { yq eval '.claude.mcps.tavily.args[1]' "$CLAUDE_YAML"; }
 }
 
 @test "context7 has an adjacent renovate annotation for its exact depName" {
-    run grep -B1 'args: \["-y", "@upstash/context7-mcp@3.2.4"\]' "$CLAUDE_YAML"
+    run grep -B1 'args: \["-y", "@upstash/context7-mcp@' "$CLAUDE_YAML"
     [ "$status" -eq 0 ]
     [[ "$output" == *"# renovate: datasource=npm depName=@upstash/context7-mcp"* ]]
 }
 
 @test "tavily has an adjacent renovate annotation for its exact depName" {
-    run grep -B1 'args: \["-y", "tavily-mcp@0.2.21"\]' "$CLAUDE_YAML"
+    run grep -B1 'args: \["-y", "tavily-mcp@' "$CLAUDE_YAML"
     [ "$status" -eq 0 ]
     [[ "$output" == *"# renovate: datasource=npm depName=tavily-mcp"* ]]
 }

--- a/tests/mise-config.bats
+++ b/tests/mise-config.bats
@@ -51,9 +51,14 @@ CONFIG="$DOTFILES_DIR/chezmoi/dot_config/mise/config.toml"
 }
 
 @test "claude, codex, and rtk are pinned to exact tags, not floating" {
-    [[ "$(yq -p=toml '.tools."aqua:anthropics/claude-code"' "$CONFIG")" == "v2.1.219" ]]
-    [[ "$(yq -p=toml '.tools."aqua:openai/codex"' "$CONFIG")" == "rust-v0.145.0" ]]
-    [[ "$(yq -p=toml '.tools."aqua:rtk-ai/rtk"' "$CONFIG")" == "v0.43.0" ]]
+    local tool version
+    for tool in \
+        'aqua:anthropics/claude-code' \
+        'aqua:openai/codex' \
+        'aqua:rtk-ai/rtk'; do
+        version="$(yq -p=toml -o=json '.tools' "$CONFIG" | jq -r --arg tool "$tool" '.[$tool]')"
+        [[ "$version" =~ ^(v|rust-v)[0-9]+\.[0-9]+\.[0-9]+$ ]]
+    done
 }
 
 @test "non-semver tag shapes are kept raw (rust-analyzer date-stamp, tmux v3.7b)" {

--- a/tests/packages.bats
+++ b/tests/packages.bats
@@ -685,6 +685,18 @@ YAML
     [[ ! -f "$CACHE_FILE" ]] || [[ ! -s "$CACHE_FILE" ]]
 }
 
+@test "mise install failure preserves stale native harness binaries" {
+    write_test_yaml
+    mkdir -p "$TEST_HOME/.local/bin"
+    touch "$TEST_HOME/.local/bin/claude" "$TEST_HOME/.local/bin/codex"
+    write_mock_mise 1
+
+    run_sync
+    assert_failure
+    [[ -e "$TEST_HOME/.local/bin/claude" ]]
+    [[ -e "$TEST_HOME/.local/bin/codex" ]]
+}
+
 # --- Integration: missing toolchain ---
 
 # Build a curated PATH for "missing toolchain" tests. Keeps real yq/jq/shasum

--- a/tests/packages.bats
+++ b/tests/packages.bats
@@ -331,6 +331,23 @@ run_sync() {
     grep -q "brew install watch" "$BREW_LOG"
 }
 
+@test "UPGRADE_MODE upgrades only declared brew formulae" {
+    cat > "$PACKAGES_FILE" << 'YAML'
+packages:
+  - curl
+  - tree
+YAML
+    # A lingering mise-migrated formula must not be pulled into the upgrade set.
+    write_mock_brew "ripgrep"
+
+    DOTFILES_DEV=false UPGRADE_MODE=true run bash "$SYNC_SCRIPT"
+    assert_success
+
+    grep -q -- "brew upgrade --formula curl tree" "$BREW_LOG"
+    ! grep -q -E '^brew upgrade --formula$' "$BREW_LOG"
+    ! grep -q -- "brew upgrade --formula.*ripgrep" "$BREW_LOG"
+}
+
 @test "sync installs mac-only packages on Darwin" {
     [[ "$(uname)" == "Darwin" ]] || skip "macOS only"
 
@@ -862,8 +879,10 @@ MOCKBREW
 
     run_sync
     assert_success
+    local expected_omp_pin
+    expected_omp_pin=$(sed -n 's/^OMP_PIN="\([^"]*\)"/\1/p' "$SYNC_SCRIPT")
     grep -q "omp.sh/install" "$CURL_LOG"
-    grep -q -- "--binary --ref v17.1.3" "$SH_LOG"
+    grep -q -- "--binary --ref $expected_omp_pin" "$SH_LOG"
     [[ ! -f "$OMP_LOG" ]] || ! grep -q "omp update" "$OMP_LOG"
 }
 
@@ -885,7 +904,9 @@ MOCKBREW
 
     UPGRADE_MODE=true run bash "$SYNC_SCRIPT"
     assert_success
-    grep -q -- "--binary --ref v17.1.3" "$SH_LOG"
+    local expected_omp_pin
+    expected_omp_pin=$(sed -n 's/^OMP_PIN="\([^"]*\)"/\1/p' "$SYNC_SCRIPT")
+    grep -q -- "--binary --ref $expected_omp_pin" "$SH_LOG"
     [[ ! -f "$OMP_LOG" ]] || ! grep -q "omp update" "$OMP_LOG"
 }
 
@@ -1074,7 +1095,7 @@ YAML
     run_sync
     assert_success
 
-    grep -q -- "extension install github/gh-stack --pin 1.2.3" "$GH_LOG"
+    grep -q -- "extension install github/gh-stack --pin 1.2.3 --force" "$GH_LOG"
 }
 
 @test "UPGRADE_MODE reconverges a pinned cargo package without floating an unpinned sibling" {


### PR DESCRIPTION
## Layer 11/11 — Review closure

Records the convergence-ordering ADR and closes the final review gaps: explicit Renovate targeting, manager ownership, and safe mise-failure handling.

Review this PR against `stack/10-convergence-cure`.

Verification: `just check`; `uvx zizmor .github/workflows`; Renovate config validation and local extraction.
Additional closure: pinned gh extensions force convergence, brew upgrades are declaration-scoped, and tests derive expected pins from source.
