### PR TITLE
chore(doc-drift): bump context7-mcp to 3.2.5 (no-op)

### DIFF
--- a/agents/doc-drift/sources.yaml
+++ b/agents/doc-drift/sources.yaml
@@ -49,7 +49,7 @@ sources:
     signal: { type: npm, ref: "@upstash/context7-mcp" }
     docs: https://github.com/upstash/context7
     governs: [chezmoi/.chezmoidata/claude.yaml, agents/mcp/registry.yaml]
-    reconciled: "3.2.4"
+    reconciled: "3.2.5"
 
   - id: tavily-mcp
     signal: { type: npm, ref: tavily-mcp }


### PR DESCRIPTION
## What
Bumps the `reconciled` marker for `context7-mcp` in `agents/doc-drift/sources.yaml` from `3.2.4` to `3.2.5`.

## Why no-op
Checked npm (`@upstash/context7-mcp`) and the [upstash/context7 GitHub releases](https://github.com/upstash/context7/releases). The only change between 3.2.4 and 3.2.5:

> `33229cb`: Clarify the `query-docs` query description so it asks for a single concept per query. When a question spans multiple distinct topics, callers are now told to make a separate query per concept instead of combining them (unless the question is about how the concepts interact), which avoids diluted, shallow results. Applied consistently across the MCP server, CLI, pi, and AI SDK tools.

This is an internal prompt/tool-description wording tweak inside the context7-mcp server itself — no changes to CLI flags, env vars, invocation args, or config schema. Nothing in our mirrored surface (`chezmoi/.chezmoidata/claude.yaml`'s `context7` mcp entry, `agents/mcp/registry.yaml`'s `context7` entry) needs edits.

Note: the version literal pinned in `claude.yaml` (`@upstash/context7-mcp@3.2.4`) carries a `# renovate:` marker, so bumping that pin is Renovate's job, not this doc-drift routine's — consistent with treating this as no-op.

Part of the weekly doc-drift routine (`agents/doc-drift/routine.md`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01LMQHEnRa5CipuUGH7Dt82F)_