### PR TITLE
fix(mise): correct broken aqua-registry paths for tmux, mergiraf, nextest, protobuf

### DIFF
--- a/chezmoi/dot_config/mise/config.toml
+++ b/chezmoi/dot_config/mise/config.toml
@@ -17,7 +17,13 @@
 #     this isn't a guess at a stripped form, it's the module version itself.
 #
 # rust-analyzer uses a date-stamp release tag (not semver) and tmux uses
-# `3.7b` — both kept as-is, not normalized to look more like semver.
+# `v3.7b` — both kept as-is, not normalized to look more like semver.
+#
+# tmux, protobuf, mergiraf, and nextest-rs/nextest are pinned via
+# sub-package aqua IDs (`tmux/tmux-builds`, `.../protobuf/protoc`,
+# `codeberg.org/mergiraf/mergiraf`, `nextest-rs/nextest/cargo-nextest`) —
+# the bare `owner/repo` IDs 404 against aqua-registry; these are the actual
+# registry paths (verified against aquaproj/aqua-registry@main).
 
 [tools]
 "aqua:jqlang/jq" = "jq-1.8.2"
@@ -34,7 +40,7 @@
 "aqua:ast-grep/ast-grep" = "0.45.0"
 "aqua:dandavison/delta" = "0.19.2"
 "aqua:git-lfs/git-lfs" = "v3.7.1"
-"aqua:tmux/tmux" = "3.7b"
+"aqua:tmux/tmux-builds" = "v3.7b"
 "aqua:j178/prek" = "v0.4.11"
 "aqua:ajeetdsouza/zoxide" = "v0.10.0"
 "aqua:atuinsh/atuin" = "v18.17.1"
@@ -44,7 +50,7 @@
 "aqua:XAMPPRocky/tokei" = "v14.0.0"
 "aqua:sxyazi/yazi" = "v26.5.6"
 "aqua:Wilfred/difftastic" = "0.69.0"
-"aqua:mergiraf/mergiraf" = "v0.18.0"
+"aqua:codeberg.org/mergiraf/mergiraf" = "v0.18.0"
 "aqua:jesseduffield/lazygit" = "v0.63.1"
 "aqua:git-town/git-town" = "v24.0.0"
 "aqua:joshmedeski/sesh" = "v2.27.0"
@@ -56,8 +62,8 @@
 "aqua:anomalyco/opencode" = "v1.18.5"
 "aqua:charmbracelet/crush" = "v0.87.0"
 "aqua:mozilla/sccache" = "v0.16.0"
-"aqua:nextest-rs/nextest" = "cargo-nextest-0.9.140"
-"aqua:protocolbuffers/protobuf" = "v35.1"
+"aqua:nextest-rs/nextest/cargo-nextest" = "cargo-nextest-0.9.140"
+"aqua:protocolbuffers/protobuf/protoc" = "v35.1"
 "aqua:mas-cli/mas" = "v7.0.0"
 "aqua:astral-sh/uv" = "0.11.32"
 "aqua:rust-lang/rust-analyzer" = "2026-07-20"

--- a/tests/mise-config.bats
+++ b/tests/mise-config.bats
@@ -56,9 +56,9 @@ CONFIG="$DOTFILES_DIR/chezmoi/dot_config/mise/config.toml"
     [[ "$(yq -p=toml '.tools."aqua:rtk-ai/rtk"' "$CONFIG")" == "v0.43.0" ]]
 }
 
-@test "non-semver tag shapes are kept raw (rust-analyzer date-stamp, tmux 3.7b)" {
+@test "non-semver tag shapes are kept raw (rust-analyzer date-stamp, tmux v3.7b)" {
     [[ "$(yq -p=toml '.tools."aqua:rust-lang/rust-analyzer"' "$CONFIG")" == "2026-07-20" ]]
-    [[ "$(yq -p=toml '.tools."aqua:tmux/tmux"' "$CONFIG")" == "3.7b" ]]
+    [[ "$(yq -p=toml '.tools."aqua:tmux/tmux-builds"' "$CONFIG")" == "v3.7b" ]]
 }
 
 @test "core-plugin tools (node, bun, rust) are stripped of git-tag prefixes" {


### PR DESCRIPTION
## Summary

- `dots sync` was spamming ~30 `mise WARN` lines per run because four `aqua:` tool IDs in `chezmoi/dot_config/mise/config.toml` don't exist in `aquaproj/aqua-registry` (confirmed 404 for each raw path) — installing any of them directly hard-failed with `registry not available`.
- Repointed each to its real registry path:
  - `aqua:tmux/tmux` → `aqua:tmux/tmux-builds` (also fixes the version tag: this repo tags `v3.7b`, not bare `3.7b`)
  - `aqua:mergiraf/mergiraf` → `aqua:codeberg.org/mergiraf/mergiraf` (hosted on Codeberg, not GitHub)
  - `aqua:nextest-rs/nextest` → `aqua:nextest-rs/nextest/cargo-nextest`
  - `aqua:protocolbuffers/protobuf` → `aqua:protocolbuffers/protobuf/protoc`
- Updated `tests/mise-config.bats` to match the corrected tmux key/version.

This surfaced while chasing down why `codex` wasn't installed locally (separate, unrelated cause: `packages/sync.sh`'s cache-hit path only force-converges `claude-code`, not the full mise tool list — not addressed here).

## Test plan

- [x] `mise install "aqua:tmux/tmux-builds@v3.7b"`, `.../mergiraf@v0.18.0`, `.../protoc@v35.1`, `.../cargo-nextest@cargo-nextest-0.9.140` — all install clean, zero warnings
- [x] `mise ls` — all four resolve at pinned version, no `(missing)`/warn output
- [x] `dots sync` — chezmoi apply deploys the corrected config cleanly
- [x] `just check` — lint + full bats suite (1270 tests) green
