### PR TITLE
fix(agents): stop sub-agents dying on the context ceiling

### DIFF
--- a/agents/agent_definitions/explorer.md
+++ b/agents/agent_definitions/explorer.md
@@ -3,14 +3,14 @@ You are the Explorer — a read-only investigator. The parent dispatches you to 
 ## What You Do
 
 1. Restate the question as a concrete search target.
-2. Search first — `cheez-search` (tilth) finds definitions, callers, imports, and text in one pass.
-3. Read the specific symbols/sections that matter via `cheez-read` — never whole files when a section will do.
+2. Search first — `tilth_search` finds definitions, callers, imports, and text in one pass.
+3. Read the specific symbols/sections that matter via `tilth_read` — never whole files when a section will do.
 4. Synthesize a conclusion with file:line citations and call paths.
 
 ## What You Do NOT Do
 
 - **Never write, edit, or create files.** You have no Edit/Write tool for a reason. If the answer implies a change, describe it — do not make it.
-- No host `grep`/`cat`/`find`/`ls` — route everything through the cheez-* (tilth) skills. If tilth is unavailable, stop and report; do not fall back.
+- No host `grep`/`cat`/`find`/`ls` — route everything through the tilth MCP tools. If tilth is unavailable, stop and report; do not fall back.
 - No speculation dressed as fact. Tag uncertain conclusions explicitly.
 
 ## Output Format

--- a/agents/agent_definitions/fromage-age-arch.md
+++ b/agents/agent_definitions/fromage-age-arch.md
@@ -14,7 +14,7 @@ Enforce measurable structural constraints:
 
 ## Tools
 
-- **cheez-search** for structural code shape analysis (nesting depth, function length, import patterns)
+- **tilth_search** for structural code shape analysis (nesting depth, function length, import patterns)
 
 ## Severity Tiers
 
@@ -30,7 +30,7 @@ Evidence grounding sets the calibration tag:
 
 | Evidence quality | Tag |
 |-----------------|-----|
-| Verified via cheez-search (AST confirms nesting depth, function line count) | `<certain>` |
+| Verified via tilth_search (AST confirms nesting depth, function line count) | `<certain>` |
 | Cites specific file:line with accurate measurement | `<certain>` |
 | Generic observation without measurement | `<speculative>` |
 | Wrong measurement (miscounted lines/nesting) | drop the finding |
@@ -39,7 +39,7 @@ For any borderline finding: re-read the full source file, measure independently 
 
 ## Structural Lookups
 
-Use `cheez-search` symbol and caller queries for structural reads.
+Use `tilth_search` symbol and caller queries for structural reads.
 
 ## Output
 

--- a/agents/agent_definitions/fromage-age-history.md
+++ b/agents/agent_definitions/fromage-age-history.md
@@ -29,7 +29,7 @@ This outputs a JSON array:
 ]
 ```
 
-Then use **cheez-search** to check each file for danger comments: "DO NOT CHANGE", "fragile", "HACK", "FIXME".
+Then use **tilth_search** to check each file for danger comments: "DO NOT CHANGE", "fragile", "HACK", "FIXME".
 
 **Interpret the JSON fields:**
 
@@ -79,7 +79,7 @@ Return a structured summary (max 1000 chars):
 - **Output modifiers, not findings** — you inform severity, you don't flag bugs or architecture issues
 - **Concrete evidence only** — cite git output, not speculation
 - **Read-only** — never modify files
-- **Fast execution** — 2-3 tool calls total: one `git-file-risk`, one cheez-search for danger comments, done.
+- **Fast execution** — 2-3 tool calls total: one `git-file-risk`, one tilth_search for danger comments, done.
 
 ## What You Don't Do
 

--- a/agents/agent_definitions/generalist.md
+++ b/agents/agent_definitions/generalist.md
@@ -14,7 +14,7 @@ You are the fallback, not the first choice. Do not duplicate a specialist when o
 ## What You Do
 
 1. Restate the task as a concrete, verifiable goal before acting.
-2. Search and read through the cheez-* (tilth) skills — never host `grep`/`cat`/`find`/`ls`. If tilth is unavailable, stop and report; do not fall back.
+2. Search and read through the tilth MCP tools — never host `grep`/`cat`/`find`/`ls`. If tilth is unavailable, stop and report; do not fall back.
 3. Do the smallest sequence of steps that reaches the goal. Run code for anything code can compute; don't eyeball it.
 4. Synthesize a tight, cited conclusion and hand it back.
 

--- a/agents/agent_definitions/ghostbuster.md
+++ b/agents/agent_definitions/ghostbuster.md
@@ -19,7 +19,7 @@ You receive:
 
 ### 1. Structural search
 
-Use `cheez-search` symbol and caller queries for reference counting.
+Use `tilth_search` symbol and caller queries for reference counting.
 
 ### 2. Discover Files
 
@@ -58,7 +58,7 @@ Build a lookup: `{symbol → [spec_file, line_number]}`.
 
 For each source file, identify exported/public symbols:
 
-Use `cheez-search` to list exported/public symbols and run caller queries for each. Zero external references is a candidate.
+Use `tilth_search` to list exported/public symbols and run caller queries for each. Zero external references is a candidate.
 
 ### 5. Scan for Internal Dead Code
 
@@ -123,7 +123,7 @@ Older last-touch dates strengthen the case that code is truly dead (not just rec
 
 ## Severity Tiers
 
-Use the four-tier severity vocabulary: `blocker > high > medium > low`. Surface `medium` and above; surface `low` only when evidence is `<certain>`. Tag every finding with `<certain>` when a `cheez-search` caller query verifies zero references, otherwise `<speculative>`.
+Use the four-tier severity vocabulary: `blocker > high > medium > low`. Surface `medium` and above; surface `low` only when evidence is `<certain>`. Tag every finding with `<certain>` when a `tilth_search` caller query verifies zero references, otherwise `<speculative>`.
 
 Never assign `blocker` — dead code is never a release blocker. Cap at `high`, and only for a verified dormant chain of exported symbols; dynamic dispatch, reflection, and codegen can hide callers.
 
@@ -153,7 +153,7 @@ Write the full JSON report to `$TMPDIR/ghostbuster-{slug}.json`. The JSON schema
         "referenceCount": 0,
         "specMentions": [],
         "lastGitTouch": "2025-08-14",
-        "verifiedVia": "cheez-search caller query"
+        "verifiedVia": "tilth_search caller query"
       },
       "action": "Safe to delete — zero callers, no spec references, untouched for 7 months"
     }
@@ -185,7 +185,7 @@ Return to the orchestrator ONLY a structured summary (max 2000 chars):
 
 ## Rules
 
-- Use `cheez-search` caller queries for reference counting; dynamic dispatch and codegen can still hide callers.
+- Use `tilth_search` caller queries for reference counting; dynamic dispatch and codegen can still hide callers.
 - Include the file path and symbol name for every finding — vague findings are useless
 - Specs can live anywhere: `.claude/specs/`, `docs/specs/`, `specs/`, `SPEC.md` — glob broadly
 - Surface medium+ (and certain lows) — below that, don't surface. The orchestrator trusts your threshold.

--- a/agents/agent_definitions/nih-scanner.md
+++ b/agents/agent_definitions/nih-scanner.md
@@ -13,7 +13,7 @@ You receive:
 
 ### 1. Structural search
 
-Use `cheez-search` symbol and caller queries alongside ast-grep.
+Use `tilth_search` symbol and caller queries alongside ast-grep.
 
 ### 2. Discover Files
 
@@ -111,7 +111,7 @@ Glob: {scope}/**/lib/**/*.{ts,js,py,rs,go}
 Glob: {scope}/**/common/**/*.{ts,js,py,rs,go}
 ```
 
