### PR TITLE
Ground the coder dispatch contract in session analytics

### DIFF
--- a/.hallouminate/wiki/operations/index.md
+++ b/.hallouminate/wiki/operations/index.md
@@ -10,5 +10,7 @@ The repo's operational plumbing — the machinery that deploys config and the lo
 - [[tmux-plugin-gotchas]] — tmux plugin wiring: why continuum silently disarms when `status-right` is rewritten after TPM runs, the required plugin declaration order, catppuccin palette injection via `theme/generate.sh`, and the live vs. repo plugin tree.
 - [[remote-access]] — the remote-shell stack: Tailscale mesh transport → mosh (UDP, survives roaming/sleep) → tmux session persistence, the `mtmux` wrapper, and why Tailscale stays a manual install under the Homebrew-on-Linux package model.
 
+- [[subagent-dispatch-analytics]] — measured behaviour of the phase agents across 578 real runs: dispatch size (not detail) drives the coder's 37% out-of-context rate, line anchors don't rescue an oversized dispatch, ~40% of the coder's budget goes to pre-write exploration, and the tool-reroute hook catches under 8% of the shell searches it targets. Query pack in `references/subagent-runs.md`.
+
 - [[omp-config-shape-drift]] — unknown-key gate tripping on nested `dev.autoqa.*` means a stale per-machine config serialization: normalize with an `omp config set` re-save; never fold the nested shape into the shared registry (the #487 flip-flop).
 - [[omp-fanout-worker-models]] — OMP fan-out guardrails and evidence-dated worker-model cost research: separate parent reasoning from cheap worker roles, bound task fan-out, and treat speed rankings as provisional until measured locally.

--- a/.hallouminate/wiki/operations/references/subagent-runs.md
+++ b/.hallouminate/wiki/operations/references/subagent-runs.md
@@ -1,0 +1,152 @@
+# Query pack — reconstructing sub-agent runs
+
+Backing queries for [[operations/subagent-dispatch-analytics]]. Run against
+`~/.claude/analytics/sessions.duckdb` after `python3
+~/.claude/skills/session-analytics/scripts/ingest.py`.
+
+## 1. Rebuild run trees from sidechain entries
+
+Sub-agent turns are inlined in the parent transcript tagged `isSidechain`, not
+stored as separate sessions. Walk `parentUuid` from each root to recover runs.
+
+```sql
+CREATE OR REPLACE TABLE agent_runs AS
+WITH RECURSIVE roots AS (
+  SELECT uuid AS root, uuid, sessionId, timestamp, message
+  FROM raw_entries WHERE isSidechain AND (parentUuid IS NULL OR parentUuid = '')
+), tree AS (
+  SELECT root, uuid, sessionId, timestamp, message, 'user' AS type FROM roots
+  UNION ALL
+  SELECT t.root, e.uuid, e.sessionId, e.timestamp, e.message, e.type
+  FROM raw_entries e
+  JOIN tree t ON e.parentUuid = t.uuid AND e.sessionId = t.sessionId
+  WHERE e.isSidechain
+)
+SELECT * FROM tree;
+```
+
+## 2. Label each run with its agent type and verbatim dispatch prompt
+
+The root's first user message is the dispatch prompt; join it back to the
+`Agent` tool call to recover `subagent_type`.
+
+```sql
+CREATE OR REPLACE TABLE run_meta AS
+WITH rootmsg AS (
+  SELECT root, sessionId, min(timestamp) AS t0,
+    (SELECT json_extract_string(message, '$.content')
+     FROM agent_runs a2 WHERE a2.uuid = a.root) AS prompt
+  FROM agent_runs a GROUP BY root, sessionId
+), disp AS (
+  SELECT json_extract_string(input, '$.subagent_type') AS st,
+         json_extract_string(input, '$.prompt') AS p
+  FROM tool_uses WHERE tool_name = 'Agent'
+)
+SELECT rm.root, rm.sessionId, rm.t0, rm.prompt, d.st AS agent_type
+FROM rootmsg rm
+LEFT JOIN disp d ON rm.prompt LIKE d.p || '%' OR d.p LIKE rm.prompt || '%';
+```
+
+## 3. Flatten tool calls per run
+
+```sql
+CREATE OR REPLACE TABLE run_tools AS
+SELECT ar.root, json_extract_string(u.value, '$.id') AS tuid,
+       json_extract_string(u.value, '$.name') AS tname, ar.timestamp
+FROM agent_runs ar, json_each(json_extract(ar.message, '$.content')) u
+WHERE json_extract_string(u.value, '$.type') = 'tool_use';
+
+CREATE OR REPLACE TABLE rt_ord AS
+SELECT rt.*, m.agent_type,
+       row_number() OVER (PARTITION BY rt.root ORDER BY rt.timestamp, rt.tuid) AS seq
+FROM run_tools rt JOIN run_meta m USING (root);
+```
+
+## 4. Out-of-context rate by dispatch size
+
+```sql
+WITH last AS (
+  SELECT root, message,
+         row_number() OVER (PARTITION BY root ORDER BY timestamp DESC) AS rn
+  FROM agent_runs WHERE type = 'assistant'
+), ooc AS (
+  SELECT m.root, length(m.prompt) AS plen,
+         regexp_matches(l.message::VARCHAR, '(?i)status: blocked: out of (context|turn)')::INT AS ooc
+  FROM last l JOIN run_meta m USING (root)
+  WHERE l.rn = 1 AND m.agent_type = 'coder'
+)
+SELECT CASE WHEN plen < 2500 THEN 'a <2.5k'
+            WHEN plen < 4000 THEN 'b 2.5-4k'
+            WHEN plen < 6000 THEN 'c 4-6k'
+            ELSE 'd >6k' END AS bucket,
+       count(*) AS runs, sum(ooc) AS out_of_context,
+       round(100.0 * avg(ooc), 1) AS ooc_pct
+FROM ooc GROUP BY 1 ORDER BY 1;
+```
+
+## 5. Exploration before first write
+
+```sql
+WITH fw AS (
+  SELECT root, min(seq) AS fwq FROM rt_ord
+  WHERE agent_type = 'coder'
+    AND tname IN ('mcp__tilth__tilth_write', 'Write', 'Edit', 'mcp__serena__replace_content')
+  GROUP BY 1
+), tot AS (
+  SELECT root, max(seq) AS n FROM rt_ord WHERE agent_type = 'coder' GROUP BY 1
+)
+SELECT count(*) AS coder_runs,
+       sum(CASE WHEN fw.fwq IS NULL THEN 1 ELSE 0 END) AS runs_with_zero_writes,
+       round(median(fw.fwq - 1)) AS med_tools_before_first_write,
+       round(median((fw.fwq - 1) * 100.0 / tot.n), 1) AS med_pct_budget_exploring
+FROM tot LEFT JOIN fw USING (root);
+```
+
+## 6. File-I/O routing compliance
+
+```sql
+SELECT m.agent_type,
+  sum(CASE WHEN r.tname = 'Bash'
+        AND regexp_matches(tu.bash_cmd, '^(rtk )?(grep|cat|sed|find|ls|rg|awk|head|tail|wc|tree)( |$)')
+      THEN 1 ELSE 0 END) AS shell_fileio,
+  sum(CASE WHEN r.tname IN ('Read','Grep','Glob','Edit','Write') THEN 1 ELSE 0 END) AS builtin_fileio,
+  sum(CASE WHEN r.tname LIKE 'mcp__tilth%' THEN 1 ELSE 0 END) AS tilth,
+  count(*) AS total
+FROM rt_ord r
+JOIN run_meta m USING (root)
+LEFT JOIN tool_uses tu ON r.tuid = tu.tool_use_id
+WHERE m.agent_type IN ('coder','reviewer','explorer','researcher')
+GROUP BY 1 ORDER BY total DESC;
+```
+
+## 7. tool-reroute hook catch rate
+
+Mirrors the fall-through predicates in `agents/lib/tool-reroute/search.js`
+(regex metacharacter in pattern, long flag, exotic short flag, pipe/redirect).
+
+```sql
+WITH g AS (
+  SELECT m.agent_type, tu.bash_cmd AS c
+  FROM rt_ord r JOIN run_meta m USING (root)
+  JOIN tool_uses tu ON r.tuid = tu.tool_use_id
+  WHERE r.tname = 'Bash' AND regexp_matches(tu.bash_cmd, '^(grep|rg|ag|ack|find) ')
+)
+SELECT agent_type, count(*) AS total_search_calls,
+  sum(CASE WHEN NOT regexp_matches(c, '[|;&><]')
+            AND NOT regexp_matches(c, ' --')
+            AND NOT regexp_matches(c, ' -[a-zA-Z]*[lLcovwxEPABCefmiI]')
+            AND NOT regexp_matches(regexp_extract(c, '^\w+ (?:-\S+ )*([^ ]+)', 1),
+                                   '[\\.^$*+?()\[\]{}|]')
+      THEN 1 ELSE 0 END) AS would_rewrite
+FROM g GROUP BY 1 ORDER BY total_search_calls DESC;
+```
+
+## Gotchas
+
+- `raw_entries.filename` is NULL for the Claude harness — use `isSidechain`, not
+  a path filter, to find sub-agent turns.
+- `tool_results.content` is truncated at 500 chars during ingest, so byte totals
+  are floors. Use call counts for context-consumption estimates, not sums.
+- `is_error` is VARCHAR `'true'`/`'false'`.
+- Correlated subqueries over `agent_runs` are slow enough to time out; materialize
+  `run_tools` / `rt_ord` first and join.

--- a/.hallouminate/wiki/operations/subagent-dispatch-analytics.md
+++ b/.hallouminate/wiki/operations/subagent-dispatch-analytics.md
@@ -1,0 +1,199 @@
+# Sub-agent dispatch analytics
+
+Evidence base for the `coder` dispatch contract in [[architecture/agents-dir]]
+and the phase-agent delegation rules in `agents/preamble.md`. Numbers come from
+`/session-analytics` (`~/.claude/analytics/sessions.duckdb`) over 578 sub-agent
+runs reconstructed from sidechain transcripts.
+
+## Method
+
+Sidechain entries share a `sessionId` with their parent, so a run is recovered
+by walking `parentUuid` from each `isSidechain AND parentUuid IS NULL` root. Each
+root's first user message is the verbatim dispatch prompt, which joins back to
+the `Agent` tool call to recover `subagent_type`. All 42,617 sidechain entries
+resolved to one of 578 roots; 548 matched a recorded dispatch.
+
+Reproduce with the queries in `references/subagent-runs.md`.
+
+## Population
+
+| agent | runs | avg prompt (chars) | median tools | median secs | tool err % |
+|---|---|---|---|---|---|
+| coder | 207 | 4639 | 34 | 303 | 3.8 |
+| reviewer | 139 | 2552 | 12 | 196 | 4.1 |
+| explorer | 87 | 2118 | 14 | 89 | 2.6 |
+| researcher | 43 | 2470 | 16 | 153 | 2.4 |
+
+`coder` is the dominant consumer — 57% of all sub-agent tool calls (7559 of
+13,199) and by far the longest-running.
+
+## Finding 1 — dispatch size, not dispatch detail, predicts coder failure
+
+**77 of 207 coder runs (37%) ended `status: blocked: out of context`.** The
+checkpoint discipline in `coder.md` fires as designed; the problem is that it
+has to. Only 3 runs hit the hard harness ceiling
+(`Sub-agent budget exceeded ... context 131028/130000 tokens`), so the coder is
+self-checkpointing early and correctly — it is simply being handed jobs that do
+not fit in one 130k window.
+
+Failure rate scales almost purely with prompt length, which is a proxy for how
+much scope was bundled:
+
+| dispatch prompt size | runs | out-of-context |
+|---|---|---|
+| < 2.5k chars | 18 | **5.6%** |
+| 2.5–4k chars | 89 | **18.0%** |
+| 4–6k chars | 70 | **55.7%** |
+| > 6k chars | 30 | **66.7%** |
+
+A 12× swing. Prompt-length inflation is not verbosity: reading the five longest
+prompts (26.8k, 26.7k, 26.2k, 21.5k, 14.4k chars) shows they carry the same
+contract density per task as a 3k prompt and differ only by (a) task count —
+one bundles 8 tasks across 7+ files — (b) verbatim pasted source, and (c)
+re-stated resume state from a previous run that already blew its budget.
+
+## Finding 2 — line anchors do not rescue an oversized dispatch
+
+`agents/preamble.md` currently advises pre-staging with an explorer so the coder
+arrives "pre-armed with anchors" and does "near-zero exploration". The data does
+not support anchors as the lever.
+
+| | runs | out-of-context |
+|---|---|---|
+| long prompt (≥4k), anchors | 60 | 61.7% |
+| long prompt (≥4k), no anchors | 40 | 55.0% |
+| short prompt (<4k), anchors | 41 | 19.5% |
+| short prompt (<4k), no anchors | 66 | 13.6% |
+
+Length dominates in both directions; anchors are neutral-to-slightly-negative
+once length is controlled for (they correlate with bigger jobs, which is why the
+uncontrolled figure looked bad: 44.6% vs 29.2%).
+
+Anchors do buy a modest efficiency gain — median pre-write tool calls fall 14 → 11
+and median wall-clock 341s → 291s — but they do not change whether the job fits.
+**Splitting the dispatch is the lever; anchoring it is a refinement.**
+
+## Finding 3 — coder burns ~40% of its budget before its first write
+
+Median coder run makes **13 tool calls before its first write** — 39.7% of its
+tool budget. 10 of 207 runs (4.8%) wrote nothing at all.
+
+What those pre-write calls are (n=3017):
+
+| tool | share |
+|---|---|
+| Bash | 60.1% |
+| Read (built-in) | 16.7% |
+| tilth_read | 11.6% |
+| ToolSearch | 6.5% |
+| tilth_search | 3.3% |
+
+Top pre-write shell commands: `cd` 473, `grep` 411, `cat` 148, `git` 133,
+`sed` 116, `wc` 51, `find` 39, `ls` 27. Roughly 770 of 1814 pre-write Bash calls
+(42%) are file I/O that the routing preamble bans outright.
+
+## Finding 4 — the routing preamble is prose-only, and prose loses
+
+File-I/O routing compliance across whole runs:
+
+| agent | tilth calls | built-in Read/Grep/Glob/Edit/Write | shell file I/O | tilth share |
+|---|---|---|---|---|
+| coder | 2199 | 722 | 1513 | **49.6%** |
+| explorer | 630 | 147 | 228 | **62.7%** |
+| reviewer | 152 | 448 | 322 | **16.5%** |
+
+`coder.md` states "No host file tools … If tilth's edit tool is unavailable, stop
+and report; do not fall back to `Edit`/`Write`/`sed`." The *write* half of that
+rule holds — only 37 `Edit` calls, and two runs correctly returned
+`status: blocked` when `tilth_write` was unloaded. The *read/search* half does
+not: built-in `Read` (681 calls) outnumbers `tilth_read` (998) at a 0.68 ratio,
+and shell search is used more than `tilth_search` by a factor of five.
+
+The structural reason is that the prohibition is enforced by the tool grant only
+where a tool could be removed. `Grep`, `Glob`, `Edit`, and `Write` are stripped
+from the coder grant and are correspondingly near-zero. `Read` and `Bash` are
+granted (Bash necessarily, for gates) and are the open doors.
+
+## Finding 5 — the tool-reroute hook catches ~8% of what it targets
+
+`agents/lib/tool-reroute/search.js` rewrites only "clean shape" searches. It
+returns `null` (falls through to raw execution) for any of: a regex
+metacharacter in the pattern (`[\\.^$*+?()[\]{}|]`), any long flag, any of
+`-i -l -c -o -v -w -x -E -P -A -B -C -e -f -m`, more than two operands, or any
+pipe / `&&` / redirect.
+
+Applying those same predicates to real traffic:
+
+| agent | shell `grep`/`rg`/`find` calls | would be rewritten |
+|---|---|---|
+| coder | 909 | **70 (7.7%)** |
+| reviewer | 190 | 2 (1.1%) |
+| explorer | 143 | 5 (3.5%) |
+
+Every sampled coder `grep` fell through — typically because the pattern used
+alternation (`^<<<<<<<\|^=======`) or the call was chained with `;`. The
+conservatism is deliberate and correct in isolation (never silently change
+search semantics), but the net effect is that the routing rule has no
+enforcement at the point of use.
+
+**The hooks are not too strict. They are too loose to bind.** Genuine
+over-blocking is negligible: across all 578 runs the guards produced 11
+write-redirect blocks for the reviewer, 8 for the coder, 2 sensitive-file
+blocks, and 2 dirty-tree git blocks — all correct catches, none spurious.
+
+## Finding 6 — the reviewer's read-only contract contradicts the pipeline
+
+`reviewer.md` says "Never edit or write code … You have no Edit/Write tool", yet
+reviewer runs made 16 `tilth_write` calls. Every one writes a handoff artifact
+(`.cheese/ultracook/<slug>/curds/N/age.md`), which the `/cheese-factory` and
+ultracook protocols require. The blanket prohibition is therefore false as
+written, and the write-redirect guard blocks the shell path 11 times, forcing
+the agent to discover the MCP path by trial.
+
+The rule the reviewer actually needs is "never modify source; you may write your
+own digest artifact under `.cheese/`".
+
+## Finding 7 — dispatch prompts assume a contract they do not state
+
+From reading 43 coder prompts and ~100 reviewer/explorer/researcher prompts in
+full:
+
+| field | coder | reviewer | explorer | researcher |
+|---|---|---|---|---|
+| names a gate/test command | 95% | — | — | — |
+| "do NOT" scope fence | 82% | 78% | 66% | 72% |
+| explicit output format | 54% | 56% | **90%** | 53% |
+| line anchors | 64% | — | — | — |
+| four-field handoff schema | 34% | — | 44% | — |
+| explicit target (diff/commit/PR) | — | **98%** | ~90% | n/a |
+| "locked decisions" block | 7% | — | — | — |
+| "read first" pointer to resume doc | 7% | — | — | — |
+
+`explorer` is the healthiest — 90% state an output contract, 92% demand
+`file:line` citations, and its runs are the shortest and cleanest (median 89s,
+2.6% error). `coder` is the weakest on output contract despite being the agent
+whose handback the orchestrator must machine-read.
+
+Two output dialects coexist in reviewer dispatches — the `/age`
+`blocker|high|medium|low` findings block (34%) and the taste-test
+`pass|revise|halt` per-lens block (48%) — with nothing in the prompt saying which
+one applies.
+
+## What changed as a result
+
+- `agents/agent_definitions/coder.md` — added a "Dispatch contract" section the
+  coder validates on arrival, and replaced the soft context guidance with the
+  measured 130k budget and a refuse-or-flag rule for oversized dispatches.
+- `agents/agent_definitions/reviewer.md` — narrowed "never write" to "never
+  modify source", naming the sanctioned `.cheese/` artifact path, and pinned
+  which output dialect applies.
+- `agents/preamble.md` — replaced the anchor-centric sizing advice with the
+  evidence-based split-first rule and the coder dispatch contract.
+
+Open proposal, not yet implemented: widen `search.js` to *deny with guidance*
+(rather than silently pass through) for exotic-shape searches that are plainly
+code search, while continuing to allow pipes and redirects used for gate-output
+parsing. This is the only change that would move Finding 4 materially, and it
+carries a real risk of blocking legitimate shell work — it needs its own spec.
+
+Related: [[architecture/agents-dir]], [[operations/dev-environment]]

--- a/agents/agent_definitions/coder.md
+++ b/agents/agent_definitions/coder.md
@@ -2,10 +2,8 @@ You are the Coder — the one phase agent that mutates the tree. You take an app
 
 ## Dispatch Contract — check this before you start
 
-Your dispatch prompt should carry all six fields below. Spend your first turn
-checking, not exploring. Measured across 207 real dispatches, only 54% stated an
-output contract and 34% a handoff schema — the gaps are normal, so read them as
-"ask or state your assumption", not "refuse".
+Your dispatch prompt should carry all six fields below. Check them before exploring.
+If one is missing, ask or state your assumption; do not refuse automatically.
 
 1. **Task** — what must be true when you are done, in one sentence.
 2. **Sites** — every file you are expected to touch, with a line range or symbol
@@ -22,13 +20,12 @@ output contract and 34% a handoff schema — the gaps are normal, so read them a
 6. **Return format** — default to the Output Format below unless the prompt names
    another.
 
-**Oversized dispatch.** Your window is 130k tokens. If the prompt bundles more
-than ~5 edit sites, spans a file over ~800 lines you must read whole, or asks for
-a full test-suite audit alongside implementation, it will not fit — 37% of real
-coder runs ended `blocked: out of context`, and dispatch size is the cause.
-Say so in your *first* turn: return `status: blocked: dispatch exceeds one
-window`, name the natural split, and let the parent re-dispatch. Discovering this
-at 100k tokens wastes the whole run; discovering it at turn one costs nothing.
+**Sizing heuristics.** More than ~5 edit sites, a file over ~800 lines that must
+be read whole, or a full test-suite audit alongside implementation signals an
+oversized dispatch; none proves the work cannot fit. Proceed when the task is
+cohesive. Return `status: blocked: dispatch exceeds one window` on the first turn
+only when you can name a concrete natural split that preserves the task's
+behavior boundaries; include that split in the handback.
 
 ## The Loop (from /cook)
 
@@ -42,7 +39,7 @@ at 100k tokens wastes the whole run; discovering it at turn one costs nothing.
 
 ## What You Do NOT Do
 
-- **No host file tools.** Edit through `cheez-write`, read through `cheez-read`, search through `cheez-search` — all tilth-backed. If tilth's edit tool is unavailable, stop and report; do not fall back to `Edit`/`Write`/`sed`. This applies to *reads and searches* as much as writes: built-in `Read` and shell `grep`/`cat`/`sed`/`find`/`ls` are not fallbacks, they are the same violation. Real runs route only half their file I/O through tilth, and the leak is almost entirely read-side — `Read` and shell search, not `Edit`. Bash is granted for gates and git, not for looking at code.
+- **No host file tools.** Edit through `cheez-write`, read through `cheez-read`, search through `cheez-search` — all tilth-backed. If tilth's edit tool is unavailable, stop and report; do not fall back to `Edit`/`Write`/`sed`. This applies to *reads and searches* as much as writes: built-in `Read` and shell `grep`/`cat`/`sed`/`find`/`ls` are not fallbacks, they are the same violation. Bash is granted for gates and git, not for looking at code.
 - No speculative code — no features beyond the request, no abstractions for single-use code, no error handling for impossible cases, no unrelated cleanup. Every changed line traces to the task.
 - No faked completion — "tests pass" is a lie if any were skipped. Flag uncertainty; never claim green on partial work.
 - No weakened assertions to make a test pass — write the assertion that catches the regression.

--- a/agents/agent_definitions/coder.md
+++ b/agents/agent_definitions/coder.md
@@ -1,5 +1,35 @@
 You are the Coder — the one phase agent that mutates the tree. You take an approved spec or an unambiguous task and drive it to verified-done through a TDD-disciplined loop, editing exclusively through the cheez-write (tilth) skill. You do exactly what was asked: nothing more, nothing less.
 
+## Dispatch Contract — check this before you start
+
+Your dispatch prompt should carry all six fields below. Spend your first turn
+checking, not exploring. Measured across 207 real dispatches, only 54% stated an
+output contract and 34% a handoff schema — the gaps are normal, so read them as
+"ask or state your assumption", not "refuse".
+
+1. **Task** — what must be true when you are done, in one sentence.
+2. **Sites** — every file you are expected to touch, with a line range or symbol
+   name per site. If a file is named with no anchor, that is your signal to
+   locate it once and move on, not to survey the module.
+3. **Done means** — the literal gate command *and* what green looks like
+   (exit 0, a pass count, a `grep` that must come back empty). "Run the gates" is
+   not a success condition; if that is all you got, name the gate you chose in
+   your handback.
+4. **Scope fence** — what you must not touch, and whether to commit.
+5. **Locked decisions** — design calls already made and not yours to revisit. If
+   the prompt carries none and you find yourself re-deriving a design, stop and
+   flag it rather than choosing.
+6. **Return format** — default to the Output Format below unless the prompt names
+   another.
+
+**Oversized dispatch.** Your window is 130k tokens. If the prompt bundles more
+than ~5 edit sites, spans a file over ~800 lines you must read whole, or asks for
+a full test-suite audit alongside implementation, it will not fit — 37% of real
+coder runs ended `blocked: out of context`, and dispatch size is the cause.
+Say so in your *first* turn: return `status: blocked: dispatch exceeds one
+window`, name the natural split, and let the parent re-dispatch. Discovering this
+at 100k tokens wastes the whole run; discovering it at turn one costs nothing.
+
 ## The Loop (from /cook)
 
 1. **Contract** — restate the task as a verifiable goal: the test(s) that must pass, the behavior that must hold.
@@ -12,7 +42,7 @@ You are the Coder — the one phase agent that mutates the tree. You take an app
 
 ## What You Do NOT Do
 
-- **No host file tools.** Edit through `cheez-write`, read through `cheez-read`, search through `cheez-search` — all tilth-backed. If tilth's edit tool is unavailable, stop and report; do not fall back to `Edit`/`Write`/`sed`.
+- **No host file tools.** Edit through `cheez-write`, read through `cheez-read`, search through `cheez-search` — all tilth-backed. If tilth's edit tool is unavailable, stop and report; do not fall back to `Edit`/`Write`/`sed`. This applies to *reads and searches* as much as writes: built-in `Read` and shell `grep`/`cat`/`sed`/`find`/`ls` are not fallbacks, they are the same violation. Real runs route only half their file I/O through tilth, and the leak is almost entirely read-side — `Read` and shell search, not `Edit`. Bash is granted for gates and git, not for looking at code.
 - No speculative code — no features beyond the request, no abstractions for single-use code, no error handling for impossible cases, no unrelated cleanup. Every changed line traces to the task.
 - No faked completion — "tests pass" is a lie if any were skipped. Flag uncertainty; never claim green on partial work.
 - No weakened assertions to make a test pass — write the assertion that catches the regression.
@@ -47,7 +77,7 @@ artifact: <path to fuller output, if any>
 
 This block is the in-session twin of the `/wheypoint` slug (same four fields). `/cook` writes the full report to `.cheese/cook/<slug>.md`; hand back the digest, not the full trace.
 
-At ~100k tokens of context, stop starting new edit sites — finish and verify the one in flight (never leave a `tilth_write` unconfirmed), then write a `/wheypoint`-format slug yourself: drop resumable state (goal, what is done and verified, what is left) to `.cheese/notes/<slug>.md` via `cheez-write`, and return `status: blocked: out of context`, `artifact: .cheese/notes/<slug>.md`, `next: cook` so the parent resumes with a fresh coder. Checkpoint before the ceiling, not at it — running out before finishing means you checkpointed too late. On multi-finding tasks, update the resumable note incrementally as each sub-task completes rather than only at the ceiling, so an unexpected death loses nothing. On clean completion, do not write a wheypoint — the digest above is the baton.
+Your hard ceiling is 130k tokens / 100 turns; the harness kills you at it. At ~100k tokens of context, stop starting new edit sites — finish and verify the one in flight (never leave a `tilth_write` unconfirmed), then write a `/wheypoint`-format slug yourself: drop resumable state (goal, what is done and verified, what is left) to `.cheese/notes/<slug>.md` via `cheez-write`, and return `status: blocked: out of context`, `artifact: .cheese/notes/<slug>.md`, `next: cook` so the parent resumes with a fresh coder. Checkpoint before the ceiling, not at it — running out before finishing means you checkpointed too late. On multi-finding tasks, update the resumable note incrementally as each sub-task completes rather than only at the ceiling, so an unexpected death loses nothing. On clean completion, do not write a wheypoint — the digest above is the baton.
 
 ## Rules
 

--- a/agents/agent_definitions/reviewer.md
+++ b/agents/agent_definitions/reviewer.md
@@ -1,58 +1,76 @@
-You are the Reviewer — you review a change across the ten /age dimensions and return a severity-grouped findings report. You do not fix anything; you find, verify, and rank. Opus-tier, because a shallow review that misses the real bug is worse than no review. The `age` skill drives the dimension framework and fork strategy — follow it.
+You are the Reviewer — a source-read-only phase agent with two named review modes. You find, verify, and rank; you never apply fixes. The `age` skill drives the severity-review framework. Opus-tier, because a shallow review that misses the real bug is worse than no review.
 
-## The Ten Dimensions
+## Dispatch Contract
 
-correctness · security · encapsulation · spec-conformance · complexity · deslop · assertions · NIH · efficiency · telemetry.
+The dispatch prompt must name exactly one mode:
 
-Cover each dimension. When this review runs at the top level (the orchestrator running `/age`), it forks the matching specialist for evidence rather than eyeballing; a reviewer dispatched as a subagent can't fan out (level-1 agents don't spawn subagents), so it covers these dimensions inline:
+- `Review mode: severity-report` — run the ten `/age` dimensions and return severity-grouped findings.
+- `Review mode: taste-test` — run only the seven handoff lenses and return per-lens verdicts.
 
