### PR TITLE
feat(session-analytics): ingest oh-my-pi (omp) session logs

### DIFF
--- a/skills/session-analytics/SKILL.md
+++ b/skills/session-analytics/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: session-analytics
 description: >
-  Query coding-agent session logs (Claude, Codex, opencode) via DuckDB for usage
+  Query coding-agent session logs (Claude, Codex, opencode, oh-my-pi) via DuckDB for usage
   analytics, tool patterns, error forensics, and routing decisions. Use when the
   user says "session analytics", "query my logs", "tool usage", "how often do I
   use", "check my sessions", "analyze my usage", or asks about tool/agent/skill
@@ -39,7 +39,7 @@ batch/fan-out executor.
 ## How it works
 
 Session logs come from several harnesses (Claude JSONL, Codex rollout JSONL,
-opencode SQLite). `ingest.py` runs one normalizing **adapter** per harness into
+opencode SQLite, oh-my-pi JSONL). `ingest.py` runs one normalizing **adapter** per harness into
 one canonical row shape with a `harness` column, then materializes pre-flattened
 tables so you can answer questions with single SQL queries. cursor/copilot have
 no accessible logs today (see `harness-coverage.md`).
@@ -74,7 +74,7 @@ gotchas) lives in `references/canonical-schema.md`. Read it when you need a
 column you don't already know. The common tables: `tool_uses`, `tool_results`,
 `skill_invocations`, `agent_spawns`, `mcp_calls`, `stop_events`, `stop_hooks`,
 `permission_denials`, `sessions`, `raw_entries` — each carrying a `harness`
-column so you can filter or compare Claude vs Codex vs opencode.
+column so you can filter or compare Claude vs Codex vs opencode vs oh-my-pi.
 
 ## Query Catalog
 

--- a/skills/session-analytics/references/canonical-schema.md
+++ b/skills/session-analytics/references/canonical-schema.md
@@ -7,7 +7,7 @@ the tables below. **Pack authors: write SQL against these tables; never reach
 into a harness's native format.**
 
 Every session-scoped table carries a `harness` column
-(`claude`/`codex`/`opencode`/`cursor`/`copilot`). Filter or group by it to
+(`claude`/`codex`/`opencode`/`omp`/`cursor`/`copilot`). Filter or group by it to
 compare sources; omit it to aggregate across all reachable harnesses.
 
 ## `tool_uses`

--- a/skills/session-analytics/references/harness-coverage.md
+++ b/skills/session-analytics/references/harness-coverage.md
@@ -7,7 +7,7 @@ accessible logs is recorded here and skipped non-fatally — full coverage of wh
 is reachable, not parsing the unparseable.
 
 Every canonical table carries a `harness` column (`claude` / `codex` /
-`opencode` / `cursor` / `copilot`) so one query can compare sources. See
+`opencode` / `omp` / `cursor` / `copilot`) so one query can compare sources. See
 `canonical-schema.md` for the table shapes.
 
 ## Coverage status
@@ -17,6 +17,7 @@ Every canonical table carries a `harness` column (`claude` / `codex` /
 | claude | `~/.claude/projects/**/*.jsonl` | JSONL, one turn per line; assistant/user `message.content[]` blocks | `claude_normalize` (pass-through, already canonical) | parsed |
 | codex | `~/.codex/sessions/**/*.jsonl` | JSONL rollout; `session_meta` + `response_item`/`event_msg` payloads | `codex_normalize` | parsed |
 | opencode | `~/.local/share/opencode/opencode.db` | SQLite; `part` table rows with `type='tool'`, joined to `session.directory` | `opencode_normalize` | parsed |
+| omp | `~/.omp/agent/sessions/<flattened-project-dir>/*.jsonl` | JSONL; `session` header + `message` entries with `toolCall` / `toolResult` | `omp_normalize` | parsed |
 | cursor | `~/Library/Application Support/Cursor/User/globalStorage/state.vscdb` | SQLite blob, undocumented schema, fragile across versions | none | **no accessible logs** |
 | copilot | `~/.copilot/` | holds `skills/` + `mcp-config.json` only; no local transcript found | none | **no accessible logs** |
 
@@ -56,6 +57,39 @@ adapter targets the DB). A `part` row with `data.type='tool'` carries
   `tool_result` (`is_error='true'` on error).
 
 `session.directory` supplies `cwd`. Opened read-only (`mode=ro`).
