### PR TITLE
perf(check): halve just-check wall time; fix Darwin-only cache-test failures

### DIFF
--- a/.hallouminate/wiki/operations/test-suite-performance.md
+++ b/.hallouminate/wiki/operations/test-suite-performance.md
@@ -49,11 +49,33 @@ The full agent-profile pytest result remains the same known baseline: 903 passed
 [^result-pytest]: agent-profile/tests/test_canonical_permissions.py:96-118
 [^result-pytest-baseline]: Local benchmark, 2026-07-25: `uv run pytest -q`; identical failures before and after the speed changes.
 
+## First-exec assessment tax (2026-07-31)
+
+macOS syspolicyd assesses every **new executable inode** on its first exec (~150–300 ms under load). A test file that writes or copies mock executables per test pays that tax per mock per test. `cp -p` from a `setup_file` master creates new inodes, so the 2026-07-25 packages fix (build once, copy per test) did not remove the cost. Evidence: xtrace timestamps on one solo `packages.bats` test showed each mock's *first* invocation slow (`brew tap` 175 ms, `mise install` 229 ms, one-shot `curl|sh` 318 ms) with repeats fast; the file summed 661 s of the suite's 1,826 s duration-sum (70 tests, 9.4 s avg under 15-job load, 2.06 s solo).[^12]
+
+Fix pattern (implemented in `tests/packages.bats`): **symlink** the `setup_file`-built mocks into each test's `MOCK_BIN` instead of copying — exec through a symlink assesses the shared target inode once per suite run. Invariants the pattern depends on:
+
+- Every mock writer must `rm -f` its target before `cat >`: writing through a symlink truncates the shared master and corrupts concurrently running tests. This includes inline `cat > "$MOCK_BIN/…"` sites in test bodies, not just the `write_mock_*` helpers.
+- Shared mocks must resolve log paths from the environment at runtime (escaped `\$VAR` in heredocs), never baked in at write time — `write_mock_sh`/`write_mock_mise` previously baked `$TEST_HOME` paths via unquoted heredoc delimiters.
+- Tests that simulate a missing tool via `rm -f "$MOCK_BIN/x"` still work (removes the symlink); the shared master dir must therefore never be added to `PATH`.
+
+Result: the whole file runs in 7–10 s at 15 jobs; the full Bats leg fell from 247 s to ~155 s. The same pattern applied to `tests/sync-orchestrator.bats` (renamed from `sync-rollback.bats` — the rollback subsystem it was named for was deleted in the chezmoi consolidation; the file tests the live `.sync` orchestrator) took it from 104 s duration-sum (13 tests, ~8 s avg under load) to 3.3–3.6 s for the whole file. Remaining files with the same per-test executable-writing shape (duration-sums from the 2026-07-31 profile, contention-inflated): turn-budget-guard 117 s, tool-reroute 93 s, git-guard 69 s, local-llm 66 s, sensitive-file-guard 65 s. chezmoi-wiring's end-to-end apply test ran 57.6 s under load and bounds the parallel tail.
+
+External research (2026-07-31, cited long-form under the durable corpus's `research/bats-parallel-overhead/` and `research/macos-first-exec-assessment/`): bats-core evaluates each `.bats` file n+1 times — one counting pass plus a fresh child process per `@test` that re-sources the whole file — so heavy top-level file code multiplies by test count; GNU parallel's dispatch floor is 3–10 ms/job (negligible here); no faster dispatcher exists in bats-core (rush/jobserver requests unimplemented). On the macOS side, the one Apple-supported system-level lever is the Developer Tools exemption (`spctl developer-mode enable-terminal`), which verifiably removes first-exec scanning for processes launched by that terminal; however sources only demonstrate the assessment tax for Mach-O binaries — whether bare `#!/bin/bash` scripts are assessed at all is unconfirmed (our symlink fix works either way; attribute before broadening any exemption via `log stream --predicate 'process == "syspolicyd" || process == "XprotectService"'`).
+
+## Gate layout and env leak (2026-07-31)
+
+`check` now runs `lint-fix` serially first (it mutates files, and the fixable linters gate through it — `ruff check --fix`, `eslint --fix`, and `markdownlint-cli2 --fix` all exit non-zero on unfixable findings), then fans out `lint-shell`, `test-python`, `smoke`, and `test` via GNU parallel. Plain `lint` stays out of the gate as redundant with `lint-fix` + `lint-shell`. `just check` fell from 291 s serial to 157 s wall.[^13]
+
+`packages.bats` `setup()` now unsets `DOTFILES_DEV`: leaked as `true` from the invoking shell, `heal_missing_cask_apps` (#569) runs `brew list --cask` on the cache-hit path on Darwin, failing the two cache-skip tests on dev machines while Linux CI stays green (the heal is Darwin-only). Tests opt in explicitly.
+
 ## Benchmarking protocol
 
 Use at least three warm runs and report the median. Bats supports `-T/--timing`; use JUnit output to aggregate testcase duration by `classname`, but validate suspected files alone because parallel resource contention inflates individual test durations. Compare the existing CPU-count job setting with one lower and one oversubscribed value before changing it.
 
 [^1]: Local benchmark, 2026-07-25: `/usr/bin/time -p bats --jobs {8,15,30} tests/*.bats`; 15-job runs were 239.28s, 256.02s, and 264.59s.
+[^12]: Local benchmark, 2026-07-31: `bats --formatter tap13 --timing --jobs 15 tests/*.bats` aggregated per file; solo trace via `BASH_ENV` xtrace shim with `PS4='+$EPOCHREALTIME'` gated on `$0 == */sync.sh`.
+[^13]: Local benchmark, 2026-07-31: `time just check` — 291.1 s serial-leg sum before (bats 247.5, pytest 34.9, lint 5.5, lint-fix 1.3, smoke 1.9), 157.2 s wall after, exit 0. justfile:71-80; tests/packages.bats:12-68.
 [^2]: tests/chezmoi-wiring.bats:56-300
 [^3]: chezmoi/.sync:39-49; .sync-lib.sh:489-613
 [^4]: tests/chezmoi-wiring.bats:68-77,717-798

--- a/STRIP-LIST.md
+++ b/STRIP-LIST.md
@@ -190,7 +190,7 @@ All other packages (productivity tools, editors, optional CLIs). See catalog.
 | `tests/install-bats.sh` | COPY | Bats installer |
 | `tests/test_helper.bash` | COPY | Test helper |
 | `tests/dots.bats` | COPY+GENERICIZE | Added BASH_SOURCE path-derivation regression test |
-| `tests/sync-rollback.bats` | COPY | Tests sync machinery |
+| `tests/sync-orchestrator.bats` | COPY | Tests sync machinery |
 | `tests/packages.bats` | COPY | Tests packages machinery |
 | `tests/chezmoi-wiring.bats` | COPY (adapted) | Removed tests for stripped personal content |
 | `tests/install-base-profile.bats` | COPY | Tests base profile installer |

--- a/justfile
+++ b/justfile
@@ -68,5 +68,13 @@ check-llm:
     yq -e '.' chezmoi/local-llm/configs/llama-swap.yaml > /dev/null
     @echo "check-llm: ok"
 
-# pre-push gate: autofix what we can, then lint + unit tests + smoke checks
-check: lint-fix lint test test-python smoke
+# pre-push gate: lint-fix mutates files first (must not race readers) and
+# already gates the fixable linters (ruff/eslint/markdownlint --fix all exit
+# non-zero on unfixable findings); shellcheck has no fixer so it still runs
+# standalone. The remaining legs are independent and IO/CPU-bound, so they
+# fan out via GNU parallel; bats (test) goes last since it's the slowest.
+# Plain `lint` stays out of the gate — its fixable legs are redundant with
+# lint-fix, and lint-shell already covers the one leg that needs no fixer.
+check: lint-fix
+    @mkdir -p "$HOME/.parallel" && touch "$HOME/.parallel/will-cite"
+    parallel -k --group just ::: lint-shell test-python smoke test

--- a/tests/packages.bats
+++ b/tests/packages.bats
@@ -20,6 +20,9 @@ setup_file() {
     write_mock_harness claude
     write_mock_harness codex
     write_mock_harness omp
+    write_mock_mise
+    write_mock_curl
+    write_mock_sh
 }
 setup() {
     setup_test_env
@@ -30,7 +33,15 @@ setup() {
 
     export MOCK_BIN="$TEST_HOME/bin"
     mkdir -p "$MOCK_BIN"
-    cp -p "$BATS_FILE_TMPDIR/package-mocks/"* "$MOCK_BIN/"
+    # Symlink (not copy) the mocks generated once in setup_file(): macOS
+    # syspolicyd assesses every NEW executable inode on first exec, so
+    # sharing inodes across tests pays that tax once per suite run instead
+    # of once per test. write_mock_* override helpers rm -f the symlink
+    # before writing so they never truncate the shared master.
+    local f
+    for f in "$BATS_FILE_TMPDIR/package-mocks/"*; do
+        ln -s "$f" "$MOCK_BIN/$(basename "$f")"
+    done
 
     export BREW_LOG="$TEST_HOME/brew.log"
     export CARGO_LOG="$TEST_HOME/cargo.log"
@@ -41,20 +52,23 @@ setup() {
     export CODEX_LOG="$TEST_HOME/codex.log"
     export OMP_LOG="$TEST_HOME/omp.log"
     export MISE_LOG="$TEST_HOME/mise.log"
+    export CURL_LOG="$TEST_HOME/curl.log"
+    export SH_LOG="$TEST_HOME/sh.log"
+    export UV_LOG="$TEST_HOME/uv.log"
     export MISE_CONFIG_FILE="$TEST_HOME/mise-config.toml"
     export MISE_BOOTSTRAP_CONFIG_FILE="$TEST_HOME/missing-bootstrap-config.toml"
     printf '[tools]\n' > "$MISE_CONFIG_FILE"
 
-    # mise/curl/sh mocks stay per-test: some tests override them with failure
-    # variants, and they are cheap. The expensive shared mocks are generated
-    # once in setup_file() and copied in above.
-    write_mock_mise
-    write_mock_curl
-    write_mock_sh
+    # The invoking shell may export DOTFILES_DEV; sanitize it so dev-gated
+    # behavior (e.g. cask heal's `brew list --cask`) only runs when a test
+    # opts in explicitly.
+    unset DOTFILES_DEV
+
     export PATH="$MOCK_BIN:$PATH"
 }
 
 write_mock_sudo() {
+    rm -f "$MOCK_BIN/sudo"
     cat > "$MOCK_BIN/sudo" << 'MOCKSUDO'
 #!/bin/bash
 echo "sudo $*" >> "$SUDO_LOG"
@@ -71,6 +85,7 @@ write_mock_harness() {
         codex)  log_var="CODEX_LOG" ;;
         omp)    log_var="OMP_LOG" ;;
     esac
+    rm -f "$MOCK_BIN/$name"
     cat > "$MOCK_BIN/$name" << MOCKHARNESS
 #!/bin/bash
 echo "$name \$*" >> "\$$log_var"
@@ -82,7 +97,7 @@ MOCKHARNESS
 # Mock curl for native-installer tests: record the URL, emit nothing so the
 # downstream `| bash` / `| sh` runs an empty (no-op) script.
 write_mock_curl() {
-    export CURL_LOG="$TEST_HOME/curl.log"
+    rm -f "$MOCK_BIN/curl"
     cat > "$MOCK_BIN/curl" << 'MOCKCURL'
 #!/bin/bash
 echo "curl $*" >> "$CURL_LOG"
@@ -96,17 +111,17 @@ MOCKCURL
 # of a real installer script. Records args so a `--ref` pin is assertable.
 write_mock_sh() {
     local exit_status="${1:-0}"
-    export SH_LOG="$TEST_HOME/sh.log"
+    rm -f "$MOCK_BIN/sh"
     cat > "$MOCK_BIN/sh" << MOCKSH
 #!/bin/bash
-echo "sh \$*" >> "$SH_LOG"
+echo "sh \$*" >> "\$SH_LOG"
 exit $exit_status
 MOCKSH
     chmod +x "$MOCK_BIN/sh"
 }
 
 write_mock_uv() {
-    export UV_LOG="$TEST_HOME/uv.log"
+    rm -f "$MOCK_BIN/uv"
     cat > "$MOCK_BIN/uv" << 'MOCKUV'
 #!/bin/bash
 echo "uv $*" >> "$UV_LOG"
@@ -118,9 +133,10 @@ MOCKUV
 
 write_mock_mise() {
     local exit_status="${1:-0}"
+    rm -f "$MOCK_BIN/mise"
     cat > "$MOCK_BIN/mise" << MOCKMISE
 #!/bin/bash
-echo "mise \$* config=\${MISE_GLOBAL_CONFIG_FILE:-unset}" >> "$MISE_LOG"
+echo "mise \$* config=\${MISE_GLOBAL_CONFIG_FILE:-unset}" >> "\$MISE_LOG"
 exit $exit_status
 MOCKMISE
     chmod +x "$MOCK_BIN/mise"
@@ -136,6 +152,7 @@ teardown() {
 write_mock_brew() {
     local formulae="${1:-}" casks="${2:-}" fail_pkg="${3:-}" outdated_casks="${4:-}" info_json="${5:-}"
     [[ -z "$info_json" ]] && info_json='{"casks":[]}'
+    rm -f "$MOCK_BIN/brew"
     cat > "$MOCK_BIN/brew" << MOCKBREW
 #!/bin/bash
 echo "brew \$*" >> "\$BREW_LOG"
@@ -170,6 +187,7 @@ MOCKBREW
 }
 
 write_mock_cargo() {
+    rm -f "$MOCK_BIN/cargo"
     cat > "$MOCK_BIN/cargo" << 'MOCKCARGO'
 #!/bin/bash
 echo "cargo $*" >> "$CARGO_LOG"
@@ -184,6 +202,7 @@ MOCKCARGO
 }
 
 write_mock_npm() {
+    rm -f "$MOCK_BIN/npm"
     cat > "$MOCK_BIN/npm" << 'MOCKNPM'
 #!/bin/bash
 echo "npm $*" >> "$NPM_LOG"
@@ -201,6 +220,7 @@ MOCKNPM
 #   fail_repo:       exit non-zero when `gh extension install` is asked for this repo
 write_mock_gh() {
     local installed="${1:-}" fail_repo="${2:-}"
+    rm -f "$MOCK_BIN/gh"
     cat > "$MOCK_BIN/gh" << MOCKGH
 #!/bin/bash
 echo "gh \$*" >> "\$GH_LOG"
@@ -523,6 +543,7 @@ path_without_buildtools() {
     # Stub the full toolchain so the check passes regardless of host state.
     local t
     for t in gcc make file git curl; do
+        rm -f "$MOCK_BIN/$t"
         printf '#!/bin/bash\nexit 0\n' > "$MOCK_BIN/$t"; chmod +x "$MOCK_BIN/$t"
     done
     write_test_yaml
@@ -906,6 +927,7 @@ MOCKRUSTUP
 
     # brew outdated failing must NOT be silently swallowed as "nothing to
     # upgrade" — emit a warning and skip the pass, like the other brew ops.
+    rm -f "$MOCK_BIN/brew"
     cat > "$MOCK_BIN/brew" << 'MOCKBREW'
 #!/bin/bash
 echo "brew $*" >> "$BREW_LOG"
@@ -1076,6 +1098,7 @@ MOCKBREW
     ln -sf "$(command -v jq)" "$MOCK_BIN/jq"
     # The mocked brew places a working mise on `brew install mise`, so this test
     # exercises both the bootstrap call and the subsequent convergence call.
+    rm -f "$MOCK_BIN/brew"
     cat > "$MOCK_BIN/brew" << MOCKBREW
 #!/bin/bash
 echo "brew \$*" >> "$BREW_LOG"
@@ -1186,6 +1209,7 @@ packages:
   - cargo-update: { source: cargo, version: "1.2.3" }
   - cargo-audit: { source: cargo }
 YAML
+    rm -f "$MOCK_BIN/cargo"
     cat > "$MOCK_BIN/cargo" << 'MOCKCARGO'
 #!/bin/bash
 echo "cargo $*" >> "$CARGO_LOG"

--- a/tests/sync-orchestrator.bats
+++ b/tests/sync-orchestrator.bats
@@ -7,13 +7,11 @@
 
 load test_helper
 
-SYNC_SCRIPT="$REAL_DOTFILES_DIR/.sync"
+export SYNC_SCRIPT="$REAL_DOTFILES_DIR/.sync"
 
-setup() {
-    setup_test_env
-    export MOCK_BIN="$TEST_HOME/bin"
-    export FAKE_DOTFILES="$TEST_HOME/dotfiles"
-    mkdir -p "$MOCK_BIN" "$FAKE_DOTFILES"
+setup_file() {
+    export MOCK_BIN="$BATS_FILE_TMPDIR/sync-mocks"
+    mkdir -p "$MOCK_BIN"
 
     # Mock git — canned output; clone creates fake TPM dir structure
     cat > "$MOCK_BIN/git" << 'MOCK'
@@ -39,32 +37,58 @@ MOCK
         chmod +x "$MOCK_BIN/$cmd"
     done
 
-    # Mock packages/sync.sh
+    # Helper script: sources sync functions and calls a named function.
+    # Quoted heredoc — no write-time substitution — so $TEST_HOME and
+    # $SYNC_SCRIPT resolve from the environment at runtime, letting this
+    # master executable be shared (symlinked) across every test.
+    cat > "$MOCK_BIN/call-sync-fn" << 'HELPER'
+#!/bin/bash
+set -euo pipefail
+export HOME="$TEST_HOME"
+export DOTFILES_STATE_DIR="$TEST_HOME/.local/state/dotfiles"
+eval "$(awk '/^########## Main$/{exit} {print}' "$SYNC_SCRIPT")"
+if [[ -n "${FAKE_DIR:-}" ]]; then
+    dir="$FAKE_DIR"
+    cd "$FAKE_DIR"
+fi
+"$@"
+HELPER
+    chmod +x "$MOCK_BIN/call-sync-fn"
+
+    # Mock packages/sync.sh — no-op default, symlinked into each test's
+    # fake dotfiles tree; tests that override its content rm -f first.
+    export FAKE_DOTFILES_MASTER="$BATS_FILE_TMPDIR/sync-fixtures"
+    mkdir -p "$FAKE_DOTFILES_MASTER/packages"
+    printf '#!/bin/bash\nexit 0\n' > "$FAKE_DOTFILES_MASTER/packages/sync.sh"
+    chmod +x "$FAKE_DOTFILES_MASTER/packages/sync.sh"
+}
+
+setup() {
+    setup_test_env
+    export MOCK_BIN_MASTER="$BATS_FILE_TMPDIR/sync-mocks"
+    export FAKE_DOTFILES_MASTER="$BATS_FILE_TMPDIR/sync-fixtures"
+    export MOCK_BIN="$TEST_HOME/bin"
+    export FAKE_DOTFILES="$TEST_HOME/dotfiles"
+    mkdir -p "$MOCK_BIN" "$FAKE_DOTFILES"
+
+    # Symlink (not copy) the mocks generated once in setup_file(): macOS
+    # syspolicyd assesses every NEW executable inode on first exec, so
+    # sharing inodes across tests pays that tax once per suite run instead
+    # of once per test. Any test that rewrites a mock's content must rm -f
+    # the symlink first so it never truncates the shared master.
+    local f
+    for f in "$MOCK_BIN_MASTER/"*; do
+        ln -s "$f" "$MOCK_BIN/$(basename "$f")"
+    done
+
     mkdir -p "$FAKE_DOTFILES/packages"
-    printf '#!/bin/bash\nexit 0\n' > "$FAKE_DOTFILES/packages/sync.sh"
-    chmod +x "$FAKE_DOTFILES/packages/sync.sh"
+    ln -s "$FAKE_DOTFILES_MASTER/packages/sync.sh" "$FAKE_DOTFILES/packages/sync.sh"
 
     # Mock chezmoi/.chezmoidata/omp.yaml registry — empty plugin set
     mkdir -p "$FAKE_DOTFILES/chezmoi/.chezmoidata"
     printf 'omp:\n  plugins: {}\n' > "$FAKE_DOTFILES/chezmoi/.chezmoidata/omp.yaml"
 
     export PATH="$MOCK_BIN:$PATH"
-
-    # Helper script: sources sync functions and calls a named function
-    cat > "$MOCK_BIN/call-sync-fn" << HELPER
-#!/bin/bash
-set -euo pipefail
-export HOME="$TEST_HOME"
-export DOTFILES_STATE_DIR="$TEST_HOME/.local/state/dotfiles"
-export SYNC_SCRIPT="$SYNC_SCRIPT"
-eval "\$(awk '/^########## Main\$/{exit} {print}' "$SYNC_SCRIPT")"
-if [[ -n "\${FAKE_DIR:-}" ]]; then
-    dir="\$FAKE_DIR"
-    cd "\$FAKE_DIR"
-fi
-"\$@"
-HELPER
-    chmod +x "$MOCK_BIN/call-sync-fn"
 }
 
 teardown() {
@@ -176,6 +200,7 @@ SCRIPT
 printf 'chezmoi-apply\n' >> "$SYNC_EVENTS"
 SCRIPT
     chmod +x "$FAKE_DOTFILES/chezmoi/.sync"
+    rm -f "$FAKE_DOTFILES/packages/sync.sh"
     cat > "$FAKE_DOTFILES/packages/sync.sh" << 'SCRIPT'
 #!/bin/bash
 printf 'packages-sync\n' >> "$SYNC_EVENTS"
@@ -199,6 +224,7 @@ SCRIPT
 printf 'chezmoi-apply\n' >> "$SYNC_EVENTS"
 SCRIPT
     chmod +x "$FAKE_DOTFILES/chezmoi/.sync"
+    rm -f "$FAKE_DOTFILES/packages/sync.sh"
     cat > "$FAKE_DOTFILES/packages/sync.sh" << 'SCRIPT'
 #!/bin/bash
 if [[ "${PACKAGES_BOOTSTRAP_ONLY:-false}" == "true" ]]; then


### PR DESCRIPTION
## What

Halves `just check` wall time (291s → 153s measured) and fixes two `packages.bats` tests that failed deterministically on Darwin dev machines.

## Why / how

- **macOS first-exec inode tax (the big one).** syspolicyd assesses every *new executable inode* on first exec (~150–300ms under load). `packages.bats` copied/wrote ~12 mock executables per test × 70 tests. Mocks now build once in `setup_file()` and **symlink** into each test sandbox; every rewrite site `rm -f`s first so overrides never truncate the shared master through the symlink; shared mocks resolve log paths from the environment at runtime instead of baking them at write time. `packages.bats`: 661s duration-sum → 7–10s whole-file at 15 jobs.
- **`sync-rollback.bats` → `sync-orchestrator.bats`.** The rollback subsystem it was named for was deleted in the chezmoi consolidation; the file tests the live `.sync` orchestrator. Renamed and given the same speed pattern: 104s duration-sum → 3.3s whole-file. (`STRIP-LIST.md` row updated; `run-tests.sh` globs `*.bats`, no runner change.)
- **Parallel gate legs.** `check` runs `lint-fix` serially first (it mutates files and gates the fixable linters — ruff/eslint/markdownlint `--fix` all exit non-zero on unfixable findings), then fans out `lint-shell`/`test-python`/`smoke`/`test` via GNU parallel. Plain `lint` leaves the gate as redundant; the recipe remains for standalone use. CI unaffected (`test.yml` runs `just test`).
- **DOTFILES_DEV env leak.** Since #569, `heal_missing_cask_apps` runs `brew list --cask` on the cache-hit path (Darwin only). With `DOTFILES_DEV=true` leaked from the invoking shell, the test yaml's dev cask made both cache-skip tests fail on dev Macs while Linux CI stayed green. `setup()` now unsets it; tests opt in explicitly.
- Wiki `operations/test-suite-performance.md` updated with the mechanism, invariants, measurements, and cited external research (bats-core n+1 evaluation model, Developer Tools exemption lever).

## Review classification

Mixed: the justfile `check` recipe is **semantics-altering** (gate layout — the duplicate fixable-lint pass is dropped; failure detection is preserved via the fixers' exit codes). Test changes are **semantics-preserving** (identical assertions, faster setup). Verify: (1) the `rm -f`-before-rewrite invariant holds at every `cat > "$MOCK_BIN/…"` / shared-fixture write site; (2) you're comfortable with `lint` leaving the pre-push gate.

## Verification

- `just check` exit 0, twice (before and after the rename change): 157.2s and 153.5s wall vs 291s serial baseline; 1,316 bats + 152 smoke + pytest green.
- `bats --jobs 15` per-file: packages.bats 70/70 green (7.2–10.2s), sync-orchestrator.bats 13/13 green (3.3–3.6s), cross-file run 83/83 green.
- Job-count tuning intentionally untouched: 15 jobs was already benchmarked optimal on this host (8 → 334s, 30 → 266s; see wiki).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
