### PR TITLE
fix: stop Cursor, mise, and tool state polluting the repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,14 @@ claude/reference/cheese-flair.md
 # Claude Code local state (settings.local.json, specs)
 .claude/
 
+# Milknado per-repo graph state (SQLite DB + WAL/SHM sidecars). Runtime only —
+# regenerated per run, never shared through the repo.
+.milknado/
+
+# Serena MCP per-repo state. project.yml is machine-generated from an onboarding
+# scan (absolute paths, local language-server config), so nothing here travels.
+.serena/
+
 # Hallouminate per-repo state. Track config.toml (portable, relative paths)
 # and the curated wiki/ corpus so the repo:dotfiles:wiki setup travels with a
 # clone; ignore everything else here (LanceDB caches, scratch indexes).

--- a/cursor/.gitignore
+++ b/cursor/.gitignore
@@ -1,10 +1,59 @@
-# Dotfiles-managed allowlist. Only the Cursor plugin source
-# (cursor/plugins/local/cheese-grok/) belongs in version control; it is
-# deployed into a real ~/.cursor by chezmoi's install-cursor-plugin.sh.
-# Everything else under this dir would be a deploy artifact or Cursor IDE
-# runtime cache — none of it belongs in the repo. (~/.cursor is NOT symlinked
-# here anymore; `cursor` is in SYNC_SKIP_LIST, so nothing leaks back.)
+# >>> CURSOR MANAGED BLOCK >>>
+# Ignore everything in .cursor
 *
-!.gitignore
+# Un-ignore projects so we can descend to allowlisted subdirs
+!projects/
+projects/*
+!projects/*/
+projects/*/*
+# MCP tool descriptors, resources, prompts
+!projects/*/mcps/
+!projects/*/mcps/**
+# Agent transcripts for citation
+!projects/*/agent-transcripts/
+!projects/*/agent-transcripts/**
+# Terminal output files
+!projects/*/terminals/
+!projects/*/terminals/**
+# Conversation notes (shared scratchpad)
+!projects/*/agent-notes/
+!projects/*/agent-notes/**
+# Large tool output files
+!projects/*/agent-tools/
+!projects/*/agent-tools/**
+# Plugin cache (rules, skills, agents)
 !plugins/
 !plugins/**
+# Built-in Cursor skills
+!skills-cursor/
+!skills-cursor/**
+# User's personal skills
+!skills/
+!skills/**
+# User's personal slash commands
+!commands/
+!commands/**
+# User's plan files
+!plans/
+!plans/**
+# Subagent state/transcripts
+!subagents/
+!subagents/**
+# User-level cursor rules
+!rules/
+!rules/**
+# <<< CURSOR MANAGED BLOCK <<<
+
+# >>> DOTFILES MANAGED BLOCK — MUST STAY LAST >>>
+# ~/.cursor is symlinked to this directory, so Cursor writes its runtime state
+# (skills/, commands/, rules/, projects/, subagents/, plans/, skills-cursor/)
+# straight into the repo, and its git-sync rewrites the block above to
+# re-include all of it. The root .gitignore's `/cursor/*` cannot win that
+# fight: a nested .gitignore outranks its parents. So the re-ignore lives here,
+# after Cursor's block, where last-match-wins puts us on top. Only the plugin
+# source (cursor/plugins/local/) is tracked.
+/*
+!/.gitignore
+!/plugins/
+!/plugins/**
+# <<< DOTFILES MANAGED BLOCK — MUST STAY LAST <<<

--- a/justfile
+++ b/justfile
@@ -77,4 +77,8 @@ check-llm:
 # lint-fix, and lint-shell already covers the one leg that needs no fixer.
 check: lint-fix
     @mkdir -p "$HOME/.parallel" && touch "$HOME/.parallel/will-cite"
-    parallel -k --group just ::: lint-shell test-python smoke test
+    # GNU parallel exports XDG_CACHE_HOME to its jobs even when it is unset in
+    # the parent, and an empty value makes mise resolve its cache dir to a
+    # *relative* `mise`, dumping aqua bin_paths caches into the repo root. Pin
+    # a real value so the shimmed tools every leg runs cache under $HOME.
+    XDG_CACHE_HOME="${XDG_CACHE_HOME:-$HOME/.cache}" parallel -k --group just ::: lint-shell test-python smoke test

--- a/tests/mise-config.bats
+++ b/tests/mise-config.bats
@@ -84,3 +84,16 @@ CONFIG="$DOTFILES_DIR/chezmoi/dot_config/mise/config.toml"
     run grep -c 'gopls' <(yq -p=toml -o=json '.tools | keys' "$CONFIG")
     [[ "$output" == "0" ]]
 }
+
+@test "just check pins XDG_CACHE_HOME before parallel (mise cache leak guard)" {
+    # GNU parallel exports XDG_CACHE_HOME to its jobs even when the parent
+    # leaves it unset, and mise resolves an empty value to a *relative* `mise`
+    # cache dir — every `just check` then dropped mise/aqua-*/bin_paths caches
+    # into the repo root. The bats sandbox alone can't cover this: the leak
+    # comes from the gate's own fan-out, outside any test's environment.
+    local recipe
+    recipe=$(awk '/^check:/{f=1} f' "$DOTFILES_DIR/justfile")
+    [[ -n "$recipe" ]]
+    # shellcheck disable=SC2016  # a literal grep pattern, not an expansion
+    echo "$recipe" | grep -qF 'XDG_CACHE_HOME="${XDG_CACHE_HOME:-$HOME/.cache}" parallel'
+}


