### PR TITLE
chore(doc-drift): bump opencode to 1.18.14 (no-op)

### DIFF
--- a/agents/doc-drift/sources.yaml
+++ b/agents/doc-drift/sources.yaml
@@ -37,7 +37,7 @@ sources:
     signal: { type: npm, ref: opencode-ai }
     docs: https://opencode.ai/docs
     governs: [harnesses/opencode.md]
-    reconciled: "1.18.11"
+    reconciled: "1.18.14"
 
   - id: copilot-cli
     signal: { type: npm, ref: "@github/copilot" }


### PR DESCRIPTION
Reconciles `opencode` (npm `opencode-ai`) 1.18.11 → 1.18.14 in `agents/doc-drift/sources.yaml`.

Changelog reviewed (v1.18.12–v1.18.14):
- xAI login simplified to a single device-code flow
- Provider mid-stream errors preserved for retry; more transient provider/network errors retried
- ACP usage totals now count cache writes; ACP turn-end waits for queued session updates
- Remote workspace: 5xx bodies logged, host directory path no longer sent
- TUI: GitHub PR context includes PR number/URL
- Desktop app: RTL layout fixes, localization/l10n expansion, markdown-parsing off main thread, project search and composer perf fixes
- Azure GPT-5.5+ reasoning completion fix

None of this touches the config surface `.hallouminate/wiki/harnesses/opencode.md` mirrors (opencode.json schema, MCP config, hooks/agents/skills rendering, local-LLM provider merge, isolated env-var injection). No-op — marker bump only.

---
_Generated by [Claude Code](https://claude.ai/code/session_016BL5L79SML6na5nAuPbzJs)_