### PR TITLE
test(sync): normalize expected runner path

### DIFF
--- a/.hallouminate/wiki/operations/test-suite-performance.md
+++ b/.hallouminate/wiki/operations/test-suite-performance.md
@@ -69,6 +69,12 @@ External research (2026-07-31, cited long-form under the durable corpus's `resea
 
 `packages.bats` `setup()` now unsets `DOTFILES_DEV`: leaked as `true` from the invoking shell, `heal_missing_cask_apps` (#569) runs `brew list --cask` on the cache-hit path on Darwin, failing the two cache-skip tests on dev machines while Linux CI stays green (the heal is Darwin-only). Tests opt in explicitly.
 
+## macOS fixture-path normalization (2026-08-06)
+
+macOS commonly supplies `TMPDIR` with a trailing slash. `tests/test_helper.bash` appends another separator when constructing `TEST_HOME`, while child scripts such as `.sync` derive their working directory with `pwd`, which collapses repeated separators. Tests that compare emitted absolute paths must derive the expected path from `pwd` after entering the fixture directory; do not skip these platform-independent behaviors on macOS.[^14]
+
+[^14]: tests/test_helper.bash:10; .sync:11; tests/sync-orchestrator.bats:396-404
+
 ## Benchmarking protocol
 
 Use at least three warm runs and report the median. Bats supports `-T/--timing`; use JUnit output to aggregate testcase duration by `classname`, but validate suspected files alone because parallel resource contention inflates individual test durations. Compare the existing CPU-count job setting with one lower and one oversubscribed value before changing it.

--- a/tests/sync-orchestrator.bats
+++ b/tests/sync-orchestrator.bats
@@ -399,7 +399,8 @@ SCRIPT
 
     run bash "$SYNC_SCRIPT"
     assert_failure
-    [[ "$output" == *"final chezmoi runner missing: $FAKE_DOTFILES/chezmoi/.sync"* ]]
+    local expected_runner="$(pwd)/chezmoi/.sync"
+    [[ "$output" == *"final chezmoi runner missing: $expected_runner"* ]]
     [[ "$output" == *"Sync completed with FAILURES in: chezmoi"* ]]
 }
 @test "harness version mismatch fails closed before final chezmoi apply" {


### PR DESCRIPTION
Production semantics are unchanged; this corrects a cross-platform Bats expectation.

## Summary

- Derive the expected missing-runner path from `pwd`, matching `.sync` path normalization when macOS `TMPDIR` ends in `/`.
- Keep the fail-closed behavior covered on both macOS and Linux instead of skipping it.
- Record the fixture-path portability rule in the repository wiki.

## Verification

- `just check` — passed; 917 Python tests passed, 2 skipped, with Bats, workflow, and lint legs green.
- Focused missing-runner test — passed across five consecutive reruns.

## Durable artifacts

| Target | Backend | Verified |
| --- | --- | --- |
| `operations/test-suite-performance.md` | Hallouminate | yes |

## Reviewer focus

Verify the assertion still checks the exact missing runner path while deriving it through the same `pwd` representation as production.

## Risk

`dots sync` did not complete because the OMP v17.2.5 release download returned HTTP 403; this PR does not change package installation.
