### PR TITLE
feat(agents): resolve agent models through named tiers

### DIFF
--- a/.hallouminate/wiki/architecture/agent-profile.md
+++ b/.hallouminate/wiki/architecture/agent-profile.md
@@ -29,6 +29,48 @@ registries:
 
 `ingest.py:expand_registries` reads each registry relative to the repo root, normalizes every entry into a profile *item* (a registry entry **is** a profile item — no translation layer), and stamps `_source_dir = <repo_root>` so payload files (`body_path`, hook `script`, skill `path`) resolve against the repo. The plugin registry is the exception: it resolves a marketplace root to a payload root and emits MCP, skill, agent, hook, and native-plugin items with `_source_dir` stamped at the payload root. Ingest also resolves inline `${VAR}` env refs from `$DOTFILES_DIR/.env` (`env.py`) and drops `optional` MCPs with unset credentials. Plugin `commands/` are intentionally not decomposed.
 
+#### Model tiers: `tier:` → `agents/models.yaml`
+
+An agent in `agents/registry.yaml` names a **tier** rather than transcribing model ids:
+
+```yaml
+coder:
+  tier: mid
+  models: {opencode: inherit}   # optional per-harness override
+```
+
+`agents/models.yaml` holds the lookup:
+
+```yaml
+pins:
+  fast: {claude: haiku,  codex: gpt-5.6-luna}
+  mid:  {claude: sonnet, codex: gpt-5.6-terra}
+  deep: {claude: opus,   codex: gpt-5.6-sol}
+```
+
+Resolution is `ingest.py:expand_agents` → `_resolve_agent_tier` (ingest.py:453-513), which runs at ingest time so **every renderer keeps reading `item["models"]` unchanged** — the tier never reaches a renderer. Precedence:
+
+1. the agent's own `models.<harness>` wins
+2. else `pins[tier][harness]`
+3. else the harness key stays absent
+
+An unknown `tier` is a hard `ParseError` naming the agent and the valid tiers. Regression coverage: `agent-profile/tests/test_model_tiers.py`.
+
+**Why only claude and codex are pinned.** Those two are 100% tier-consistent across all 16 agents. `cursor` and `opencode` are not — the `mid` tier alone renders as `auto` ×3, `claude-sonnet` ×1, `claude-haiku` ×1, and absent ×5 — so folding them into the pins table would change rendered output rather than refactor it. They stay inline in each agent's `models:` map until someone decides which divergences are intentional. Known open anomaly: `roquefort-wrecker` is tier `mid` but pins Cursor to `claude-haiku`, the only agent whose Cursor model sits a tier below its Claude model.
+
+`tests/agent-skill-model-effort.bats` asserts the tier↔effort mapping (fast→low, mid→medium, deep→high) and the claude↔codex pairing of the three pins rows. That pairing used to be asserted 16 times, once per agent; the pins table is now the only place it is written down.
+
+#### `ap agents-json <registry.yaml>`
+
+`.sync-lib.sh:_cz_render_claude_agent` assembles the chezmoi `dot_claude/exact_agents/` tree and was, until the tier change, a **second independent reader** of `agents/registry.yaml` — it rendered Claude frontmatter with its own yq/jq pipeline, including `line("model"; .models.claude)`. Keeping it working would have meant duplicating tier resolution in jq.
+
+Instead the shell now consumes `ap agents-json <registry.yaml>` (`cli.py:cmd_agents_json`), which prints `expand_agents(...)`'s resolved item list as a JSON array. Tier resolution has exactly one implementation.
+
+Two wiring details worth knowing:
+
+- The command takes a **registry path, not a profile name**. The assembly renders an arbitrary repo root — `tests/sync-claude-sources.bats` drives it with a synthetic one that has a registry but no `profiles/` tree — so a profile-scoped command would not work there.
+- `.sync-lib.sh` invokes `${BASH_SOURCE[0]%/*}/bin/ap` with `DOTFILES_DIR=` cleared. `bin/ap` prefers `$DOTFILES_DIR/agent-profile` over its own location when resolving the uv project, so an inherited `DOTFILES_DIR` pointing at another clone (routine in a Conductor workspace) would otherwise run the wrong `agent_profile`. The tool comes from the library's own clone; the data comes from `$root`.
+
 ### `parse.py`: profile.yaml → `Manifest`
 
 `parse_manifest` resolves a profile into a `Manifest` dataclass. It DFS-walks the `include:` graph (`_parse_with_includes`, cycle-detecting on the resolution stack so a diamond DAG is legal), concatenates item arrays (includes first so the outer profile's items append last), and deep-merges `settings` (with `permissions_allow` unioned + sorted).

--- a/.sync-lib.sh
+++ b/.sync-lib.sh
@@ -361,22 +361,32 @@ _cz_copy_encoded() {
     return 0
 }
 
-# Render one claude sub-agent file: YAML frontmatter from agents/registry.yaml
-# metadata + the instruction body from body_path. Mirrors ap's claude renderer
-# output shape (verified by diff against a live render).
-#   _cz_render_claude_agent <registry_yaml> <name> <dotfiles_root> <out_file>
+# Render one claude sub-agent file: YAML frontmatter from ap's resolved
+# agent JSON (see `ap agents-json`) + the instruction body from body_path.
+# ap's ingest resolves tier -> models once (agents/registry.yaml + tier ->
+# agents/models.yaml pins); reading that resolved dump here keeps this the
+# only Claude-side reader of the registry instead of re-deriving tier
+# resolution in jq. Mirrors ap's claude renderer output shape (verified by
+# diff against a live render).
+#   _cz_render_claude_agent <agents_json> <name> <dotfiles_root> <out_file>
 _cz_render_claude_agent() {
-    local registry="$1" name="$2" root="$3" out="$4"
+    local agents_json="$1" name="$2" root="$3" out="$4"
+    local agent_json
+    agent_json=$(jq -c --arg name "$name" '.[] | select(.name == $name)' <<<"$agents_json")
+    if [[ -z "$agent_json" ]]; then
+        log_error "claude agent '$name': not found in ap agents-json output"
+        return 1
+    fi
     local body_path
-    body_path=$(yq -r ".agents.\"$name\".body_path // \"\"" "$registry")
+    body_path=$(jq -r '.body_path // ""' <<<"$agent_json")
     if [[ -z "$body_path" || ! -f "$root/$body_path" ]]; then
-        log_error "claude agent '$name': body_path missing (registry: $registry)"
+        log_error "claude agent '$name': body_path missing (registry: $root/agents/registry.yaml)"
         return 1
     fi
     {
         echo "---"
         echo "name: $name"
-        yq -o=json ".agents.\"$name\"" "$registry" | jq -r '
+        jq -r '
             def line(k; v): if v == null then empty else k + ": " + v end;
             line("description";     .description),
             line("tools";           (if .tools then (.tools | join(", ")) else null end)),
@@ -386,7 +396,7 @@ _cz_render_claude_agent() {
             line("effort";          .effort),
             line("maxTurns";        (if .maxTurns then (.maxTurns | tostring) else null end)),
             line("skills";          (if .skills then "[" + (.skills | join(", ")) + "]" else null end))
-        '
+        ' <<<"$agent_json"
         echo "---"
         cat "$root/$body_path"
     } > "$out"
@@ -510,11 +520,22 @@ sync_claude_chezmoi_sources() {
     _cz_vendor_external_skills "$root/skills/_registry.yaml" "$staging/exact_skills" claude || return 1
     mkdir -p "$staging/exact_skills"
 
-    # agents — rendered from agents/registry.yaml
+    # agents — rendered from ap's resolved agent JSON (one reader of
+    # agents/registry.yaml + tier resolution instead of two independent ones)
+    # `ap` comes from THIS library's own clone, the registry from $root: the
+    # assembly renders an arbitrary repo root (its tests pass a synthetic one),
+    # which owns a registry but not necessarily a bin/ or profiles/ tree.
+    # DOTFILES_DIR= forces bin/ap to resolve its uv project from its own
+    # location rather than an inherited env var pointing at another clone.
+    local agents_json ap_bin="${BASH_SOURCE[0]%/*}/bin/ap"
+    if ! agents_json=$(DOTFILES_DIR='' "$ap_bin" agents-json "$root/agents/registry.yaml"); then
+        log_error "claude source assembly: $ap_bin agents-json failed"
+        return 1
+    fi
     mkdir -p "$staging/exact_agents"
     while IFS= read -r name; do
         [[ -z "$name" ]] && continue
-        _cz_render_claude_agent "$root/agents/registry.yaml" "$name" "$root" \
+        _cz_render_claude_agent "$agents_json" "$name" "$root" \
             "$staging/exact_agents/$name.md" || return 1
     done < <(yq -r '.claude.agents // [] | .[]' "$claude_reg")
 

--- a/agent-profile/agent_profile/cli.py
+++ b/agent-profile/agent_profile/cli.py
@@ -30,6 +30,7 @@ from agent_profile import (
     compile_command,
     discover,
     fetch_sources_command,
+    ingest,
 )
 from agent_profile import (
     manifest as manifest_mod,
@@ -80,6 +81,7 @@ Commands:
   list                          List available profiles
   describe <name>               Show resolved manifest for a profile
   path <name>                   Print profile source dir
+  agents-json <registry.yaml>   Print resolved agent items (tier -> models)
   compile <name> --baseline <dir> --out <dir>
                                 Compile live profile fragments
   install <name> [opts]         Deprecated; use dots sync or ap compile
@@ -227,6 +229,25 @@ def cmd_copilot_flags(name: str, out: Any) -> int:
     manifest = parse_manifest(profile_dir)
     for flag in launch_flags(manifest):
         print(flag, file=out)
+    return 0
+
+
+def cmd_agents_json(registry: str, out: Any) -> int:
+    """Print an agent registry's resolved items as a JSON array.
+
+    Each agent's ``tier`` is resolved into ``models`` against the sibling
+    ``models.yaml`` (see ingest.expand_agents). The Claude source-assembly
+    renderer in .sync-lib.sh consumes this instead of reading the registry
+    with yq, so tier resolution has exactly one implementation rather than
+    one per language.
+
+    Takes a registry path, not a profile: the assembly runs against an
+    arbitrary repo root (its own tests drive it with a synthetic one), which
+    has a registry but no profile tree."""
+    path = Path(registry)
+    if not path.is_file():
+        raise CliError(f"ap: agent registry '{registry}' not found")
+    print(json.dumps(ingest.expand_agents(path, str(path.parent.parent))), file=out)
     return 0
 
 
@@ -887,6 +908,10 @@ def main(argv: list[str] | None = None) -> int:
             if not rest:
                 raise CliError("profile name required")
             return cmd_copilot_flags(rest[0], sys.stdout)
+        if sub == "agents-json":
+            if not rest:
+                raise CliError("ap: agents-json needs an agent registry path")
+            return cmd_agents_json(rest[0], sys.stdout)
         if sub == "perms":
             local = "--local" in rest
             rest_no_local = [a for a in rest if a != "--local"]

--- a/agent-profile/agent_profile/cli.py
+++ b/agent-profile/agent_profile/cli.py
@@ -30,17 +30,19 @@ from agent_profile import (
     compile_command,
     discover,
     fetch_sources_command,
+)
+from agent_profile import (
     manifest as manifest_mod,
 )
 from agent_profile.install_command import install_deprecation_message
 from agent_profile.manifest import ManifestCorrupt
 from agent_profile.parse import ParseError, parse_manifest
+from agent_profile.permissions import parse_mcp_rule
 from agent_profile.renderers.base import (
     MergedConfigError,
     Renderer,
     includes_harness,
 )
-from agent_profile.permissions import parse_mcp_rule
 
 ALL_HARNESSES = ["claude", "codex", "opencode", "cursor", "copilot", "crush"]
 

--- a/agent-profile/agent_profile/compile_command.py
+++ b/agent-profile/agent_profile/compile_command.py
@@ -12,10 +12,10 @@ from typing import Any, Protocol
 
 from agent_profile import discover
 from agent_profile.compiled_types import (
+    MERGED_SETTINGS_BY_HARNESS,
     CompiledFile,
     CompiledManifest,
     CompileTarget,
-    MERGED_SETTINGS_BY_HARNESS,
 )
 from agent_profile.drift import FileComparison, compute_drift
 from agent_profile.parse import parse_manifest

--- a/agent-profile/agent_profile/compile_target_validation.py
+++ b/agent-profile/agent_profile/compile_target_validation.py
@@ -6,7 +6,7 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
-from agent_profile.compiled_types import CompileTarget, VALID_COMPILE_HARNESSES
+from agent_profile.compiled_types import VALID_COMPILE_HARNESSES, CompileTarget
 
 _ENV_REF_RE = re.compile(r"\$(?:\{[A-Za-z_][A-Za-z0-9_]*\}|[A-Za-z_][A-Za-z0-9_]*)")
 

--- a/agent-profile/agent_profile/fetch.py
+++ b/agent-profile/agent_profile/fetch.py
@@ -43,8 +43,9 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 
 
 def _load_skill_agents() -> dict[str, str]:
@@ -114,11 +115,7 @@ def _default_runner(argv: list[str]) -> int:
     for line in combined.splitlines():
         lower = line.lstrip().lower()
         if (
-            lower.startswith("error")
-            or lower.startswith("failed")
-            or "error:" in lower
-            or "failed to" in lower
-            or "✖" in line
+            lower.startswith(("error", "failed")) or "error:" in lower or "failed to" in lower or "✖" in line
         ):
             # Print the suspicious line so the caller can surface it.
             print(line, file=sys.stderr)

--- a/agent-profile/agent_profile/ingest.py
+++ b/agent-profile/agent_profile/ingest.py
@@ -441,7 +441,41 @@ def _expand_hooks(
     return out
 
 
-def _expand_agents(
+def _load_model_pins(path: Path) -> dict[str, dict[str, Any]]:
+    """Load ``agents/models.yaml``'s ``pins:`` map, or {} if the file is absent."""
+    if not path.is_file():
+        return {}
+    data = _load_yaml_mapping(path)
+    pins = data.get("pins") or {}
+    return pins if isinstance(pins, dict) else {}
+
+
+def _resolve_agent_tier(
+    item: dict[str, Any], pins: dict[str, dict[str, Any]]
+) -> dict[str, Any]:
+    """Resolve ``tier:`` (agents/models.yaml) into ``models``.
+
+    Precedence: the agent's own ``models.<harness>`` wins, else
+    ``pins[tier][harness]``, else the field stays absent. An unknown
+    ``tier`` is a hard failure naming the agent and the valid tiers."""
+    tier = item.pop("tier", None)
+    if tier is None:
+        return item
+    if tier not in pins:
+        from agent_profile._validate import ParseError
+
+        valid = ", ".join(sorted(pins)) or "(none defined in agents/models.yaml)"
+        raise ParseError(
+            f"ap: agent '{item.get('name')}' references unknown tier "
+            f"'{tier}' (valid tiers: {valid})"
+        )
+    resolved = dict(pins[tier])
+    resolved.update(item.get("models") or {})
+    item["models"] = resolved
+    return item
+
+
+def expand_agents(
     path: Path, source_dir: str
 ) -> list[dict[str, Any]]:
     """Normalize the agent registry mapping into a profile item list.
@@ -450,14 +484,20 @@ def _expand_agents(
     entry becomes ``{name, ...fields, _source_dir}`` with ``_source_dir`` set
     to the repo root so ``body_path`` (e.g. ``agents/agent_definitions/<name>.md``)
     resolves against the repo, not the profile dir. No env resolution — agent
-    metadata carries no ``${VAR}`` refs."""
+    metadata carries no ``${VAR}`` refs.
+
+    An agent's ``tier:`` (looked up against ``models.yaml`` beside ``path``)
+    resolves into ``models`` here — see ``_resolve_agent_tier`` — so
+    downstream renderers keep reading ``item["models"]`` unchanged."""
     data = _load_yaml_mapping(path)
     agents = data.get("agents") or {}
+    pins = _load_model_pins(path.parent / "models.yaml")
     out: list[dict[str, Any]] = []
     for name, body in agents.items():
         if not isinstance(body, dict):
             continue
-        out.append({"name": name, **body, "_source_dir": source_dir})
+        item = {"name": name, **body, "_source_dir": source_dir}
+        out.append(_resolve_agent_tier(item, pins))
     return out
 
 
@@ -854,7 +894,7 @@ def expand_registries(
 
     agents_path = directive.get("agents")
     if agents_path:
-        out["agents"] = _expand_agents(repo_root / agents_path, source_dir)
+        out["agents"] = expand_agents(repo_root / agents_path, source_dir)
 
     hooks_path = directive.get("hooks")
     if hooks_path:

--- a/agent-profile/agent_profile/ingest.py
+++ b/agent-profile/agent_profile/ingest.py
@@ -291,6 +291,7 @@ def _plugin_hooks(
     native_harnesses: set[str],
 ) -> list[dict[str, Any]]:
     import json as _json
+
     from agent_profile._validate import ParseError
 
     manifest = payload_root / ".claude-plugin" / "plugin.json"
@@ -532,7 +533,7 @@ def _expand_skills(
     out: list[dict[str, Any]] = []
     for rel in paths:
         target = repo_root / rel
-        if rel.endswith(".yaml") or rel.endswith(".yml"):
+        if rel.endswith((".yaml", ".yml")):
             out.extend(_expand_external_skills(target, source_dir))
         else:
             out.extend(_expand_local_skills(target, source_dir))
@@ -626,6 +627,7 @@ def _expand_plugins(
     still provide command behavior inside the native harness.
     """
     import json as _json
+
     from agent_profile._validate import ParseError
 
     data = _load_yaml_mapping(path)

--- a/agent-profile/agent_profile/manifest.py
+++ b/agent-profile/agent_profile/manifest.py
@@ -249,9 +249,10 @@ def diff_and_clean(
     for f in dropped:
         if not f:
             continue
-        if selected_harnesses is not None:
-            if not _owner_overlap(selected_harnesses, _path_owners(f)):
-                continue
+        if selected_harnesses is not None and not _owner_overlap(
+            selected_harnesses, _path_owners(f)
+        ):
+            continue
         if other_profiles_claim_file(target, profile, f):
             continue
         abs_path = base / f

--- a/agent-profile/agent_profile/overlay.py
+++ b/agent-profile/agent_profile/overlay.py
@@ -61,6 +61,7 @@ import sys
 import tempfile
 from dataclasses import replace
 from pathlib import Path
+
 from agent_profile.env import load_dotenv, resolve_env_value, resolve_item_env
 from agent_profile.parse import Manifest
 from agent_profile.renderers.base import mcp_server_entry
@@ -409,9 +410,9 @@ def _write_codex_config(
     and MCP world. The fresh config trusts no projects, so any
     ``.codex/config.toml`` in the working tree is loaded but inert."""
     sections: list[str] = [
-        'approval_policy = "on-request"\n'
+        ('approval_policy = "on-request"\n'
         'approvals_reviewer = "auto_review"\n'
-        'sandbox_mode = "workspace-write"\n'
+        'sandbox_mode = "workspace-write"\n')
     ]
     if manifest.system_prompt:
         sp = profile_dir / manifest.system_prompt

--- a/agent-profile/agent_profile/renderers/claude.py
+++ b/agent-profile/agent_profile/renderers/claude.py
@@ -827,7 +827,7 @@ def _managed_signatures_per_event(
 
 def _prune_settings_blocks(
     event_array: list, signatures: _ManagedSigs
-) -> "list | None":
+) -> list | None:
     """Rebuild a settings.json event array with managed hooks removed at the
     inner-hook level. Returns ``None`` when nothing matched (the caller
     short-circuits to avoid a no-op rewrite). A block whose inner hooks are

--- a/agent-profile/agent_profile/renderers/codex.py
+++ b/agent-profile/agent_profile/renderers/codex.py
@@ -28,8 +28,8 @@ from __future__ import annotations
 
 import json
 import os
-import shutil
 import shlex
+import shutil
 import stat
 import subprocess
 import sys
@@ -793,7 +793,7 @@ def _managed_basenames_per_event(
 
 def _prune_event_blocks(
     event_array: object, event_managed: set[str]
-) -> "tomlkit.items.AoT | None":
+) -> tomlkit.items.AoT | None:
     """Return a rebuilt AoT containing only the blocks the caller should
     keep, or ``None`` when no block matched ``event_managed`` (the
     caller short-circuits in that case to avoid a no-op rewrite).
@@ -821,7 +821,7 @@ def _is_array_of_tables(value: object) -> bool:
     """tomlkit exposes [[hooks.SessionStart]] as an Array-of-Tables. Other
     `hooks.<key>` values (a scalar typo, a sub-table for some future
     feature) are not arrays and must not be walked."""
-    return isinstance(value, list) or isinstance(value, tomlkit.items.AoT)
+    return isinstance(value, (list, tomlkit.items.AoT))
 
 
 def _is_managed_legacy_block(

--- a/agent-profile/agent_profile/renderers/registry.py
+++ b/agent-profile/agent_profile/renderers/registry.py
@@ -13,8 +13,8 @@ from agent_profile.renderers.base import Renderer
 from agent_profile.renderers.claude import ClaudeRenderer
 from agent_profile.renderers.codex import CodexRenderer
 from agent_profile.renderers.copilot import CopilotRenderer
-from agent_profile.renderers.cursor import CursorRenderer
 from agent_profile.renderers.crush import CrushRenderer
+from agent_profile.renderers.cursor import CursorRenderer
 from agent_profile.renderers.opencode import OpencodeRenderer
 
 

--- a/agent-profile/tests/fixtures/golden/strings/help.txt
+++ b/agent-profile/tests/fixtures/golden/strings/help.txt
@@ -4,6 +4,7 @@ Commands:
   list                          List available profiles
   describe <name>               Show resolved manifest for a profile
   path <name>                   Print profile source dir
+  agents-json <registry.yaml>   Print resolved agent items (tier -> models)
   compile <name> --baseline <dir> --out <dir>
                                 Compile live profile fragments
   install <name> [opts]         Deprecated; use dots sync or ap compile

--- a/agent-profile/tests/test_model_tiers.py
+++ b/agent-profile/tests/test_model_tiers.py
@@ -1,0 +1,108 @@
+"""test_model_tiers.py — `tier:` resolution against agents/models.yaml.
+
+`agents/registry.yaml` agents name a tier instead of transcribing the
+claude/codex model ids; `agents/models.yaml` holds the lookup. Resolution
+runs in `expand_agents` so renderers keep reading `item["models"]`.
+
+Precedence under test:
+  1. the agent's own `models.<harness>` wins
+  2. else `pins[tier][harness]`
+  3. else the harness key stays absent
+plus: an unknown `tier` is a hard failure, not a silent passthrough.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+from agent_profile._validate import ParseError
+from agent_profile.cli import CliError, cmd_agents_json
+from agent_profile.ingest import expand_agents
+
+PINS = {
+    "fast": {"claude": "haiku", "codex": "gpt-5.6-luna"},
+    "deep": {"claude": "opus", "codex": "gpt-5.6-sol"},
+}
+
+
+def _registry(tmp_path: Path, agents: dict, *, pins: dict | None = PINS) -> Path:
+    """Write a registry + sibling models.yaml, return the registry path."""
+    reg = tmp_path / "registry.yaml"
+    reg.write_text(yaml.safe_dump({"agents": agents}), encoding="utf-8")
+    if pins is not None:
+        (tmp_path / "models.yaml").write_text(
+            yaml.safe_dump({"pins": pins}), encoding="utf-8"
+        )
+    return reg
+
+
+def _models(tmp_path: Path, agents: dict, **kw) -> dict:
+    items = expand_agents(_registry(tmp_path, agents, **kw), ".")
+    return {i["name"]: i.get("models") for i in items}
+
+
+def test_tier_resolves_to_pinned_models(tmp_path):
+    out = _models(tmp_path, {"a": {"tier": "deep"}})
+    assert out["a"] == {"claude": "opus", "codex": "gpt-5.6-sol"}
+
+
+def test_own_models_entry_overrides_the_tier(tmp_path):
+    out = _models(tmp_path, {"a": {"tier": "deep", "models": {"codex": "gpt-pinned"}}})
+    # claude still comes from the tier; codex is the agent's own override.
+    assert out["a"] == {"claude": "opus", "codex": "gpt-pinned"}
+
+
+def test_harness_absent_from_the_tier_stays_absent(tmp_path):
+    """cursor/opencode are not tier-derived — they only appear when the agent
+    sets them, and setting one must not synthesize the others."""
+    out = _models(tmp_path, {"a": {"tier": "fast", "models": {"cursor": "auto"}}})
+    assert out["a"] == {"claude": "haiku", "codex": "gpt-5.6-luna", "cursor": "auto"}
+    assert "opencode" not in out["a"]
+
+
+def test_agent_without_a_tier_is_untouched(tmp_path):
+    out = _models(tmp_path, {"a": {"models": {"claude": "sonnet"}}, "b": {}})
+    assert out["a"] == {"claude": "sonnet"}
+    assert out["b"] is None
+
+
+def test_unknown_tier_is_a_hard_failure_naming_the_agent(tmp_path):
+    with pytest.raises(ParseError) as excinfo:
+        _models(tmp_path, {"typo-agent": {"tier": "medium"}})
+    message = str(excinfo.value)
+    assert "typo-agent" in message
+    assert "medium" in message
+    # the error must list what the agent could have said instead
+    assert "deep" in message and "fast" in message
+
+
+def test_tier_without_models_yaml_is_a_hard_failure(tmp_path):
+    """A missing models.yaml must not silently drop every agent's model."""
+    with pytest.raises(ParseError):
+        _models(tmp_path, {"a": {"tier": "fast"}}, pins=None)
+
+
+def test_tier_key_is_consumed_not_leaked_into_frontmatter(tmp_path):
+    items = expand_agents(_registry(tmp_path, {"a": {"tier": "fast"}}), ".")
+    assert "tier" not in items[0]
+
+
+def test_agents_json_emits_resolved_models(tmp_path, capsys):
+    """`ap agents-json` is the sync-lib assembly's only view of the registry —
+    it must hand over models already resolved, not the raw tier."""
+    reg = _registry(tmp_path, {"a": {"tier": "deep", "body_path": "x.md"}})
+    assert cmd_agents_json(str(reg), sys.stdout) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert [i["name"] for i in payload] == ["a"]
+    assert payload[0]["models"] == {"claude": "opus", "codex": "gpt-5.6-sol"}
+    assert "tier" not in payload[0]
+
+
+def test_agents_json_rejects_a_missing_registry(tmp_path):
+    with pytest.raises(CliError):
+        cmd_agents_json(str(tmp_path / "nope.yaml"), sys.stdout)

--- a/agent-profile/tests/test_overlay.py
+++ b/agent-profile/tests/test_overlay.py
@@ -731,9 +731,9 @@ def _hermetic_dotenv(monkeypatch, tmp_path):
 
 
 def test_real_review_profile_locks_security_contract(monkeypatch, tmp_path):
-    """The shipped review profile must keep: Edit/Write/NotebookEdit + every
-    serena mutator + tilth_write denied; a read-only tool whitelist; a closed
-    MCP world of exactly tilth + context7."""
+    """The shipped review profile must keep: Edit/Write/NotebookEdit + tilth_write
+    denied; a read-only tool whitelist; a closed MCP world of exactly tilth +
+    context7."""
     _hermetic_dotenv(monkeypatch, tmp_path)
     pdir = find_profile_dir("review")
     assert pdir is not None, "real profiles/review not found"
@@ -748,12 +748,6 @@ def test_real_review_profile_locks_security_contract(monkeypatch, tmp_path):
         "Write",
         "NotebookEdit",
         "mcp__tilth__tilth_write",
-        "mcp__serena__replace_symbol_body",
-        "mcp__serena__replace_content",
-        "mcp__serena__insert_before_symbol",
-        "mcp__serena__insert_after_symbol",
-        "mcp__serena__rename_symbol",
-        "mcp__serena__safe_delete_symbol",
     ):
         assert must_deny in deny, f"review profile dropped deny: {must_deny}"
 
@@ -1397,9 +1391,9 @@ def test_opencode_launch_profile_wins_name_collision(env, monkeypatch):
 
 def test_real_review_profile_read_only_on_opencode(monkeypatch, tmp_path):
     """The shipped review profile launched on opencode must stay read-only:
-    OPENCODE_PERMISSION denies edit (from Edit/Write) and every serena
-    mutator + tilth_write appears as an mcp__* deny key. Closed MCP world is
-    exactly tilth + context7 (own, enabled)."""
+    OPENCODE_PERMISSION denies edit (from Edit/Write) and tilth_write appears
+    as an mcp__* deny key. Closed MCP world is exactly tilth + context7
+    (own, enabled)."""
     _hermetic_dotenv(monkeypatch, tmp_path)
     pdir = find_profile_dir("review")
     assert pdir is not None, "real profiles/review not found"
@@ -1408,12 +1402,7 @@ def test_real_review_profile_read_only_on_opencode(monkeypatch, tmp_path):
 
     perm = json.loads(env["OPENCODE_PERMISSION"])
     assert perm["edit"] == "deny"
-    for mutator in (
-        "mcp__tilth__tilth_write",
-        "mcp__serena__replace_symbol_body",
-        "mcp__serena__rename_symbol",
-        "mcp__serena__safe_delete_symbol",
-    ):
+    for mutator in ("mcp__tilth__tilth_write",):
         assert perm[mutator] == "deny", f"review lost opencode deny: {mutator}"
 
     config = json.loads(env["OPENCODE_CONFIG_CONTENT"])

--- a/agent-profile/tests/test_renderer_agents.py
+++ b/agent-profile/tests/test_renderer_agents.py
@@ -102,16 +102,10 @@ def test_agent_writable_when_whitelist_grants_tilth_write() -> None:
     )
 
 
-def test_agent_writable_when_whitelist_grants_serena_editor() -> None:
+def test_agent_writable_when_whitelist_grants_tilth_wildcard() -> None:
+    # mcp__tilth__* subsumes tilth's writer — not read-only.
     assert not agent_is_read_only(
-        {"tools": ["Read", "mcp__serena__replace_symbol_body"]}
-    )
-
-
-def test_agent_writable_when_whitelist_grants_serena_wildcard() -> None:
-    # mcp__serena__* subsumes serena's editors — not read-only.
-    assert not agent_is_read_only(
-        {"tools": ["Read", "Grep", "Glob", "Bash", "mcp__serena__*"]}
+        {"tools": ["Read", "Grep", "Glob", "Bash", "mcp__tilth__*"]}
     )
 
 

--- a/agents/models.yaml
+++ b/agents/models.yaml
@@ -1,0 +1,15 @@
+# agents/models.yaml — model-tier lookup table for agents/registry.yaml.
+#
+# Each agent references a tier via `tier: <name>` instead of transcribing
+# claude/codex model ids. Precedence, resolved in ap's ingest layer
+# (agent_profile/ingest.py, expand_registries):
+#   1. the agent's own `models.<harness>` wins
+#   2. else `pins[tier][harness]`
+#   3. else the field is absent (unchanged from today)
+# An unknown `tier` on an agent is a hard error. `cursor:`/`opencode:` are
+# NOT tier-derived — see agents/registry.yaml's header and the spec's
+# Deliberate non-goal.
+pins:
+  fast: {claude: haiku, codex: gpt-5.6-luna}
+  mid: {claude: sonnet, codex: gpt-5.6-terra}
+  deep: {claude: opus, codex: gpt-5.6-sol}

--- a/agents/registry.yaml
+++ b/agents/registry.yaml
@@ -8,13 +8,15 @@
 # Bodies are instruction-only Markdown at body_path (frontmatter stripped);
 # all metadata lives here. tools/disallowedTools are LISTS (renderers join
 # to CSV for claude/cursor and derive sandbox/permission for codex/opencode).
-# models is per-harness; color/effort/maxTurns/skills are Claude-honored fields.
+# tier resolves models.claude/models.codex per agents/models.yaml; an agent's own
+# models.<harness> overrides its tier, and models.cursor/models.opencode stay
+# inline because they are not tier-consistent. color/effort/maxTurns/skills are
+# Claude-honored fields.
 agents:
   fromage-age-arch:
     description: Complexity and structure reviewer. Enforces complexity budgets (line counts, params, nesting) and Sliced Bread file organization. Does NOT cover encapsulation, dead code, or bugs.
+    tier: deep
     models:
-      claude: opus
-      codex: gpt-5.6-sol
       cursor: auto
     disallowedTools:
     - Edit
@@ -30,9 +32,8 @@ agents:
     body_path: agents/agent_definitions/fromage-age-arch.md
   fromage-age-history:
     description: Git history analyst. Produces per-file risk scores that the orchestrator uses to adjust sibling findings. Does NOT find bugs or architecture issues — only outputs score modifiers.
+    tier: fast
     models:
-      claude: haiku
-      codex: gpt-5.6-luna
       cursor: claude-haiku
     disallowedTools:
     - Edit
@@ -51,9 +52,8 @@ agents:
     body_path: agents/agent_definitions/fromage-age-history.md
   fromage-fort:
     description: PR review comment responder. Triages both inline review threads AND PR-level review body comments using severity tiers (blocker/high/medium/low) — fixes high-severity items, pushes back on bad suggestions, asks about uncertain ones. Named for the strong cheese made from leftover scraps — it takes leftover review comments and turns them into something useful.
+    tier: mid
     models:
-      claude: sonnet
-      codex: gpt-5.6-terra
       cursor: auto
     effort: medium
     tools:
@@ -70,9 +70,8 @@ agents:
     body_path: agents/agent_definitions/fromage-fort.md
   fromage-secaudit:
     description: Security and dependency health auditor. Scans for vulnerabilities, unused/overweight deps, stdlib alternatives, and OWASP issues. Read-only. Returns stake-grouped findings (high/medium) with file:line citations and one-line recommendations — ~2 KB digest, no severity rewriting, no auto-fixes. Used as an easy-cheese fork target when /age needs evidence on the security dimension.
+    tier: deep
     models:
-      claude: opus
-      codex: gpt-5.6-sol
       cursor: auto
     disallowedTools:
     - Write
@@ -89,9 +88,8 @@ agents:
     body_path: agents/agent_definitions/fromage-secaudit.md
   ghostbuster:
     description: Forensic examination of expired cheese — finds code that's gone off, specs pointing at empty shelves, and curds that never set. Dead code detector + spec cross-referencer. Categorizes findings as DEAD, ZOMBIE, GHOST, or DORMANT with severity-tier scoring. Read-only — never modifies code. Returns a categorized findings digest (~2 KB). Suitable as an easy-cheese fork target when /age needs evidence on the deslop dimension.
+    tier: mid
     models:
-      claude: sonnet
-      codex: gpt-5.6-terra
       cursor: auto
     effort: medium
     disallowedTools:
@@ -107,9 +105,8 @@ agents:
     body_path: agents/agent_definitions/ghostbuster.md
   nih-scanner:
     description: Structural NIH pattern scanner. Uses AST search and ast-grep to find code that reinvents well-known library functionality. Returns JSON candidate list (~2 KB digest) with usage counts and categories. Does not judge — the orchestrator scores and filters. Suitable as an easy-cheese fork target when /age needs evidence on the NIH dimension.
+    tier: mid
     models:
-      claude: sonnet
-      codex: gpt-5.6-terra
       cursor: auto
     effort: medium
     disallowedTools:
@@ -127,9 +124,8 @@ agents:
     body_path: agents/agent_definitions/nih-scanner.md
   ricotta-reducer:
     description: Code simplification and distillation agent. Strips genAI bloat, speculative abstractions, and unnecessary documentation. Produces a simplification report categorized by DELETE, INLINE, UNDOCUMENT, and DECOUPLE with severity-tier scoring. Analysis and detection only — never adds code (de-slop runs in scan mode, not auto-fix).
+    tier: mid
     models:
-      claude: sonnet
-      codex: gpt-5.6-terra
       cursor: claude-sonnet
     effort: medium
     tools:
@@ -143,9 +139,8 @@ agents:
     body_path: agents/agent_definitions/ricotta-reducer.md
   roquefort-wrecker:
     description: Writes and executes unit, integration, or other tests for new or modified code. Use PROACTIVELY to validate code functionality and find bugs. Adversarial approach with severity-tier scoring per finding.
+    tier: mid
     models:
-      claude: sonnet
-      codex: gpt-5.6-terra
       cursor: claude-haiku
     effort: medium
     tools:
@@ -158,9 +153,8 @@ agents:
     body_path: agents/agent_definitions/roquefort-wrecker.md
   duckdb-expert:
     description: Read-only DuckDB analyst for the coding-agent session-analytics database. Spawned with ONE analytics pack pointer (skills/<skill>/references/<domain>.md) plus a target and a harness filter; runs that single domain's queries and returns one structured ~2 KB digest. Reads queries from the caller's pack and the canonical schema from session-analytics. Built for context isolation — consumer skills fan out one parallel spawn per owned domain. Used by skill-improver, tool-efficiency, prompt-analytics, and work-recovery.
+    tier: fast
     models:
-      claude: haiku
-      codex: gpt-5.6-luna
       cursor: claude-haiku
     effort: low
     tools:
@@ -181,9 +175,8 @@ agents:
     body_path: agents/agent_definitions/duckdb-expert.md
   whey-drainer:
     description: Runs existing tests and returns only failures and summary counts (~2 KB digest). Use this agent to validate code without flooding the parent context with verbose test output. Fits easy-cheese's small/fast read-only sub-agent contract — call from /cook taste-test, /press, or /cure post-fix to gate the next step on test pass. Does NOT write tests.
+    tier: fast
     models:
-      claude: haiku
-      codex: gpt-5.6-luna
       cursor: claude-haiku
     effort: low
     tools:
@@ -195,9 +188,8 @@ agents:
     body_path: agents/agent_definitions/whey-drainer.md
   worktree-content-digest:
     description: Read-only worktree inspector. Given one worktree path, runs git log/diff/ls-files and returns a 2-3 line digest — unique commits, uncommitted diff summary, and whether untracked files look throwaway vs. worth keeping. Fanned out one-per-worktree (in parallel) by the worktree-triage skill so diff bodies stay in the sub-agent's window.
+    tier: fast
     models:
-      claude: haiku
-      codex: gpt-5.6-luna
       cursor: claude-haiku
     effort: low
     tools:
@@ -217,9 +209,8 @@ agents:
   # Copilot CLI renders these agents too, but ignores per-agent model overrides.
   explorer:
     description: Read-only codebase investigator. Answers "where / how / what" questions by searching and reading — never writes. Returns a structured findings digest (file:line citations, call paths, conclusions), keeping the file dumps out of the parent's context. Models the easy-cheese explore phase. Use PROACTIVELY to orient before any task touches unfamiliar code — blast-radius scoping, "find me X" sweeps, "how does Y work" — whether the active skill is /mold, /cook, /age, or any user-installed skill that needs grounding before it acts.
+    tier: mid
     models:
-      claude: sonnet
-      codex: gpt-5.6-terra
       opencode: inherit
     disallowedTools:
     - Edit
@@ -237,9 +228,8 @@ agents:
     body_path: agents/agent_definitions/explorer.md
   researcher:
     description: External-research agent. Answers questions outside the codebase — library/API docs, current web facts, version/changelog checks, best-practice comparisons, GitHub examples — via Context7, Tavily, web fetch, and gh, then writes a durable cited research slug under .cheese/research/. Read-only against code. Returns a condensed claim-level digest (the heavy fetch bodies stay on disk, out of the parent's context). Models the easy-cheese research phase. Use PROACTIVELY before implementing against an unfamiliar library or API, when a claim needs a current source instead of a guess, or whenever a skill (/mold, /cook, /briesearch, or any user-installed skill) would otherwise rely on stale training data.
+    tier: mid
     models:
-      claude: sonnet
-      codex: gpt-5.6-terra
       opencode: inherit
     disallowedTools:
     - Edit
@@ -257,9 +247,8 @@ agents:
     body_path: agents/agent_definitions/researcher.md
   reviewer:
     description: Multi-dimension code reviewer. Reviews a diff, PR, branch, or path through an explicit severity-report or taste-test contract. Source-read-only — never writes fixes; may write only its own .cheese artifact through cheez-write. A top-level /age orchestrator may supply specialist evidence. Models the easy-cheese review phase. Opus-tier. Use PROACTIVELY before merging or shipping any change, after /cook or /cure, and whenever a user-installed skill produces a diff that should be checked before it lands.
+    tier: deep
     models:
-      claude: opus
-      codex: gpt-5.6-sol
       opencode: inherit
     disallowedTools:
     - Edit
@@ -284,9 +273,8 @@ agents:
     # route through tilth directly. Denies Agent — a dispatched coder is a
     # level-1 subagent and cannot fan out.
     description: TDD-disciplined implementer. Takes an approved spec or unambiguous task and drives the contract → cut → implement → taste-test loop through tilth MCP tools. Runs the project's test/lint/build gates and applies review fixes. Models the easy-cheese code phase (/cook, /press, /cure). Mutates the tree exclusively through tilth_write — the one phase agent that changes code. Use PROACTIVELY whenever a task requires writing or changing code — implementing a spec, fixing a bug, applying review findings — under /cook, /press, /cure, or any user-installed skill that needs a code change made.
+    tier: mid
     models:
-      claude: sonnet
-      codex: gpt-5.6-terra
       opencode: inherit
     disallowedTools:
     - Agent
@@ -317,9 +305,8 @@ agents:
     # clips only the runaway tail, not legitimate p90 runs. Denies Agent (a
     # level-1 subagent cannot fan out).
     description: General-purpose catch-all for an open-ended, multi-step task that does not fit a specialist phase agent — mixed research, code reading, and synthesis in one dispatch. The capped stand-in for the built-in general-purpose agent. Prefer a specialist when the task is cleanly one shape — explorer for "where/how/what" code questions, researcher for external/library/web facts, reviewer for checking a diff before it lands, coder for writing or changing code. Use this only as the fallback when no single specialist owns the task. Routes file I/O through the cheez-* (tilth) skills.
+    tier: mid
     models:
-      claude: sonnet
-      codex: gpt-5.6-terra
       opencode: inherit
     disallowedTools:
     - Agent

--- a/justfile
+++ b/justfile
@@ -18,7 +18,7 @@ lint-shell:
 
 # ruff on python files
 lint-python:
-    ruff check skills/session-analytics/scripts/
+    ruff check skills/session-analytics/scripts/ agent-profile/agent_profile/
 
 # eslint on JS hooks (config in claude/hooks/eslint.config.js)
 lint-js:
@@ -31,9 +31,11 @@ lint-markdown:
 # autofix where supported (shellcheck has no autofix)
 lint-fix: lint-python-fix lint-js-fix lint-markdown-fix
 
-# ruff --fix + ruff format
+# ruff --fix + ruff format. agent-profile is check-only: `ruff format` over the
+# package is a ~300-line reformat unrelated to any lint rule, so it stays out
+# until someone lands it as its own commit.
 lint-python-fix:
-    ruff check --fix skills/session-analytics/scripts/
+    ruff check --fix skills/session-analytics/scripts/ agent-profile/agent_profile/
     ruff format skills/session-analytics/scripts/
 
 # eslint --fix
@@ -44,8 +46,15 @@ lint-js-fix:
 lint-markdown-fix:
     markdownlint-cli2 --fix '**/*.md'
 
-# run all tests
-test *ARGS:
+# run python + bats tests
+test *ARGS: test-python (test-bats ARGS)
+
+# agent-profile pytest suite
+test-python:
+    uv run --project agent-profile --frozen -m pytest agent-profile/tests
+
+# bats test suite
+test-bats *ARGS:
     ./tests/run-tests.sh {{ARGS}}
 
 # smoke tests — execute workflow definitions offline

--- a/tests/agent-skill-model-effort.bats
+++ b/tests/agent-skill-model-effort.bats
@@ -15,6 +15,7 @@
 
 DOTFILES_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME}")/.." && pwd)"
 REGISTRY="$DOTFILES_DIR/agents/registry.yaml"
+MODELS="$DOTFILES_DIR/agents/models.yaml"
 CLAUDE_YAML="$DOTFILES_DIR/chezmoi/.chezmoidata/claude.yaml"
 
 setup() { command -v yq >/dev/null 2>&1 || skip "yq not installed"; }
@@ -29,6 +30,17 @@ expected_effort() {
     esac
 }
 
+# Expected effort for a registry tier name. Agents name a tier; the claude
+# model behind it lives in agents/models.yaml.
+expected_effort_for_tier() {
+    case "$1" in
+        fast) echo low ;;
+        mid) echo medium ;;
+        deep) echo high ;;
+        *) echo "UNMAPPED" ;;
+    esac
+}
+
 expected_codex_model() {
     case "$1" in
         haiku) echo gpt-5.6-luna ;;
@@ -38,27 +50,50 @@ expected_codex_model() {
     esac
 }
 
-@test "every agent has an explicit claude model and effort" {
-    local a model effort
+@test "every agent has an explicit tier and effort" {
+    local a tier effort
     while IFS= read -r a; do
-        model="$(yq -r ".agents.\"$a\".models.claude // \"\"" "$REGISTRY")"
+        tier="$(yq -r ".agents.\"$a\".tier // \"\"" "$REGISTRY")"
         effort="$(yq -r ".agents.\"$a\".effort // \"\"" "$REGISTRY")"
-        [[ -n "$model" ]] || { echo "agent '$a' has no models.claude" >&2; return 1; }
+        [[ -n "$tier" ]] || { echo "agent '$a' has no tier" >&2; return 1; }
         [[ -n "$effort" ]] || { echo "agent '$a' has no effort" >&2; return 1; }
     done < <(yq -r '.agents | keys | .[]' "$REGISTRY")
 }
 
 @test "every agent's effort matches the tier→effort mapping" {
-    local a model effort want
+    local a tier effort want
     while IFS= read -r a; do
-        model="$(yq -r ".agents.\"$a\".models.claude" "$REGISTRY")"
+        tier="$(yq -r ".agents.\"$a\".tier" "$REGISTRY")"
         effort="$(yq -r ".agents.\"$a\".effort" "$REGISTRY")"
-        want="$(expected_effort "$model")"
+        want="$(expected_effort_for_tier "$tier")"
         [[ "$want" != "UNMAPPED" ]] \
-            || { echo "agent '$a' claude model '$model' is outside the haiku/sonnet/opus mapping" >&2; return 1; }
+            || { echo "agent '$a' tier '$tier' is outside the fast/mid/deep mapping" >&2; return 1; }
         [[ "$effort" == "$want" ]] \
-            || { echo "agent '$a' is $model/$effort — mapping wants $model/$want" >&2; return 1; }
+            || { echo "agent '$a' is $tier/$effort — mapping wants $tier/$want" >&2; return 1; }
     done < <(yq -r '.agents | keys | .[]' "$REGISTRY")
+}
+
+@test "every tier in agents/models.yaml pairs its claude and codex models" {
+    # This used to be asserted 16 times, once per agent. The pins table is now
+    # the only place the pairing is written down, so assert it there — and
+    # assert every tier the effort mapping knows about actually exists.
+    local tier claude_model codex_model want
+    while IFS= read -r tier; do
+        claude_model="$(yq -r ".pins.\"$tier\".claude // \"\"" "$MODELS")"
+        codex_model="$(yq -r ".pins.\"$tier\".codex // \"\"" "$MODELS")"
+        want="$(expected_codex_model "$claude_model")"
+        [[ "$want" != "UNMAPPED" ]] \
+            || { echo "tier '$tier' claude model '$claude_model' has no Codex tier mapping" >&2; return 1; }
+        [[ "$codex_model" == "$want" ]] \
+            || { echo "tier '$tier' codex model '$codex_model' — mapping wants '$want'" >&2; return 1; }
+        [[ "$(expected_effort "$claude_model")" == "$(expected_effort_for_tier "$tier")" ]] \
+            || { echo "tier '$tier' names claude model '$claude_model' but their efforts disagree" >&2; return 1; }
+    done < <(yq -r '.pins | keys | .[]' "$MODELS")
+
+    for tier in fast mid deep; do
+        [[ "$(yq -r ".pins.\"$tier\" // \"\"" "$MODELS")" != "" ]] \
+            || { echo "agents/models.yaml is missing tier '$tier'" >&2; return 1; }
+    done
 }
 
 @test "no agent carries a reserved xhigh/max effort" {
@@ -70,16 +105,21 @@ expected_codex_model() {
     done < <(yq -r '.agents | keys | .[]' "$REGISTRY")
 }
 
-@test "every agent uses the GPT-5.6 Codex model matching its tier" {
-    local a claude_model codex_model want
+# An agent may still override a single harness inline. Those overrides are
+# deliberate escapes from the tier, so assert only that they are not a silent
+# re-transcription of what the tier already says.
+@test "no agent's inline models override restates its tier" {
+    local a tier harness inline pinned
     while IFS= read -r a; do
-        claude_model="$(yq -r ".agents.\"$a\".models.claude // \"\"" "$REGISTRY")"
-        codex_model="$(yq -r ".agents.\"$a\".models.codex // \"\"" "$REGISTRY")"
-        want="$(expected_codex_model "$claude_model")"
-        [[ "$want" != "UNMAPPED" ]] \
-            || { echo "agent '$a' claude model '$claude_model' has no Codex tier mapping" >&2; return 1; }
-        [[ "$codex_model" == "$want" ]] \
-            || { echo "agent '$a' codex model '$codex_model' — mapping wants '$want'" >&2; return 1; }
+        tier="$(yq -r ".agents.\"$a\".tier // \"\"" "$REGISTRY")"
+        [[ -n "$tier" ]] || continue
+        for harness in claude codex; do
+            inline="$(yq -r ".agents.\"$a\".models.$harness // \"\"" "$REGISTRY")"
+            [[ -n "$inline" ]] || continue
+            pinned="$(yq -r ".pins.\"$tier\".$harness // \"\"" "$MODELS")"
+            [[ "$inline" != "$pinned" ]] \
+                || { echo "agent '$a' sets models.$harness to '$inline', which tier '$tier' already gives — drop it" >&2; return 1; }
+        done
     done < <(yq -r '.agents | keys | .[]' "$REGISTRY")
 }
 

--- a/tests/phase-agent-handoff.bats
+++ b/tests/phase-agent-handoff.bats
@@ -155,17 +155,27 @@ block_sha() {
 # coder that edits only through tilth. Lock those tool-surface contracts in the
 # registry so they cannot silently drift. The same metadata renders to Claude,
 # Codex, opencode, and Copilot CLI; Copilot ignores model overrides.
+# Asserted against the RESOLVED view (`ap agents-json`), not the registry text:
+# claude/codex now arrive from the agent's `tier:` via agents/models.yaml, so
+# reading `.models.claude` off the registry would see null and prove nothing.
+# What matters is that a model reaches the renderer, wherever it came from.
 @test "phase agents declare model intent for model-aware harnesses" {
-    local registry="$AGENTS_DIR/registry.yaml"
+    local resolved
+    resolved=$(uv run --project "$REAL_DOTFILES_DIR/agent-profile" --frozen \
+        -m agent_profile agents-json "$AGENTS_DIR/registry.yaml") \
+        || { echo "ap agents-json failed" >&2; return 1; }
+    local agent harness model
     for agent in explorer researcher reviewer coder; do
         for harness in claude codex opencode; do
-            run yq ".agents.${agent}.models.${harness}" "$registry"
-            assert_success
-            [[ "$output" != "null" ]] || { echo "$agent missing $harness model" >&2; return 1; }
+            model=$(jq -r --arg a "$agent" --arg h "$harness" \
+                '.[] | select(.name == $a) | .models[$h] // "null"' <<<"$resolved")
+            [[ "$model" != "null" && -n "$model" ]] \
+                || { echo "$agent missing $harness model" >&2; return 1; }
         done
-        run yq ".agents.${agent}.models.copilot" "$registry"
-        assert_success
-        [[ "$output" == "null" ]] || { echo "$agent must not set Copilot model (renderer ignores it)" >&2; return 1; }
+        model=$(jq -r --arg a "$agent" \
+            '.[] | select(.name == $a) | .models.copilot // "null"' <<<"$resolved")
+        [[ "$model" == "null" ]] \
+            || { echo "$agent must not set Copilot model (renderer ignores it)" >&2; return 1; }
     done
 }
 


### PR DESCRIPTION
Semantics-altering: agents in `agents/registry.yaml` now declare `tier: fast|mid|deep` instead of transcribing per-harness model ids, and ap's ingest layer resolves each tier against the new `agents/models.yaml` (an agent's own `models.<harness>` still wins; `cursor`/`opencode` stay inline because they aren't tier-consistent). A new `ap agents-json` command emits the resolved agent items so `.sync-lib.sh`'s Claude source assembly consumes one resolution instead of re-deriving tier lookup in jq.

Also in this diff: `just test` and CI now run agent-profile's pytest suite, with the accompanying justfile wiring and small test/typing cleanups across `agent_profile/`.

Reviewer should verify that rendered Claude agent frontmatter is byte-identical to the pre-tier render and that an unknown `tier` fails loudly. Covered by `agent-profile/tests/test_model_tiers.py`, `tests/agent-skill-model-effort.bats`, and `tests/phase-agent-handoff.bats`.
