### PR TITLE
ci: run Python tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,5 +70,8 @@ jobs:
     - name: Run tests
       run: just test
 
+    - name: Run Python tests
+      run: just test-python
+
     - name: Run smoke tests
       run: just smoke

--- a/.hallouminate/wiki/operations/test-suite-performance.md
+++ b/.hallouminate/wiki/operations/test-suite-performance.md
@@ -27,7 +27,7 @@ The implementation extracts config/bootstrap/migration logic into sourced functi
 
 ## Gate mismatch
 
-`just test` and `just check` run Bats, while `just smoke` runs Node workflow tests; neither invokes the 909-test `agent-profile` pytest suite.[^10] A local pytest run took 25–38 seconds and exposed four failures on 2026-07-25. Treat adding pytest to the gate as a coverage correction, benchmarked separately from Bats speed work.[^11]
+GitHub CI's `test` job runs `just test` (Bats), `just test-python` (agent-profile pytest), and `just smoke` (Node workflow tests) as separate steps. The workflow-smoke test asserts those exact recipes so deleting one fails before merge.[^10]
 
 ## Implemented results (2026-07-25)
 
@@ -85,4 +85,3 @@ Use at least three warm runs and report the median. Bats supports `-T/--timing`;
 [^8]: tests/test_helper.bash:44-58
 [^9]: agent-profile/tests/test_canonical_permissions.py:93-118; local `uv run pytest -q --durations=20`, 2026-07-25.
 [^10]: justfile:51-68; tests/workflows-test.sh:1-18
-[^11]: Local benchmark, 2026-07-25: `uv run pytest -q --durations=20`; 903 passed, 2 skipped, 4 failed in 25.11s.

--- a/agent-profile/tests/conftest.py
+++ b/agent-profile/tests/conftest.py
@@ -16,7 +16,7 @@ import sys
 from pathlib import Path
 
 import pytest
-from agent_profile import cli, compile_command, shared
+from agent_profile import cli, compile_command, overlay, parse, shared
 from agent_profile.cli import ALL_HARNESSES, CliError
 from agent_profile.manifest import ManifestCorrupt
 from agent_profile.parse import Manifest, ParseError
@@ -80,6 +80,21 @@ def env(monkeypatch, tmp_path):
     e.target = target
     e.tmp = tmp_path
     return e
+
+
+SHIPPED_PROFILE_DOTENV = {
+    "CONTEXT7_API_KEY": "test-context7",
+    "TAVILY_API_KEY": "test-tavily",
+}
+
+
+@pytest.fixture
+def shipped_profile_secrets(monkeypatch):
+    """Give checked-in profiles deterministic non-secret MCP credentials."""
+    dotenv = dict(SHIPPED_PROFILE_DOTENV)
+    monkeypatch.setattr(parse, "load_layered_env", lambda _repo_root: dict(dotenv))
+    monkeypatch.setattr(overlay, "_dotenv", lambda: dict(dotenv))
+    return dotenv
 
 
 def write_profile(root: Path, name: str, yaml_text: str, files: dict | None = None):

--- a/agent-profile/tests/test_canonical_permissions.py
+++ b/agent-profile/tests/test_canonical_permissions.py
@@ -21,7 +21,7 @@ from pathlib import Path
 import pytest
 from agent_profile.parse import parse_manifest
 
-from tests.conftest import write_profile
+from tests.conftest import SHIPPED_PROFILE_DOTENV, write_profile
 
 # ── settings-level deny channel union-merge (parse) ──────────────────
 
@@ -114,7 +114,13 @@ def opencode_global_manifest():
     odir = repo / "profiles" / "opencode-global"
     if not (odir / "profile.yaml").is_file():
         pytest.skip(f"opencode-global profile not found at {odir}")