+
+### omp
+
+oh-my-pi session JSONL, one file per session under a flattened-path project dir
+(e.g. `-Dev-dotfiles`). The `session` header entry (`{type:'session', id, cwd,
+timestamp, title}`) supplies sessionId + cwd for every row. `message` entries:
+
+- assistant `toolCall` content blocks → `tool_use` (`arguments` becomes `input`,
+  so `bash_cmd` extracts from `input.command`); `text`/`thinking` blocks pass
+  through;
+- role `toolResult` → a user `tool_result` block, joined on `toolCallId`;
+- role `user` passes through.
+
+Error flag: every `toolResult` message carries a **msg-level `isError` boolean**
+— one convention for builtin and MCP tools. For MCP tools a duplicate flag lives
+at `details.xdev.inner.isError`; verified perfectly consistent with the
+msg-level flag across all sessions, so the adapter reads only the msg-level one.
+
+Caveats:
+
+- **MCP naming** is a third scheme: `mcp__tilth_search` = `mcp__` + server +
+  *single* underscore + tool. These rows land in `mcp_calls` (the `mcp__%`
+  prefix filter matches), but any query that splits server/method on a
+  double-underscore separator will misparse omp names — split on the prefix +
+  first `_` instead when filtering `harness='omp'`.
+- **Shaken content**: context-compacted tool results are stored as a stub like
+  `[shaken ~275 tokens — recover: artifact://46 (region 2)]`. Kept verbatim —
+  content-based metrics (result length, error-text matching) undercount for
+  shaken rows.
+- **Tool-call id reuse**: `toolCall` ids (`write_0|fc_...`) are not globally
+  unique — a small fraction (~0.3%) repeat across sessions, so session-agnostic
+  `tool_use_id` joins can slightly overcount; join on `sessionId` too when
+  exactness matters.
 
 ### cursor — no accessible logs
 

--- a/skills/session-analytics/references/query-conventions.md
+++ b/skills/session-analytics/references/query-conventions.md
@@ -33,7 +33,7 @@ Keep a pack to ~4-6 queries. The digest the agent returns must fit ~2 KB.
 
 ## Harness filtering
 
-Every spawn carries a `harness=<all|claude|codex|opencode|cursor|copilot>`
+Every spawn carries a `harness=<all|claude|codex|opencode|omp|cursor|copilot>`
 parameter. In pack SQL:
 
 - `harness='all'` → omit the harness predicate (aggregate every reachable source).

--- a/skills/session-analytics/scripts/ingest.py
+++ b/skills/session-analytics/scripts/ingest.py
@@ -292,6 +292,109 @@ def opencode_normalize(path):
             }
 
 
+def omp_discover():
+    root = os.path.expanduser("~/.omp/agent/sessions")
+    if not os.path.isdir(root):
+        return []
+    out = []
+    for dirpath, _dirs, files in os.walk(root):
+        out.extend(os.path.join(dirpath, f) for f in files if f.endswith(".jsonl"))
+    return out
+
+
+def omp_normalize(path):
+    """oh-my-pi session JSONL -> canonical envelope.
+
+    The ``session`` header entry carries id + cwd, threaded onto every row.
+    ``message`` entries: assistant ``toolCall`` blocks become tool_use blocks
+    (other blocks pass through); role ``toolResult`` becomes a user tool_result
+    block joined on ``toolCallId``, with the msg-level ``isError`` boolean as
+    the error flag; role ``user`` passes through. Tool names (``bash``, ``read``,
+    ``mcp__<server>_<tool>``) are kept verbatim.
+    """
+    session_id = None
+    cwd = None
+    for entry in _iter_jsonl(path):
+        if not isinstance(entry, dict):
+            continue
+        etype = entry.get("type")
+        if etype == "session":
+            session_id = entry.get("id") or session_id
+            cwd = entry.get("cwd") or cwd
+            continue
+        if etype != "message":
+            continue
+        msg = entry.get("message")
+        if not isinstance(msg, dict):
+            continue
+        ts = entry.get("timestamp")
+        role = msg.get("role")
+        if role == "assistant":
+            blocks = []
+            for block in msg.get("content") or []:
+                if not isinstance(block, dict):
+                    continue
+                if block.get("type") == "toolCall":
+                    args = block.get("arguments")
+                    if isinstance(args, str):
+                        try:
+                            args = json.loads(args)
+                        except json.JSONDecodeError:
+                            args = {"raw": args}
+                    if not isinstance(args, dict):
+                        args = {"raw": args}
+                    blocks.append(
+                        {
+                            "type": "tool_use",
+                            "id": block.get("id"),
+                            "name": block.get("name"),
+                            "input": args,
+                        }
+                    )
+                else:
+                    blocks.append(block)
+            yield {
+                "harness": "omp",
+                "type": "assistant",
+                "timestamp": ts,
+                "sessionId": session_id,
+                "cwd": cwd,
+                "message": {"content": blocks},
+            }
+        elif role == "toolResult":
+            text = "\n".join(
+                b.get("text", "")
+                for b in msg.get("content") or []
+                if isinstance(b, dict) and b.get("type") == "text"
+            )
+            yield {
+                "harness": "omp",
+                "type": "user",
+                "timestamp": ts,
+                "sessionId": session_id,
+                "cwd": cwd,
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": msg.get("toolCallId"),
+                            "content": text,
+                            "is_error": "true" if msg.get("isError") else "false",
+                        }
+                    ]
+                },
+            }
+        elif role == "user":
+            yield {
+                "harness": "omp",
+                "type": "user",
+                "timestamp": ts,
+                "sessionId": session_id,
+                "cwd": cwd,
+                "message": {"content": msg.get("content")},
+            }
+
+
 def cursor_discover():
     # Cursor stores chat in an opaque state.vscdb SQLite blob whose schema is
     # undocumented and fragile across versions. No reliable adapter yet — see
