### PR TITLE
chore(oss): add community health files (CoC, contributing, issue/PR templates)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,70 @@
+name: Bug report
+description: Something is broken or behaves incorrectly
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. Please fill out the fields
+        below — the more concrete the repro, the faster the fix.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+      placeholder: When I run X, Y happens instead of Z.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Minimal, copy-pasteable steps.
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version / commit
+      description: Output of `<tool> --version` or the commit SHA.
+    validations:
+      required: true
+
+  - type: input
+    id: environment
+    attributes:
+      label: OS / runtime
+      description: e.g. macOS 14.5, Ubuntu 24.04, Node 20.11
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / output
+      description: Paste relevant log output. Will be auto-formatted as code.
+      render: shell
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-flight
+      options:
+        - label: I searched existing issues and this is not a duplicate
+          required: true
+        - label: I am running the latest released version
+          required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,7 @@
+# Disable blank issues so users start from a template, and surface
+# alternative support channels for non-bug, non-feature questions.
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/paulnsorensen/dotfiles/security/advisories/new
+    about: Report a vulnerability privately via a draft security advisory.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,41 @@
+name: Feature request
+description: Suggest an enhancement or new capability
+labels: [enhancement]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the user-facing pain, not the implementation.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like to see happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you weighed and why they did not fit.
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Links, screenshots, prior art.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-flight
+      options:
+        - label: I searched existing issues and this is not a duplicate
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,30 @@
+<!-- markdownlint-disable-file MD041 -->
+<!--
+Thanks for opening a PR. Please fill out the sections below — short is fine,
+but blank is not. The reviewer should be able to understand intent and risk
+from the description alone.
+-->
+
+## What changed
+
+<!-- One or two sentences. The "what". -->
+
+## Why
+
+<!-- The motivation. Link any tracking issue: `Fixes #123`. -->
+
+## How to verify
+
+<!-- Commands the reviewer can run, or what to click in the UI. -->
+
+## Risk / rollout notes
+
+<!-- Anything reviewers should pay extra attention to. Migrations, breaking
+     changes, feature flags, follow-ups, etc. Write "none" if there is none. -->
+
+## Checklist
+
+- [ ] Conventional Commits PR title (`feat:`, `fix:`, `chore:`, `docs:`, ...)
+- [ ] Tests added or updated (or N/A)
+- [ ] Documentation updated (or N/A)
+- [ ] No secrets or credentials added

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,41 @@
+# Code of Conduct
+
+This project adopts the
+[**Contributor Covenant**, version 2.1][cc-2-1] as its Code of Conduct.
+
+The full text of the Code of Conduct is available at the link above
+and applies to all community spaces associated with this project,
+including issues, pull requests, discussions, and any project-related
+chat or events.
+
+## Reporting
+
+Reports of behaviour that does not align with the Code of Conduct
+should be sent to the maintainers at:
+
+> **<paulnsorensen@gmail.com>**
+
+All reports will be reviewed and investigated promptly and fairly.
+The maintainers are obligated to respect the privacy and safety of
+the reporter.
+
+## Enforcement
+
+Maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by
+other members of the project's leadership, in line with the
+[Enforcement Guidelines][cc-2-1-guidelines] published with the
+Contributor Covenant.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][cc],
+version 2.1.
+
+For answers to common questions, see the [FAQ][cc-faq], or read the
+[full text][cc-2-1].
+
+[cc]: https://www.contributor-covenant.org
+[cc-2-1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct/
+[cc-2-1-guidelines]: https://www.contributor-covenant.org/version/2/1/code_of_conduct/#enforcement-guidelines
+[cc-faq]: https://www.contributor-covenant.org/faq

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,57 @@
+# Contributing to dotfiles
+
+Thanks for your interest. Contributions of all sizes are welcome — a
+typo fix is just as useful as a feature. This document describes how
+to get from "I want to help" to "my change is merged".
+
+## Filing issues
+
+- Search [open issues](https://github.com/paulnsorensen/dotfiles/issues)
+  before opening a new one.
+- Use the bug-report or feature-request template.
+- For security vulnerabilities, do **not** open a public issue — see
+  [`SECURITY.md`](./SECURITY.md).
+
+## Setting up locally
+
+```sh
+git clone https://github.com/paulnsorensen/dotfiles.git
+cd dotfiles
+dots sync   # render registries + apply chezmoi
+```
+
+See [`AGENTS.md`](./AGENTS.md) for the repo layout and source-of-truth
+rules — never edit a rendered target; edit the source and re-run
+`dots sync`.
+
+## Running tests
+
+```sh
+just check   # full gate: shell lint + Bats + renderer tests
+dots test    # Bats suites only
+```
+
+Please run the full test suite before opening a PR.
+
+## Submitting a pull request
+
+1. Fork the repo and create a topic branch from `main`.
+2. Make your change. Keep commits focused; one concern per commit is
+   easier to review than a kitchen-sink commit.
+3. Use [Conventional Commits](https://www.conventionalcommits.org)
+   for the PR title (e.g. `feat: add X`, `fix: handle Y`,
+   `docs: explain Z`). Squash-merge will use the PR title as the
+   commit subject.
+4. Fill out the PR template — the "why" matters more than the "what".
+5. Wait for CI to go green and address review feedback.
+
+## Code of Conduct
+
+Participation in this project is governed by the
+[Contributor Covenant](./CODE_OF_CONDUCT.md). By contributing you
+agree to abide by it.
+
+## Licensing
+
+By submitting a contribution you agree that it will be licensed under
+the same terms as the project itself (see [`LICENSE`](./LICENSE)).


### PR DESCRIPTION
## What changed

Fills the remaining GitHub Community Standards gap found by /oss-hygiene (community profile was at 42%):

- `CODE_OF_CONDUCT.md` — Contributor Covenant 2.1
- `CONTRIBUTING.md` — wired to this repo's real workflow (`dots sync`, `just check`, `dots test`, AGENTS.md source-of-truth rules)
- `.github/ISSUE_TEMPLATE/` — structured bug/feature forms, blank issues disabled, private-advisory contact link (Discussions link omitted — Discussions is off)
- `.github/PULL_REQUEST_TEMPLATE.md`

## Why

Contributor-facing half of OSS hygiene. Already in place and untouched: LICENSE (MIT), README, tailored SECURITY.md, dependabot/codeql/dependency-review/scorecard/zizmor workflows, secret scanning + push protection. Also enabled Dependabot automated security fixes via API (not a repo file).

## Verification

`just check` exit 0 (152/152).

🤖 Generated with [Claude Code](https://claude.com/claude-code)