### PR TITLE
fix: restore mise-managed Claude launchers

### DIFF
--- a/bin/claude
+++ b/bin/claude
@@ -4,7 +4,7 @@
 # Bypass all checks: CLAUDE_GUARD=0 claude ...
 
 set -euo pipefail
-REAL="$HOME/.local/bin/claude"
+REAL="${XDG_DATA_HOME:-$HOME/.local/share}/mise/shims/claude"
 
 # Guard checks are Linux-only (crabbot): pgrep -c and /proc/meminfo don't exist on macOS.
 if [[ "${CLAUDE_GUARD:-1}" != "0" && -r /proc/meminfo ]]; then

--- a/bin/dotsclaude
+++ b/bin/dotsclaude
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 AGENTS_DOTFILES="${AGENTS_DOTFILES:-$HOME/Dev/dotfiles/agents}"
-CLAUDE_BIN="${CLAUDE_BIN:-$HOME/.local/bin/claude}"
+CLAUDE_BIN="${CLAUDE_BIN:-${XDG_DATA_HOME:-$HOME/.local/share}/mise/shims/claude}"
 
 flags=()
 

--- a/packages/sync.sh
+++ b/packages/sync.sh
@@ -58,10 +58,6 @@ save_cache() {
     shasum -a 256 "$PACKAGES_FILE" | cut -d' ' -f1 > "$CACHE_FILE"
 }
 
-if check_cache; then
-    log_success "packages.yaml unchanged (cached), skipping"
-    exit 0
-fi
 
 ########## Query helpers
 # Entry format: bare string OR single-key map (key = name, value = overrides)
@@ -281,7 +277,7 @@ sync_mise() {
     fi
 
     log_info "Converging mise-managed tool versions..."
-    if ! mise install </dev/null; then
+    if ! mise install "$@" </dev/null; then
         log_warning "mise install failed — continuing"
     fi
 }
@@ -760,6 +756,13 @@ sync_native_harnesses() {
 
     log_success "Native harness sync complete"
 }
+# Claude is invoked by chezmoi later in this sync, so keep its mise binary
+# present even when the package declaration cache is valid.
+if check_cache; then
+    log_success "packages.yaml unchanged (cached), syncing Claude"
+    sync_mise "aqua:anthropics/claude-code@v2.1.219"
+    exit 0
+fi
 ########## Main
 
 if [[ "$PLATFORM" == "Darwin" ]]; then

--- a/tests/cc-env.bats
+++ b/tests/cc-env.bats
@@ -20,6 +20,7 @@ load test_helper
 
 CLAUDE_ZSH="$REAL_DOTFILES_DIR/zsh/claude.zsh"
 CC_ENV_EXEC="$REAL_DOTFILES_DIR/bin/cc-env-exec"
+DOTSCLAUDE="$REAL_DOTFILES_DIR/bin/dotsclaude"
 
 setup() {
     FIXTURE_DIR="$(mktemp -d)"
@@ -120,6 +121,22 @@ EOF
     run env -u DOTFILES_DIR HOME="$FIXTURE_DIR" "$CC_ENV_EXEC" sh -c 'printf %s "$FB_KEY"'
     [ "$status" -eq 0 ]
     [ "$output" = "fb" ]
+}
+
+@test "dotsclaude uses the mise Claude shim by default" {
+    export HOME="$FIXTURE_DIR"
+    export XDG_DATA_HOME="$FIXTURE_DIR/.local/share"
+    mkdir -p "$XDG_DATA_HOME/mise/shims"
+    cat > "$XDG_DATA_HOME/mise/shims/claude" <<'EOF'
+#!/usr/bin/env bash
+echo mise-claude "$@"
+EOF
+    chmod +x "$XDG_DATA_HOME/mise/shims/claude"
+
+    run env DOTFILES_DIR="$FIXTURE_DIR" AGENTS_DOTFILES="$FIXTURE_DIR/agents" "$DOTSCLAUDE" --version
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "mise-claude --version" ]
 }
 
 # ── _cc_base wiring (end-to-end in zsh, tmux/claude mocked) ──

--- a/tests/claude-wrapper.bats
+++ b/tests/claude-wrapper.bats
@@ -1,0 +1,25 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+    setup_test_env
+    export XDG_DATA_HOME="$TEST_HOME/.local/share"
+    mkdir -p "$XDG_DATA_HOME/mise/shims"
+    cat > "$XDG_DATA_HOME/mise/shims/claude" <<'SH'
+#!/bin/sh
+echo "mise claude $*"
+SH
+    chmod +x "$XDG_DATA_HOME/mise/shims/claude"
+}
+
+teardown() {
+    teardown_test_env
+}
+
+@test "claude wrapper delegates to the mise shim" {
+    run "$REAL_DOTFILES_DIR/bin/claude" --version
+
+    assert_success
+    [ "$output" = "mise claude --version" ]
+}

--- a/tests/packages.bats
+++ b/tests/packages.bats
@@ -584,8 +584,20 @@ YAML
 
     run bash "$SYNC_SCRIPT"
     assert_success
-    assert_output_contains "unchanged (cached), skipping"
+    assert_output_contains "unchanged (cached), syncing Claude"
 
+    [[ ! -f "$BREW_LOG" ]]
+}
+
+@test "sync cache restores the Claude mise package" {
+    write_test_yaml
+    shasum -a 256 "$PACKAGES_FILE" | cut -d' ' -f1 > "$CACHE_FILE"
+
+    run bash "$SYNC_SCRIPT"
+
+    assert_success
+    assert_output_contains "syncing Claude"
+    grep -q "mise install aqua:anthropics/claude-code@v2.1.219" "$MISE_LOG"
     [[ ! -f "$BREW_LOG" ]]
 }
 
@@ -1007,12 +1019,14 @@ MOCKOMP
 @test "sync_mise bootstraps mise via brew when absent" {
     write_test_yaml
     rm -f "$MOCK_BIN/mise"
-    # The mocked brew doesn't simulate actually placing a working `mise`
-    # binary on PATH the way a real `brew install` would, so this test only
-    # proves the bootstrap call fires — the "already present" test below
-    # covers the subsequent `mise install` convergence call.
+    # Remove host mise binaries too; this test must exercise the bootstrap
+    # branch even on a developer machine where mise is installed.
+    local path_without_mise
+    path_without_mise=$(tr ':' '\n' <<<"$PATH" | while IFS= read -r dir; do
+        [[ -x "$dir/mise" ]] || printf '%s:' "$dir"
+    done)
 
-    run_sync
+    PATH="$MOCK_BIN:${path_without_mise%:}" run_sync
     assert_success
 
     grep -q "install mise" "$BREW_LOG"


### PR DESCRIPTION
## Summary
- Route Claude and dotsclaude to mise-managed Claude.
- Restore the pinned Claude package on cached syncs before MCP reconciliation.

## Verification
- just check
