### PR TITLE
fix(tests): sandbox mise config/data/cache dirs to stop repo-root leak

### DIFF
--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -38,6 +38,14 @@ setup_test_env() {
     export ORIGINAL_XDG_DATA_HOME="${XDG_DATA_HOME-__unset__}"
     export ORIGINAL_XDG_CACHE_HOME="${XDG_CACHE_HOME-__unset__}"
     unset XDG_CONFIG_HOME XDG_DATA_HOME XDG_CACHE_HOME
+
+    # Pin mise's config/data/cache dirs under the sandbox. mise discovers
+    # its config by climbing cwd, not via $HOME, so an unset MISE_CONFIG_DIR
+    # lets it find the real ~/.config/mise/config.toml and leak cache files
+    # (mise/aqua-*/**/bin_paths-*.msgpack.z) into the repo root.
+    export MISE_CONFIG_DIR="$TEST_HOME/.config/mise"
+    export MISE_DATA_DIR="$TEST_HOME/.local/share/mise"
+    export MISE_CACHE_DIR="$TEST_HOME/.cache/mise"
 }
 
 # Teardown test environment


### PR DESCRIPTION
Every full test-suite run dropped an untracked `mise/` directory (~168K of `mise/aqua-*/**/bin_paths-*.msgpack.z`) into the repo root.

## Why the existing sandbox didn't catch it

`setup_test_env()` already redirects `HOME` and the `XDG_*` dirs, which is normally enough. It isn't for `mise`: **mise discovers its config by climbing the cwd directory tree, not via `$HOME`.** Since `/Users/paul` is an ancestor of the repo path, `env HOME=/tmp/fake mise cfg` run from the repo root still resolves the real `~/.config/mise/config.toml` — and the leaked cache's tool set matched that real 43-tool manifest exactly.

Data/install lookups *do* honor `$HOME` (`env HOME=/tmp/fake mise which fd` correctly fails), so config discovery was the only hole.

## The fix

Pin all three dirs explicitly under `$TEST_HOME`, since `MISE_CONFIG_DIR` is honored even though `$HOME` is not:

```bash
export MISE_CONFIG_DIR="$TEST_HOME/.config/mise"
export MISE_DATA_DIR="$TEST_HOME/.local/share/mise"
export MISE_CACHE_DIR="$TEST_HOME/.cache/mise"
```

No teardown restore, matching the surrounding convention only where it applies: unlike the `XDG_*` vars these aren't ambiently preset by dev shells or CI, so there's nothing to save and restore.

## Verification

The triggering call site was never identified — an earlier investigation falsified the lead suspect (`chezmoi-wiring.bats` left the leaked dir's mtimes untouched on re-run). So this fix targets the mechanism rather than a known writer, and was verified empirically end-to-end:

1. `rm -rf mise/`, confirmed gone.
2. Full suite: `env -u DOTFILES_DEV bats --jobs 15 tests/*.bats`.
3. `mise/` did **not** reappear. Re-confirmed absent after a subsequent full `just check`.

Suite health: bats leg 1319/1319 pass. `tests/packages.bats` (which mocks mise) and `tests/mise-config.bats` (static TOML checks) were also run in isolation and are unaffected by the new vars.

`just check` remains red only on the five pre-existing `agent-profile` pytest failures (`EnvResolutionError: ap: env var ${CONTEXT7_API_KEY} is unset`), which reproduce on pristine `origin/main` with this diff absent.

## Unrelated note

`DOTFILES_DEV=true` is set by the dev profile, not merely exported ad hoc in a shell. Two `packages.bats` cache tests fail whenever it's set; they pass under `env -u DOTFILES_DEV`. That fix lives in #579, not on main yet.