### PR TITLE
chore(doc-drift): bump oh-my-pi to v17.2.0 (no-op)

### DIFF
--- a/agents/doc-drift/sources.yaml
+++ b/agents/doc-drift/sources.yaml
@@ -69,4 +69,4 @@ sources:
     signal: { type: gh_release, ref: can1357/oh-my-pi }
     docs: https://github.com/can1357/oh-my-pi
     governs: [chezmoi/.chezmoidata/omp.yaml, chezmoi/dot_omp/private_agent/modify_config.yml]
-    reconciled: "v17.0.9"
+    reconciled: "v17.2.0"


### PR DESCRIPTION
## Summary

Weekly doc-drift check for `can1357/oh-my-pi` — reconciled version was `v17.0.9`, current release is `v17.2.0` (spans `v17.1.0`–`v17.1.8` plus `v17.2.0`).

Read the full changelog across all intermediate releases (v17.1.0, v17.1.1, v17.1.2, v17.1.3, v17.1.4, v17.1.5, v17.1.6, v17.1.7, v17.1.8, v17.2.0) and compared against the config surface this repo mirrors in `chezmoi/.chezmoidata/omp.yaml` (rendered wholesale into `~/.omp/agent/config.yml` by `chezmoi/dot_omp/private_agent/modify_config.yml`).

Breaking changes found upstream, none of which touch our mirrored keys:
- v17.1.0: `providers.webSearch`/`providers.image` single-preference options replaced by `providers.webSearchOrder`/`providers.imageOrder` priority lists (auto-migrates on startup) — we don't set either key in the registry.
- v17.1.8: `tab.screenshot()` extension API no longer takes a per-call save path (uses `browser.screenshotDir` instead) — an extension/scripting API change, not a `config.yml` key.
- v17.2.0: hashline patch language removed `DEL`/`DEL.BLK`/`COPY`/`COPY.BLK` edit ops in favor of `CUT`/`PASTE` — this is the model-facing patch tool vocabulary, not a config schema key.

No repeat of the `dev.autoqa.consent` → `dev.autoqaConsent` style key rename that PR #473 fixed for v17.0.5. Every key we currently set (`symbolPreset`, `disabledProviders`, `compaction.*`, `lsp.*`, `github.enabled`, `astGrep.enabled`, `task.eager`, `dev.autoqaConsent`, `hideThinkingBlock`, `modelRoles`, etc.) is unaffected. Several new opt-in features landed (`providers.autoThinkingMaxEffort`, `browser.cdpUrl`, `tui.codexResetFireworks`, `startup.changelogMode`, `omp cleanse` command) — none conflict with or require changes to what we already configure, so adopting them (if desired) is a separate decision, not doc drift.

This PR only bumps `reconciled` for `oh-my-pi` in `agents/doc-drift/sources.yaml`; no governs-file changes needed.

## Test plan

- [x] No config/schema changes — nothing to test locally beyond the version bump.
- Note: `just check` could not be run in this environment (no `just` binary present); relying on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LMQHEnRa5CipuUGH7Dt82F)_