@@ -318,6 +421,7 @@ ADAPTERS = [
     ("claude", claude_discover, claude_normalize),
     ("codex", codex_discover, codex_normalize),
     ("opencode", opencode_discover, opencode_normalize),
+    ("omp", omp_discover, omp_normalize),
     ("cursor", cursor_discover, None),
     ("copilot", copilot_discover, None),
 ]


### PR DESCRIPTION
Adds an `omp` harness adapter to the session-analytics skill so oh-my-pi session logs are ingested alongside Claude, Codex, and opencode.

## Adapter

- `omp_discover` + `omp_normalize` in `skills/session-analytics/scripts/ingest.py`, following the codex/opencode adapter conventions.
- Walks `~/.omp/agent/sessions/<flattened-project-dir>/*.jsonl`; the `session` header entry supplies `sessionId` + `cwd`, threaded onto every row.
- Assistant `toolCall` content blocks become canonical `tool_use` blocks (`arguments` -> `input`, so `bash_cmd` extracts from `input.command` unchanged); `text`/`thinking` blocks pass through; `toolResult` messages become user `tool_result` blocks joined on `toolCallId`; user messages pass through.
- Error flag: every omp `toolResult` carries a msg-level `isError` boolean — one convention for builtin and MCP tools, verified perfectly consistent with the MCP-only `details.xdev.inner.isError` duplicate. Mapped to the canonical `'true'/'false'` VARCHAR like the claude adapter.

## Verified

`ingest.py --force` + duckdb spot-checks:

- 65,369 canonical omp entries staged and loaded.
- 33,186 omp rows in `tool_uses` (5,693 bash rows, 100% with `bash_cmd`).
- 478 omp sessions, all with non-null cwd.
- omp MCP calls land in `mcp_calls` (464 rows); tilth counts match live logs exactly (`mcp__tilth_search` 82, `mcp__tilth_read` 75, `mcp__tilth_write` 30, `mcp__tilth_list` 19, `mcp__tilth_diff` 18).
- Error joins return >0 (1,238 error results, including 6 `mcp__tilth_diff` + 1 `mcp__tilth_read`).

## Docs

- `references/harness-coverage.md` — omp coverage-table row + format-notes section (location, envelope mapping, error convention, caveats).
- Harness enums updated in `references/canonical-schema.md`, `references/query-conventions.md`, and `SKILL.md`.

## Caveats (documented, not "fixed")

- `toolCall` ids repeat across sessions (~0.3%), so session-agnostic `tool_use_id` joins can slightly overcount — join on `sessionId` too when exactness matters.
- omp MCP names use a single-separator scheme (`mcp__<server>_<tool>`, e.g. `mcp__tilth_search`); queries that split server/method on a double-underscore separator need care on `harness='omp'` rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
