### PR TITLE
fix(claude): self-heal native plugin installs on out-of-band drift

### DIFF
--- a/chezmoi/.chezmoiscripts/run_onchange_after_sync-claude-plugins.sh.tmpl
+++ b/chezmoi/.chezmoiscripts/run_onchange_after_sync-claude-plugins.sh.tmpl
@@ -14,6 +14,15 @@
 # apply.
 #
 # registry plugins hash: {{ output "sh" "-c" (printf "shasum -a 256 %q/../agents/plugins/registry.yaml 2>/dev/null | cut -d' ' -f1" .chezmoi.sourceDir) }}
+#
+# Also embed a projection (not a whole-file hash) of live runtime state:
+# installed_plugins.json carries lastUpdated/gitCommitSha fields that churn on
+# every CLI plugin refresh, so hashing the whole file would re-run this prime
+# on every apply. Projecting just the set of user-scope install ids and
+# indexed marketplace names catches an out-of-band uninstall (the drift class
+# that motivated this) while staying quiet when nothing meaningful changed.
+# installed user-scope ids: {{ output "sh" "-c" "jq -r '(.plugins // {}) | to_entries[] | select(.value | any(.scope==\"user\")) | .key' ~/.claude/plugins/installed_plugins.json 2>/dev/null | sort | tr '\n' ' ' || true" }}
+# indexed marketplaces:     {{ output "sh" "-c" "jq -r 'keys[]' ~/.claude/plugins/known_marketplaces.json 2>/dev/null | sort | tr '\n' ' ' || true" }}
 
 set -euo pipefail
 