-For each utility file found, use `cheez-search` to inventory exported functions. Flag functions whose names match known library functionality:
+For each utility file found, use `tilth_search` to inventory exported functions. Flag functions whose names match known library functionality:
 
 | Function name pattern | Category | Common library |
 |----------------------|----------|----------------|
@@ -133,7 +133,7 @@ For each utility file found, use `cheez-search` to inventory exported functions.
 
 ### 5. Measure Usage
 
-For each flagged function, use `cheez-search` caller queries to count callers:
+For each flagged function, use `tilth_search` caller queries to count callers:
 
 - 0 callers → dead code (note, but lower priority for NIH audit)
 - 1-3 callers → low coupling, easy migration (S effort)

--- a/agents/agent_definitions/researcher.md
+++ b/agents/agent_definitions/researcher.md
@@ -1,9 +1,9 @@
-You are the Researcher — you answer questions that live *outside* the codebase and hand back a tight, cited conclusion. Library and API behavior, current vendor/web facts, version and changelog checks, best-practice comparisons, real-world GitHub examples. The point is context isolation: you fetch widely in your own window and return only the synthesis the parent needs to decide its next move, never the raw page dumps. The `briesearch` skill drives the routing and synthesis framework — follow it.
+You are the Researcher — you answer questions that live *outside* the codebase and hand back a tight, cited conclusion. Library and API behavior, current vendor/web facts, version and changelog checks, best-practice comparisons, real-world GitHub examples. The point is context isolation: you fetch widely in your own window and return only the synthesis the parent needs to decide its next move, never the raw page dumps. Invoke the `briesearch` skill through the Skill tool before routing — it drives the routing and synthesis framework and is not preloaded. Follow it.
 
 ## What You Do
 
 1. Restate the question as the decision it supports, and decompose it into 2–5 focused subqueries.
-2. Route each subquery to the right source: **Context7** for library/API docs, **Tavily** (or web fetch) for current web/vendor facts, **gh** for GitHub examples, `cheez-search` / `cheez-read` for local precedent. Commit to the source plan before gathering.
+2. Route each subquery to the right source: **Context7** for library/API docs, **Tavily** (or web fetch) for current web/vendor facts, **gh** for GitHub examples, `tilth_search` / `tilth_read` for local precedent. Commit to the source plan before gathering.
 3. Gather. Heavy fetch bodies are written to disk under `.cheese/research/<slug>/raw/`, not pasted into your reasoning — keep the noise out.
 4. Synthesize a claim-level evidence table (claim · source URL · confidence) and write the durable research slug to `.cheese/research/<slug>/<slug>.md`.
 

--- a/agents/agent_definitions/reviewer.md
+++ b/agents/agent_definitions/reviewer.md
@@ -1,4 +1,4 @@
-You are the Reviewer — a source-read-only phase agent with two named review modes. You find, verify, and rank; you never apply fixes. The `age` skill drives the severity-review framework. Opus-tier, because a shallow review that misses the real bug is worse than no review.
+You are the Reviewer — a source-read-only phase agent with two named review modes. You find, verify, and rank; you never apply fixes. Invoke the `age` skill through the Skill tool before you start — it drives the severity-review framework and is not preloaded. Opus-tier, because a shallow review that misses the real bug is worse than no review.
 
 ## Dispatch Contract
 
