### PR TITLE
fix(mise): migrate tokei/eza to cargo backend, drop gopls

### DIFF
--- a/.hallouminate/wiki/operations/mise-aqua-backend-retypes.md
+++ b/.hallouminate/wiki/operations/mise-aqua-backend-retypes.md
@@ -1,0 +1,31 @@
+# mise gotcha — aqua-registry package retypes break pins without a version change
+
+The aqua registry can retype a package upstream (e.g. when a project stops
+shipping prebuilt binaries). mise's aqua backend only supports binary-type
+packages, so a pin that installed fine yesterday fails today with
+`package type X is not supported in the aqua backend` — **the version is
+irrelevant; the fix is a backend migration, not a version bump.**
+
+Observed 2026-07-27 (session: dots sync failure):
+
+- `aqua:XAMPPRocky/tokei` and `aqua:eza-community/eza` retyped to `cargo`
+  → migrated to `cargo:tokei` / `cargo:eza` (bare crates.io semver, compiled
+  by the mise-managed rust toolchain; no cargo-binstall on the machine).
+- `aqua:golang.org/x/tools/gopls` is `go_install`-type — unusable via aqua
+  AND the go backend needs a full Go toolchain. gopls was **dropped** from
+  the manifest (no Go work on this machine; `bin/gopls` wrapper pointed at a
+  long-gone `/opt/homebrew/bin/gopls` and was deleted too). Re-add alongside
+  a pinned `go` core-plugin entry if Go work starts.
+
+Verify a backend migration before editing: `mise ls-remote <backend>:<pkg>`
+must list the pinned version. `tests/mise-config.bats` asserts the manifest
+tool count and per-backend pins — update it in the same change.
+
+Related fallout: the pinning migration's brew shrink removed brew bash 5, so
+`/bin/bash` (3.2) is now the only bash on PATH. Under `set -u`, bash 3.2
+treats empty-array expansion `"${arr[@]}"` as unbound (legal in bash 4.4+) —
+a latent class of breakage in `bin/` scripts that CI (newer bash) never
+catches. Guard with `${arr[@]+"${arr[@]}"}` (fixed in `bin/dotsclaude`;
+`tests/cc-env.bats` test 109 is the canary).
+
+Related: [[adr/manifest-pinned-packages]], [[operations/sync-and-chezmoi]].

--- a/bin/gopls
+++ b/bin/gopls
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-# Wrapper that runs gopls in daemon mode (-remote=auto).
-# A single shared daemon serves all clients (editors, worktrees, agents),
-# eliminating redundant cold starts and type-checking across parallel sessions.
-# Falls back to direct invocation if the daemon flag is unsupported.
-exec /opt/homebrew/bin/gopls -remote=auto "$@"

--- a/chezmoi/dot_config/mise/config.toml
+++ b/chezmoi/dot_config/mise/config.toml
@@ -12,9 +12,14 @@
 #     itself reports, stripped of any git-tag prefix (mise core plugins
 #     query the tool's own version scheme, not a GitHub tag).
 #   - npm-backend entries: bare semver (npm versions never carry a prefix).
-#   - go-backend entry (gopls): kept with its `v` prefix — Go module
-#     versions are always `vX.Y.Z` per the Go modules versioning spec, so
-#     this isn't a guess at a stripped form, it's the module version itself.
+#   - cargo-backend entries (eza, tokei): bare crates.io semver. Both were
+#     aqua-pinned until the aqua registry retyped them as `cargo`-type
+#     packages (no prebuilt binaries), which mise's aqua backend refuses.
+#
+# gopls was dropped 2026-07-27: the aqua registry types it `go_install`
+# (unsupported by mise's aqua backend) and the go backend needs a full Go
+# toolchain — no Go work on this machine. Re-add alongside a pinned `go`
+# core-plugin entry if that changes.
 #
 # rust-analyzer uses a date-stamp release tag (not semver) and tmux uses
 # `v3.7b` — both kept as-is, not normalized to look more like semver.
@@ -34,7 +39,6 @@
 "aqua:bats-core/bats-core" = "v1.14.0"
 "aqua:BurntSushi/ripgrep" = "15.2.0"
 "aqua:sharkdp/fd" = "v10.4.2"
-"aqua:eza-community/eza" = "v0.23.5"
 "aqua:sharkdp/bat" = "v0.26.1"
 "aqua:charmbracelet/glow" = "v2.1.2"
 "aqua:ast-grep/ast-grep" = "0.45.0"
