### PR TITLE
test(agent-profile): align Context7 profile pin

### DIFF
--- a/agent-profile/tests/test_overlay.py
+++ b/agent-profile/tests/test_overlay.py
@@ -966,7 +966,7 @@ def test_oss_docs_profile_writes_pinned_playwright_mcp_for_codex(tmp_path, monke
         "command": "npx",
         "args": ["-y", "@playwright/mcp@0.0.78"],
     }
-    assert cfg["mcp_servers"]["context7"]["args"] == ["-y", "@upstash/context7-mcp@3.2.4"]
+    assert cfg["mcp_servers"]["context7"]["args"] == ["-y", "@upstash/context7-mcp@3.2.5"]
     assert cfg["mcp_servers"]["tavily"]["args"] == ["-y", "tavily-mcp@0.2.21"]
 
 


### PR DESCRIPTION
## Summary

- Align the OSS docs profile assertion with the repository's existing Context7 MCP pin, `@upstash/context7-mcp@3.2.5`.
- Restore the root quality gate without changing generated profile behavior.

This is the bottom, semantics-preserving layer of the Codex/OMP harness stack. PR #589 depends on it.

## Verification

- `just test-python tests/test_overlay.py::test_oss_docs_profile_writes_pinned_playwright_mcp_for_codex`
- `just check` — green; Python suite: 909 passed, 2 skipped
