### PR TITLE
feat(worktree): add -o/-m base-branch flags to wt, add wto/wtm shortcuts

### DIFF
--- a/bin/ccw-rm
+++ b/bin/ccw-rm
@@ -61,7 +61,7 @@ if git -C "$repo_root" show-ref --verify --quiet "refs/heads/${branch}"; then
     fi
 fi
 
-# Drop the symlinked Claude projects dir created by ccw-init, if present.
+# Drop the symlinked Claude projects dir created by wt, if present.
 wt_key="${wt_dir//[\/.]/-}"
 projects="${HOME}/.claude/projects/${wt_key}"
 if [[ -L "$projects" ]]; then

--- a/bin/cheatsheet
+++ b/bin/cheatsheet
@@ -66,6 +66,9 @@ print_cheatsheet() {
     row "ccw-rm <slug>"       "remove worktree + branch + tmux session"
     row "ccw-sweep"           "sweep all repos under ~/Dev"
     row "ccw-check"           "verify worktree permissions"
+    row "wt <slug>"           "create/resume a worktree, no claude launch"
+    row "wto <slug>"          "wt -o: branch off origin/<default-branch>"
+    row "wtm <slug>"          "wt -m: branch off the current branch"
     row "wt-git <path>"       "git in a worktree (no cd)"
 
     hdr "MCP / Hooks / Agents"

--- a/bin/lib/worktree.sh
+++ b/bin/lib/worktree.sh
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-# worktree.sh — shared worktree helpers, sourced by bin/ccw-sweep and bin/ccw-find.
+# worktree.sh — shared worktree helpers, sourced by bin/ccw-sweep, bin/ccw-find, and bin/wt.
 #
 # Parallels the .sync <-> .sync-lib.sh "lib beside script" precedent, scoped to
 # bin/. Every consumer sources this via its own resolved dir; bats tests source
@@ -35,7 +35,7 @@ resolve_default_branch() {
 
 # wt_list_nested <wt_path> — emit nested child worktree paths one level under
 # <wt_path>/.worktrees/*. That is the only basis worktrees are created on:
-# ccw-init writes <repo>/.worktrees/<slug>, and ccw()'s nested picker
+# wt writes <repo>/.worktrees/<slug>, and ccw()'s nested picker
 # (zsh/claude.zsh) globs .worktrees/* (and .worktrees/*/.worktrees/*). Only
 # paths that are real git worktrees (have a .git entry) are emitted; one path
 # per line.

--- a/bin/wt
+++ b/bin/wt
@@ -1,11 +1,29 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-slug="${1:-}"
-if [[ -z "$slug" ]]; then
-    echo "Usage: ccw-init <slug>" >&2
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=bin/lib/worktree.sh
+source "${SCRIPT_DIR}/lib/worktree.sh"
+
+usage() {
+    echo "Usage: wt [-o|-m] <slug>" >&2
+    echo "  -o   branch off origin/<default-branch> (fetches first)" >&2
+    echo "  -m   branch off the current branch (default)" >&2
     exit 1
-fi
+}
+
+base_mode="current"
+while getopts "om" opt; do
+    case "$opt" in
+        o) base_mode="origin" ;;
+        m) base_mode="current" ;;
+        *) usage ;;
+    esac
+done
+shift $((OPTIND - 1))
+
+slug="${1:-}"
+[[ -z "$slug" ]] && usage
 
 if [[ "$slug" =~ [^a-zA-Z0-9_-] ]]; then
     echo "slug must contain only a-z, 0-9, hyphens, underscores" >&2
@@ -22,11 +40,22 @@ wt_dir="${repo_root}/.worktrees/${slug}"
 branch="claude/${slug}"
 
 created=false
+start_point=""
 if [[ -d "${wt_dir}" ]]; then
     echo "Resuming worktree: ${wt_dir}" >&2
 else
-    echo "Creating worktree: ${wt_dir} (branch: ${branch})" >&2
-    git -C "${repo_root}" worktree add "${wt_dir}" -b "${branch}" 1>&2 || exit 1
+    start_point="$(git -C "${repo_root}" rev-parse --abbrev-ref HEAD)"
+    if [[ "$base_mode" == "origin" ]]; then
+        git -C "${repo_root}" fetch origin 1>&2 \
+            || { echo "wt: git fetch origin failed" >&2; exit 1; }
+        default_branch="$(resolve_default_branch "${repo_root}")" || {
+            echo "wt: could not resolve origin's default branch" >&2
+            exit 1
+        }
+        start_point="origin/${default_branch}"
+    fi
+    echo "Creating worktree: ${wt_dir} (branch: ${branch}, from: ${start_point})" >&2
+    git -C "${repo_root}" worktree add "${wt_dir}" -b "${branch}" "${start_point}" 1>&2 || exit 1
     created=true
 fi
 
@@ -68,7 +97,11 @@ if [[ ! -f "${claude_local}" ]]; then
 fi
 
 base_sha="$(git -C "${wt_dir}" rev-parse --short HEAD)"
-base_branch="$(git -C "${repo_root}" rev-parse --abbrev-ref HEAD)"
+if [[ "${created}" == true ]]; then
+    base_branch="${start_point}"
+else
+    base_branch="$(git -C "${repo_root}" rev-parse --abbrev-ref HEAD)"
+fi
 
 jq -n \
     --arg path "${wt_dir}" \

--- a/skills/worktree/SKILL.md
+++ b/skills/worktree/SKILL.md
@@ -19,11 +19,29 @@ Create or resume an isolated git worktree for a task.
 
 The task slug is provided as an argument. If none was given, ask the user for one.
 