@@ -47,7 +51,6 @@
 "aqua:ClementTsang/bottom" = "0.14.6"
 "aqua:bootandy/dust" = "v1.2.4"
 "aqua:dalance/procs" = "v0.14.12"
-"aqua:XAMPPRocky/tokei" = "v14.0.0"
 "aqua:sxyazi/yazi" = "v26.5.6"
 "aqua:Wilfred/difftastic" = "0.69.0"
 "aqua:codeberg.org/mergiraf/mergiraf" = "v0.18.0"
@@ -79,4 +82,5 @@ rust = "1.97.1"
 "npm:bash-language-server" = "5.6.0"
 "npm:yaml-language-server" = "1.24.0"
 "npm:pyright" = "1.1.411"
-"go:golang.org/x/tools/gopls" = "v0.23.0"
+"cargo:eza" = "0.23.5"
+"cargo:tokei" = "14.0.0"

--- a/tests/mise-config.bats
+++ b/tests/mise-config.bats
@@ -14,10 +14,10 @@ CONFIG="$DOTFILES_DIR/chezmoi/dot_config/mise/config.toml"
     [[ $status -eq 0 ]]
 }
 
-@test "mise config pins exactly 52 tools (45 aqua + 3 core-plugin + 4 backend)" {
+@test "mise config pins exactly 51 tools (43 aqua + 3 core-plugin + 5 backend)" {
     run yq -p=toml -o=json '.tools | length' "$CONFIG"
     [[ $status -eq 0 ]]
-    [[ "$output" == "52" ]]
+    [[ "$output" == "51" ]]
 }
 
 @test "no tool version is 'latest' or a floating range specifier" {
@@ -76,5 +76,11 @@ CONFIG="$DOTFILES_DIR/chezmoi/dot_config/mise/config.toml"
     [[ "$(yq -p=toml '.tools."npm:bash-language-server"' "$CONFIG")" == "5.6.0" ]]
     [[ "$(yq -p=toml '.tools."npm:yaml-language-server"' "$CONFIG")" == "1.24.0" ]]
     [[ "$(yq -p=toml '.tools."npm:pyright"' "$CONFIG")" == "1.1.411" ]]
-    [[ "$(yq -p=toml '.tools."go:golang.org/x/tools/gopls"' "$CONFIG")" == "v0.23.0" ]]
+    [[ "$(yq -p=toml '.tools."cargo:eza"' "$CONFIG")" == "0.23.5" ]]
+    [[ "$(yq -p=toml '.tools."cargo:tokei"' "$CONFIG")" == "14.0.0" ]]
+}
+
+@test "gopls stays dropped (needs a Go toolchain; aqua entry is go_install-type)" {
+    run grep -c 'gopls' <(yq -p=toml -o=json '.tools | keys' "$CONFIG")
+    [[ "$output" == "0" ]]
 }


### PR DESCRIPTION
## What

- Migrate `tokei` and `eza` from the aqua backend to the cargo backend —
  same pins (`14.0.0`, `0.23.5`), new install path.
- Drop `gopls` from the mise manifest and delete the dead `bin/gopls`
  wrapper.
- Update `tests/mise-config.bats` (51 tools, cargo-backend assertions,
  gopls-stays-dropped canary) and record the gotcha in the wiki
  (`operations/mise-aqua-backend-retypes`).

**Semantics-altering** (fixes `dots sync` convergence): the aqua registry
retyped tokei and eza as `cargo`-type packages (no prebuilt binaries),
which mise's aqua backend refuses — every sync failed and the package
cache never saved.

## Why gopls is dropped rather than fixed

Its aqua entry is `go_install`-type (also unsupported), and the go backend
needs a full Go toolchain. No Go work exists on this machine, gopls never
installed since the pinning migration, and `bin/gopls` pointed at a
long-gone `/opt/homebrew/bin/gopls`. Re-add alongside a pinned `go`
core-plugin entry if Go work starts.

## Reviewer verification

- Pins unchanged for tokei/eza; both versions verified present on the
  cargo backend via `mise ls-remote` before the edit.
- `dots sync` exit 0 with package cache saved; `tokei 14.0.0` and
  `eza v0.23.5` resolve on PATH.
- Local gate: `just check` green on this branch (bats 1..1280).

Stacked on #541: the local test suite needs the dotsclaude bash-3.2
guard to run green on this machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
