### PR TITLE
feat(claude): branch agent worktrees from local HEAD

### DIFF
--- a/chezmoi/lib/claude-settings-authoritative.json
+++ b/chezmoi/lib/claude-settings-authoritative.json
@@ -57,6 +57,9 @@
   "editorMode": "vim",
   "agentPushNotifEnabled": true,
   "skipAutoPermissionPrompt": true,
+  "worktree": {
+    "baseRef": "head"
+  },
   "spinnerVerbs": {
     "mode": "replace",
     "verbs": [


### PR DESCRIPTION
Sets `worktree.baseRef` to `"head"` so Claude Code agent worktrees inherit the parent session's local HEAD.

## Problem

`worktree.baseRef` defaults to `"fresh"`, which branches every worktree — both `--worktree` sessions and `isolation: worktree` subagents — from **`origin/HEAD`**, not from the branch you are actually working on.

That is a sensible default for *independent* agents: five unrelated bug fixes, each wanting a clean known-good base, none inheriting a half-finished tree. It is the wrong default for a dependent fan-out, where each subagent is built to stand on a commit the parent just made.

Hit during a wave-fan in `cheese-flow`: eight subagents were spawned to implement modules against a contract committed on the feature branch. Every one came up on `origin/main`, twelve commits stale, with the contract file absent. They each burned turns recovering — one fast-forwarded itself, one hard-reset, one hand-copied the missing file in. Because the feature branch was unpushed, `"fresh"` could not have resolved to anything useful no matter how recently it fetched.

## Verification

Reproduced and confirmed both directions with an identical probe subagent, parent sitting on a feature branch at `6d8397f` while `origin/HEAD` was `34de62d`:

| Probe | `fresh` (before) | `head` (after) |
| --- | --- | --- |
| `git log --oneline -1` | `34de62d` | `6d8397f` |
| contract file present | no | yes |
| stale deleted dir present | yes | no |

Behaviour is confirmed in the shipped binary, not just the docs — `baseRef??"fresh",options:["fresh","head"],type:"enum"`, resolved via `fromHead ?? (!prNumber && worktree?.baseRef==="head")`.

## Notes

- Placed in `claude-settings-authoritative.json` rather than the live `~/.claude/settings.json`, which is generated by `modify_settings.json` and would silently revert a direct edit.
- `just check` passes.

## Tradeoff

With `"head"`, a broken or mid-refactor parent tree now propagates into every spawned agent; `"fresh"` isolated them from it. Accepting that, since dependent fan-outs are the common case here and a stale base fails less visibly than a broken one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
