### PR TITLE
docs(wiki-harvest): curate dotfiles wiki

### DIFF
--- a/.hallouminate/wiki/architecture/cc-launch-env.md
+++ b/.hallouminate/wiki/architecture/cc-launch-env.md
@@ -3,7 +3,8 @@
 ## Why a launch-time loader exists at all
 
 The `${VAR}` MCP secret passthrough ([[mcp-secret-handling]]) assumes the
-claude process inherits `.env` keys from its environment. Shell init
+claude process inherits the secret keys from its environment — the vault cache
+(`secrets.env`) plus `.env`. Shell init
 (`zsh/core.zsh`) covers a freshly started interactive shell — but **not** the
 tmux path `_cc_base` uses: a `tmux new-session` command runs with the **tmux
 server's** environment, not the launching client's (verified empirically on
@@ -14,9 +15,12 @@ and one unset referenced `${VAR}` makes Claude fail to parse the entire
 
 ## The design: exec wrapper, not `tmux -e` (PR #282)
 
-`bin/cc-env-exec` does a safe `.env` parse (skip blanks/comments, split on
-first `=`, no command execution — same loop as `zsh/core.zsh`), exports the
-pairs, then `exec "$@"`. `_cc_base` (`zsh/claude.zsh`) prepends it to the
+`bin/cc-env-exec` sources `bin/lib/vault.sh`, then does a safe key=value parse
+(skip blanks/comments, split on first `=`, no command execution — same loop as
+`zsh/core.zsh`) over **both** `.env` and the vault cache (`secrets.env`, cache
+wins), exports the pairs, then `exec "$@"`. Unlike shell init it **fails loud**
+(exit 1) when the vault cache is unreadable — a headless launch must not run
+claude with half its credentials. `_cc_base` (`zsh/claude.zsh`) prepends it to the
 claude command on all three launch paths and degrades to plain `claude` when
 the wrapper is missing.
 

--- a/.hallouminate/wiki/architecture/config-drift.md
+++ b/.hallouminate/wiki/architecture/config-drift.md
@@ -397,10 +397,12 @@ settings disconnected): no code path prunes it at all anymore.
 
 **Fix**: manual `jq 'del(.mcp.<name>)'` (opencode) / `del(.mcpServers.<name>)`
 (cursor) to a temp file, validate, move into place. While healing cursor, also
-check `envFile` values — a render from a worktree checkout bakes the worktree's
-dotenv path in (`renderers/cursor.py:_dotenv_abs_path` resolves
-`${DOTFILES_DIR}` at render time), which goes stale when the worktree is
-removed; repoint at the main clone's dotenv path. Permanent fix (stateless
+check `envFile` values — when the envFile resolves to `.env` (not the
+vault-cache `secrets.env`, which is XDG-stable), a render from a worktree
+checkout bakes the worktree's `${DOTFILES_DIR}/.env` path in
+(`renderers/cursor.py:_env_file_for_keys` resolves it at render time), which
+goes stale when the worktree is removed; repoint at the main clone's `.env`
+path. Permanent fix (stateless
 reconcile against the current registry) tracked in #561.
 
 **Detection**: live server names absent from `agents/mcp/registry.yaml` with

--- a/.hallouminate/wiki/architecture/mcp-secret-handling.md
+++ b/.hallouminate/wiki/architecture/mcp-secret-handling.md
@@ -7,8 +7,12 @@ way to each renderer, instead of resolving the secret at sync time. The goal:
 keep real API keys out of the rendered config files on disk
 (`~/.claude.json`, `~/.cursor/mcp.json`, `~/.config/opencode/opencode.json`,
 `~/.copilot/mcp-config.json`). Each harness expands the placeholder itself at
-launch from its process env (zsh exports every `.env` key on shell init, so
-shell-launched CLIs already have the vars).
+launch from its process env. The secret *values* now come from the vault cache
+(`$XDG_CACHE_HOME/dotfiles/secrets.env`, materialized from 1Password/Bitwarden
+by `bin/lib/vault.sh` — see AGENTS.md), which `zsh/core.zsh` sources alongside
+`.env` on shell init (cache wins on collision); `.env` itself now holds only
+non-secret toggles. So shell-launched CLIs still inherit the vars, just from
+the cache rather than `.env`.
 
 Before this change, `ingest._expand_mcps` called `resolve_item_env`, so every
 renderer received the resolved secret and wrote it to disk — the keys sat in
@@ -41,7 +45,7 @@ The hard part: the `${VAR}` runtime-expansion syntax is **not** uniform.
 | **claude** | yes | `${VAR}` (literal) | `claude mcp add -e K='${VAR}'` (user scope) / plugin `.mcp.json` |
 | **codex** | n/a — inherits shell env | — (scrubbed) | `~/.codex/config.toml` |
 | **opencode** | yes | `{env:VAR}` | `opencode.json` `mcp.*.environment` |
-| **cursor** | yes, but GUI-launched | `envFile` → abs `.env` | `~/.cursor/mcp.json` |
+| **cursor** | yes, but GUI-launched | `envFile` → abs `.env`/cache | `~/.cursor/mcp.json` |
 | **copilot** | yes (fragile) | `${VAR}` (literal) | chezmoi template, NOT the `ap` renderer |
 
 ### claude — literal passthrough, no code change
