### PR TITLE
chore(doc-drift): bump copilot-cli to 1.0.77 (no-op)

### DIFF
--- a/agents/doc-drift/sources.yaml
+++ b/agents/doc-drift/sources.yaml
@@ -43,7 +43,7 @@ sources:
     signal: { type: npm, ref: "@github/copilot" }
     docs: https://docs.github.com/en/copilot/how-tos/copilot-cli
     governs: [harnesses/copilot.md]
-    reconciled: "1.0.76"
+    reconciled: "1.0.77"
 
   - id: context7-mcp
     signal: { type: npm, ref: "@upstash/context7-mcp" }


### PR DESCRIPTION
## Summary
Doc-drift watcher detected `@github/copilot` (Copilot CLI) advanced from 1.0.76 to 1.0.77. This bumps the `reconciled` marker only — no edits to `harnesses/copilot.md` (the governed doc) were needed.

## Why no-op
Upstream changelog for 1.0.77 (2026-07-30):
- Unconditional autopilot approval now disables sandbox for the current session when bypass is allowed
- Ctrl+G opens the editor to edit `ask_user` freeform answers without closing the prompt
- Add a browser-based (web) OAuth login flow, now the default for `copilot login` on local interactive terminals (device code remains default on remote/headless terminals); `--web-flow`/`--device-code` force a mode
- Support enforcing managed sandbox policy via macOS and Windows native MDM settings
- Allow reasoning effort to be omitted so the server can select the default

None of these touch the config surface `harnesses/copilot.md` mirrors: hooks (`agents/hooks/registry.yaml`), sub-agents (`agents/registry.yaml`), MCP (`mcp-config.json` schema), system prompt/instructions precedence, `~/.copilot/` settings/config layout, skills, or the "no closed-world launch flags" isolated-settings note. They're interactive-UX, auth-flow-default, and enterprise-MDM changes outside our documented surface.

## Change
- `agents/doc-drift/sources.yaml`: `copilot-cli` entry `reconciled: "1.0.76"` → `"1.0.77"`. No other files touched.


---
_Generated by [Claude Code](https://claude.ai/code/session_012THBiC7UzsBaSQSyrsZSSv)_