--- a/chezmoi/lib/claude-plugin-reconcile.sh
+++ b/chezmoi/lib/claude-plugin-reconcile.sh
@@ -55,6 +55,7 @@ claude_plugin_reconcile() {
         < <(jq -r '.[].key' <<<"$desired_json")
 
     _in() { local n="$1"; shift; local x; for x in "$@"; do [[ "$x" == "$n" ]] && return 0; done; return 1; }
+    _user_installed() { [[ -f "$installed_file" ]] && jq -e --arg id "$1" '(.plugins[$id] // []) | any(.scope == "user")' "$installed_file" >/dev/null 2>&1; }
 
     # ── prime ──────────────────────────────────────────────────────────────
     # Add each desired marketplace by root; record its canonical name (taken
@@ -82,6 +83,31 @@ claude_plugin_reconcile() {
         fi
     done < <(jq -r '.[] | [.key, .marketplace_root] | @tsv' <<<"$desired_json")
 
+    # ── install desired plugins at user scope ────────────────────────────────
+    # Enabling via settings.json does not populate installed_plugins.json; the
+    # CLI must install. Idempotent: skip ids already user-installed. Verify by
+    # post-condition rather than exit code: `claude plugin install`'s exit code
+    # does not distinguish a real failure from an "already installed" nonzero,
+    # so re-read installed_file and assert the id landed at user scope. A real
+    # failure sets rc=1, which defers the destructive prune/uninstall legs
+    # below, leaves the manifest unchanged, and propagates to the caller so
+    # chezmoi retries this run_onchange on the next apply.
+    if [[ -n "$installed_file" ]]; then
+        local id
+        for id in "${owned_ids[@]:-}"; do
+            [[ -z "$id" ]] && continue
+            if _user_installed "$id"; then
+                continue
+            fi
+            echo "  Installing plugin (user scope): $id"
+            claude plugin install "$id" >/dev/null 2>&1 || true
+            if ! _user_installed "$id"; then
+                echo "  WARN: 'claude plugin install $id' did not result in a user-scope install — run 'claude plugin install $id' by hand." >&2
+                rc=1
+            fi
+        done
+    fi
+
     # ── prune (manifest-owned marketplaces only) ───────────────────────────
     if [[ -f "$manifest" ]]; then
         while IFS= read -r _n; do [[ -n "$_n" ]] && prior_names+=("$_n"); done < "$manifest"
@@ -102,24 +128,6 @@ claude_plugin_reconcile() {
                 echo "  Removing retired marketplace: $m"
                 claude plugin marketplace remove "$m" >/dev/null 2>&1 || rc=1
             fi
-        done
-    fi
-
-    # ── install desired plugins at user scope ────────────────────────────────
-    # Enabling via settings.json does not populate installed_plugins.json; the
-    # CLI must install. Idempotent: skip ids already user-installed; tolerate an
-    # "already installed" nonzero exit without failing the reconcile.
-    if [[ -n "$installed_file" ]]; then
-        local id
-        for id in "${owned_ids[@]:-}"; do
-            [[ -z "$id" ]] && continue
-            if [[ -f "$installed_file" ]] \
-                && jq -e --arg id "$id" '(.plugins[$id] // []) | any(.scope == "user")' "$installed_file" >/dev/null 2>&1; then
-                continue
-            fi
-            echo "  Installing plugin (user scope): $id"
-            claude plugin install "$id" >/dev/null 2>&1 \
-                || echo "  WARN: 'claude plugin install $id' failed (may already be installed) — left as-is." >&2
         done
     fi
 

--- a/tests/chezmoi-wiring.bats
+++ b/tests/chezmoi-wiring.bats
@@ -447,6 +447,17 @@ EOF
     grep -qF '.chezmoi-mcp-manifest' "$MCP_TMPL"
 }
 
+@test "plugin reconcile run_onchange embeds an installed user-scope ids projection" {
+    local plugin_tmpl="$REAL_DOTFILES_DIR/chezmoi/.chezmoiscripts/run_onchange_after_sync-claude-plugins.sh.tmpl"
+    assert_file_exists "$plugin_tmpl"
+    # A projection of installed_plugins.json (not a whole-file hash — see the
+    # in-template rationale) so an out-of-band uninstall re-runs the reconcile
+    # on the next sync without any repo file changing (spec:
+    # plugin-reconcile-self-heal, Change 1).
+    grep -qF 'installed user-scope ids:' "$plugin_tmpl"
+    grep -qF '.claude/plugins/installed_plugins.json' "$plugin_tmpl"
+}
+
 @test "MCP reconcile run_onchange renders and fails loud without jq/yq" {
     command -v chezmoi >/dev/null 2>&1 || skip "chezmoi not installed"
     local script="$TEST_HOME/mcp-onchange.sh"

--- a/tests/claude-plugin-reconcile.bats
+++ b/tests/claude-plugin-reconcile.bats
@@ -294,3 +294,92 @@ SH
     # Manifest byte-for-byte unchanged.
     diff <(printf 'gone\nmilknado\n') "$MANIFEST"
 }
+
+@test "reconcile: install exits 0 but does not write installed_plugins.json → verified failure, WARN, manifest unchanged" {
+    # A plugin install that reports success but never lands the entry must not
+    # be swallowed as "already installed" — verify the post-condition instead
+    # of trusting the exit code (spec: plugin-reconcile-self-heal, Change 2).
+    mk_cache milknado milknado >/dev/null
+
+    # Override the mock: 'plugin install' exits 0 without touching $INSTALLED.
+    cat > "$TEST_HOME/fake-bin/claude" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$CALLS"
+case "$1 $2" in
+    "plugin marketplace")
+        case "$3" in
+            add)
+                root="$4"
+                name=$(jq -r '.name' "$root/.claude-plugin/marketplace.json")
+                jq --arg n "$name" --arg p "$root" \
+                    '.[$n] = {source: {source: "directory", path: $p}}' "$KNOWN" > "$KNOWN.tmp" \
+                    && mv "$KNOWN.tmp" "$KNOWN"
+                ;;
+        esac
+        ;;
+    "plugin install") ;;  # exits 0, INSTALLED left untouched
+esac
+exit 0
+SH
+    chmod +x "$TEST_HOME/fake-bin/claude"
+
+    mkdir -p "${MANIFEST%/*}"
+    printf 'stale\n' > "$MANIFEST"
+    local manifest_before
+    manifest_before=$(cat "$MANIFEST")
+
+    run_reconcile_installed "$(jq -nc --argjson a "$(desired_entry milknado)" '[$a]')"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"WARN"* ]]
+    [[ "$output" == *"milknado@milknado"* ]]
+    [[ "$output" == *"claude plugin install milknado@milknado"* ]]
+    # Failed install → manifest rewrite skipped → byte-identical to before.
+    [ "$(cat "$MANIFEST")" = "$manifest_before" ]
+    # No destructive marketplace op ran despite the install failure.
+    run grep -q "marketplace remove" "$CALLS"; [ "$status" -ne 0 ]
+}
+
+@test "reconcile: install exits 1 but the id lands at user scope → treated as success (|| true tolerance)" {
+    # The CLI's install exit code is ambiguous (nonzero can mean "already
+    # installed"); the post-condition check is what actually decides. Drive
+    # the real install path (not the skip check) by leaving milknado@milknado
+    # OUT of $INSTALLED beforehand, and have the stub land the user-scope
+    # entry itself before exiting 1 — this is the only way to exercise the
+    # `|| true` tolerance around a real 'claude plugin install' call.
+    mk_cache milknado milknado >/dev/null
+
+    cat > "$TEST_HOME/fake-bin/claude" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$CALLS"
+case "$1 $2" in
+    "plugin marketplace")
+        case "$3" in
+            add)
+                root="$4"
+                name=$(jq -r '.name' "$root/.claude-plugin/marketplace.json")
+                jq --arg n "$name" --arg p "$root" \
+                    '.[$n] = {source: {source: "directory", path: $p}}' "$KNOWN" > "$KNOWN.tmp" \
+                    && mv "$KNOWN.tmp" "$KNOWN"
+                ;;
+        esac
+        ;;
+    "plugin install")
+        id="$3"
+        jq --arg id "$id" '.plugins[$id] = [{scope: "user"}]' "$INSTALLED" > "$INSTALLED.tmp" \
+            && mv "$INSTALLED.tmp" "$INSTALLED"
+        exit 1
+        ;;
+esac
+exit 0
+SH
+    chmod +x "$TEST_HOME/fake-bin/claude"
+
+    run_reconcile_installed "$(jq -nc --argjson a "$(desired_entry milknado)" '[$a]')"
+    [ "$status" -eq 0 ]
+    # Real install path ran (id not pre-seeded — skip check did not short-circuit).
+    grep -q "plugin install milknado@milknado" "$CALLS"
+    # Post-condition verify saw the user-scope landing despite the nonzero exit.
+    [ "$(jq -r '.plugins["milknado@milknado"][0].scope' "$INSTALLED")" = "user" ]
+    [ -f "$MANIFEST" ]
+    grep -qx "milknado" "$MANIFEST"
+}