@@ -53,10 +57,12 @@ stores `"${FAKE}"` literally.
 
 ### codex — scrub-by-keyname, unchanged
 
-`codex.py` drops any env key present in `$DOTFILES_DIR/.env` from the rendered
-TOML (zsh already exports them; codex is terminal-launched so its MCP children
-inherit at runtime). The registry shape is `KEY: "${KEY}"` (key == varname), so
-the scrub stays correct regardless of whether the value is the literal `${VAR}`
+`codex.py`'s `_inherited_env_keys` drops any env key present in the layered
+env — `$DOTFILES_DIR/.env` **plus** the vault cache, via `load_layered_env`
+(`AP_CODEX_INHERIT_ENV=0` disables the scrub, baking every value) — from the
+rendered TOML (zsh already exports them; codex is terminal-launched so its MCP
+children inherit at runtime). The registry shape is `KEY: "${KEY}"` (key ==
+varname), so the scrub stays correct regardless of whether the value is the literal `${VAR}`
 or a resolved secret. Neither the placeholder nor a secret lands in
 `config.toml`.
 
@@ -74,10 +80,13 @@ Cursor's `${env:VAR}` resolves against Cursor's *process* env, but a Finder/Dock
 launch inherits **no** shell `.env`. So `_cursor_mcp_entry` splits env into
 `${VAR}`-referencing entries vs plain literals: literals stay in `env`; if any
 `${VAR}`-ref existed, the entry drops those keys and gains an `envFile` field
-pointing at the absolute `.env` (stdio servers only — all ours are stdio).
-The abs path resolves `${DOTFILES_DIR}/.env` via `os.path.expandvars` with the
-`~/Dev/dotfiles` fallback (the `discover.py` pattern). A machine-specific abs
-path in user config is acceptable — same precedent as the marketplace path in
+(stdio servers only — all ours are stdio). `_env_file_for_keys` picks that
+single path per server: the vault cache (`secrets.env`) for keys the vault has
+taken over, otherwise `${DOTFILES_DIR}/.env` (`os.path.expandvars`, `~/Dev/dotfiles`
+fallback — the `discover.py` pattern). A server whose keys split across both
+sources can't be one `envFile`, so it fails loud rather than losing half its
+credentials.
+A machine-specific absolute path in user config is acceptable — same precedent as the marketplace path in
 `claude.py`'s `_merge_root_settings`.
 
 ### copilot — chezmoi template, not the renderer

--- a/.hallouminate/wiki/domain-model.md
+++ b/.hallouminate/wiki/domain-model.md
@@ -43,7 +43,7 @@ _Code_: NEW ENTITY (chezmoi/dot_config/mise/config.toml → ~/.config/mise/confi
 
 **Harness** — a native AI coding agent binary (claude, codex, omp) managed by sync's native-harness loop.
 _Avoid_: agent binary
-_Code_: packages/sync.sh:584-614 (`sync_native_harnesses`)
+_Code_: packages/sync.sh:680-708 (`sync_native_harnesses`)
 
 **Renovate runner** — the self-hosted cron workflow executing Renovate against this repo's four pinned surfaces.
 _Avoid_: update bot


### PR DESCRIPTION
Weekly wiki harvest. All changes stem from PR #580 (secrets moved out of the dotenv file into a detected 1Password/Bitwarden vault, materialized to `$XDG_CACHE_HOME/dotfiles/secrets.env`), which left four wiki claims stale, plus one drifted code anchor. Each correction was verified against current code.

## Pages changed

- **architecture/mcp-secret-handling.md** — secret *values* now come from the vault cache (sourced by `zsh/core.zsh` alongside the toggles file, cache wins), not the dotenv file which now holds only non-secret toggles. Codex scrub now keys off `load_layered_env` (toggles + cache) via `_inherited_env_keys`, with the `AP_CODEX_INHERIT_ENV=0` escape hatch. Cursor `envFile` is chosen per-server by `_env_file_for_keys` (cache vs toggles file; fails loud on a split), replacing the always-dotenv description. Quick-reference table row updated.
- **architecture/config-drift.md** — `renderers/cursor.py:_dotenv_abs_path` no longer exists in code; updated to `_env_file_for_keys` and narrowed the worktree-stale-path concern to the toggles-file case (the XDG cache path is stable).
- **architecture/cc-launch-env.md** — `bin/cc-env-exec` now sources `bin/lib/vault.sh` and loads both the toggles file and the vault cache, failing loud (exit 1) when the cache is unreadable.
- **domain-model.md** — `sync_native_harnesses` code anchor `packages/sync.sh:584-614` → `680-708`.

## Note on branch name

The mandated branch `wiki-harvest/dotfiles-20260802` could not be pushed: the remote already has a `wiki-harvest` branch (a file ref), so the slash-path namespace is blocked (directory/file conflict). Used the dash form `wiki-harvest-dotfiles-20260802`, matching the existing `wiki-harvest-curate-2026-07-19` branch on this remote.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EJic4HDqKycf5gGW2EiJq2)_