### PR TITLE
chore(doc-drift): bump copilot-cli to 1.0.76 (no-op)

### DIFF
--- a/agents/doc-drift/sources.yaml
+++ b/agents/doc-drift/sources.yaml
@@ -43,7 +43,7 @@ sources:
     signal: { type: npm, ref: "@github/copilot" }
     docs: https://docs.github.com/en/copilot/how-tos/copilot-cli
     governs: [harnesses/copilot.md]
-    reconciled: "1.0.73"
+    reconciled: "1.0.76"
 
   - id: context7-mcp
     signal: { type: npm, ref: "@upstash/context7-mcp" }


### PR DESCRIPTION
## What
Bumps the `copilot-cli` `reconciled` marker in `agents/doc-drift/sources.yaml` from `1.0.73` → `1.0.76`. No other files changed.

## Why (no-op)
Reviewed the GitHub Copilot CLI changelog for 1.0.74, 1.0.75, and 1.0.76 (via the `github/copilot-cli` releases/changelog):

- **1.0.74** — Open Plugin Spec v1 plugin manifest / `.mcp.json` support, subagent-timeline UI ordering fixes, IDE/MCP reconnect reliability, `/mcp add`/`/mcp edit` env-var quoting fix, first-run sandbox opt-in splash, Gemini-3.6-flash support, misc UI/perf polish.
- **1.0.75** — Adds Claude Opus 5 model support (single-line release).
- **1.0.76** — `/plugins` enable/disable UI, Grok-4.5 support, sandbox denied-path enforcement hardening, session/queue/status-line UI improvements, `userPromptSubmitted` hook output now bounded at 10 MiB (a runtime safety cap, not a schema change), enterprise-managed sandbox floor, subagent delegation improvements.

Checked each against the capability table this item governs in `harnesses/copilot.md` (hooks, sub-agents, MCP, instructions/system-prompt precedence, settings/config, skills):

- Hooks schema (`version`/`hooks` array in `.github/hooks/*.json`) is unchanged; the 10 MiB output bound is an internal guard, not a new field.
- Sub-agent rendering/model-override behavior is unchanged.
- `~/.copilot/mcp-config.json` (`mcpServers`, stdio/HTTP/SSE) schema is unchanged — the new Open Plugin Spec `.mcp.json` is a separate plugin-scoped config surface that this item's doc (`harnesses/copilot.md`) doesn't currently document (no "Plugins" row exists there today), so nothing we mirror went stale.
- Instructions precedence and `settings.json`/`config.json` layout are unchanged; the new enterprise "managed sandbox floor" is an org-policy feature, not something this personal dotfiles config exercises.
- Skills directory resolution (`.github/skills`, `.claude/skills`, `.agents/skills`, `~/.copilot/skills`) is unchanged.

Net: no flag, key, schema, or documented behavior in `harnesses/copilot.md` changed between 1.0.73 and 1.0.76. This is a pure marker bump.

## Notes
- `just check` was not run locally — no `just` binary in this environment. Relying on CI.
- Per the doc-drift routine, a no-op bump PR with nothing else changed is safe to merge directly.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LMQHEnRa5CipuUGH7Dt82F)_