-### 2. Run the helper
+### 2. Decide the base branch
+
+Two modes (`wtm`/`wto` are the interactive-shell aliases for these — this
+skill calls `wt` directly since Bash-tool commands aren't an interactive
+shell):
+
+- **`-m`** (or the flagless default) — branch off the current branch. Use
+  when the task extends what's already happening here: continuing
+  in-progress work, splitting a large feature into sub-tasks, or the new
+  work depends on local commits/changes that aren't upstream yet.
+- **`-o`** — branch off `origin/<default-branch>` (fetches first). Use when
+  the task is independent of the current branch: an unrelated fix or
+  feature, or the current branch already has committed work or an open PR
+  for something else — starting from origin keeps the new task from being
+  entangled with it.
+
+If it's unclear which the task is, ask the user.
+
+### 3. Run the helper
 
 ```bash
-wt <slug>       # branch off the current branch (default)
-wt -o <slug>    # branch off origin/<default-branch> (fetches first)
+wt <slug>       # -m: branch off the current branch (default) — extends current work
+wt -o <slug>    # branch off origin/<default-branch> (fetches first) — independent task
 ```
 
 This single command handles everything:
@@ -36,7 +54,7 @@ This single command handles everything:
 
 It outputs JSON to stdout with: `path`, `branch`, `base_sha`, `base_branch`, `created`.
 
-### 3. Confirm
+### 4. Confirm
 
 Parse the JSON output and report:
 

--- a/skills/worktree/SKILL.md
+++ b/skills/worktree/SKILL.md
@@ -2,7 +2,7 @@
 name: worktree
 model: haiku
 effort: low
-allowed-tools: Bash(ccw-init:*), Bash(cd:*)
+allowed-tools: Bash(wt:*), Bash(cd:*)
 description: >
   Create or resume an isolated git worktree for a Claude Code task, keeping main
   clean. Use when asked to "create a worktree", "resume a worktree", set up an
@@ -22,7 +22,8 @@ The task slug is provided as an argument. If none was given, ask the user for on
 ### 2. Run the helper
 
 ```bash
-ccw-init <slug>
+wt <slug>       # branch off the current branch (default)
+wt -o <slug>    # branch off origin/<default-branch> (fetches first)
 ```
 
 This single command handles everything:

--- a/zsh/claude.zsh
+++ b/zsh/claude.zsh
@@ -272,13 +272,13 @@ ccw() {
             || { echo "ccw: not in a git repo — use ccw <repo>/<slug>" >&2; return 1; }
     fi
 
-    # Find ccw-init in DOTFILES_DIR or the target repo.
-    local ccw_init="${DOTFILES_DIR}/bin/ccw-init"
-    [[ -f "${ccw_init}" ]] || ccw_init="${repo_dir}/bin/ccw-init"
-    [[ -f "${ccw_init}" ]] || { echo "ccw-init not found" >&2; return 1; }
+    # Find wt in DOTFILES_DIR or the target repo.
+    local wt_bin="${DOTFILES_DIR}/bin/wt"
+    [[ -f "${wt_bin}" ]] || wt_bin="${repo_dir}/bin/wt"
+    [[ -f "${wt_bin}" ]] || { echo "wt not found" >&2; return 1; }
 
     local result
-    result="$(cd "${repo_dir}" && "${ccw_init}" "${slug}")" || return 1
+    result="$(cd "${repo_dir}" && "${wt_bin}" "${slug}")" || return 1
 
     local wt_path
     wt_path="$(echo "$result" | jq -er '.path')" || { echo "ccw: failed to parse worktree path" >&2; return 1; }
@@ -286,6 +286,15 @@ ccw() {
 
     cd "${wt_path}" && cc "$@"
 }
+
+# wt — create (or resume) a worktree without launching Claude (lives in bin/).
+#   wt <slug>     → branch off the current branch (default)
+#   wt -m <slug>  → same, explicit
+#   wt -o <slug>  → branch off origin/<default-branch> (fetches first)
+# Prints the {path, branch, base_sha, base_branch, created} JSON — same
+# machinery ccw() uses, minus the cd + claude launch.
+alias wto='wt -o'
+alias wtm='wt -m'
 
 # Clean worktrees — single-repo (current dir) or full sweep (~/Dev)
 ccw-clean() {


### PR DESCRIPTION
## Summary
- Renamed `bin/ccw-init` to `bin/wt` — creates/resumes a worktree without launching Claude.
- Added `-o`/`-m` flags to pick the worktree's base: `-o` branches off `origin/<default-branch>` (fetches first, via the existing `resolve_default_branch` helper); `-m` branches off the current branch (unchanged default).
- Added `wto`/`wtm` shell aliases (`wt -o` / `wt -m`) in `zsh/claude.zsh`.
- Updated all references: `ccw()`'s internal lookup, `bin/lib/worktree.sh` comments, `bin/ccw-rm` comment, the `worktree` skill (regenerated via `dots sync`), and `bin/cheatsheet`.

## Test plan
- [x] `wt`, `wt -m <slug>`, `wt -o <slug>` exercised manually — verified JSON output, branch base, and cleanup
- [x] `bats tests/worktree-lib.bats tests/ccw-sweep.bats tests/ccw-rm.bats tests/ccw-find.bats tests/worktree-settings.bats tests/sync-worktree-guard.bats` — 79/79 pass
- [x] `just check` — full gate green