### PR TITLE
fix(deps): bump markdownlint-cli2 to 0.23.2 to patch js-yaml DoS

### DIFF
--- a/.github/lint-deps/package-lock.json
+++ b/.github/lint-deps/package-lock.json
@@ -7,7 +7,7 @@
       "name": "dotfiles-lint-deps",
       "devDependencies": {
         "eslint": "8.57.1",
-        "markdownlint-cli2": "0.23.1"
+        "markdownlint-cli2": "0.23.2"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -867,9 +867,9 @@
       }
     },
     "node_modules/globby": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-16.2.1.tgz",
-      "integrity": "sha512-JmsqJalahxxgW8V2ecSQ2G7UjPlI9cpKdrkG9KoNiXhd/YslXOTEB0cViENWUznuovIuNT+FkMbraDGjr4FCUg==",
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-16.2.2.tgz",
+      "integrity": "sha512-NLvV9ubZ6NDsJaOpKPy3cQeJpKi9DcWiyCiFUpJPA0YihRqiE6RWaLUmgNNPr8MgPpLZjnBjSmou7uZBRJv9wA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1279,14 +1279,14 @@
       }
     },
     "node_modules/markdownlint-cli2": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/markdownlint-cli2/-/markdownlint-cli2-0.23.1.tgz",
-      "integrity": "sha512-20JPI5W+HpV1OA+pUM712wgvL4GzYNUvbmhLU8KlEYJ1kCDx4soZ4/Xqd+WkLrPTOKMAn8SfO3zYFrK8GLlwQg==",
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli2/-/markdownlint-cli2-0.23.2.tgz",
+      "integrity": "sha512-eUhcnkSpzURo/o4htSqc7LPDszgOOTknhU4eY/sPHvMCLxnTCYscv1gw1/js/idmaZPisv9ECVEIORcllqjTUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "globby": "16.2.1",
-        "js-yaml": "5.2.1",
+        "globby": "16.2.2",
+        "js-yaml": "5.2.2",
         "jsonc-parser": "3.3.1",
         "jsonpointer": "5.0.1",
         "markdown-it": "14.3.0",
@@ -1319,9 +1319,9 @@
       }
     },
     "node_modules/markdownlint-cli2/node_modules/js-yaml": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
-      "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.2.tgz",
+      "integrity": "sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==",
       "dev": true,
       "funding": [
         {

--- a/.github/lint-deps/package.json
+++ b/.github/lint-deps/package.json
@@ -4,6 +4,6 @@
   "description": "Pinned Node lint tool versions for .github/workflows/test.yml (avoids adhoc npm -g installs).",
   "devDependencies": {
     "eslint": "8.57.1",
-    "markdownlint-cli2": "0.23.1"
+    "markdownlint-cli2": "0.23.2"
   }
 }


### PR DESCRIPTION
Closes Dependabot alert #1 (GHSA-pm4m-ph32-ghv5, high): exponential parsing DoS in `js-yaml >=5.0.0 <=5.2.1`.

## The dependency

`js-yaml` appears twice in `.github/lint-deps/package-lock.json`:

- `js-yaml@4.3.0` under eslint's `@eslint/eslintrc` (range `^4.1.0`) — not vulnerable, untouched.
- `js-yaml@5.2.1` under `markdownlint-cli2` — the vulnerable copy. `markdownlint-cli2@0.23.1` pins it *exactly*, not by range, so it can't be bumped transitively.

js-yaml does have a real 5.x line (3.x → 4.x → 5.x), so the advisory's 5.x range is genuine rather than a data oddity.

## The fix

Bump `markdownlint-cli2` 0.23.1 → 0.23.2, which pins the patched `js-yaml@5.2.2`. Lockfile regenerated with `npm install --package-lock-only`; the only movement is `markdownlint-cli2`, its transitive `globby` 16.2.1 → 16.2.2, and `js-yaml` 5.2.1 → 5.2.2.

## Verification

- `npm ci` installs cleanly from the regenerated lockfile.
- `markdownlint-cli2 v0.23.2` runs; `just lint-markdown` clean across 285 files, 0 issues.
- `lint-shell`, `smoke`, and the full bats suite pass.

`just check` is red on this machine for two pre-existing reasons, both reproduced on unmodified `origin/main` with this diff absent:

1. Two `packages.bats` cache tests fail when `DOTFILES_DEV=true` is exported in the shell; they pass under `env -u DOTFILES_DEV`. The fix for this is in #579, not yet on main.
2. Five `agent-profile` pytest failures on `EnvResolutionError: ap: env var ${CONTEXT7_API_KEY} is unset`, an environment-resolution issue unrelated to this change.

Neither is caused by this diff.

The unrelated `brace-expansion` advisory (GHSA-mh99-v99m-4gvg) remains open and is out of scope here.