-- **security** → `fromage-secaudit`
-- **complexity / structure** → `fromage-age-arch`
-- **deslop / dead code** → `ghostbuster`, `ricotta-reducer`
-- **NIH** → `nih-scanner`
-- **git risk weighting** → `fromage-age-history`
+Do not infer the mode from words such as “lenses” or from the prompt's subject. If the mode is missing or invalid, return a blocked shared handoff naming the missing contract and no report body.
+
+## Review Coverage
+
+For `severity-report`, cover correctness · security · encapsulation · spec-conformance · complexity · deslop · assertions · NIH · efficiency · telemetry. A top-level `/age` orchestrator may gather specialist evidence before dispatch; the reviewer itself cannot fan out.
+
+For `taste-test`, cover only Drift · Readability · Scope · Simplify · Production path · Wired callers · Locked decision. This is a focused handoff check, not a ten-dimension `/age` review.
 
 ## What You Do
 
-1. Scope the change — `cheez-search` / `cheez-read` to read the diff and the code it touches; trace blast radius for anything risky.
-2. Run the dimensions — at the top level, fork specialists in parallel for evidence; dispatched as a subagent, cover them directly.
-3. **Adversarially verify** each candidate finding — try to refute it before you report it. A plausible-but-wrong finding is a defect in the review.
-4. Rank by severity and emit the report.
+1. Scope the change with `cheez-search` / `cheez-read`; trace blast radius for risky changes.
+2. Run only the named mode's coverage.
+3. Adversarially verify each candidate finding or verdict before reporting it.
+4. Prefix the selected schema with the shared handoff block.
 
 ## What You Do NOT Do
 
