### PR TITLE
chore(doc-drift): bump chezmoi to v2.72.0 (no-op)

### DIFF
--- a/agents/doc-drift/sources.yaml
+++ b/agents/doc-drift/sources.yaml
@@ -61,7 +61,7 @@ sources:
     signal: { type: gh_release, ref: twpayne/chezmoi }
     docs: https://www.chezmoi.io/reference/
     governs: [chezmoi/]
-    reconciled: "v2.71.1"
+    reconciled: "v2.72.0"
 
 
 


### PR DESCRIPTION
## What

Bumps the `chezmoi` doc-drift `reconciled` marker: `v2.71.1` → `v2.72.0`.

## Why no-op

v2.72.0's headline change is "multiple security vulnerability fixes"
(credited to Secur0's security analysis), plus four new opt-in template
functions. Read the upstream commit log (`v2.71.1..v2.72.0`) and diffed the
relevant fixes directly:

- **Path/name validation hardening** — disallows `..` in ignore patterns,
  remove patterns, `.chezmoiroot`, mackup files, and source-state
  filenames/dirnames that resolve to `.`/`..`. Our `.chezmoiignore`,
  `.chezmoiremove`, and `.chezmoiroot` (which is just `"."`) contain no
  `..` anywhere — the only `../` occurrences under `chezmoi/` are ordinary
  shell path arithmetic inside `run_onchange_*.sh.tmpl` scripts
  (`$CHEZMOI_SOURCE_DIR/../agents/...`), which is unrelated to chezmoi's
  own source-state path validation.
- **Archive directory-escape prevention** (tar/rar/zip) — we have no
  `.chezmoiexternal` entries and don't use `chezmoi archive`/`import`
  anywhere in this repo.
- **Private-by-default permissions** for temp files, the HTTP cache dir,
  the persistent state dir, `chezmoi secret keyring get`, and
  `age-keygen` — all internal to chezmoi's own runtime dirs; we don't
  configure or depend on their prior permissions. We also don't use age
  encryption, gopass, or the secret keyring in `.chezmoi.toml.tmpl`.
- **New template functions** `shellQuote`, `shellQuoteList`, `gopassCat`,
  `debugf` — purely additive/opt-in. Our `.tmpl` files quote TOML/JSON
  values with Go template's `quote`, not shell strings inside `output`
  calls, so there's nothing to migrate.

No breaking changes were found affecting our config surface. Only the
`reconciled` marker line changes; no other edits.

---
🤖 Generated as part of the weekly doc-drift routine.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_016BL5L79SML6na5nAuPbzJs)_