### PR TITLE
feat(dev): contain agent sessions and heavy builds in a measured I/O slice

### DIFF
--- a/agents/hooks/heavy-admission.sh
+++ b/agents/hooks/heavy-admission.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# PreToolUse: require heavy-run for compiler/linker-heavy agent commands.
+
+set -u
+command -v jq >/dev/null 2>&1 || exit 0
+payload=$(cat) || exit 0
+[[ "$(jq -r '.tool_name // ""' <<<"$payload")" == Bash ]] || exit 0
+command=$(jq -r '.tool_input.command // ""' <<<"$payload")
+
+heavy_re='(^|[[:space:];|&])(sudo[[:space:]]+)?(cargo[[:space:]]+(build|test|check|clippy|nextest|bench|run)|rustc|rust-lld|ld[.]lld|mold|just[[:space:]]+(ci|llm))([[:space:];|&]|$)'
+[[ "$command" =~ $heavy_re ]] || exit 0
+
+route_re='(^|[[:space:];|&])heavy-run([[:space:];|&]|$)'
+[[ "$command" =~ $route_re ]] && exit 0
+
+jq -cn --arg reason "Blocked: compiler/linker-heavy commands must run through heavy-run so only one admitted job can use the development I/O budget. Example: heavy-run $command" \
+    '{hookSpecificOutput:{permissionDecision:"deny",permissionDecisionReason:$reason}}'

--- a/agents/hooks/registry.yaml
+++ b/agents/hooks/registry.yaml
@@ -234,3 +234,15 @@ hooks:
     async: true
     harnesses: [claude]
     description: Moshi bridge — turn-end notification to phone
+
+
+  # ─── Heavy-job admission ─────────────────────────────────────────────
+  # Agent-issued compiler/linker-heavy commands must use the queued wrapper;
+  # ordinary reads, formatting, and MCP work remain concurrent.
+  heavy-admission:
+    event: PreToolUse
+    script: agents/hooks/heavy-admission.sh
+    harnesses: [claude, codex]
+    matcher: "Bash"
+    timeout: 5
+    description: Require heavy-run for compiler/linker-heavy agent commands