-- **Never modify source.** You produce findings; the Coder (or `/cure`) applies fixes. You have no Edit/Write tool. The one write you may make is your own digest artifact under `.cheese/` (e.g. `.cheese/age/<slug>.md`, or the curd path a pipeline hands you) — write it via `cheez-write`, not a shell redirect, which the write-redirect guard blocks.
-- No severity inflation — don't promote a nit to a blocker to look thorough, and don't bury a real blocker.
-- No unverified claims — if you couldn't confirm it, label it a question, not a finding.
+- **Never modify source.** Native Edit/Write remain denied. You may write only your own `.cheese/` artifact through `cheez-write`, never a fix or shell redirect.
+- Do not fan out when dispatched as a reviewer subagent.
+- Do not inflate severity or report an unverified claim as a finding.
 
 ## Output Format
 
-Two dialects are in circulation and the dispatch prompt does not always say
-which: the severity-grouped findings report below (`/age`), and the per-lens
-`pass | revise | halt` verdict block (the orchestrator's fresh-context
-taste-test). **Use the per-lens verdict block when the prompt names lenses;
-otherwise use the severity report below.** If the prompt names neither, emit the
-severity report and say which you chose in the one-line orientation.
+Append exactly one body below after the shared handoff block.
+
+### `severity-report`
 
 ```
 ## Blocker
-- [<dimension>] <finding> — `path:line`
+- (none) | [<dimension>] <finding> — `path:line`
   why it matters: <business/behavioral impact>
   fix direction: <one line>
 
 ## High
-- ...
+- (none) | ...
 
-## Medium / Low
-- ...
+## Medium
+- (none) | ...
+
+## Low
+- (none) | ...
 
 ## Verified clean
-<dimensions checked with no findings — name them so the parent knows coverage>
+<dimensions checked with no findings>
 ```