### PR DESCRIPTION
Two independent causes of persistent untracked noise in `git status`.

## 1. Cursor was rewriting its own gitignore (`805ff7f0`)

`~/.cursor` is symlinked to `cursor/`, so Cursor writes runtime state into the working tree and its git-sync replaces `cursor/.gitignore` with a managed block that un-ignores `skills/`, `commands/`, `rules/`, `projects/`, and `skills-cursor/`.

The root `.gitignore`'s `/cursor/*` cannot win: a nested gitignore outranks its parents for paths beneath it. Confirmed with `git check-ignore -v`, which resolved each path to `cursor/.gitignore:31:!skills/`.

Reverting the file would lose the race again on the next sync. Instead Cursor's block stays intact — so its rewrites are no-ops — with a dotfiles-owned block appended after it. Last match wins within a file, so a trailing `/*` plus `!/plugins/` re-ignores everything Cursor re-includes, including directories it hasn't invented yet. All 22 tracked `cursor/plugins/` files are unaffected.

Also ignores `.milknado/` and `.serena/`, neither of which travels with a clone. `git add -f` still works on both, which is what milknado's guidance prescribes for ephemeral cloud containers.

## 2. GNU parallel was leaking the mise cache into the repo root (`8f5f8397`)

Every `just check` dropped 42 files of `mise/aqua-*/**/bin_paths-*.msgpack.z` into the repo root. GNU parallel exports `XDG_CACHE_HOME` to its jobs even when unset in the parent — and exports it *empty*:

```
$ parallel -k --group 'env | grep XDG' ::: 1
XDG_CACHE_HOME=
```

mise resolves an empty value to a *relative* `mise` cache dir, so every shimmed tool the gate runs cached into `$PWD`.

This is why #583 couldn't have caught it. That fix pinned `MISE_{CONFIG,DATA,CACHE}_DIR` inside `setup_test_env`, which holds — the bats leg alone is clean, and so is each of `lint-shell`, `lint-fix`, `test-python`, and `smoke` run individually. The leak lives in the gate's own fan-out, outside any test's environment, and only reproduces through the full `just check`.

Guarded in `tests/mise-config.bats`, verified to fail against an unfixed copy of the recipe. #583 shipped without a regression test, which is why this went unnoticed.

## Verification

`just check` green on the rebased branch: bats 1323/1323, pytest passing, shellcheck and smoke clean, working tree clean afterward and no `mise/` created.

## Follow-ups not in this PR

- **`just test-python` is not in CI.** `.github/workflows/test.yml` runs `just test`, `just smoke`, and `just lint` only, so the agent-profile pytest suite has no remote coverage. That is why the stale `context7-mcp@3.2.4` assertion in `test_overlay.py` survived on main for days after #577 bumped the pin — nothing on the remote was looking. (That specific pin has since been fixed on main independently; the coverage gap has not.)
- Version literals in `agent-profile/tests/` are unreachable by Renovate's `customManagers`, whose `managerFilePatterns` cover only `profiles/*/profile.yaml`, `claude.yaml`, and `codex.yaml` — and which additionally require a `# renovate:` marker comment. They will drift again on the next MCP bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)