--- a/bin/agent-run
+++ b/bin/agent-run
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Launch a whole Claude/Codex session inside the measured development slice.
+
+set -euo pipefail
+
+if (( $# == 0 )); then
+    echo "Usage: agent-run <command> [args…]" >&2
+    exit 2
+fi
+[[ "${1:-}" == -- ]] && shift
+(( $# > 0 )) || { echo "agent-run: missing command" >&2; exit 2; }
+
+DOTFILES_DIR="${DOTFILES_DIR:-$HOME/Dev/dotfiles}"
+# shellcheck source=lib/dev-heavy.sh
+source "$DOTFILES_DIR/bin/lib/dev-heavy.sh"
+dev_heavy_require_ready
+
+dev_heavy_run_scope "agent-session-$$.scope" "$@"

--- a/bin/claude
+++ b/bin/claude
@@ -30,4 +30,9 @@ fi
 # Per-server NODE_OPTIONS in MCP configs override this for MCP children.
 export NODE_OPTIONS="${NODE_OPTIONS:---max-old-space-size=8192}"
 
+AGENT_RUN="${DOTFILES_DIR:-$HOME/Dev/dotfiles}/bin/agent-run"
+if [[ "${DEV_HEAVY_ACTIVE:-0}" != 1 && -x "$AGENT_RUN" ]]; then
+    exec "$AGENT_RUN" "$REAL" "$@"
+fi
+
 exec "$REAL" "$@"

--- a/bin/codex
+++ b/bin/codex
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# PATH wrapper: keep Codex sessions inside dev-heavy.slice on Linux.
+
+set -euo pipefail
+REAL="${CODEX_REAL:-$HOME/.local/bin/codex}"
+[[ -x "$REAL" ]] || { echo "codex wrapper: $REAL is missing" >&2; exit 1; }
+
+if [[ "${DEV_HEAVY_ACTIVE:-0}" == 1 ]]; then
+    exec "$REAL" "$@"
+fi
+
+exec "${DOTFILES_DIR:-$HOME/Dev/dotfiles}/bin/agent-run" "$REAL" "$@"

--- a/bin/dotsclaude
+++ b/bin/dotsclaude
@@ -14,10 +14,18 @@ flags=()
 [[ -f "$AGENTS_DOTFILES/preamble.md" ]] && \
     flags+=(--system-prompt-file "$AGENTS_DOTFILES/preamble.md")
 
+
 # Fresh .env keys at process start (mirrors _cc_base's launcher prefix) —
 # Conductor doesn't source zsh init, so .env keys may be absent from its env.
 launcher="${DOTFILES_DIR:-$HOME/Dev/dotfiles}/bin/cc-env-exec"
+runner="${DOTFILES_DIR:-$HOME/Dev/dotfiles}/bin/agent-run"
 if [[ -x "$launcher" ]]; then
+    if [[ -x "$runner" && "${DEV_HEAVY_ACTIVE:-0}" != 1 ]]; then
+        exec "$launcher" "$runner" "$CLAUDE_BIN" "${flags[@]}" "$@"
+    fi
     exec "$launcher" "$CLAUDE_BIN" "${flags[@]}" "$@"
+fi
+if [[ -x "$runner" && "${DEV_HEAVY_ACTIVE:-0}" != 1 ]]; then
+    exec "$runner" "$CLAUDE_BIN" "${flags[@]}" "$@"
 fi
 exec "$CLAUDE_BIN" "${flags[@]}" "$@"

--- a/bin/heavy-run
+++ b/bin/heavy-run
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Queue and run one heavyweight build/test/link job across all worktrees.
+
+set -euo pipefail
+
+if (( $# == 0 )); then
+    echo "Usage: heavy-run <command> [args…]" >&2
+    exit 2
+fi
+[[ "${1:-}" == -- ]] && shift
+(( $# > 0 )) || { echo "heavy-run: missing command" >&2; exit 2; }
+
+DOTFILES_DIR="${DOTFILES_DIR:-$HOME/Dev/dotfiles}"
+# shellcheck source=lib/dev-heavy.sh
+source "$DOTFILES_DIR/bin/lib/dev-heavy.sh"
+dev_heavy_require_ready
+
+STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/crabbot-heavy-run"
+WAIT_SECONDS="${HEAVY_RUN_WAIT_SECONDS:-900}"
+umask 077
+mkdir -p "$STATE_DIR"
+exec 9>"$STATE_DIR/lease.lock"
+
+started=$SECONDS
+while ! flock -n 9; do
+    if [[ -s "$STATE_DIR/holder" ]]; then
+        echo "heavy-run: waiting for current lease ($(tr '\n' ' ' < "$STATE_DIR/holder"))" >&2
+    else
+        echo "heavy-run: waiting for the current heavyweight job" >&2
+    fi
+    if (( WAIT_SECONDS > 0 && SECONDS - started >= WAIT_SECONDS )); then
+        echo "heavy-run: timed out after ${WAIT_SECONDS}s" >&2
+        exit 75
+    fi
+    sleep 5
+done
+
+unit="heavy-job-$(date +%s)-$$.scope"
+holder="$STATE_DIR/holder"
+tmp="$holder.$$"
+{
+    printf 'pid=%s\nstarted=%s\ncommand=' "$$" "$(date --iso-8601=seconds)"
+    printf '%q ' "$@"
+    printf '\n'
+} > "$tmp"
+mv -f "$tmp" "$holder"
+trap 'rm -f "$holder"' EXIT
+
+dev_heavy_run_scope "$unit" "$@"

--- a/bin/lib/dev-heavy.sh
+++ b/bin/lib/dev-heavy.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Shared cgroup helpers for agent-run and heavy-run.
+
+set -euo pipefail
+
+DEV_HEAVY_SLICE="${DEV_HEAVY_SLICE:-dev-heavy.slice}"
+DEV_HEAVY_CGROUP_ROOT="${DEV_HEAVY_CGROUP_ROOT:-/sys/fs/cgroup}"
+
+_dev_heavy_linux() {
+    [[ "$(uname -s)" == Linux ]]
+}
+
+dev_heavy_require_ready() {
+    _dev_heavy_linux || return 0
+
+    command -v systemd-run >/dev/null 2>&1 || {
+        echo "agent containment unavailable: systemd-run is missing" >&2
+        return 1
+    }
+    command -v systemctl >/dev/null 2>&1 || {
+        echo "agent containment unavailable: systemctl is missing" >&2
+        return 1
+    }
+
+    systemctl --user start "$DEV_HEAVY_SLICE" >/dev/null 2>&1 || {
+        echo "agent containment unavailable: cannot start $DEV_HEAVY_SLICE" >&2
+        return 1
+    }
+
+    local load_state control_group io_max io_max_content
+    load_state=$(systemctl --user show "$DEV_HEAVY_SLICE" -p LoadState --value)
+    [[ "$load_state" == loaded ]] || {
+        echo "agent containment unavailable: $DEV_HEAVY_SLICE is $load_state" >&2
+        return 1
+    }
+
+    control_group=$(systemctl --user show "$DEV_HEAVY_SLICE" -p ControlGroup --value)
+    [[ -n "$control_group" ]] || {
+        echo "agent containment unavailable: $DEV_HEAVY_SLICE has no cgroup" >&2
+        return 1
+    }
+
+    io_max="$DEV_HEAVY_CGROUP_ROOT$control_group/io.max"
+    # cgroup pseudo-files report size zero even when they hold a limit.
+    io_max_content=""
+    if [[ -r "$io_max" ]]; then
+        io_max_content=$(< "$io_max")
+    fi
+    [[ -n "$io_max_content" ]] || {
+        echo "agent containment unavailable: $DEV_HEAVY_SLICE has no io.max ceiling" >&2
+        return 1
+    }
+}
+
+dev_heavy_run_scope() {
+    local unit="$1"
+    shift
+    _dev_heavy_linux || { "$@"; return; }
+    DEV_HEAVY_ACTIVE=1 systemd-run --user --quiet --scope --collect \
+        --slice="$DEV_HEAVY_SLICE" --unit="$unit" -- "$@"
+}

--- a/chezmoi/dot_config/systemd/user/dev-heavy.slice
+++ b/chezmoi/dot_config/systemd/user/dev-heavy.slice
@@ -1,0 +1,7 @@
+[Unit]
+Description=Development workloads with measured NVMe I/O ceiling
+
+[Slice]
+IOAccounting=yes
+IOReadBandwidthMax=/dev/nvme0n1 629145600
+IOWriteBandwidthMax=/dev/nvme0n1 209715200

--- a/chezmoi/lib/install-shared-assets.sh
+++ b/chezmoi/lib/install-shared-assets.sh
@@ -38,9 +38,9 @@ for target in "$@"; do
         chmod +x "$target"
     else
         # `cp -f` overwrites content but preserves the destination's mode,
-        # so a stale +x from a previous deploy would persist. Clear it
-        # explicitly to keep the target mode in sync with the source.
-        chmod -x "$target"
+        # so stale executable bits from a previous deploy would persist.
+        # Clear all of them explicitly to keep the target mode in sync.
+        chmod a-x "$target"
     fi
     echo "  Copied $(basename "$source_file") -> $target"
 done

--- a/tests/heavy-admission.bats
+++ b/tests/heavy-admission.bats
@@ -1,0 +1,33 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+HOOK="$REAL_DOTFILES_DIR/agents/hooks/heavy-admission.sh"
+
+run_hook() {
+    run bash -c 'printf "%s\n" "$1" | "$2"' _ "$1" "$HOOK"
+}
+
+@test "denies direct cargo test" {
+    run_hook '{"tool_name":"Bash","tool_input":{"command":"cargo test"}}'
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"permissionDecision":"deny"'* ]]
+}
+
+@test "allows cargo test through heavy-run" {
+    run_hook '{"tool_name":"Bash","tool_input":{"command":"heavy-run cargo test"}}'
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "allows ordinary cargo formatting" {
+    run_hook '{"tool_name":"Bash","tool_input":{"command":"cargo fmt"}}'
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "denies canonical just ci" {
+    run_hook '{"tool_name":"Bash","tool_input":{"command":"cd repo && just ci"}}'
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"permissionDecision":"deny"'* ]]
+}

--- a/zsh/core.zsh
+++ b/zsh/core.zsh
@@ -33,11 +33,11 @@ elif [[ $OSTYPE == linux* ]]; then
   unset _brew_bin
 fi
 
-# Add dotfiles bin to PATH
-export PATH="$DOTFILES_DIR/bin:$PATH"
-
-# Add local bin to PATH
+# Add local bin before dotfiles-owned launchers.
 export PATH="$HOME/.local/bin:$PATH"
+
+# Keep dotfiles launchers ahead of installed binaries.
+export PATH="$DOTFILES_DIR/bin:$PATH"
 
 # cargo install puts binaries in ~/.cargo/bin
 [[ -d "$HOME/.cargo/bin" ]] && export PATH="$HOME/.cargo/bin:$PATH"


### PR DESCRIPTION
## What

Puts a measurable I/O ceiling under agent sessions and heavyweight build jobs, so concurrent worktrees stop starving each other on NVMe.

**Semantics-altering.** It changes how `claude`, `dotsclaude`, and `codex` are launched, and adds a `PreToolUse` hook that can deny agent-issued Bash commands.

### Containment

- `chezmoi/dot_config/systemd/user/dev-heavy.slice` — read/write bandwidth caps with `IOAccounting=yes`.
- `bin/lib/dev-heavy.sh` — shared readiness check and scope runner. Fails loud when containment is unavailable (missing `systemd-run`/`systemctl`, unloaded slice, no `io.max` ceiling) and no-ops off Linux, so macOS is unaffected.
- `bin/agent-run` — runs a whole agent session inside the slice.
- `bin/heavy-run` — serialises one heavyweight job at a time behind a `flock` lease shared across worktrees, records the holder, and times out (`HEAVY_RUN_WAIT_SECONDS`, default 900) instead of waiting forever.

### Routing

- `bin/claude`, `bin/dotsclaude`, and the new `bin/codex` wrapper route through `agent-run` once, guarded by `DEV_HEAVY_ACTIVE` so a nested launch does not re-wrap.
- `zsh/core.zsh` puts `$DOTFILES_DIR/bin` ahead of `~/.local/bin` so the wrappers are what a session actually resolves.

### Admission

- `agents/hooks/heavy-admission.sh` (`PreToolUse`, claude + codex) denies agent-issued `cargo build|test|check|clippy|nextest|bench|run`, `rustc`, linkers, and `just ci|llm` unless they go through `heavy-run`. Reads, formatting, and MCP work stay concurrent.
- `tests/heavy-admission.bats` covers deny, allow-through-`heavy-run`, allow-`cargo fmt`, and the `cd repo && just ci` compound-command case.

The second commit is an unrelated one-line fix carried along: `chmod -x` in `install-shared-assets.sh` only cleared the owner bit, so a stale group/other `+x` survived a redeploy. Now `chmod a-x`.

## Verification

`just check` exits 0 on this branch: 1224/1224 bats tests pass, smoke passes, shellcheck / ruff / eslint / markdownlint all clean.

## What a reviewer should check

Two open questions this branch does **not** resolve, both from the `mise` migration that landed on `main` while this work was in progress:

1. **`bin/codex` targets `~/.local/bin/codex`, not a `mise` shim.** Its sibling `bin/claude` now resolves `${XDG_DATA_HOME:-~/.local/share}/mise/shims/claude`. The wrapper was left pointing at the path that actually exists today (overridable via `CODEX_REAL`) rather than silently adopting a convention that currently resolves to nothing.
2. **`mise activate zsh` runs after the PATH reorder.** On a machine with `mise` installed, `mise activate` prepends its shims directory, so the shims land ahead of `$DOTFILES_DIR/bin` and the wrappers — and therefore the containment and the existing `claude-guard` — would be bypassed. This machine has no `mise`, so the wrappers win today and the tests reflect that. Deciding which of the two should be first is a follow-up.

Separately, `dots sync` currently fails at the claude MCP reconcile step on this machine because `origin/main`'s `bin/claude:33` points at a `mise` shim that does not exist. That reproduces on `origin/main` unchanged and is not introduced here.