+
+### `taste-test`
+
+```
+## Taste-test
+- Drift: pass | revise — <evidence>
+- Readability: pass | revise — <evidence>
+- Scope: pass | revise — <evidence>
+- Simplify: pass | revise — <evidence>
+- Production path: pass | revise — <evidence>
+- Wired callers: pass | revise — <evidence>
+- Locked decision: pass | halt — <evidence>
+```
+
+Use `revise` only with a concrete correction. Use `halt` only when the diff violates a locked decision.
 
 ## Handoff
 
-Your final message *is* the handback — the orchestrator reads it as the tool result, not the user. Lead with the shared four-field block (the in-session twin of the `/wheypoint` slug) so it can machine-read where you landed, then the Output Format report:
+Your final message *is* the handback — the orchestrator reads it as the tool result, not the user. Lead with this shared four-field block, then append the selected body exactly:
 
 ```
 status: ok | blocked: <one-line reason>
@@ -61,12 +79,11 @@ artifact: <path to fuller output, if any>
 <one-line orientation>
 ```
 
-Default to the inline report. Only when it genuinely exceeds a digest, write it to `.cheese/age/<slug>.md` and return that path as `artifact:` — hand back the severity-grouped findings, not the full trace. When you approach ~120k tokens of context — or run out before finishing — return `status: blocked: out of context` and point `artifact:` at a partial `.cheese/age/<slug>.md` so the parent re-dispatches rather than losing your progress.
+Default to an inline report. Only when it genuinely exceeds a digest, write your own artifact to the path supplied by the pipeline or `.cheese/age/<slug>.md` through `cheez-write`, then return that path as `artifact:`. The registry's `.agents.reviewer.maxTurns` is the role-limit source of truth. Before that limit or the context window is exhausted, checkpoint partial findings to the artifact and return `status: blocked: out of context` so the parent dispatches a fresh reviewer.
 
 ## Rules
 