@@ -17,14 +17,14 @@ For `taste-test`, cover only Drift · Readability · Scope · Simplify · Produc
 
 ## What You Do
 
-1. Scope the change with `cheez-search` / `cheez-read`; trace blast radius for risky changes.
+1. Scope the change with `tilth_search` / `tilth_read`; trace blast radius for risky changes.
 2. Run only the named mode's coverage.
 3. Adversarially verify each candidate finding or verdict before reporting it.
 4. Prefix the selected schema with the shared handoff block.
 
 ## What You Do NOT Do
 
-- **Never modify source.** Native Edit/Write remain denied. You may write only your own `.cheese/` artifact through `cheez-write`, never a fix or shell redirect.
+- **Never modify source.** Native Edit/Write remain denied. You may write only your own `.cheese/` artifact through `tilth_write`, never a fix or shell redirect.
 - Do not fan out when dispatched as a reviewer subagent.
 - Do not inflate severity or report an unverified claim as a finding.
 
@@ -79,7 +79,7 @@ artifact: <path to fuller output, if any>
 <one-line orientation>
 ```
 
-Default to an inline report. Only when it genuinely exceeds a digest, write your own artifact to the path supplied by the pipeline or `.cheese/age/<slug>.md` through `cheez-write`, then return that path as `artifact:`. The registry's `.agents.reviewer.maxTurns` is the role-limit source of truth. Before that limit or the context window is exhausted, checkpoint partial findings to the artifact and return `status: blocked: out of context` so the parent dispatches a fresh reviewer.
+Default to an inline report. Only when it genuinely exceeds a digest, write your own artifact to the path supplied by the pipeline or `.cheese/age/<slug>.md` through `tilth_write`, then return that path as `artifact:`. The registry's `.agents.reviewer.maxTurns` is the role-limit source of truth. Before that limit or the context window is exhausted, checkpoint partial findings to the artifact and return `status: blocked: out of context` so the parent dispatches a fresh reviewer.
 
 ## Rules
 

--- a/agents/agent_definitions/roquefort-wrecker.md
+++ b/agents/agent_definitions/roquefort-wrecker.md
@@ -115,7 +115,7 @@ N low findings not surfaced (speculative or out-of-scope)
 
 ## Symbol Intelligence
 
-Use `cheez-search` symbol and caller queries to inspect the production path and identify affected tests.
+Use `tilth_search` symbol and caller queries to inspect the production path and identify affected tests.
 
 ## Quality Gates
 

--- a/agents/lib/turn-budget-guard.js
+++ b/agents/lib/turn-budget-guard.js
@@ -82,6 +82,11 @@ const BUDGETS = {
   coder: { turnSoft: 75, turnHard: 100, ctxSoft: CONTEXT_SOFT_TOKENS, ctxHard: CONTEXT_HARD_TOKENS },
   // general-purpose sub-agents run the same coder-shaped workloads.
   'general-purpose': { turnSoft: 75, turnHard: 100, ctxSoft: CONTEXT_SOFT_TOKENS, ctxHard: CONTEXT_HARD_TOKENS },
+  // generalist is the capped stand-in for the built-in general-purpose
+  // agent (agents/registry.yaml declares maxTurns: 100) — mirror
+  // general-purpose's budget exactly so it isn't halved by falling to
+  // `default`.
+  generalist: { turnSoft: 75, turnHard: 100, ctxSoft: CONTEXT_SOFT_TOKENS, ctxHard: CONTEXT_HARD_TOKENS },
   // milknado worker's exact reported agent_type is unobserved — key both
   // plausible spellings at coder tier so whichever the plugin emits resolves
   // correctly instead of silently falling to `default`.
@@ -90,6 +95,10 @@ const BUDGETS = {
   reviewer: { turnSoft: 40, turnHard: 50, ctxSoft: CONTEXT_SOFT_TOKENS, ctxHard: CONTEXT_HARD_TOKENS },
   explorer: { turnSoft: 40, turnHard: 50, ctxSoft: CONTEXT_SOFT_TOKENS, ctxHard: CONTEXT_HARD_TOKENS },
   researcher: { turnSoft: 40, turnHard: 50, ctxSoft: CONTEXT_SOFT_TOKENS, ctxHard: CONTEXT_HARD_TOKENS },
+  // fork inherits the parent's full transcript at spawn; PreToolUse
+  // captures a baseline snapshot and charges only accumulation past it (see
+  // chargedTokens). Turn/context ceilings match `default`.
+  fork: { turnSoft: 40, turnHard: 50, ctxSoft: CONTEXT_SOFT_TOKENS, ctxHard: CONTEXT_HARD_TOKENS },
   default: { turnSoft: 40, turnHard: 50, ctxSoft: CONTEXT_SOFT_TOKENS, ctxHard: CONTEXT_HARD_TOKENS },
 };
 
@@ -210,6 +219,12 @@ function hardNudgedFile(dir) {
   return path.join(dir, 'hard-nudged');
 }
 
+// Fork's captured baseline: the inherited context-token reading at its first
+// PreToolUse. Absent for every other agent type.
+function baselineFile(dir) {
+  return path.join(dir, 'baseline');
+}
+
 function fileSize(file) {
   try {
     return fs.statSync(file).size;
@@ -236,7 +251,47 @@ function readState(dir) {
     checkpointSpent: fileExists(checkpointSpentFile(dir)),
     nudged: fileExists(nudgedFile(dir)),
     hardNudged: fileExists(hardNudgedFile(dir)),
+    baseline: readBaseline(dir),
   };
+}
+
+// Fork's captured baseline token count, or null when absent/unparseable —
+// null means "no baseline yet" and callers fail open to the absolute
+// comparison. Never throws.
+function readBaseline(dir) {
+  try {
+    const raw = fs.readFileSync(baselineFile(dir), 'utf8');
+    const n = Number(raw);
+    return Number.isFinite(n) ? n : null;
+  } catch {
+    return null;
+  }
+}
+
+// Create-if-absent snapshot of a fork's inherited context tokens, taken at
+// its first PreToolUse. Atomic 'wx' create: first writer wins, so concurrent
+// batched PreToolUse calls can't race a read-modify-write. Fail-open — a
+// write error (EEXIST from losing the race, or any other failure) is
+// swallowed; baseline capture is best-effort and never blocks the call.
+function captureBaseline(dir, tokens) {
+  try {
+    ensureCounterDir(dir);
+    fs.writeFileSync(baselineFile(dir), String(tokens), { flag: 'wx' });
+  } catch {
+    /* fail-open */
+  }
+}
+
+// Tokens to charge against ctxSoft/ctxHard. Forks with a captured baseline
+// are charged only accumulation past it, and only when the current reading
+// is itself trustworthy (source === 'tokens') — a bytes-fallback or absent
+// reading is a different scale and must never be diffed against a
+// tokens-scale baseline. Every other type, a fork with no baseline yet, or
+// an untrustworthy current reading keeps today's absolute token count — the
+// fail-open path.
+function chargedTokens(type, tokens, baseline, source) {
+  if (type !== 'fork' || baseline === null || source !== 'tokens') return tokens;
+  return Math.max(0, tokens - baseline);
 }
 
 function ensureCounterDir(dir) {
@@ -614,19 +669,23 @@ function handle(event, emit = { deny: emitDeny, nudge: emitNudge }) {
   }
 
   if (evt === 'PreToolUse') {
-    const state = incrementTurn(dir);
     const { tokens, source: ctxSource } = contextTokensFromEvent(event);
+    if (type === 'fork' && ctxSource === 'tokens') captureBaseline(dir, tokens);
+    const state = incrementTurn(dir);
+    const charged = chargedTokens(type, tokens, state.baseline, ctxSource);
     debug(`pre type=${type} turns=${state.turns}/${budget.turnHard} ` +
-      `tokens=${tokens}/${budget.ctxHard} checkpointSpent=${state.checkpointSpent}`);
+      `tokens=${charged}/${budget.ctxHard} checkpointSpent=${state.checkpointSpent}`);
     const fields = {
       budget_type: type,
       turns: state.turns,
       tokens,
+      baseline: state.baseline,
+      charged_tokens: charged,
       ctx_source: ctxSource,
       checkpointSpent: state.checkpointSpent,
       ...thresholdFields(budget),
     };
-    if (state.turns > budget.turnHard || tokens > budget.ctxHard) {
+    if (state.turns > budget.turnHard || charged > budget.ctxHard) {
       if (isCheckpointWrite(event) && !state.checkpointSpent) {
         if (markOnce(dir, checkpointSpentFile(dir))) {
           writeDecision(event, { ...fields, checkpointSpent: true, action: 'allow', reason: 'checkpoint-write' });
@@ -634,7 +693,7 @@ function handle(event, emit = { deny: emitDeny, nudge: emitNudge }) {
         }
       }
       const checkpointSpent = fileExists(checkpointSpentFile(dir));
-      const reason = denyReason(type, state.turns, tokens, budget, checkpointSpent);
+      const reason = denyReason(type, state.turns, charged, budget, checkpointSpent);
       writeDecision(event, { ...fields, checkpointSpent, action: 'deny', reason: 'hard-ceiling' });
       emit.deny(reason);
       return { action: 'deny', reason };
@@ -646,21 +705,24 @@ function handle(event, emit = { deny: emitDeny, nudge: emitNudge }) {
   if (evt === 'PostToolUse') {
     let state = readState(dir);
     const { tokens, source: ctxSource } = contextTokensFromEvent(event);
+    const charged = chargedTokens(type, tokens, state.baseline, ctxSource);
     const fields = {
       budget_type: type,
       turns: state.turns,
       tokens,
+      baseline: state.baseline,
+      charged_tokens: charged,
       ctx_source: ctxSource,
       checkpointSpent: state.checkpointSpent,
       ...thresholdFields(budget),
     };
 
-    if (tokens > budget.ctxHard && !state.hardNudged) {
+    if (charged > budget.ctxHard && !state.hardNudged) {
       const created = markHardNudged(dir);
       if (created) {
         markNudged(dir); // suppress the soft nudge too — one nudge per agent max
         const checkpointSpent = fileExists(checkpointSpentFile(dir));
-        debug(`hard-nudge type=${type} turns=${state.turns} tokens=${tokens} checkpointSpent=${checkpointSpent}`);
+        debug(`hard-nudge type=${type} turns=${state.turns} tokens=${charged} checkpointSpent=${checkpointSpent}`);
         const context = hardNudgeContext(type, budget, checkpointSpent);
         writeDecision(event, { ...fields, action: 'nudge', reason: 'hard-threshold' });
         emit.nudge(context);
@@ -675,9 +737,9 @@ function handle(event, emit = { deny: emitDeny, nudge: emitNudge }) {
       writeDecision(event, { ...fields, action: 'allow', reason: 'already-nudged' });
       return { action: 'allow', reason: 'already-nudged' };
     }
-    if (state.turns >= budget.turnSoft || tokens >= budget.ctxSoft) {
+    if (state.turns >= budget.turnSoft || charged >= budget.ctxSoft) {
       markNudged(dir);
-      debug(`nudge type=${type} turns=${state.turns} tokens=${tokens}`);
+      debug(`nudge type=${type} turns=${state.turns} tokens=${charged}`);
       const context = nudgeContext(type, budget);
       writeDecision(event, { ...fields, action: 'nudge', reason: 'soft-threshold' });
       emit.nudge(context);

--- a/agents/registry.yaml
+++ b/agents/registry.yaml
@@ -24,8 +24,7 @@ agents:
     - Glob
     color: red
     effort: high
-    skills:
-    - cheez-search
+    skills: []
     maxTurns: 50
     body_path: agents/agent_definitions/fromage-age-arch.md
   fromage-age-history:
@@ -45,8 +44,7 @@ agents:
     - Glob
     color: red
     effort: low
-    skills:
-    - cheez-search
+    skills: []
     maxTurns: 50
     body_path: agents/agent_definitions/fromage-age-history.md
   fromage-fort:
@@ -63,9 +61,6 @@ agents:
     - Bash
     skills:
     - gh
-    - cheez-search
-    - cheez-write
-    - commit
     maxTurns: 50
     body_path: agents/agent_definitions/fromage-fort.md
   fromage-secaudit:
@@ -83,8 +78,7 @@ agents:
     - Glob
     color: red
     effort: high
-    skills:
-    - cheez-search
+    skills: []
     maxTurns: 50
     body_path: agents/agent_definitions/fromage-secaudit.md
   ghostbuster:
@@ -121,8 +115,7 @@ agents:
     - AskUserQuestion
     - Grep
     - Glob
-    skills:
-    - cheez-search
+    skills: []
     maxTurns: 50
     body_path: agents/agent_definitions/nih-scanner.md
   ricotta-reducer:
@@ -137,7 +130,6 @@ agents:
     - Bash
     - Agent
     skills:
-    - cheez-search
     - de-slop
     maxTurns: 50
     body_path: agents/agent_definitions/ricotta-reducer.md
@@ -152,8 +144,7 @@ agents:
     - Read
     - Write
     - Bash
-    skills:
-    - cheez-search
+    skills: []
     maxTurns: 50
     body_path: agents/agent_definitions/roquefort-wrecker.md
   duckdb-expert:
@@ -189,8 +180,7 @@ agents:
     tools:
     - Bash
     - Read
-    skills:
-    - cheez-search
+    skills: []
     maxTurns: 50
     body_path: agents/agent_definitions/whey-drainer.md
   worktree-content-digest:
@@ -213,7 +203,7 @@ agents:
   # are full-phase workers an orchestrator dispatches to. Their descriptions
   # carry PROACTIVE triggers so they fire under every easy-cheese skill and any
   # user-installed skill that needs grounding before it acts. They route file
-  # I/O through the cheez-* skills (tilth MCP), not host tools.
+  # I/O through the tilth MCP tools, not host tools.
   # Copilot CLI renders these agents too, but ignores per-agent model overrides.
   explorer:
     description: Read-only codebase investigator. Answers "where / how / what" questions by searching and reading — never writes. Returns a structured findings digest (file:line citations, call paths, conclusions), keeping the file dumps out of the parent's context. Models the easy-cheese explore phase. Use PROACTIVELY to orient before any task touches unfamiliar code — blast-radius scoping, "find me X" sweeps, "how does Y work" — whether the active skill is /mold, /cook, /age, or any user-installed skill that needs grounding before it acts.
@@ -230,9 +220,7 @@ agents:
     - Glob
     color: cyan
     effort: medium
-    skills:
-    - cheez-search
-    - cheez-read
+    skills: []
     maxTurns: 50
     body_path: agents/agent_definitions/explorer.md
   researcher:
@@ -249,14 +237,11 @@ agents:
     - Glob
     color: blue
     effort: medium
-    skills:
-    - briesearch
-    - cheez-search
-    - cheez-read
+    skills: []
     maxTurns: 50
     body_path: agents/agent_definitions/researcher.md
   reviewer:
-    description: Multi-dimension code reviewer. Reviews a diff, PR, branch, or path through an explicit severity-report or taste-test contract. Source-read-only — never writes fixes; may write only its own .cheese artifact through cheez-write. A top-level /age orchestrator may supply specialist evidence. Models the easy-cheese review phase. Opus-tier. Use PROACTIVELY before merging or shipping any change, after /cook or /cure, and whenever a user-installed skill produces a diff that should be checked before it lands.
+    description: Multi-dimension code reviewer. Reviews a diff, PR, branch, or path through an explicit severity-report or taste-test contract. Source-read-only — never writes fixes; may write only its own .cheese artifact through tilth_write. A top-level /age orchestrator may supply specialist evidence. Models the easy-cheese review phase. Opus-tier. Use PROACTIVELY before merging or shipping any change, after /cook or /cure, and whenever a user-installed skill produces a diff that should be checked before it lands.
     models:
       claude: opus
       codex: gpt-5.6-sol
@@ -270,11 +255,7 @@ agents:
     - Glob
     color: red
     effort: high
-    skills:
-    - age
-    - cheez-search
-    - cheez-read
-    - cheez-write
+    skills: []
     maxTurns: 50
     body_path: agents/agent_definitions/reviewer.md
   coder:
@@ -297,13 +278,13 @@ agents:
     - NotebookEdit
     color: green
     effort: medium
-    skills:
-    - cook
-    - press
-    - cure
-    - de-slop
-    - tdd-assertions
-    - commit
+    # No frontmatter skills. Claude Code auto-invokes every listed skill at
+    # spawn, pasting each full SKILL.md body in as a user message before the
+    # agent reads its task — it is an auto-invoke list, not an availability
+    # list. The old list (cook/press/cure/de-slop/tdd-assertions/commit) cost
+    # 32,740 tokens, 52% of the 130k context ceiling, every dispatch. The
+    # coder still reaches any skill on demand via the Skill tool.
+    skills: []
     maxTurns: 100
     body_path: agents/agent_definitions/coder.md
   generalist:
@@ -316,7 +297,7 @@ agents:
     # built-in. Cap 100 matches measured general-purpose work (p90 101) so it
     # clips only the runaway tail, not legitimate p90 runs. Denies Agent (a
     # level-1 subagent cannot fan out).
-    description: General-purpose catch-all for an open-ended, multi-step task that does not fit a specialist phase agent — mixed research, code reading, and synthesis in one dispatch. The capped stand-in for the built-in general-purpose agent. Prefer a specialist when the task is cleanly one shape — explorer for "where/how/what" code questions, researcher for external/library/web facts, reviewer for checking a diff before it lands, coder for writing or changing code. Use this only as the fallback when no single specialist owns the task. Routes file I/O through the cheez-* (tilth) skills.
+    description: General-purpose catch-all for an open-ended, multi-step task that does not fit a specialist phase agent — mixed research, code reading, and synthesis in one dispatch. The capped stand-in for the built-in general-purpose agent. Prefer a specialist when the task is cleanly one shape — explorer for "where/how/what" code questions, researcher for external/library/web facts, reviewer for checking a diff before it lands, coder for writing or changing code. Use this only as the fallback when no single specialist owns the task. Routes file I/O through the tilth MCP tools.
     models:
       claude: sonnet
       codex: gpt-5.6-terra
@@ -328,9 +309,6 @@ agents:
     - NotebookEdit
     color: yellow
     effort: medium
-    skills:
-    - cheez-search
-    - cheez-read
-    - cheez-write
+    skills: []
     maxTurns: 100
     body_path: agents/agent_definitions/generalist.md

--- a/chezmoi/lib/claude-settings-authoritative.json
+++ b/chezmoi/lib/claude-settings-authoritative.json
@@ -57,6 +57,9 @@
   "editorMode": "vim",
   "agentPushNotifEnabled": true,
   "skipAutoPermissionPrompt": true,
+  "worktree": {
+    "baseRef": "head"
+  },
   "spinnerVerbs": {
     "mode": "replace",
     "verbs": [

--- a/tests/phase-agent-handoff.bats
+++ b/tests/phase-agent-handoff.bats
@@ -140,15 +140,16 @@ block_sha() {
     assert_success
 }
 
-@test "reviewer may write only its own artifact through cheez-write" {
+@test "reviewer may write only its own artifact through tilth_write" {
     local registry="$AGENTS_DIR/registry.yaml"
 
-    run yq -e '.agents.reviewer.skills[] | select(. == "cheez-write")' "$registry"
-    assert_success
     run yq -e '.agents.reviewer.disallowedTools[] | select(. == "Write")' "$registry"
     assert_success
-    run grep -Fq 'write only your own `.cheese/` artifact through `cheez-write`' "$AGENTS_DIR/agent_definitions/reviewer.md"
+    run grep -Fq 'write only your own `.cheese/` artifact through `tilth_write`' "$AGENTS_DIR/agent_definitions/reviewer.md"
     assert_success
+    # The retired cheez-write skill must not return as the reviewer's write path.
+    run grep -Fq 'cheez-write' "$AGENTS_DIR/agent_definitions/reviewer.md"
+    assert_failure
 }
 
 # The descriptions promise read-only phase agents that cannot recurse, and a
@@ -172,25 +173,42 @@ block_sha() {
 @test "phase-agent skill references use installed names and stay scoped" {
     local registry="$AGENTS_DIR/registry.yaml"
 
+    # explorer carries no frontmatter skills. Its two former entries
+    # (cheez-search, cheez-read) named skills that no longer exist on disk.
     run yq '.agents.explorer.skills | join(" ")' "$registry"
     assert_success
-    [[ "$output" == "cheez-search cheez-read" ]] || { echo "explorer skills drifted: $output" >&2; return 1; }
+    [[ -z "$output" ]] || { echo "explorer skills drifted: $output" >&2; return 1; }
 
-    for agent in researcher reviewer; do
-        run yq ".agents.${agent}.skills | join(\" \")" "$registry"
-        assert_success
-        [[ "$output" != *cheese-flow:* ]] || { echo "$agent still references cheese-flow" >&2; return 1; }
-        [[ "$output" != *scout* ]] || { echo "$agent should not carry scout" >&2; return 1; }
+    # Retired names must never reappear in ANY agent's skills list. They cost
+    # nothing while the file is absent — but frontmatter skills are auto-invoked
+    # at spawn, so the day someone adds a skill under one of these names, every
+    # agent still listing it silently starts pasting that entire SKILL.md into
+    # its context on every dispatch. A fleet-wide context regression would be
+    # near-impossible to trace back to a stale registry entry, so guard the
+    # names directly rather than trusting them to stay unresolvable.
+    for dead in cheez-search cheez-read cheez-write commit scout; do
+        run yq -e ".agents[].skills[] | select(. == \"$dead\")" "$registry"
+        [[ "$status" -ne 0 ]] || { echo "retired skill '$dead' is back in an agent skills list" >&2; return 1; }
     done
 
+    run yq -r '.agents[].skills[]' "$registry"
+    assert_success
+    [[ "$output" != *cheese-flow:* ]] || { echo "a cheese-flow: prefixed skill is back in an agent skills list" >&2; return 1; }
+
+    # The coder carries NO frontmatter skills. Claude Code auto-invokes every
+    # listed skill at spawn, pasting each full SKILL.md body in as a user
+    # message before the agent reads its task — it is an auto-invoke list, not
+    # an availability list. Measured at 32,740 tokens for the old six-skill
+    # list: 52% of the 130k context ceiling burned before the first tool call.
+    # Skills stay reachable on demand through the Skill tool.
     run yq '.agents.coder.skills | join(" ")' "$registry"
     assert_success
-    [[ "$output" == "cook press cure de-slop tdd-assertions commit" ]] || { echo "coder skills drifted: $output" >&2; return 1; }
+    [[ -z "$output" ]] || { echo "coder must carry no frontmatter skills (auto-invoked at spawn, costs context): $output" >&2; return 1; }
 }
 
 @test "read-only phase agents deny code edits and subagent fan-out in the registry" {
     local registry="$AGENTS_DIR/registry.yaml"
-    # explorer + reviewer deny native Write and subagent fan-out; reviewer writes only its own artifact through cheez-write.
+    # explorer + reviewer deny native Write and subagent fan-out; reviewer writes only its own artifact through tilth_write.
     for agent in explorer reviewer; do
         run yq ".agents.${agent}.disallowedTools" "$registry"
         assert_success

--- a/tests/turn-budget-guard.bats
+++ b/tests/turn-budget-guard.bats
@@ -812,3 +812,70 @@ backdate_mtime() {
     [[ "$(log_record | jq -r '.harness')" == "opencode" ]]
     [[ "$(log_record | jq -r '.action')" == "deny" ]]
 }
+
+# ── A12 ── fork baseline exemption ───────────────────────────────────
+
+@test "A12: fork's first call, inherited context far above ctxHard, is allowed" {
+    seed_turns s3 f1 5
+    seed_usage_transcript s3 f1 "178791:0:0"  # real observed inherited figure, > ctxHard (130000)
+    fire "$(pre_event s3 f1 fork)"
+    [[ "$(verdict)" == "allow" ]]
+    [[ "$(log_record | jq -r '.budget_type')" == "fork" ]]
+    [[ "$(log_record | jq -r '.tokens')" == "178791" ]]
+    [[ "$(log_record | jq -r '.baseline')" == "178791" ]]
+    [[ "$(log_record | jq -r '.charged_tokens')" == "0" ]]
+    [[ "$(cat "$CLAUDE_TURN_BUDGET_DIR/s3/f1/baseline")" == "178791" ]]
+}
+
+@test "A12: fork is denied once its OWN accumulation past baseline exceeds ctxHard" {
+    seed_turns s4 f2 5
+    seed_usage_transcript s4 f2 "178791:0:0"
+    fire "$(pre_event s4 f2 fork)"
+    [[ "$(verdict)" == "allow" ]]
+
+    seed_usage_transcript s4 f2 "$((178791 + 130001)):0:0"  # baseline + 130001 charged tokens
+    fire "$(pre_event s4 f2 fork)"
+    [[ "$(verdict)" == "deny" ]]
+    [[ "$(log_record | jq -r '.baseline')" == "178791" ]]
+    [[ "$(log_record | jq -r '.charged_tokens')" == "130001" ]]
+}
+
+@test "A12: a non-fork type (coder) at 130001 tokens is still denied — absolute path untouched" {
+    seed_turns s5 c1 5
+    seed_usage_transcript s5 c1 "130001:0:0"
+    fire "$(pre_event s5 c1 coder)"
+    [[ "$(verdict)" == "deny" ]]
+    [[ "$(log_record | jq -r '.charged_tokens')" == "130001" ]]
+    [[ -z "$(log_record | jq -r '.baseline')" || "$(log_record | jq -r '.baseline')" == "null" ]]
+}
+
+@test "A12: fork's first call with an untrustworthy (source=none) reading does not poison the baseline" {
+    seed_turns s6 f3 5
+    # No transcript fixture written -> contextTokensFromEvent resolves to
+    # tokens:0, source:'none'. An untrustworthy first reading must not
+    # captureBaseline at 0, or the fork would be charged absolutely forever.
+    fire "$(pre_event s6 f3 fork)"
+    [[ "$(verdict)" == "allow" ]]
+    [[ ! -e "$CLAUDE_TURN_BUDGET_DIR/s6/f3/baseline" ]]
+
+    # A later, trustworthy (source='tokens') reading still establishes the
+    # baseline -- even though the inherited figure alone exceeds ctxHard,
+    # it is allowed because it becomes the baseline rather than being
+    # compared against a stale/absent one.
+    seed_usage_transcript s6 f3 "178791:0:0"
+    fire "$(pre_event s6 f3 fork)"
+    [[ "$(verdict)" == "allow" ]]
+    [[ "$(log_record | jq -r '.baseline')" == "178791" ]]
+    [[ "$(log_record | jq -r '.charged_tokens')" == "0" ]]
+    [[ "$(cat "$CLAUDE_TURN_BUDGET_DIR/s6/f3/baseline")" == "178791" ]]
+}
+
+# ── A13 — generalist resolves the general-purpose tier ───────────────
+
+@test "A13: generalist at 51 turns is allowed (registry maxTurns: 100, not default's 50)" {
+    seed_turns s13 g1 51
+    fire "$(pre_event s13 g1 generalist)"
+    [[ "$(verdict)" == "allow" ]]
+    [[ "$(log_record | jq -r '.budget_type')" == "generalist" ]]
+    [[ "$(log_record | jq -r '.turnHard')" == "100" ]]
+}


### PR DESCRIPTION
## What and why

Sub-agents were being hard-denied by the turn-budget guard's context ceiling. Of 84 hard denials, **83 were context and 1 was turns** — and 82 of the 84 were the `coder`, dying at turns 17–24 of a *100-turn* budget. The turn axis has never bound. Four causes, four fixes.

## Changes

### 1. Fork baseline exemption — `agents/lib/turn-budget-guard.js` *(semantics-altering)*

A fork inherits the parent's occupancy at spawn, so charging it absolutely denies it for context it never chose to accumulate. Forks are now charged only what they accumulate past spawn.

- Capture is atomic (`wx` flag) and gated on `ctx_source === 'tokens'`, so an untrustworthy first reading can't permanently poison the baseline.
- Decision records gain `baseline` and `charged_tokens`. **`tokens` is unchanged**, so existing log analysis keeps working.
- Scoped to `fork` deliberately: the coder's occupancy was self-inflicted config, and baseline-relative charging everywhere would have hidden that rather than exposing it.

A pre-fix fork record on this machine read **178,791 tokens at turn 1** — 37% over the 130k ceiling — which is what this exists to survive.

### 2. `generalist` budget entry — `agents/registry.yaml` *(semantics-altering)*

Fell through to `default` and was capped at 50 against its own `maxTurns: 100`. Now 75/100.

### 3. Skill preloads removed — `agents/registry.yaml` *(semantics-altering)*

Agent frontmatter `skills:` is an **auto-invoke list, not an availability list**. Upstream docs are explicit:

> The full skill content is injected, not only the description.

and, decisively:

> This field controls which skills are preloaded, not which skills the subagent can access: without it, the subagent can still discover and invoke project, user, and plugin skills through the Skill tool during execution.

So removing a preload costs **zero capability** — it converts eager injection into on-demand invocation.

| Agent | Removed | Was costing |
| --- | --- | --- |
| `coder` | cook, press, cure, de-slop, tdd-assertions | 63,278 tokens/dispatch |
| `reviewer` | age | 13,389 |
| `researcher` | briesearch | 3,404 |

`reviewer` and `researcher` referenced their skills *passively* ("drives the framework"), which with the preload gone left them pointing at absent methodology. Both line-1 references now instruct explicit Skill-tool invocation.

Retained: `gh` (fromage-fort), `de-slop` (ricotta-reducer), `session-analytics` (duckdb-expert) — each is that agent's whole job, and all three sit on lightweight allowlist agents with ample headroom.

### 4. Retired skill names purged — 9 agent bodies *(semantics-preserving)*

`cheez-search`, `cheez-read`, `cheez-write` and `commit` no longer exist on disk. 19 references across 9 bodies now name the tilth MCP tools they actually resolve to. A new guard test asserts none of the retired names can reappear in any agent's `skills:` list.

## Measured result

| | coder turn-1 spawn weight |
| --- | --- |
| Before (7 dispatches) | 60,176 – 65,219 |
| **After** | **32,017** |

Verified from a **fresh session** on a live dispatch: 9 turns, peak 61,272, zero denials, zero nudges — against a prior pattern of dying at turns 17–24.

## Review shape

This PR mixes **semantics-altering** changes (1–3: guard behavior, budget table, agent capability surface) with a **semantics-preserving** rename (4). Normally that argues for a stack; it was landed as one at the author's explicit request, because all four came out of a single investigation and the rename is mechanical. Reviewers who prefer to read them separately can use the file split above — item 4 touches only agent-definition prose.

## What a reviewer should verify

- **`turn-budget-guard.js`**: that the `fork`-only scoping is intentional and that `tokens` semantics are genuinely unchanged for existing consumers of `decisions.jsonl`.
- **`registry.yaml`**: that dropping `age` / `briesearch` / the coder's five is acceptable given the agents now invoke on demand — this trades guaranteed-present methodology for invocation reliability.
- **`reviewer.md` / `researcher.md` line 1**: that the invocation instruction is strong enough that the agent will actually follow it.
- **One unrelated file**: `chezmoi/lib/claude-settings-authoritative.json` gains `worktree.baseRef: head`, captured by `dots sync` from live settings while this work was in progress. Not part of the agent work; excluding it only means the next sync re-adds it.

## Follow-up, not in this PR

MCP tool schemas were measured per server by direct stdio `tools/list` probes: **milknado 8,196 / hallouminate 4,040 / tilth 3,912 / tavily 1,923 / context7 1,231 = 19,304 tokens**, loaded eagerly into every sub-agent that lacks a `tools:` allowlist. A natural experiment across four unmodified agents puts sonnet-with-allowlist at 13,552 vs sonnet-without at ~32,400 — an 18,848 gap matching the probe total within 2%. Narrowing per-agent tool grants is the next lever and needs its own PR.

**Gotcha for whoever picks that up:** agent definitions load at session start, so a registry edit *cannot* be measured from the session that made it. That trap produced a false refutation in two consecutive sessions.

## Verification

- `dots sync` → exit 0
- `just check` → exit 0 (**1293 bats + 152 node, zero failures**)
- 12/12 prek hooks passed on commit
