### PR TITLE
chore(doc-drift): bump opencode to 1.18.10 (no-op)

### DIFF
--- a/agents/doc-drift/sources.yaml
+++ b/agents/doc-drift/sources.yaml
@@ -37,7 +37,7 @@ sources:
     signal: { type: npm, ref: opencode-ai }
     docs: https://opencode.ai/docs
     governs: [harnesses/opencode.md]
-    reconciled: "1.18.4"
+    reconciled: "1.18.10"
 
   - id: copilot-cli
     signal: { type: npm, ref: "@github/copilot" }


### PR DESCRIPTION
Doc-drift watcher: `opencode-ai` moved 1.18.4 → 1.18.10 on npm.

Reviewed the full changelog across 1.18.5–1.18.10 (opencode.ai/changelog + GitHub releases for anomalyco/opencode):

- **1.18.5**: Claude adaptive-thinking handling, OpenAI Responses phase handling, grep symlink paths, Mistral reasoning/prompt-cache stability, MiniMax M3 thinking-variant fix. Desktop: crash/session-loading fixes, V2 settings polish.
- **1.18.6**: branch-specific repo cache fix. Desktop: client-API compat, MCP state refresh, provider list refresh.
- **1.18.7**: Desktop-only UI fixes (titlebar inset, command palette, project selector scrolling).
- **1.18.8**: MCP server/OAuth compatibility improvements, MCP reconnect after expired SDK sessions, honors configured MCP OAuth callback ports in `mcp debug`, stopped sending deprecated sampling defaults to newer Gemini models.
- **1.18.9**: restored compatibility with legacy MCP SDK clients; a community fix correcting an MCP environment field in an opencode-internal built-in skill; Desktop crash/session fixes, Linux AppStream packaging.
- **1.18.10**: Desktop-only (attachment dedup, toast/tab UI polish, saved-tab repair, model-variant-selector loading, custom agent picker preserved); a new "discover Modal models" provider feature and a docs-ecosystem addition (opencode-tavily plugin) via community PRs.

None of this touches the config surface `harnesses/opencode.md` mirrors: no changes to the `opencode.json` schema, the plugin/hook API, sub-agent (`agents/<name>.md`) rendering, `AGENTS.md`/rules/`instructions` precedence, MCP config keys, or skill loading. The MCP/provider changes are internal reliability fixes, not documented-surface changes. Classified **no-op** — this PR only bumps the `reconciled` marker in `agents/doc-drift/sources.yaml`.

`just check` could not be run locally (no `just` binary in this environment); relying on CI. Since this is a marker-only no-op bump per the doc-drift routine's invariants, merging directly after opening.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LMQHEnRa5CipuUGH7Dt82F)_