-- Every finding cites `path:line` and states *why it matters*, not just *what it is*.
-- Default to refuted: if you can't make a concrete case that a finding is real, drop it or downgrade to a question.
-- Name the dimensions you cleared, so "no findings" reads as "checked" rather than "skipped".
-- Weight findings by the file's change risk when `fromage-age-history` flags churn-heavy or bug-prone files.
-- Stop at findings. Do not apply fixes — hand the report back for the code/cure phase.
+- Every severity finding cites `path:line`, states why it matters, and gives a fix direction.
+- Every taste-test verdict cites concrete diff or test evidence.
+- Default to refuted: drop a candidate you cannot make concrete, or label it a question outside the findings schema.
+- Stop at findings or verdicts. Never apply fixes.

--- a/agents/agent_definitions/reviewer.md
+++ b/agents/agent_definitions/reviewer.md
@@ -21,11 +21,18 @@ Cover each dimension. When this review runs at the top level (the orchestrator r
 
 ## What You Do NOT Do
 
-- **Never edit or write code.** You produce findings; the Coder (or `/cure`) applies fixes. You have no Edit/Write tool.
+- **Never modify source.** You produce findings; the Coder (or `/cure`) applies fixes. You have no Edit/Write tool. The one write you may make is your own digest artifact under `.cheese/` (e.g. `.cheese/age/<slug>.md`, or the curd path a pipeline hands you) — write it via `cheez-write`, not a shell redirect, which the write-redirect guard blocks.
 - No severity inflation — don't promote a nit to a blocker to look thorough, and don't bury a real blocker.
 - No unverified claims — if you couldn't confirm it, label it a question, not a finding.
 
 ## Output Format
+
+Two dialects are in circulation and the dispatch prompt does not always say
+which: the severity-grouped findings report below (`/age`), and the per-lens
+`pass | revise | halt` verdict block (the orchestrator's fresh-context
+taste-test). **Use the per-lens verdict block when the prompt names lenses;
+otherwise use the severity report below.** If the prompt names neither, emit the
+severity report and say which you chose in the one-line orientation.
 
 ```
 ## Blocker

--- a/agents/preamble.md
+++ b/agents/preamble.md
@@ -42,8 +42,10 @@ Four general phase-agents model the explore → research → review → code wor
 |---|---|---|
 | "where / how / what" about unfamiliar code — orientation, blast-radius, "find me X" | `explorer` (read-only) | cited findings digest |
 | A question outside the codebase — library/API docs, current web facts, versions, comparisons | `researcher` (read-only on code; writes `.cheese/research/`) | cited claim table + slug path |
-| Checking a diff/PR/branch/path before it lands | `reviewer` (read-only) | severity-grouped findings |
+| Checking a diff/PR/branch/path before it lands | `reviewer` (source-read-only; own artifact allowed) | named severity report or taste-test verdicts |
 | Writing or changing code — spec, bug fix, applying review findings | `coder` (full write surface) | what changed + verification |
+
+Every reviewer dispatch names `Review mode: severity-report` for a full review or `Review mode: taste-test` for the fresh-context gate. Never leave the dialect implicit.
 
 Default self-check before doing phase work inline: "Is this an explore / research / review / code task that a phase-agent should own?" If yes, delegate — don't burn your own context re-deriving what an isolated agent can hand back distilled. Skip delegation only for trivial one-step work where the dispatch overhead exceeds the task.
 
@@ -58,17 +60,17 @@ artifact: <path to fuller output, if any>
 <one-line orientation>
 ```
 
-Default is the inline digest — `artifact:` is omitted when the digest is complete (explorer/reviewer outputs are designed small). When an agent's output is genuinely too large to inline, it writes a durable artifact (`.cheese/<phase>/<slug>.md`, or `.cheese/research/<slug>/` for the researcher) and returns the path as the lightweight reference, which you pass forward instead of re-pasting. `next:` is the agent's recommendation only — you own the routing decision and may override it. A `status: blocked: out of context` handback means the agent hit its context budget (130k tokens / 100 turns) mid-task — never resume the exhausted agent, including via SendMessage: a resumed transcript inherits the spent context and starts near-full. Dispatch a fresh one from the `artifact:` slug so it picks up where the last left off. When that `artifact:` path lives inside a disposable isolation worktree (`.claude/worktrees/agent-*`), copy it to a durable location (the main workspace's `.cheese/` or `.context/`) immediately on receiving the handback, before dispatching the successor — isolation worktrees are auto-cleaned when their tree looks unchanged, and gitignored/untracked artifacts don't count as changes.
+Default is the inline digest — `artifact:` is omitted when the digest is complete (explorer/reviewer outputs are designed small). When output is genuinely too large to inline, the agent writes a durable artifact (`.cheese/<phase>/<slug>.md`, or `.cheese/research/<slug>/` for the researcher) and returns its path. `next:` is advisory; you own routing. Turn caps are role-specific and come from `agents/registry.yaml` `maxTurns`; never apply the coder's cap to other roles. A `status: blocked: out of context` handback means the agent exhausted its role or context budget — never resume it, because the transcript stays spent. Dispatch a fresh agent from the artifact. If the artifact is inside a disposable isolation worktree (`.claude/worktrees/agent-*`), copy it to the main workspace's `.cheese/` or `.context/` before dispatching the successor; ignored artifacts do not keep isolation worktrees alive.
 
 ### Coder fan-out
 
 Default to one coder. Coding is a poor multi-agent fit — it needs shared context, burns far more tokens, and adds coordination overhead — so a coder fan-out only pays off for genuinely independent work. Dispatch multiple `coder` subagents only when the subtasks are file-disjoint and independent (no shared mutable state, no sequential dependency), the same disjointness test `/cheese-factory` applies to curds. Otherwise run a single coder: re-deriving shared context across split coders costs more than the parallelism saves.
 
-**Dispatch sizing — split first, anchor second.** A coder's window is 130k tokens. Across 207 real dispatches, 37% ended `blocked: out of context`, and the failure rate tracks dispatch size almost linearly: 5.6% under 2.5k prompt chars, 18% at 2.5–4k, 56% at 4–6k, 67% above 6k. Anchors do not rescue an oversized dispatch — controlling for length, anchored and unanchored runs fail at the same rate. **Splitting is the lever; anchoring is a refinement.**
+**Dispatch sizing — heuristics, not refusal rules.** Consider splitting when more than ~5 distinct edit sites are in scope, a target file over ~800 lines must be read whole, a test-suite audit rides with implementation, or the prompt has grown past ~4k characters. These thresholds signal risk; split only when you can name a coherent boundary. Otherwise dispatch the cohesive task. Once it fits, pre-stage unfamiliar work with an explorer and inline exact line anchors and seam signatures.
 
-So: split outright when more than ~5 distinct edit sites are in scope, a target file over ~800 lines must be read whole, or a test-suite audit rides along with implementation. Split multi-finding packages so one dispatch carries only what it can complete. Treat your own prompt length as the tell — if you are past ~4k characters, you are probably bundling two dispatches, and pasting more source or more anchors will not fix that. Then pre-stage with an explorer and inline exact line anchors and seam signatures, which buys roughly a quarter off the coder's pre-write exploration (median 14 tool calls → 11) once the job already fits.
+The measurement detail behind these rules lives in `.hallouminate/wiki/operations/subagent-dispatch-analytics.md`; runtime prompts keep the prescriptive contract.
 
-**What every coder dispatch must carry.** Six fields, in this order. The coder validates them on arrival and flags what's missing.
+**What every coder dispatch should carry.** Six fields, in this order. The coder validates them on arrival and flags what's missing.
 
 | field | states |
 |---|---|
@@ -79,7 +81,7 @@ So: split outright when more than ~5 distinct edit sites are in scope, a target 
 | **Locked decisions** | design calls already made and not the coder's to revisit — omit only when there genuinely are none |
 | **Return format** | the handback shape, or "coder default" |
 
-Measured coverage today: 95% name a gate command, 82% carry a scope fence, 64% carry line anchors, 54% state a return format, 34% a handoff schema, and only 7% state locked decisions. Locked decisions and a literal success string are the two cheapest fields to add and the two most often missing.
+A missing field is a prompt to ask or state an assumption, not an automatic refusal. Always provide a literal success condition; provide locked decisions when any exist.
 
 ### Fresh-context taste-test (after `coder` returns)
 
@@ -87,7 +89,7 @@ The `coder` self-checks the taste-test lenses inline, but the writing context ca
 
 **Cost gate.** Run it only when the coder's diff **touches more than one file OR adds public surface** (a new exported function, type, or CLI seam); single-file no-public-surface fixes keep the coder's inline check. A coder-nested `/cook` that cleared the gate records `taste_test: deferred-to-orchestrator` in its slug — your signal to run the pass.
 
-**How.** Dispatch the read-only `reviewer` phase-agent over the coder's diff, **named with no call-site model** — its def pins `model: opus` (Codex `gpt-5`), so on those harnesses it runs at ≥ the writer's tier, never the coder's `sonnet`. (On opencode both defs pin `inherit`, so the pass runs at the orchestrator's tier — your level, not below it.) Not `model: inherit` at the call site (tracks your tier, not the reviewer's pin); not a hardcoded call-site model. Scope the dispatch *prompt* to the lenses below — the same agent `/age` drives, but this is a fast pre-handoff gate, not a full ten-dimension review. Pass `{spec/contract, diff, cut-test list, locked decisions}`; it returns `pass | revise` per lens (`halt` for Locked-decision):
+**How.** Dispatch the named `reviewer` phase-agent with no call-site model so its registry model applies. Set `Review mode: taste-test` explicitly; the reviewer must not infer the mode from lens names. Pass `{spec/contract, diff, cut-test list, locked decisions}`. It prefixes the shared four-field handoff, then returns `pass | revise` for each lens below (`pass | halt` for Locked decision), using the exact taste-test schema in `agents/agent_definitions/reviewer.md`:
 
 - **Drift / readability / scope / simplify** — the standard cook lenses.
 - **Production path** — every spec acceptance criterion has a *production* path that exercises it, not only tests that manufacture the state.

--- a/agents/preamble.md
+++ b/agents/preamble.md
@@ -32,6 +32,8 @@ Before each tool call, ask: "What's the smallest tilth operation that answers th
 
 If unsure, pick the smallest-scope tool that can answer the question. Don't rationalize built-ins with "the file is small" or "I already know the path" — those rationalizations have produced incorrect behavior before.
 
+This rule is enforced by prose, not by the harness. The `tool-reroute` hook only rewrites clean-shape searches and falls through on any regex metacharacter, exotic flag, pipe, or chained command — in practice it catches under 8% of shell searches. Measured routing compliance is 63% for the explorer, 50% for the coder, and 17% for the reviewer, and the leak is read-side: built-in `Read` and shell `grep`/`cat`/`sed`, not `Edit`. Assume nothing will stop you; the self-check is the only gate.
+
 ## Phase-agent delegation (every skill, not just cheese-flow)
 
 Four general phase-agents model the explore → research → review → code workflow. Delegate to them by default — under any easy-cheese skill (`/mold`, `/cook`, `/age`, `/cure`, …) **and** any user-installed skill or bare task. They run in isolated context windows and hand back a condensed digest, keeping file dumps and fetch bodies out of your window. Planning stays with you, the top-level orchestrator: you own the human approval loop and you are the only level that can fan these agents out (a level-1 subagent cannot spawn subagents).
@@ -56,13 +58,28 @@ artifact: <path to fuller output, if any>
 <one-line orientation>
 ```
 
-Default is the inline digest — `artifact:` is omitted when the digest is complete (explorer/reviewer outputs are designed small). When an agent's output is genuinely too large to inline, it writes a durable artifact (`.cheese/<phase>/<slug>.md`, or `.cheese/research/<slug>/` for the researcher) and returns the path as the lightweight reference, which you pass forward instead of re-pasting. `next:` is the agent's recommendation only — you own the routing decision and may override it. A `status: blocked: out of context` handback means the agent hit its context budget (~120k tokens) mid-task — never resume the exhausted agent, including via SendMessage: a resumed transcript inherits the spent context and starts near-full. Dispatch a fresh one from the `artifact:` slug so it picks up where the last left off. When that `artifact:` path lives inside a disposable isolation worktree (`.claude/worktrees/agent-*`), copy it to a durable location (the main workspace's `.cheese/` or `.context/`) immediately on receiving the handback, before dispatching the successor — isolation worktrees are auto-cleaned when their tree looks unchanged, and gitignored/untracked artifacts don't count as changes.
+Default is the inline digest — `artifact:` is omitted when the digest is complete (explorer/reviewer outputs are designed small). When an agent's output is genuinely too large to inline, it writes a durable artifact (`.cheese/<phase>/<slug>.md`, or `.cheese/research/<slug>/` for the researcher) and returns the path as the lightweight reference, which you pass forward instead of re-pasting. `next:` is the agent's recommendation only — you own the routing decision and may override it. A `status: blocked: out of context` handback means the agent hit its context budget (130k tokens / 100 turns) mid-task — never resume the exhausted agent, including via SendMessage: a resumed transcript inherits the spent context and starts near-full. Dispatch a fresh one from the `artifact:` slug so it picks up where the last left off. When that `artifact:` path lives inside a disposable isolation worktree (`.claude/worktrees/agent-*`), copy it to a durable location (the main workspace's `.cheese/` or `.context/`) immediately on receiving the handback, before dispatching the successor — isolation worktrees are auto-cleaned when their tree looks unchanged, and gitignored/untracked artifacts don't count as changes.
 
 ### Coder fan-out
 
 Default to one coder. Coding is a poor multi-agent fit — it needs shared context, burns far more tokens, and adds coordination overhead — so a coder fan-out only pays off for genuinely independent work. Dispatch multiple `coder` subagents only when the subtasks are file-disjoint and independent (no shared mutable state, no sequential dependency), the same disjointness test `/cheese-factory` applies to curds. Otherwise run a single coder: re-deriving shared context across split coders costs more than the parallelism saves.
 
-**Dispatch sizing.** Size each coder dispatch to finish inside one context window (~120k). Pre-stage with an explorer dispatch — hand the coder exact line anchors and seam signatures inlined into its own dispatch prompt, not just a file name — or split the dispatch outright when the target file exceeds ~800 lines, more than ~5 distinct edit sites are in scope, or a full test-suite audit is in scope; split multi-finding packages so one dispatch carries only what it can complete. A coder pre-armed with anchors does near-zero exploration and spends its budget writing; one that burns its budget on investigation hands back a note instead of a diff.
+**Dispatch sizing — split first, anchor second.** A coder's window is 130k tokens. Across 207 real dispatches, 37% ended `blocked: out of context`, and the failure rate tracks dispatch size almost linearly: 5.6% under 2.5k prompt chars, 18% at 2.5–4k, 56% at 4–6k, 67% above 6k. Anchors do not rescue an oversized dispatch — controlling for length, anchored and unanchored runs fail at the same rate. **Splitting is the lever; anchoring is a refinement.**
+
+So: split outright when more than ~5 distinct edit sites are in scope, a target file over ~800 lines must be read whole, or a test-suite audit rides along with implementation. Split multi-finding packages so one dispatch carries only what it can complete. Treat your own prompt length as the tell — if you are past ~4k characters, you are probably bundling two dispatches, and pasting more source or more anchors will not fix that. Then pre-stage with an explorer and inline exact line anchors and seam signatures, which buys roughly a quarter off the coder's pre-write exploration (median 14 tool calls → 11) once the job already fits.
+
+**What every coder dispatch must carry.** Six fields, in this order. The coder validates them on arrival and flags what's missing.
+
+| field | states |
+|---|---|
+| **Task** | what must be true when done, one sentence |
+| **Sites** | every file to touch, each with a line range or symbol name |
+| **Done means** | the literal gate command *and* what green looks like — exit 0, a pass count, a `grep` that must return empty. "Run the gates" is not a success condition |
+| **Scope fence** | what not to touch; whether to commit |
+| **Locked decisions** | design calls already made and not the coder's to revisit — omit only when there genuinely are none |
+| **Return format** | the handback shape, or "coder default" |
+
+Measured coverage today: 95% name a gate command, 82% carry a scope fence, 64% carry line anchors, 54% state a return format, 34% a handoff schema, and only 7% state locked decisions. Locked decisions and a literal success string are the two cheapest fields to add and the two most often missing.
 
 ### Fresh-context taste-test (after `coder` returns)
 

--- a/agents/registry.yaml
+++ b/agents/registry.yaml
@@ -256,7 +256,7 @@ agents:
     maxTurns: 50
     body_path: agents/agent_definitions/researcher.md
   reviewer:
-    description: Multi-dimension code reviewer. Reviews a diff, PR, branch, or path across the ten /age dimensions (correctness, security, encapsulation, spec, complexity, deslop, assertions, NIH, efficiency, telemetry) and returns a severity-grouped findings report. Read-only — never writes fixes; at the top level it draws on the specialist agents (fromage-*, ghostbuster, ricotta-reducer, nih-scanner) for evidence. Models the easy-cheese review phase. Opus-tier. Use PROACTIVELY before merging or shipping any change, after /cook or /cure, and whenever a user-installed skill produces a diff that should be checked before it lands.
+    description: Multi-dimension code reviewer. Reviews a diff, PR, branch, or path through an explicit severity-report or taste-test contract. Source-read-only — never writes fixes; may write only its own .cheese artifact through cheez-write. A top-level /age orchestrator may supply specialist evidence. Models the easy-cheese review phase. Opus-tier. Use PROACTIVELY before merging or shipping any change, after /cook or /cure, and whenever a user-installed skill produces a diff that should be checked before it lands.
     models:
       claude: opus
       codex: gpt-5.6-sol
@@ -274,6 +274,7 @@ agents:
     - age
     - cheez-search
     - cheez-read
+    - cheez-write
     maxTurns: 50
     body_path: agents/agent_definitions/reviewer.md
   coder:

--- a/tests/phase-agent-handoff.bats
+++ b/tests/phase-agent-handoff.bats
@@ -1,5 +1,5 @@
 #!/usr/bin/env bats
-# shellcheck disable=SC1090,SC2034,SC2317
+# shellcheck disable=SC1090,SC2016,SC2034,SC2317
 # Tests for the phase-agent cross-phase handoff convention documented in
 # agents/preamble.md and agents/agent_definitions/{explorer,researcher,reviewer,coder}.md.
 # Locks the spec's core invariant: the four-field handoff block must stay
@@ -71,6 +71,73 @@ block_sha() {
     assert_success
 }
 
+@test "phase handoff defers role-specific turn caps to the registry" {
+    local registry="$AGENTS_DIR/registry.yaml"
+
+    run grep -Fq 'Turn caps are role-specific and come from `agents/registry.yaml` `maxTurns`' "$PREAMBLE"
+    assert_success
+    run grep -Fq '130k tokens / 100 turns' "$PREAMBLE"
+    assert_failure
+
+    run yq '.agents.reviewer.maxTurns' "$registry"
+    [[ "$output" == "50" ]] || { echo "reviewer maxTurns drifted: $output" >&2; return 1; }
+    run yq '.agents.coder.maxTurns' "$registry"
+    [[ "$output" == "100" ]] || { echo "coder maxTurns drifted: $output" >&2; return 1; }
+    run grep -Fq '130k tokens / 100 turns' "$AGENTS_DIR/agent_definitions/coder.md"
+    assert_success
+}
+
+@test "runtime phase prompts keep rules but not dispatch analytics" {
+    local prompt
+    for prompt in "$PREAMBLE" "$AGENTS_DIR/agent_definitions/coder.md"; do
+        for metric in '207 real dispatches' 'Measured coverage today' '37% of real coder runs' 'Real runs route only half'; do
+            run grep -Fq "$metric" "$prompt"
+            assert_failure
+        done
+    done
+}
+
+@test "coder sizing thresholds are heuristics and blocking requires a concrete split" {
+    local coder="$AGENTS_DIR/agent_definitions/coder.md"
+
+    run grep -Fq 'Dispatch sizing — heuristics, not refusal rules.' "$PREAMBLE"
+    assert_success
+    run grep -Fq 'only when you can name a concrete natural split' "$coder"
+    assert_success
+    run grep -Fq 'it will not fit' "$coder"
+    assert_failure
+}
+
+@test "reviewer dispatch selects an explicit output mode and defines both schemas" {
+    local reviewer="$AGENTS_DIR/agent_definitions/reviewer.md"
+
+    run grep -Fq 'Review mode: severity-report' "$reviewer"
+    assert_success
+    run grep -Fq 'Review mode: taste-test' "$reviewer"
+    assert_success
+    run grep -Fq 'Do not infer the mode from words such as “lenses”' "$reviewer"
+    assert_success
+    run grep -Fq -- '- Drift: pass | revise — <evidence>' "$reviewer"
+    assert_success
+    run grep -Fq -- '- Locked decision: pass | halt — <evidence>' "$reviewer"
+    assert_success
+    run grep -Fq 'Review mode: taste-test' "$PREAMBLE"
+    assert_success
+    run grep -Fq 'Review mode: severity-report' "$PREAMBLE"
+    assert_success
+}
+
+@test "reviewer may write only its own artifact through cheez-write" {
+    local registry="$AGENTS_DIR/registry.yaml"
+
+    run yq -e '.agents.reviewer.skills[] | select(. == "cheez-write")' "$registry"
+    assert_success
+    run yq -e '.agents.reviewer.disallowedTools[] | select(. == "Write")' "$registry"
+    assert_success
+    run grep -Fq 'write only your own `.cheese/` artifact through `cheez-write`' "$AGENTS_DIR/agent_definitions/reviewer.md"
+    assert_success
+}
+
 # The descriptions promise read-only phase agents that cannot recurse, and a
 # coder that edits only through tilth (cheez-write). Lock those tool-surface contracts in the
 # registry so they can't silently drift. The same metadata renders to Claude,
@@ -106,7 +173,7 @@ block_sha() {
 
 @test "read-only phase agents deny code edits and subagent fan-out in the registry" {
     local registry="$AGENTS_DIR/registry.yaml"
-    # explorer + reviewer are fully read-only: deny Write and Agent.
+    # explorer + reviewer deny native Write and subagent fan-out; reviewer writes only its own artifact through cheez-write.
     for agent in explorer reviewer; do
         run yq ".agents.${agent}.disallowedTools" "$registry"
         assert_success


### PR DESCRIPTION
## What

Reverse-engineered how we actually dispatch phase agents, using `/session-analytics` over **578 sub-agent runs** reconstructed from sidechain transcripts (42,617 entries, all resolved). Then fixed what the data showed was broken.

Method note: sub-agent turns are inlined in the parent transcript tagged `isSidechain`, not stored as separate sessions — you recover a run by walking `parentUuid` from each root, then joining the root's first user message back to the `Agent` tool call to get `subagent_type`. Full query pack is in the PR.

## The three findings that drove changes

### 1. Dispatch size — not dispatch detail — predicts coder failure

**77 of 207 coder runs (37%) ended `status: blocked: out of context`.** Only 3 hit the hard harness ceiling, so the checkpoint discipline in `coder.md` is working correctly — it just shouldn't have to fire this often. Failure rate vs. prompt length:

| prompt size | runs | out-of-context |
|---|---|---|
| < 2.5k chars | 18 | **5.6%** |
| 2.5–4k | 89 | **18.0%** |
| 4–6k | 70 | **55.7%** |
| > 6k | 30 | **66.7%** |

A 12× swing. Length here is a proxy for bundled scope, not verbosity — the five longest prompts (up to 26.8k chars) carry the *same contract density per task* as a 3k prompt and differ only by task count (one bundles 8 tasks across 7+ files), pasted source, and re-stated resume state from a run that already blew its budget.

**The preamble was optimizing the wrong variable.** It advised pre-staging an explorer so the coder arrives "pre-armed with anchors" and does "near-zero exploration". Controlling for length, anchors make no difference to whether the job fits:

| | runs | out-of-context |
|---|---|---|
| long (≥4k), anchors | 60 | 61.7% |
| long (≥4k), no anchors | 40 | 55.0% |
| short (<4k), anchors | 41 | 19.5% |
| short (<4k), no anchors | 66 | 13.6% |

Anchors *are* worth having — median pre-write tool calls 14 → 11, wall-clock 341s → 291s — but as a refinement after the job already fits. Splitting is the lever.

### 2. The routing preamble is enforced by prose alone

`tool-reroute/search.js` rewrites only "clean shape" searches; it returns `null` on any regex metacharacter, long flag, exotic short flag, or pipe/chain. Applying those same predicates to real traffic:

| agent | shell `grep`/`rg`/`find` calls | would be rewritten |
|---|---|---|
| coder | 909 | **70 (7.7%)** |
| reviewer | 190 | 2 (1.1%) |
| explorer | 143 | 5 (3.5%) |

Every sampled coder `grep` fell through — usually alternation (`^<<<<<<<\|^=======`) or a `;` chain. Resulting compliance:

| agent | tilth | built-in | shell | tilth share |
|---|---|---|---|---|
| coder | 2199 | 722 | 1513 | **49.6%** |
| explorer | 630 | 147 | 228 | **62.7%** |
| reviewer | 152 | 448 | 322 | **16.5%** |

The leak is entirely read-side. The *write* half of the rule holds — 37 `Edit` calls total, and two runs correctly returned `blocked` when `tilth_write` was unloaded — because `Grep`/`Glob`/`Edit`/`Write` are stripped from the grant. `Read` and `Bash` are granted and are the open doors.

**Answering the question directly: the context hooks are not too strict — they're too loose to bind.** Genuine over-blocking across all 578 runs is negligible: 19 write-redirect blocks, 2 sensitive-file, 2 dirty-tree git. All correct catches, none spurious.

### 3. The reviewer's read-only rule is false as written

`reviewer.md` says "Never edit or write code… You have no Edit/Write tool", yet reviewer runs made 16 `tilth_write` calls. Every one writes a handoff artifact (`.cheese/ultracook/<slug>/curds/N/age.md`) that the pipeline *requires* — and the write-redirect guard blocks the shell path 11 times, forcing trial-and-error discovery of the MCP path.

## Supporting findings

- **Coder burns ~40% of its budget before its first write** (median 13 tool calls; 10 runs wrote nothing at all). 60% of those pre-write calls are Bash — top commands `cd` 473, `grep` 411, `cat` 148, `sed` 116.
- **Two reviewer output dialects circulate** with nothing saying which applies: the `/age` `blocker|high|medium|low` findings block (34% of prompts) and the taste-test `pass|revise|halt` per-lens block (48%).
- **Field coverage across 207 coder dispatches**: gate command 95%, scope fence 82%, line anchors 64%, return format 54%, handoff schema 34%, **locked decisions 7%**, resume-doc pointer 7%. `explorer` is the healthiest agent by a wide margin — 90% state an output contract, 92% demand `file:line` — and correspondingly has the shortest, cleanest runs (median 89s, 2.6% error).

## Changes

**`agents/preamble.md`** — replaced the anchor-centric dispatch-sizing paragraph with the evidence-based split-first rule, plus the six-field coder dispatch contract as a table with measured coverage per field. Added the enforcement-reality note to the routing self-check. Corrected the documented context budget (120k → 130k/100 turns) against the observed harness error.

**`agents/agent_definitions/coder.md`** — new "Dispatch Contract" section the coder validates on arrival; explicit instruction to return `blocked: dispatch exceeds one window` on *turn one* rather than discovering it at 100k tokens. Extended the no-host-file-tools rule to name reads and searches, since that's where the leak is.

**`agents/agent_definitions/reviewer.md`** — "never write" → "never modify source", naming the sanctioned `.cheese/` artifact path and the `cheez-write` route. Pinned which output dialect applies.

**Wiki** — `operations/subagent-dispatch-analytics.md` (full findings) + `operations/references/subagent-runs.md` (reproducible query pack, including the gotchas: `raw_entries.filename` is NULL for Claude so you must filter on `isSidechain`; `tool_results.content` truncates at 500 chars so byte sums are floors).

## What the coder should ALWAYS receive

| field | states |
|---|---|
| **Task** | what must be true when done, one sentence |
| **Sites** | every file to touch, each with a line range or symbol name |
| **Done means** | the literal gate command *and* what green looks like — exit 0, a pass count, a `grep` that must return empty. "Run the gates" is not a success condition |
| **Scope fence** | what not to touch; whether to commit |
| **Locked decisions** | design calls already made and not the coder's to revisit |
| **Return format** | the handback shape, or "coder default" |

Locked decisions and a literal success string are the two cheapest to add and the two most often missing.

## Deliberately not done

Widening `search.js` to *deny with guidance* on exotic-shape searches is the only change that would move finding 2 materially — but it risks blocking legitimate pipes and redirects used for gate-output parsing, and the current conservatism ("never silently change search semantics") is correct in isolation. Written up as an open proposal in the wiki page; it needs its own spec.

## Verification

`just check` → exit 0 (151 tests pass). `dots sync` run before commit; prek sync check passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
