### PR TITLE
chore(doc-drift): bump oh-my-pi to v17.2.4 (no-op)

### DIFF
--- a/agents/doc-drift/sources.yaml
+++ b/agents/doc-drift/sources.yaml
@@ -69,4 +69,4 @@ sources:
     signal: { type: gh_release, ref: can1357/oh-my-pi }
     docs: https://github.com/can1357/oh-my-pi
     governs: [chezmoi/.chezmoidata/omp.yaml, chezmoi/dot_omp/private_agent/modify_config.yml]
-    reconciled: "v17.2.0"
+    reconciled: "v17.2.4"


### PR DESCRIPTION
## Drift

`oh-my-pi` (can1357/oh-my-pi): `v17.2.0` → `v17.2.4` (reconciled marker only — 4 point releases behind).

## Cumulative changelog review (v17.2.1 → v17.2.4)

Read the release notes for v17.2.1, v17.2.2, v17.2.3, and v17.2.4 (the "latest" GitHub page only shows the v17.2.3→v17.2.4 delta, so all four were pulled individually via Tavily). Highlights across the range:

- **v17.2.1** — OAuth credential-row resolution fix, Cowork request-profile parity, Ollama cache-key scoping fix, `--from-claude`/`--from-codex` session imports, opt-in native security-scan subsystem (`security.enabled`, default off), Wayland `computer`-tool fail-fast, `postmortem.quit` option.
- **v17.2.2** — `gmi-cloud` provider, usage-accounting fixes, hashline PUT/CUT grammar rewrite (breaking change to the *edit-tool grammar*, not our config), keybinding changes, `secrets.enabled` credential-token edit fix.
- **v17.2.3** — `aiand` provider, fix for Anthropic OAuth hard-429 on 1M-context beta (subscription accounts get the standard 200k window again), Codex Responses cache-retention fix, browser-daemon dedup fixes.
- **v17.2.4** — Codex WebSocket/SSE transport fixes, `AnthropicCompat.streamIdleTimeoutMs`, new MCP server option `requestIdFormat` (defaults MCP JSON-RPC ids to sequential integers instead of snowflake strings), and **XDG relocations**: `secret-placeholder.key` → `$XDG_STATE_HOME/omp/`, daemon runtime dirs → `$XDG_STATE_HOME/omp/run/`, `marketplaces.json` → `$XDG_DATA_HOME/omp/`. Existing installs get their legacy files auto-copied to the new XDG locations on first resolution.

## Why this is a no-op for our governed surface

Checked both files this source governs against every change above:

- `chezmoi/.chezmoidata/omp.yaml` mirrors the `omp.config` / `omp.models` / `omp.localModels` / `omp.plugins` subtrees rendered into `~/.omp/agent/config.yml` and `~/.omp/agent/models.yml`. No release in this range adds, renames, or removes a key under `omp.config` (no changes to `symbolPreset`, `disabledProviders`, `modelRoles`/tier aliases, `compaction`, `lsp`, `dev.autoqaConsent`, etc.), and no `models.yml` schema change beyond an internal bug fix (custom `thinking` metadata no longer gets clobbered by catalog policy — a bugfix in our favor, needs no registry edit).
- `chezmoi/dot_omp/private_agent/modify_config.yml` authors `~/.omp/agent/config.yml` wholesale from the registry and gates on unknown key-paths in that same file. The v17.2.4 XDG moves relocate `secret-placeholder.key`, `marketplaces.json`, and daemon runtime dirs — none of which live inside `config.yml` or are referenced by this script — and ship with automatic legacy-path migration, so the unknown-key gate is unaffected.
- The new `requestIdFormat` MCP option applies to `mcp.json`, which is a separate, non-governed file for this source.

No config/renderer edits needed. This PR only bumps `reconciled: "v17.2.0"` → `"v17.2.4"` in `agents/doc-drift/sources.yaml` per the no-op path in `agents/doc-drift/routine.md`.


---
_Generated by [Claude Code](https://claude.ai/code/session_012THBiC7UzsBaSQSyrsZSSv)_