### PR TITLE
fix(vault): align BWS Keychain token bootstrap

### DIFF
--- a/.hallouminate/wiki/architecture/mcp-secret-handling.md
+++ b/.hallouminate/wiki/architecture/mcp-secret-handling.md
@@ -92,6 +92,13 @@ apply-time key to resolve now). Copilot's `${VAR}` expansion regressed in CLI
 v0.0.407 (gh#1403) and is thinly documented — if env passthrough breaks on a CLI
 upgrade, that template is where to revisit.
 
+## Bitwarden access-token bootstrap
+
+On macOS, interactive zsh reads the machine-account token from the Keychain service `bws_access_token` under `$USER` and exports it as `BWS_ACCESS_TOKEN`; this matches the existing machine entry.[^1] Linux keeps the existing 0600 token-file path.[^2]
+
+[^1]: zsh/core.zsh:116-122
+[^2]: bin/lib/vault.sh:30-57
+
 ## What was intentionally left alone
 
 - **codex stays on scrub** (already clean — never wrote secrets in the

--- a/bin/lib/vault.sh
+++ b/bin/lib/vault.sh
@@ -27,15 +27,16 @@ vault_token_file() {
     echo "${XDG_CONFIG_HOME:-$HOME/.config}/dotfiles/bws-token"
 }
 
-# Token storage is platform-specific. macOS uses the Keychain (Bitwarden's own
-# documented pattern). A headless Linux box has no keyring daemon, so libsecret
-# is unavailable and the token lives in a 0600 file instead; this refuses to
-# read one that is group- or world-readable rather than leaking it silently.
+# Token storage is platform-specific. macOS uses the Keychain service
+# `bws_access_token` (Bitwarden's own documented pattern). A headless Linux
+# box has no keyring daemon, so libsecret is unavailable and the token lives
+# in a 0600 file instead; this refuses to read one that is group- or
+# world-readable rather than leaking it silently.
 vault_token() {
     local file mode
     if [[ "$(uname -s)" == Darwin ]]; then
-        security find-generic-password -w -s BWS_ACCESS_TOKEN -a "$USER" 2>/dev/null || {
-            echo "vault: no Bitwarden access token in Keychain (service BWS_ACCESS_TOKEN)." >&2
+        security find-generic-password -w -s bws_access_token -a "$USER" 2>/dev/null || {
+            echo "vault: no Bitwarden access token in Keychain (service bws_access_token)." >&2
             echo "vault: run bin/vault-provision to store one." >&2
             return 1
         }

--- a/bin/vault-provision
+++ b/bin/vault-provision
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # vault-provision — one-time setup of the Bitwarden Secrets Manager vault that
 # backs this machine's secrets. Stores the machine-account access token in the
-# macOS Keychain (Bitwarden's own documented pattern), creates the project,
-# pushes each secret named in secrets/secrets.env.tmpl, then materializes the
-# cache via bin/lib/vault.sh.
+# macOS Keychain under the `bws_access_token` service (Bitwarden's own documented
+# pattern), creates the project, pushes each secret named in secrets/secrets.env.tmpl,
+# then materializes the cache via bin/lib/vault.sh.
 #
 # Web-vault prerequisites (no CLI path exists for these):
 #   1. Enable Secrets Manager on the account
@@ -44,7 +44,7 @@ Store the six secrets as fields on the 1Password item referenced by $TMPL,
 then run: source bin/lib/vault.sh && vault_materialize"
 fi
 
-# ─── access token → Keychain ────────────────────────────────────────────────
+# ─── access token → Keychain (service bws_access_token) ──────────────────────
 
 step "Bitwarden access token"
 if vault_token &>/dev/null; then
@@ -68,11 +68,11 @@ if [[ -n "$store_token" ]]; then
         # confirmation) from stdin via readpassphrase(3) when no tty is
         # attached, keeping the token out of argv (research:
         # .cheese/research/secret-argv-exposure/secret-argv-exposure.md).
-        security add-generic-password -U -s BWS_ACCESS_TOKEN -a "$USER" -w <<EOF
+        security add-generic-password -U -s bws_access_token -a "$USER" -w <<EOF
 $token
 $token
 EOF
-        echo "Stored in Keychain (service BWS_ACCESS_TOKEN)."
+        echo "Stored in Keychain (service bws_access_token)."
     else
         # Headless Linux has no keyring daemon; a 0600 file is the storage.
         # Create it empty at 0600 BEFORE writing so the token is never briefly
@@ -165,3 +165,4 @@ echo "Cache written: $(vault_secrets_file)"
 
 step "Done. Now remove these lines from $ENV_FILE:"
 cut -d= -f1 "$TMPL" | grep -v '^#' | grep -v '^$' | sed 's/^/  /'
+echo "  BWS_ACCESS_TOKEN (if present; keep the machine-account token in Keychain)"

--- a/tests/vault.bats
+++ b/tests/vault.bats
@@ -63,17 +63,97 @@ EOF
 
 # ── vault_token ──
 
-@test "vault_token: missing Keychain item fails naming bin/vault-provision" {
+@test "vault_token: missing Keychain item uses bws_access_token and names bin/vault-provision" {
+    cat > "$MOCK_BIN/uname" <<'EOF'
+#!/usr/bin/env bash
+echo Darwin
+EOF
     cat > "$MOCK_BIN/security" <<'EOF'
 #!/usr/bin/env bash
+printf '%s\n' "$@" > "$TEST_HOME/security.args"
 exit 1
 EOF
-    chmod +x "$MOCK_BIN/security"
+    chmod +x "$MOCK_BIN/uname" "$MOCK_BIN/security"
 
     source "$VAULT_LIB"
     run vault_token
     [ "$status" -ne 0 ]
+    [ "$(sed -n '3p' "$TEST_HOME/security.args")" = "-s" ]
+    [ "$(sed -n '4p' "$TEST_HOME/security.args")" = "bws_access_token" ]
     [[ "$output" == *"bin/vault-provision"* ]]
+}
+
+@test "vault-provision stores Darwin tokens in the bws_access_token Keychain service" {
+    [[ "$(uname)" == Darwin ]] || skip "macOS only"
+    command -v bash &>/dev/null || skip "bash not installed"
+    local fixture="$TEST_HOME/dotfiles"
+    local bash_path
+    bash_path="$(command -v bash)"
+    mkdir -p "$fixture/bin/lib" "$fixture/secrets"
+    cp "$REAL_DOTFILES_DIR/bin/vault-provision" "$fixture/bin/vault-provision"
+    cp "$REAL_DOTFILES_DIR/bin/lib/vault.sh" "$fixture/bin/lib/vault.sh"
+    cp "$REAL_DOTFILES_DIR/secrets/secrets.env.tmpl" "$fixture/secrets/secrets.env.tmpl"
+    cat > "$fixture/.env" <<'EOF'
+DOTFILES_DEV=false
+GH_TOKEN=gh
+GITHUB_PERSONAL_ACCESS_TOKEN=github
+CONTEXT7_API_KEY=context7
+TAVILY_API_KEY=tavily
+SERPER_API_KEY=serper
+TODOIST_API_KEY=todoist
+EOF
+
+    cat > "$MOCK_BIN/security" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" == find-generic-password ]]; then
+    [[ -f "$TEST_HOME/security.state" ]] || exit 1
+    printf '%s\n' machine-token
+    exit 0
+fi
+if [[ "$1" == add-generic-password ]]; then
+    printf '%s\n' "$@" > "$TEST_HOME/security.args"
+    cat >/dev/null
+    : > "$TEST_HOME/security.state"
+    exit 0
+fi
+exit 1
+EOF
+
+    cat > "$MOCK_BIN/bws" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" == project && "$2" == list ]]; then
+    printf '[]'
+elif [[ "$1" == project && "$2" == create ]]; then
+    printf '{"id":"proj-1"}'
+elif [[ "$1" == secret && "$2" == list ]]; then
+    if [[ "$5" == env ]]; then
+        printf 'GH_TOKEN=gh\nGITHUB_PERSONAL_ACCESS_TOKEN=github\nCONTEXT7_API_KEY=context7\nTAVILY_API_KEY=tavily\nSERPER_API_KEY=serper\nTODOIST_API_KEY=todoist\n'
+    else
+        printf '[]'
+    fi
+elif [[ "$1" == secret && "$2" == create ]]; then
+    exit 0
+else
+    exit 1
+fi
+EOF
+
+    cat > "$MOCK_BIN/jq" <<'EOF'
+#!/usr/bin/env bash
+input="$(cat)"
+if [[ "$1" == -e ]]; then
+    exit 1
+fi
+if [[ "$input" == *'"id":"proj-1"'* ]]; then printf 'proj-1\n'; fi; exit 0
+EOF
+    chmod +x "$MOCK_BIN/security" "$MOCK_BIN/bws" "$MOCK_BIN/jq"
+    printf 'machine-token\n' > "$TEST_HOME/token.input"
+
+    run env "PATH=$MOCK_BIN:/usr/bin:/bin" "HOME=$TEST_HOME" "USER=$USER" "XDG_CACHE_HOME=$TEST_HOME/.cache" "$bash_path" "$fixture/bin/vault-provision" < "$TEST_HOME/token.input"
+    assert_success
+    [ "$(sed -n '3p' "$TEST_HOME/security.args")" = "-s" ]
+    [ "$(sed -n '4p' "$TEST_HOME/security.args")" = "bws_access_token" ]
+    grep -q '^BWS_PROJECT_ID=proj-1$' "$fixture/.env"
 }
 
 # ── vault_materialize ──

--- a/tests/zsh-config.bats
+++ b/tests/zsh-config.bats
@@ -391,3 +391,41 @@ SH
     occurrences=$(grep -o "$shims_dir" <<< "$output" | wc -l | tr -d ' ')
     [ "$occurrences" -eq 1 ]
 }
+
+
+@test "macOS core.zsh loads the BWS token from Keychain and preserves existing tokens" {
+    command -v zsh &>/dev/null || skip "zsh not installed"
+    [[ $OSTYPE == darwin* ]] || skip "macOS only"
+    local fakebin="$TEST_HOME/Dev/dotfiles/bin"
+    local security_log="$TEST_HOME/security.log"
+    mkdir -p "$fakebin" "$TEST_HOME/.cache/dotfiles"
+    : > "$TEST_HOME/.cache/dotfiles/secrets.env"
+    : > "$security_log"
+    cat > "$fakebin/security" <<'SH'
+#!/bin/sh
+[ "$1" = "find-generic-password" ] &&
+[ "$2" = "-a" ] &&
+[ "$3" = "$USER" ] &&
+[ "$4" = "-s" ] &&
+[ "$5" = "bws_access_token" ] &&
+[ "$6" = "-w" ] || exit 1
+printf '%s\n' called >> "$SECURITY_LOG"
+printf '%s\n' 'token-from-keychain'
+SH
+    chmod +x "$fakebin/security"
+
+    run env "PATH=$fakebin:/usr/bin:/bin" "HOME=$TEST_HOME" "USER=$USER" "DOTFILES_DIR=$TEST_HOME/Dev/dotfiles" "XDG_CACHE_HOME=$TEST_HOME/.cache" "SECURITY_LOG=$security_log" zsh -fic "unset BWS_ACCESS_TOKEN; source '$TEST_HOME/Dev/dotfiles/zsh/core.zsh'; printenv BWS_ACCESS_TOKEN"
+    assert_success
+    [[ "$output" == "token-from-keychain" ]]
+    [ "$(cat "$security_log")" = called ]
+
+    run env "PATH=$fakebin:/usr/bin:/bin" "HOME=$TEST_HOME" "USER=$USER" "DOTFILES_DIR=$TEST_HOME/Dev/dotfiles" "XDG_CACHE_HOME=$TEST_HOME/.cache" "SECURITY_LOG=$security_log" BWS_ACCESS_TOKEN=already-set zsh -fic "source '$TEST_HOME/Dev/dotfiles/zsh/core.zsh'; printenv BWS_ACCESS_TOKEN"
+    assert_success
+    [[ "$output" == "already-set" ]]
+    [ "$(cat "$security_log")" = called ]
+
+    run env "PATH=$fakebin:/usr/bin:/bin" "HOME=$TEST_HOME" "USER=$USER" "DOTFILES_DIR=$TEST_HOME/Dev/dotfiles" "XDG_CACHE_HOME=$TEST_HOME/.cache" "SECURITY_LOG=$security_log" BWS_ACCESS_TOKEN= zsh -fic "source '$TEST_HOME/Dev/dotfiles/zsh/core.zsh'"
+    assert_success
+    [[ -z "$output" ]]
+    [ "$(cat "$security_log")" = called ]
+}

--- a/zsh/core.zsh
+++ b/zsh/core.zsh
@@ -112,6 +112,16 @@ done
 [[ -f "$_dotfiles_cache_env" ]] || echo "dotfiles: vault secrets cache missing ($_dotfiles_cache_env) — run 'bin/vault-provision'" >&2
 unset _dotfiles_env_file _dotfiles_cache_env
 
+
+# Fall back to the macOS Keychain for BWS credentials in interactive shells.
+if [[ $OSTYPE == darwin* && -o interactive ]] &&
+  (( ! ${+BWS_ACCESS_TOKEN} )) &&
+  command -v security 1>/dev/null 2>&1; then
+  _bws_access_token=$(security find-generic-password -a "$USER" -s bws_access_token -w 2>/dev/null)
+  [[ -n $_bws_access_token ]] && export BWS_ACCESS_TOKEN="$_bws_access_token"
+  unset _bws_access_token
+fi
+
 # Vi mode cursor shapes (orthogonal to prompt choice — works with any prompt)
 function zle-line-init zle-keymap-select {
   if [[ $KEYMAP == vicmd ]]; then


### PR DESCRIPTION
## Summary

- <certain>Interactive macOS zsh exports `BWS_ACCESS_TOKEN` from the Keychain service `bws_access_token` when the variable is unset.</certain>
- <certain>`bin/lib/vault.sh` and `bin/vault-provision` now use the same service name.</certain>
- <certain>Regression coverage exercises both token retrieval and the provisioning write path without printing the token.</certain>

## Manual setup

1. <certain>In Bitwarden, enable Secrets Manager, create a machine account, generate its access token, and grant it access to the `dotfiles` project.</certain>
2. <certain>Install `bws`, `jq`, and Bash 4+; keep `op` out of `PATH` when using the Bitwarden path because the script aborts if 1Password is detected.</certain>
3. <certain>Run `bin/vault-provision --interactive` on a fresh machine, or `bin/vault-provision` to migrate values from the local environment file.</certain>
4. <certain>After success, remove the six secret assignments and any `BWS_ACCESS_TOKEN` assignment from the local environment file; keep `BWS_PROJECT_ID` and other non-secret toggles, then run `dots sync`.</certain>

## Verification

- <certain>`bats tests/vault.bats`: 26 passed.</certain>
- <certain>Focused zsh Keychain regression: 1 passed.</certain>
- <certain>`just check`: exit 0; 917 passed, 2 skipped in the Python suite.</certain>
- <certain>Live smoke test authenticated `bws project list`; the current machine account returned no visible projects.</certain>