### PR TITLE
chore(doc-drift): bump copilot-cli to 1.0.78 (no-op)

### DIFF
--- a/agents/doc-drift/sources.yaml
+++ b/agents/doc-drift/sources.yaml
@@ -43,7 +43,7 @@ sources:
     signal: { type: npm, ref: "@github/copilot" }
     docs: https://docs.github.com/en/copilot/how-tos/copilot-cli
     governs: [harnesses/copilot.md]
-    reconciled: "1.0.77"
+    reconciled: "1.0.78"
 
   - id: context7-mcp
     signal: { type: npm, ref: "@upstash/context7-mcp" }


### PR DESCRIPTION
Bumps `copilot-cli` `reconciled` marker 1.0.77 → 1.0.78 in `agents/doc-drift/sources.yaml`.

## Changelog delta (1.0.77 → 1.0.78, released Aug 3 2026)
- Timeline headers show tool-call duration (live-ticking for calls ≥5s), on by default (`/settings showToolDurations` to disable)
- First-party plugins auto-update at session start
- New experimental `/new-worktree` command
- Login-flow polish (browser-based OAuth as default `copilot login` flow, IDE integration improvements)
- `/rewind` no longer requires git; restores only Copilot-modified files with unmodified contents
- New `/permissions` command to switch approval modes
- Sandbox `allowDevToolCaches` setting (on by default): sandboxed builds get toolchain cache/registry access
- Session resumption dramatically faster / lighter on memory (parallel history reading, progressive transcript rendering)
- ACP mode supports `closeSession`; token usage exposed in ACP prompt results
- Bug fixes: interactive shell shortcut launch, inline image scroll-repeat rendering

## Why this is a no-op
None of the above touches the config surface `.hallouminate/wiki/harnesses/copilot.md` mirrors: hooks registry (`agents/hooks/registry.yaml`), sub-agents (`agents/registry.yaml`), MCP config (`~/.copilot/mcp-config.json` / chezmoi template), instructions precedence (`.github/copilot-instructions.md` / `*.instructions.md`), settings/config dir layout (`~/.copilot/`, `settings.json`, `config.json`), skills dirs, or isolated-launch support (still N/A — no closed-world flags added). No wiki edit made.

Sources: [Release 1.0.78](https://github.com/github/copilot-cli/releases/tag/v1.0.78), [changelog.md](https://github.com/github/copilot-cli/blob/main/changelog.md)

---
_Generated by [Claude Code](https://claude.ai/code/session_016BL5L79SML6na5nAuPbzJs)_