### PR TITLE
fix(packages): drop serena-agent re-added by pinning migration

### DIFF
--- a/packages/packages.yaml
+++ b/packages/packages.yaml
@@ -77,9 +77,6 @@ packages:
   # renovate: datasource=pypi depName=tavily-cli
   - tavily-cli: { source: uv, version: "0.1.5" } # provides `tvly` CLI for Tavily API
   - milknado: { source: uv, pkg: "git+https://github.com/paulnsorensen/milknado@main" } # approved floating own-authored channel
-  # Serena pins Python 3.13 and ships pre-release builds on PyPI.
-  # renovate: datasource=pypi depName=serena-agent
-  - serena-agent: { source: uv, version: "1.6.1", flags: ["--python", "3.13", "--prerelease=allow"] }
 
   # gh CLI extensions
   # renovate: datasource=github-releases depName=github/gh-stack

--- a/tests/packages-yaml-pins.bats
+++ b/tests/packages-yaml-pins.bats
@@ -6,7 +6,7 @@
 DOTFILES_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME}")/.." && pwd)"
 PACKAGES_YAML="$DOTFILES_DIR/packages/packages.yaml"
 
-# entry_name:datasource — the 14 pinned entries and their expected Renovate datasource
+# entry_name:datasource — the 13 pinned entries and their expected Renovate datasource
 PINNED_ENTRIES=(
     "vtsls:npm"
     "eslint:npm"
@@ -19,7 +19,6 @@ PINNED_ENTRIES=(
     "check-jsonschema:pypi"
     "skills-ref:git-refs"
     "tavily-cli:pypi"
-    "serena-agent:pypi"
     "gh-stack:github-releases"
     "cargo-update:crate"
 )
@@ -29,7 +28,7 @@ PINNED_ENTRIES=(
     [[ $status -eq 0 ]]
 }
 
-@test "each of the 14 pinned entries has a version or rev key" {
+@test "each of the 13 pinned entries has a version or rev key" {
     for pair in "${PINNED_ENTRIES[@]}"; do
         local name="${pair%%:*}"
         local version rev
@@ -86,7 +85,7 @@ PINNED_ENTRIES=(
     [[ -z "$pkg" ]]
 }
 
-@test "each of the 14 pinned entries has an adjacent renovate annotation with a valid datasource" {
+@test "each of the 13 pinned entries has an adjacent renovate annotation with a valid datasource" {
     for pair in "${PINNED_ENTRIES[@]}"; do
         local name="${pair%%:*}"
         local expected_ds="${pair##*:}"


### PR DESCRIPTION
## Why

PR #512 (Jul 24) retired Serena entirely — MCP registry, package entry, chezmoi config, Copilot template ([wiki: architecture/serena-retirement](.hallouminate/wiki/architecture/serena-retirement.md)). PR #516 (Jul 25, the pinning migration) branched before #512 merged and reintroduced the `serena-agent` uv entry, with a comment claiming the MCP registry still invokes the binary — it doesn't. Repo-wide search shows zero consumers.

## Changes

- `packages/packages.yaml`: remove the `serena-agent` entry (+ its renovate annotation)
- `tests/packages-yaml-pins.bats`: pin-coverage list 14 → 13 entries

Machine-side, `serena-agent` is already `uv tool uninstall`ed.

## Verification

`just check` exit 0 (lint + test + smoke, 152 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)