-    return parse_manifest(odir)
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setenv("DOTFILES_DIR", str(repo))
+        patch.setattr(
+            "agent_profile.parse.load_layered_env",
+            lambda _repo_root: dict(SHIPPED_PROFILE_DOTENV),
+        )
+        return parse_manifest(odir)
 
 
 def test_opencode_global_resolves_canonical_permissions_at_opencode_target(

--- a/agent-profile/tests/test_compile_apply_preservation.py
+++ b/agent-profile/tests/test_compile_apply_preservation.py
@@ -19,7 +19,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def test_live_global_settings_stay_unmanaged_across_compile_then_apply(
-    tmp_path, monkeypatch
+    tmp_path, monkeypatch, shipped_profile_secrets
 ):
     home = tmp_path / "home"
     (home / ".claude").mkdir(parents=True)

--- a/agent-profile/tests/test_compile_drift_wiring.py
+++ b/agent-profile/tests/test_compile_drift_wiring.py
@@ -23,7 +23,9 @@ from agent_profile.renderers.registry import build_registry
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
-def test_compile_skips_drift_for_disconnected_live_settings(tmp_path, monkeypatch):
+def test_compile_skips_drift_for_disconnected_live_settings(
+    tmp_path, monkeypatch, shipped_profile_secrets
+):
     home = tmp_path / "home"
     (home / ".claude").mkdir(parents=True)
     (home / ".claude" / "settings.json").write_text(

--- a/agent-profile/tests/test_compile_generated_discriminator.py
+++ b/agent-profile/tests/test_compile_generated_discriminator.py
@@ -46,7 +46,9 @@ def _compile_live(tmp_path, monkeypatch, *, with_live_settings: bool) -> dict:
     return json.loads((out / "manifest.json").read_text())
 
 
-def test_live_compile_emits_only_generated_fragments(tmp_path, monkeypatch):
+def test_live_compile_emits_only_generated_fragments(
+    tmp_path, monkeypatch, shipped_profile_secrets
+):
     data = _compile_live(tmp_path, monkeypatch, with_live_settings=True)
     files = data["files"]
 
@@ -66,7 +68,9 @@ def test_live_compile_emits_only_generated_fragments(tmp_path, monkeypatch):
     assert all(f["generated"] is True for f in files)
 
 
-def test_absent_live_settings_is_clean_create_not_drift(tmp_path, monkeypatch):
+def test_absent_live_settings_is_clean_create_not_drift(
+    tmp_path, monkeypatch, shipped_profile_secrets
+):
     data = _compile_live(tmp_path, monkeypatch, with_live_settings=False)
     settings_drift = [
         r for r in data["drift"] if r["relative_path"] == ".claude/settings.json"

--- a/agent-profile/tests/test_overlay.py
+++ b/agent-profile/tests/test_overlay.py
@@ -953,7 +953,9 @@ def test_codex_mcp_servers_are_toml_tables(tmp_path, monkeypatch):
     }
 
 
-def test_oss_docs_profile_writes_pinned_playwright_mcp_for_codex(tmp_path, monkeypatch):
+def test_oss_docs_profile_writes_pinned_playwright_mcp_for_codex(
+    tmp_path, monkeypatch, shipped_profile_secrets
+):
     """Codex ignores enabled_plugins, so browser verification must be a profile MCP."""
     monkeypatch.setenv("DOTFILES_DIR", str(REPO_ROOT))
     profile = REPO_ROOT / "profiles" / "oss-docs"

--- a/chezmoi/dot_config/mise/config.toml
+++ b/chezmoi/dot_config/mise/config.toml
@@ -66,7 +66,7 @@
 "aqua:charmbracelet/vhs" = "v0.11.0"
 "aqua:anomalyco/opencode" = "v1.18.9"
 "aqua:charmbracelet/crush" = "v0.87.0"
-"aqua:mozilla/sccache" = "v0.16.0"
+"aqua:mozilla/sccache" = "v0.17.0"
 "aqua:nextest-rs/nextest/cargo-nextest" = "cargo-nextest-0.9.140"
 "aqua:protocolbuffers/protobuf/protoc" = "v35.1"
 "aqua:astral-sh/uv" = "0.12.0"

--- a/tests/workflows/all-parse.test.mjs
+++ b/tests/workflows/all-parse.test.mjs
@@ -99,7 +99,7 @@ test('milknado worker config retains its required execution keys', async () => {
 })
 
 
-test('workflow smoke wiring invokes the wrapper, CI runs smoke, and the old parse guard is gone', async () => {
+test('workflow smoke wiring invokes the wrapper, CI runs every test recipe, and the old parse guard is gone', async () => {
   const [justfile, ci] = await Promise.all([
     readFile(resolve(root, 'justfile'), 'utf8'),
     readFile(resolve(root, '.github/workflows/test.yml'), 'utf8'),
@@ -107,6 +107,8 @@ test('workflow smoke wiring invokes the wrapper, CI runs smoke, and the old pars
 
   assert.match(justfile, /^smoke:\n\s+\.\/tests\/workflows-test\.sh$/m)
   assert.doesNotMatch(justfile, /workflows-parse\.sh/)
+  assert.match(ci, /- name: Run tests\n\s+run: just test/)
+  assert.match(ci, /- name: Run Python tests\n\s+run: just test-python/)
   assert.match(ci, /- name: Run smoke tests\n\s+run: just smoke/)
   await assert.rejects(readFile(resolve(root, 'tests/workflows-parse.sh')), { code: 'ENOENT' })
 })


### PR DESCRIPTION
## Summary
- run agent-profile pytest in CI
- assert all CI test recipes remain wired

## Validation
- rtk just check