### PR TITLE
chore(doc-drift): bump tavily-mcp to 0.2.22 (no-op)

### DIFF
--- a/agents/doc-drift/sources.yaml
+++ b/agents/doc-drift/sources.yaml
@@ -55,7 +55,7 @@ sources:
     signal: { type: npm, ref: tavily-mcp }
     docs: https://github.com/tavily-ai/tavily-mcp
     governs: [chezmoi/.chezmoidata/claude.yaml, agents/mcp/registry.yaml]
-    reconciled: "0.2.21"
+    reconciled: "0.2.22"
 
   - id: chezmoi
     signal: { type: gh_release, ref: twpayne/chezmoi }


### PR DESCRIPTION
## Drift item
`tavily-mcp` (npm) reconciled `0.2.21` → current `0.2.22`.

## Upstream change
tavily-ai/tavily-mcp#198 "feat: add result id" (merged 2026-08-05, gitHead `d928425`): adds an `id` field to each search-result object returned by the search tool, plus a trivial comment-removal follow-up commit. No changelog/release notes are published on GitHub for this repo; npm registry metadata confirms 0.2.22 published 2026-08-05 with only an 80-byte package size increase over 0.2.21.

## Why no-op
Nothing we mirror changed:
- `chezmoi/.chezmoidata/claude.yaml` pins `npx -y tavily-mcp@0.2.21` with `TAVILY_API_KEY` — command/args/env shape unaffected by an output-schema addition.
- `agents/mcp/registry.yaml` uses `npx -y tavily-mcp@latest` with `TAVILY_API_KEY` — same, and already floats to latest.
- No new required env var, no CLI/invocation change, no tool added/removed.

Only edit in this PR: `agents/doc-drift/sources.yaml` `tavily-mcp` entry's `reconciled: "0.2.21"` → `"0.2.22"`.

---
_Generated by [Claude Code](https://claude.ai/code/session_016BL5L79SML6na5nAuPbzJs)_