### PR TITLE
chore(doc-drift): bump opencode to 1.18.11 (no-op)

### DIFF
--- a/agents/doc-drift/sources.yaml
+++ b/agents/doc-drift/sources.yaml
@@ -37,7 +37,7 @@ sources:
     signal: { type: npm, ref: opencode-ai }
     docs: https://opencode.ai/docs
     governs: [harnesses/opencode.md]
-    reconciled: "1.18.10"
+    reconciled: "1.18.11"
 
   - id: copilot-cli
     signal: { type: npm, ref: "@github/copilot" }


### PR DESCRIPTION
## What

Bumps the `reconciled` marker for `opencode` in `agents/doc-drift/sources.yaml` from `1.18.10` to `1.18.11`. No other files touched.

## Why this is a no-op

Reviewed the opencode-ai 1.18.10 → 1.18.11 changelog (npm package, upstream repo `anomalyco/opencode`, formerly `sst/opencode`):

**Core**
- Stopped MCP SSE connections from getting stuck in reconnect loops after server error responses.
- Fixed provider model configs that use interleaved reasoning fields like `reasoning_text` or custom field names.

**Desktop**
- Open external links in the system browser instead of inside the app.
- Fixed stale session tab state in the desktop title bar.
- Open the legacy directory picker at your home folder when no home path is loaded yet.
- Prevent the file tree tab from clipping when resized smaller.
- Fixed debug gutter labels and values misaligning.

None of this touches the config surface our doc mirrors (`.hallouminate/wiki/harnesses/opencode.md`): hooks/plugin API, sub-agent registry rendering, MCP config keys, system prompt/rules, `opencode.json` settings schema, skills, the local-LLM provider integration, or isolated-launch env vars (`OPENCODE_CONFIG_CONTENT`, `OPENCODE_PERMISSION`, etc.). These are internal bugfixes (MCP transport reliability, reasoning-field parsing) and desktop-app-only fixes — no flag, key, or documented behavior changed.


---
_Generated by [Claude Code](https://claude.ai/code/session_012THBiC7UzsBaSQSyrsZSSv)_