### PR DESCRIPTION
## Problem

Native-claude plugins (`hallouminate`, `milknado`) are installed into `~/.claude/plugins/installed_plugins.json` by exactly one thing: the install leg of `claude_plugin_reconcile`, dispatched from `run_onchange_after_sync-claude-plugins.sh.tmpl`. That script's only rerun trigger was the sha256 of `agents/plugins/registry.yaml`, so `dots sync` could only repair plugin state on a sync where that file changed.

Observed 2026-07-27: the Claude CLI rewrote `installed_plugins.json` to `"version": 2` and kept only the four `claude-plugins-official` entries. Everything else stayed consistent, so nothing noticed:

| State | hallouminate / milknado |
|---|---|
| `settings.json` `enabledPlugins` | ✅ both `true` |
| `settings.json` `extraKnownMarketplaces` | ✅ both |
| `known_marketplaces.json` | ✅ both |
| `installed_plugins.json` | ❌ **neither** |

Enabled and indexed but not installed → the CLI loads nothing. Both plugins' MCP servers and skills vanished from every session. `chezmoi diff` was clean and `dots sync` was a no-op, because the registry hash had not moved. A manual `claude plugin install <id>` succeeded first try for both, so nothing was wrong with the payloads.

Compounding: the install leg treated any nonzero `claude plugin install` as "may already be installed" and swallowed it, so a genuinely failed install neither failed the sync nor got retried.

## Changes

**1 — state-aware rerun trigger** (`run_onchange_after_sync-claude-plugins.sh.tmpl`). Embeds a *projection* of live runtime state — sorted user-scope install ids, sorted indexed marketplace names — beside the existing registry hash.

A projection rather than a whole-file hash because `installed_plugins.json` carries `lastUpdated` and `gitCommitSha` fields that churn on every CLI plugin refresh; hashing the file would re-run the prime on every apply, forfeiting the "quiet in steady state" property. Both `output "sh" "-c"` commands are unconditionally zero-exit (`2>/dev/null … || true`) — chezmoi's `output` aborts rendering the **entire source state** on a nonzero exit.

**2 — verify-after-install** (`claude-plugin-reconcile.sh`). `claude plugin install`'s exit code cannot distinguish a real failure from an "already installed" nonzero, so the leg now re-reads `installed_file` and asserts the id landed at user scope, setting `rc=1` otherwise. That reuses semantics the lib already has: defer the destructive legs, leave the manifest unchanged, propagate so chezmoi retries next apply.

**2b — leg reorder** (found in review). The install leg moves above the prune leg. In the old order (prime → prune → install → uninstall) the prune gate `(( any_missing == 0 && rc == 0 ))` had already run by the time install set `rc=1`, so a marketplace removal fired while the manifest rewrite was skipped — desyncing the CLI index from the manifest, then sticking permanently (next sync retries `marketplace remove` on an absent marketplace → `|| rc=1` → manifest never rewritten). Install reads only `owned_ids` and `$installed_file`, so the move is safe.

## Verification

- `bats tests/claude-plugin-reconcile.bats` — 13/13 pass (2 new).
- New wiring test pins the projection line against silent removal.
- `just check` — exit 0.
- **Red-without-fix**: with the lib change stashed, the AC3 test fails as intended. With the install/prune order manually swapped back, AC3 fails specifically at the new `marketplace remove` assertion — so the reorder is pinned, not incidental.
- **Live**: `chezmoi apply` detected a real dropped `milknado@milknado` via the new projection and reinstalled it.

## Notes

- Convergence takes two syncs, not one: the projection is read at template-render time, so the sync that heals the drift changes the projection and the *next* sync re-runs the reconcile once idempotently before going quiet. Steady state is unaffected.
- Known false-quiet classes, both outside this fix's drift class: a `known_marketplaces.json` entry whose `source.path` goes dead with the name unchanged; and an on-disk payload deleted while the `installed_plugins.json` entry survives.
- **Separate pre-existing issue, not addressed here**: something in the `dots sync` tail re-drifts `~/.claude/settings.json` after `chezmoi apply` (`enabledPlugins` and the `hooks` block came back stripped between runs). Worth its own investigation.
- **Follow-up**: `run_onchange_after_sync-claude-mcps.sh.tmpl` is keyed on the registry `mcps` hash alone and plausibly has the same gap against an out-of-band `claude mcp remove`. Same projection fix shape, against `~/.claude.json`'s `mcpServers` keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
