### PR TITLE
fix(packages): self-heal casks whose app bundle was deleted out-of-band

### DIFF
--- a/.hallouminate/wiki/architecture/config-drift.md
+++ b/.hallouminate/wiki/architecture/config-drift.md
@@ -357,6 +357,56 @@ leg hard-fail loudly when `cargo` is absent instead of silently skipping.
 `git ls-remote <repo> <branch>`; and `command -v cargo` — absent on a machine
 that lists ungated `source: cargo` packages is the tell.
 
+## Known drift pattern: brew cask state survives an out-of-band app deletion
+
+**Symptom**: A managed cask's app bundle is gone from `/Applications` but
+`brew list --cask` still lists it, so `dots sync` skips it as installed and no
+upgrade path ever repairs it. First hit 2026-07-29: `/Applications/Cursor.app`
+missing (Caskroom copy still present, `cursor` binary link never created), so
+`ap launch cursor` failed with `cannot exec 'cursor'`.
+
+**Why it happens**: brew's install state lives in the Caskroom, not the
+artifact locations. Deleting the app (Trash, or an in-app self-update gone
+wrong) leaves the state intact. `greedy: false` casks (cursor, docker-desktop)
+never get an upgrade-triggered reinstall either, and the packages manifest-hash
+cache short-circuits sync entirely when nothing was edited — so the drift is
+permanent until manual `brew reinstall --cask <name>`.
+
+**Fix (automated since 2026-07-29)**: `packages/sync.sh:heal_missing_cask_apps`
+checks each installed managed cask's `app` artifacts (via
+`brew info --cask --json=v2` + yq) against `/Applications` (override:
+`CASK_APPDIR`) and `~/Applications`, and reinstalls on a miss. It runs inside
+`sync_brew` AND on the cached fast-path, so a valid manifest cache no longer
+masks the drift. Covered in `tests/packages.bats` (heal tests).
+
+**Detection**: `brew list --cask` name present + `[[ ! -e /Applications/<App> ]]`.
+
+## Known drift pattern: registry MCP drops stranded in opencode/cursor live configs
+
+**Symptom**: An MCP removed from `agents/mcp/registry.yaml` lingers in
+`~/.config/opencode/opencode.json` / `~/.cursor/mcp.json` indefinitely. First
+hit 2026-07-29: `serena` (dropped 5d43056e, 2026-07-24) still live in both
+five days and many syncs later, its binary long gone.
+
+**Why it happens**: two gaps ([#561](https://github.com/paulnsorensen/dotfiles/issues/561)).
+`_reconcile_dropped_mcps` diffs the *prior cached manifest* against the current
+one, so the prune fires only on the sync that crosses the drop — miss that
+window (sync error, manifest refreshed first) and the evidence is gone. And
+cursor's live `mcp.json` is a disconnected user-owned surface (see § global
+settings disconnected): no code path prunes it at all anymore.
+
+**Fix**: manual `jq 'del(.mcp.<name>)'` (opencode) / `del(.mcpServers.<name>)`
+(cursor) to a temp file, validate, move into place. While healing cursor, also
+check `envFile` values — a render from a worktree checkout bakes the worktree's
+dotenv path in (`renderers/cursor.py:_dotenv_abs_path` resolves
+`${DOTFILES_DIR}` at render time), which goes stale when the worktree is
+removed; repoint at the main clone's dotenv path. Permanent fix (stateless
+reconcile against the current registry) tracked in #561.
+
+**Detection**: live server names absent from `agents/mcp/registry.yaml` with
+repo provenance (matching command shape); any cursor `envFile` containing
+`.worktrees/`.
+
 ## Gotcha: `just check` fails locally on macOS while green in CI (GNU-only test idioms)
 
 **Symptom**: `just check` red on a single bats test locally on macOS, but CI

--- a/packages/sync.sh
+++ b/packages/sync.sh
@@ -183,6 +183,50 @@ upgrade_casks_greedy() {
     fi
 }
 
+# Repairs a class of drift `brew_install_pkgs` and `upgrade_casks_greedy`
+# can't see: brew's own state says a managed cask is installed, but its app
+# bundle was deleted out-of-band (e.g. dragged to the Trash). `brew list
+# --cask` still lists it, so the install pass skips it as already-present,
+# and there's no upgrade path that would ever reinstall it — real incident:
+# Cursor.app vanished from /Applications while `brew list --cask` still
+# showed `cursor`, requiring a manual `brew reinstall --cask cursor`.
+# Two brew calls are cheap enough to run even when the manifest-hash cache
+# short-circuits the rest of sync_brew.
+heal_missing_cask_apps() {
+    [[ "$PLATFORM" == "Darwin" ]] || return 0
+    command -v brew &>/dev/null || return 0
+    local managed installed
+    managed=$(get_source_pkgs "cask")
+    if [[ "${DOTFILES_DEV:-false}" == "true" ]]; then
+        managed+=$'\n'"$(get_source_pkgs "cask" "--dev")"
+    fi
+    [[ -n "$managed" ]] || return 0
+    installed=$(brew list --cask 2>/dev/null || true)
+    local -a present=()
+    local cask
+    while IFS= read -r cask; do
+        [[ -z "$cask" ]] && continue
+        grep -qx "${cask##*/}" <<< "$installed" && present+=("${cask##*/}")
+    done <<< "$managed"
+    ((${#present[@]})) || return 0
+    local json
+    if ! json=$(brew info --cask --json=v2 "${present[@]}" 2>/dev/null); then
+        log_warning "brew info --cask failed; skipping cask app heal"
+        return 0
+    fi
+    local appdir="${CASK_APPDIR:-/Applications}" token app
+    # shellcheck disable=SC2016  # $t in the yq expression is a yq variable, not shell
+    while IFS=$'\t' read -r token app; do
+        [[ -z "$token" || -z "$app" ]] && continue
+        [[ -e "$appdir/$app" || -e "$HOME/Applications/$app" ]] && continue
+        echo "  ! $token: $app missing from $appdir — reinstalling"
+        if ! brew reinstall --cask "$token" </dev/null; then
+            log_error "Failed to reinstall $token"
+            FAILED+=("$token")
+        fi
+    done < <(yq -r '.casks[] | .token as $t | .artifacts[] | select(tag == "!!map") | .app | select(. != null) | .[] | select(tag == "!!str") | $t + "\t" + .' <<< "$json" 2>/dev/null)
+}
+
 sync_brew() {
     # Install the OS build toolchain first so any sudo prompt is up front.
     bootstrap_brew_deps_linux
@@ -251,6 +295,8 @@ sync_brew() {
             brew_install_pkgs "Dev casks" "$(get_source_pkgs "cask" "--dev")" "$installed_casks" --cask
         fi
     fi
+
+    [[ "$PLATFORM" == "Darwin" ]] && heal_missing_cask_apps
 
     if [[ "${UPGRADE_MODE:-false}" == "true" ]]; then
         log_info "Upgrading brew packages..."
@@ -659,6 +705,11 @@ sync_native_harnesses() {
 # present even when the package declaration cache is valid.
 if check_cache; then
     log_success "Package manifests unchanged (cached), syncing Claude"
+    heal_missing_cask_apps
+    if ((${#FAILED[@]})); then
+        log_error "failed to heal ${#FAILED[@]} package(s): ${FAILED[*]}"
+        exit 1
+    fi
     sync_mise "aqua:anthropics/claude-code@v2.1.219"
     exit 0
 fi

--- a/skills/harness-doctor/SKILL.md
+++ b/skills/harness-doctor/SKILL.md
@@ -41,9 +41,16 @@ Read before judging. The repo's design rationale lives in the wiki; the
 *direction of travel* lives in git history.
 
 - **Wiki** (`repo:dotfiles:wiki`): `list_tree`, then `read_markdown` /
-  `ground` on `architecture/agent-profile.md`, `architecture/agents-dir.md`,
-  and the relevant `harnesses/<harness>.md`. These define what `ap` is
+  `ground` on `architecture/config-drift.md` **first** (its "Current state"
+  section defines who owns each live surface *today* and catalogs known drift
+  patterns), then `architecture/agent-profile.md`, `architecture/agents-dir.md`,
+  and the relevant `harnesses/<harness>.md`. These define what the repo is
   *supposed* to produce and where each harness's config lives.
+  - **The wiki overrides this skill.** Any target-state fact baked into this
+    file (paths, ownership, anchor commits) can go stale; when the wiki's
+    current-state pages disagree with a claim here, follow the wiki and flag
+    the skill for a `/skill-improver` pass — do not classify drift against the
+    stale model.
   - If `ground` errors with a schema/index error (e.g. `missing column
     chunk_id`), the LanceDB index is stale — run `hallouminate index` (or note
     it as a dotfiles bug if it won't rebuild) and fall back to `read_markdown`.
@@ -54,22 +61,27 @@ Read before judging. The repo's design rationale lives in the wiki; the
   git -C "$DOTFILES_DIR" log --oneline --grep='ap\|migrat\|settings\|hook' -20
   ```
 
-  Anchor commit: **#217 `feat(ap): add global profile + migrate settings.json
-  to chezmoi seed`** — the point hooks moved from `settings.json` into the
-  plugin tree and `settings.json` became a seed-once `create_` file. Anything
-  in `settings.json` matching a *pre-#217* shape is a stale-remnant candidate.
+  Historical anchor commit: **#217 `feat(ap): add global profile + migrate
+  settings.json to chezmoi seed`** — the point hooks first moved out of
+  `settings.json`. Since then Claude went **fully chezmoi-authoritative**:
+  `settings.json` is composed wholesale by `chezmoi/dot_claude/modify_settings.json`
+  from `chezmoi/.chezmoidata/claude.yaml`. Anything live matching a pre-#217
+  shape is still a stale-remnant candidate, but the *current* owner is the
+  modify script, not a plugin tree (which may not exist at all on the machine).
 
 Key target-state facts to hold:
 
 - Registries (edit surface): `agents/mcp/registry.yaml`,
   `agents/hooks/registry.yaml`, `agents/registry.yaml`, `skills/`.
-- `base` = registry union (render primitive); `global` = live install overlay
-  (`target_default: $HOME`, `local` marketplace, `enabled_plugins: global@local`).
-- Hook wiring lives in the **plugin tree's** `plugin.json`
-  (`~/.claude/plugins/local/global/.claude-plugin/plugin.json`), **NOT** in
-  `~/.claude/settings.json`. `ap install global` only jq-merges
-  `enabledPlugins` + `extraKnownMarketplaces` into `settings.json`, preserving
-  user keys — it never writes `.hooks` there.
+- `base` = registry union (render primitive). `profiles/global` is a
+  **deprecated stub** superseded by `profiles/live` — check the profile's own
+  yaml before describing it.
+- Claude's `~/.claude/settings.json` (hooks, enabledPlugins,
+  extraKnownMarketplaces, permissions) is **chezmoi-authoritative**: composed
+  wholesale by `chezmoi/dot_claude/modify_settings.json` from
+  `chezmoi/.chezmoidata/claude.yaml` + the plugin registries. Skills and
+  agents render flat to `~/.claude/skills/` and `~/.claude/agents/`; a
+  `~/.claude/plugins/local/` tree is historical and may be absent entirely.
 - The Claude-specific JS guards (`~/.claude/hooks/*.js`), `rtk`, and any tmux
   hook are **settings-only and legit** — not plugin-managed, so not drift.
 
@@ -79,7 +91,7 @@ Read the live files per harness (use `cheez-read`/`jq`, not blind cat):
 
 | Harness | Live files |
 |---|---|
-| claude | `~/.claude/settings.json`, `~/.claude/plugins/local/global/.claude-plugin/plugin.json`, `~/.claude/plugins/local/global/.mcp.json` |
+| claude | `~/.claude/settings.json` (+ `~/.claude/plugins/local/global/` only if that historical tree exists) |
 | codex | `~/.codex/config.toml` (`[mcp_servers]`, `[[hooks.*]]`), `~/.codex/hooks.json` |
 | opencode | `~/.config/opencode/opencode.json` (`mcp`, `provider`) |
 | cursor | `~/.cursor/mcp.json`, `~/.cursor/hooks.json` |
@@ -87,14 +99,24 @@ Read the live files per harness (use `cheez-read`/`jq`, not blind cat):
 
 ### 3. Render the target — diff live vs `ap`
 
-Render `base` into a throwaway target (never touches live config) and diff:
+For **Claude**, the authoritative check is the chezmoi modify script itself —
+feed it the live file and diff the result against live (byte-identical = no
+drift):
+
+```bash
+sh "$DOTFILES_DIR/chezmoi/dot_claude/modify_settings.json" \
+  < ~/.claude/settings.json | diff - ~/.claude/settings.json
+```
+
+For the other harnesses, render `base` into a throwaway target (never touches
+live config) and diff:
 
 ```bash
 TMP="$(mktemp -d)"
 DOTFILES_DIR="$DOTFILES_DIR" ap install base --target "$TMP"
-dots profile describe global          # resolved manifest for the live overlay
-# Compare e.g. rendered plugin.json hooks vs live plugin.json,
-# rendered .mcp.json vs live, codex config_servers vs rendered.
+dots profile describe live            # resolved manifest for the live overlay
+# Compare e.g. codex mcp_servers vs rendered, opencode/cursor mcp files vs
+# rendered payloads.
 ```
 
 For each difference, ask: *is the live side a superset (extra entries) or does
@@ -146,10 +168,16 @@ Two stale-remnant classes self-heal **inside the renderers**, on every
   prior render merged into a persistent file (codex `config.toml`,
   opencode/cursor/copilot JSON, claude user-scope `~/.claude.json`). claude
   plugin-scoped `.mcp.json` is whole-file so it never drifts.
+  **Caveat ([#561](https://github.com/paulnsorensen/dotfiles/issues/561))**:
+  this reconcile is *windowed* — it only fires on the sync that crosses the
+  drop, and cursor's live `mcp.json` is a disconnected surface no code path
+  prunes at all. A registry-dropped MCP found live in opencode/cursor with the
+  drop already behind the manifest cache needs a manual `jq del(...)` heal —
+  see the wiki's config-drift § "registry MCP drops stranded in opencode/cursor".
 
-So the heal for both is just **`dots profile install global`** (or a full
-`dots sync`) — it re-runs the renderers + reconcile. opencode/cursor/copilot
-receive no registry hooks, so there's no hook drift there.
+So the heal for both is just **`dots sync`** — it re-runs the renderers +
+reconcile. opencode/cursor/copilot receive no registry hooks, so there's no
+hook drift there.
 
 The doctor's value is *explaining why* drift appeared and catching the classes
 the renderers don't auto-heal. For those, propose the precise edit and confirm

--- a/tests/packages.bats
+++ b/tests/packages.bats
@@ -132,9 +132,10 @@ teardown() {
 
 # --- Mock helpers ---
 
-# Usage: write_mock_brew [installed_formulae] [installed_casks] [fail_pkg] [outdated_greedy_casks]
+# Usage: write_mock_brew [installed_formulae] [installed_casks] [fail_pkg] [outdated_greedy_casks] [info_json]
 write_mock_brew() {
-    local formulae="${1:-}" casks="${2:-}" fail_pkg="${3:-}" outdated_casks="${4:-}"
+    local formulae="${1:-}" casks="${2:-}" fail_pkg="${3:-}" outdated_casks="${4:-}" info_json="${5:-}"
+    [[ -z "$info_json" ]] && info_json='{"casks":[]}'
     cat > "$MOCK_BIN/brew" << MOCKBREW
 #!/bin/bash
 echo "brew \$*" >> "\$BREW_LOG"
@@ -154,7 +155,10 @@ case "\$1" in
     tap)
         if [[ \$# -eq 1 ]]; then echo ""; fi
         ;;
-    install)
+    info)
+        echo '$info_json'
+        ;;
+    install|reinstall)
         if [[ -n "$fail_pkg" && ("\$2" == "$fail_pkg" || "\$3" == "$fail_pkg") ]]; then
             exit 1
         fi
@@ -403,6 +407,81 @@ YAML
     assert_success
 
     ! grep -q "brew install --cask" "$BREW_LOG"
+}
+
+@test "heal reinstalls managed cask whose app bundle is missing" {
+    [[ "$(uname)" == "Darwin" ]] || skip "macOS only"
+
+    export CASK_APPDIR="$TEST_HOME/Applications"
+    mkdir -p "$CASK_APPDIR"
+    cat > "$PACKAGES_FILE" << 'YAML'
+packages:
+  - fakecask: { source: cask, platform: mac }
+YAML
+    write_mock_brew "" "fakecask" "" "" '{"casks":[{"token":"fakecask","artifacts":[{"app":["Fakecask.app"]}]}]}'
+
+    run_sync
+    assert_success
+
+    grep -q "brew reinstall --cask fakecask" "$BREW_LOG"
+}
+
+@test "heal skips cask whose app bundle is present" {
+    [[ "$(uname)" == "Darwin" ]] || skip "macOS only"
+
+    export CASK_APPDIR="$TEST_HOME/Applications"
+    mkdir -p "$CASK_APPDIR/Fakecask.app"
+    cat > "$PACKAGES_FILE" << 'YAML'
+packages:
+  - fakecask: { source: cask, platform: mac }
+YAML
+    write_mock_brew "" "fakecask" "" "" '{"casks":[{"token":"fakecask","artifacts":[{"app":["Fakecask.app"]}]}]}'
+
+    run_sync
+    assert_success
+
+    ! grep -q "reinstall" "$BREW_LOG"
+}
+
+@test "heal runs on the cached fast-path" {
+    [[ "$(uname)" == "Darwin" ]] || skip "macOS only"
+
+    export CASK_APPDIR="$TEST_HOME/Applications"
+    mkdir -p "$CASK_APPDIR/Fakecask.app"
+    cat > "$PACKAGES_FILE" << 'YAML'
+packages:
+  - fakecask: { source: cask, platform: mac }
+YAML
+    write_mock_brew "" "fakecask" "" "" '{"casks":[{"token":"fakecask","artifacts":[{"app":["Fakecask.app"]}]}]}'
+    run_sync
+    assert_success
+    rm -f "$BREW_LOG"
+
+    rm -rf "$CASK_APPDIR/Fakecask.app"
+    run bash "$SYNC_SCRIPT"
+    assert_success
+    assert_output_contains "unchanged (cached)"
+    grep -q "brew reinstall --cask fakecask" "$BREW_LOG"
+}
+
+@test "failed heal reinstall fails the cached sync" {
+    [[ "$(uname)" == "Darwin" ]] || skip "macOS only"
+
+    export CASK_APPDIR="$TEST_HOME/Applications"
+    mkdir -p "$CASK_APPDIR/Fakecask.app"
+    cat > "$PACKAGES_FILE" << 'YAML'
+packages:
+  - fakecask: { source: cask, platform: mac }
+YAML
+    write_mock_brew "" "fakecask" "" "" '{"casks":[{"token":"fakecask","artifacts":[{"app":["Fakecask.app"]}]}]}'
+    run_sync
+    assert_success
+    rm -f "$BREW_LOG"
+
+    rm -rf "$CASK_APPDIR/Fakecask.app"
+    write_mock_brew "" "fakecask" "fakecask" "" '{"casks":[{"token":"fakecask","artifacts":[{"app":["Fakecask.app"]}]}]}'
+    run bash "$SYNC_SCRIPT"
+    assert_failure
 }
 
 # A PATH with the C build toolchain (gcc/make/file) absent but every tool


### PR DESCRIPTION
## Summary

Fallout from a `/harness-doctor` session: Cursor.app had been deleted from /Applications while brew's Caskroom state still said installed, so `dots sync` never reinstalled it and `ap launch cursor` failed on a missing binary.

- **`packages/sync.sh`** — new `heal_missing_cask_apps()`: for each managed, installed cask, reads `brew info --cask --json=v2` app artifacts and reinstalls when the bundle is missing from `/Applications` (or `~/Applications`). Runs on both the full brew path and the manifest-cached fast path, so a cached sync still converges. `CASK_APPDIR` is the test seam.
- **`tests/packages.bats`** — 4 tests: reinstall-when-missing, skip-when-present, heal-runs-on-cached-path, failed-heal-fails-cached-sync (70/70 green).
- **`skills/harness-doctor/SKILL.md`** — wiki now overrides baked skill facts (stale claims → follow wiki, flag skill); updated to the chezmoi-authoritative settings model (`modify_settings.json` owns `~/.claude/settings.json` wholesale; plugin tree / `profiles/global` are historical); heal is `dots sync`; documents the windowed-reconcile gap for stranded opencode/cursor MCP drops (#561).
- **`config-drift` wiki page** — records both drift patterns for future doctor runs.

Refs #561.

## Test plan

- [x] `just check` exit 0 (bats 70/70, shellcheck clean)
- [x] `dots sync` deploys the skill; deployed copy verified byte-identical
- [x] yq artifact expression validated against real `brew info --cask --json=v2` output (cursor, obsidian)

🤖 Generated with [Claude Code](https://claude.com/claude-code)