### PR TITLE
docs(wiki): add Bitwarden Secrets Manager runbook and vendor sources

### DIFF
--- a/.hallouminate/wiki/architecture/mcp-secret-handling.md
+++ b/.hallouminate/wiki/architecture/mcp-secret-handling.md
@@ -81,3 +81,7 @@ mirrored by `profiles/*/profile.yaml`,
 See [[agent-secret-isolation-001]], [[agent-secret-isolation-002]], and
 [[agent-secret-isolation-003]] for the accepted identity, firewall, and approval
 decisions.
+
+[[../operations/bitwarden-secrets-manager]] is the provider-side runbook for the
+Bitwarden path: exact Secret names, machine-account permission, the temporary
+root-shell access token, and key rotation.

--- a/.hallouminate/wiki/index.md
+++ b/.hallouminate/wiki/index.md
@@ -33,3 +33,6 @@ relevant page rather than loading the whole reference into every session.
 - [[operations/index]] — the operational plumbing: the sync + chezmoi deploy
   system, the opt-in local-LLM stack, and the local dev environment (git
   tooling, prek, plugins, skhd).
+- [[sources/index]] — localized vendor evidence: what an external doc or
+  upstream source actually says, verified and dated, so a page here can cite a
+  claim instead of restating a guess.

--- a/.hallouminate/wiki/log.md
+++ b/.hallouminate/wiki/log.md
@@ -45,3 +45,9 @@
 2026-07-28 · preamble-20260728 · merged · adr/cheese-factory-workflow.md · Replaced stale preamble fan-out and continuation attributions with ADR-005 and coder-owned contracts.
 
 2026-08-01 · 6d6acbacd0478a02 · merged · harnesses/omp.md · Corrected exact-version verification to include both pre-final-apply and post-successful-final-apply probes, retention on post-probe failure, and current regression ranges.
+
+2026-08-09 · bitwarden-runbook-20260809 · new-page · operations/bitwarden-secrets-manager.md · Bitwarden provider runbook reconciled against b09e39c: three-Secret inventory (GitHub App dropped), web-application creation to keep values out of the `bws secret create` argv fallback, the single-line constraint imposed by env-output parsing, least-privilege machine account, root-shell token boundary, and rotation with broker restart.
+2026-08-09 · bitwarden-runbook-20260809 · new-page · sources/*.md · Localized verified Bitwarden vendor evidence (Secrets, access tokens, machine accounts, CLI, quick start, plans) plus the bws 2.1.0 renderer source behind the single-line constraint.
+2026-08-09 · bitwarden-runbook-20260809 · merged · architecture/mcp-secret-handling.md · Linked the provider-side Bitwarden runbook from the broker architecture page.
+2026-08-09 · bitwarden-runbook-20260809 · merged · index.md, operations/index.md · Registered the sources section and the Bitwarden runbook.
+2026-08-09 · bitwarden-runbook-20260809 · conflict-flagged · sources/bws-2-1-0-output-rendering.md · Corrected the superseded claim that the fetch path uses `-o json` with `jq`: b09e39c ships `bws secret list -o env` with matched-quote stripping, so multiline values remain unsupported and JSON is recorded as the fix if that need returns.

--- a/.hallouminate/wiki/operations/bitwarden-secrets-manager.md
+++ b/.hallouminate/wiki/operations/bitwarden-secrets-manager.md
@@ -1,0 +1,121 @@
+# Bitwarden Secrets Manager operations
+
+The dotfiles Bitwarden provider uses the **Secrets Manager** product and its `bws` CLI, not Password Manager items or the `bw` CLI. A human maintains three provider credentials in one project; `bin/vault-provision` copies them across a privileged operator boundary into root-owned per-consumer credential files.
+
+This page is the provider-side runbook. [[../architecture/mcp-secret-handling]] owns the runtime broker, socket, and approval design.
+
+## Install and enable the right product
+
+Open Bitwarden's web application and use the product switcher to select Secrets Manager. If it is not enabled, activate a Secrets Manager organization and plan. The Free tier is sufficient for this single-project, single-machine-account topology; current plan details live in [[../sources/bitwarden-secrets-manager-plans]].
+
+Install the separate `bws` client. Do not substitute the Password Manager CLI `bw`. `bin/lib/vault.sh:198-201` reports `cargo install bws --locked` when `bws` is missing. The workstation had `bws` 2.1.0 when this runbook was verified. The canonical onboarding sequence is [[../sources/bitwarden-secrets-manager-quick-start]].
+
+## Create the project and Secret objects
+
+Create one Secrets Manager project, such as `dotfiles`. Then follow [Bitwarden's **New → Secret** instructions](https://bitwarden.com/help/secrets/#create-a-secret) and assign these exact Secret objects to that project:
+
+| Secret name | Consumer | Required content |
+|---|---|---|
+| `CONTEXT7_API_KEY` | context7 | Context7 API key |
+| `TAVILY_API_KEY` | tavily | Tavily API key |
+| `TODOIST_API_KEY` | todoist | Todoist API token |
+
+These three names are the complete runtime set. `bin/lib/vault.sh:348-350` is the canonical list, and `bin/lib/vault.sh:314-317` refuses any other key with `refusing non-runtime secret key`; `tests/vault.bats:101-105` locks that refusal. Retired names — including `GH_TOKEN`, `GITHUB_PERSONAL_ACCESS_TOKEN`, `GITHUB_APP_PRIVATE_KEY`, and `SERPER_API_KEY` — are actively unset before any child exec at `bin/lib/vault.sh:19-40`, locked by `tests/vault.bats:74-92`. Do not recreate them as Secret objects.
+
+These are Secrets Manager **Secret** records, not Password Manager login items. See [[../sources/bitwarden-secrets]].
+
+### Create them in the web application, not the CLI
+
+Enter and edit values in the web application so secret material never appears in process arguments.
+
+When a Secret is missing, `bin/vault-provision:148-166` falls back to a hidden prompt and then runs `bws secret create "$key" "$value" "$project_id"` — which places the value in `bws` process arguments, visible to anything that can read the process table. That fallback also requires a write-capable machine account. Creating all three records in the web application first avoids both.
+
+### Single-line values only
+
+The Bitwarden fetch path uses **env output**: `bin/lib/vault.sh:300-302` runs `bws secret list "$project_id" -o env`, and `bin/lib/vault.sh:329-342` matches `KEY=` on a physical line and strips one surrounding quote pair. A value containing a newline is truncated at its first newline, because the env renderer emits `KEY="VALUE"` on one line without escaping. See [[../sources/bws-2-1-0-output-rendering]].
+
+All three managed credentials are single-line API keys, so this is sufficient today. Do not add a multiline credential to this project without first changing the fetch path — a truncated key fails at the consumer, not at provisioning.
+
+`tests/vault.bats:107-159` locks the parsing behaviour: quoted values are unwrapped, unquoted values pass through unchanged, and an unmatched interior quote is preserved.
+
+## Non-secret settings in `.env`
+
+Keep only these Bitwarden-related keys in the checkout's `.env`:
+
+```dotenv
+DOTFILES_VAULT_PROVIDER=bitwarden
+BWS_PROJECT_ID=<project-uuid>
+```
+
+`bin/lib/vault.sh:56-57` is the exported allowlist; unknown keys and every retired secret name are dropped, locked by `tests/vault.bats:51-72`. `.env.example:6-19` documents the supported non-secret fields.
+
+Never put `BWS_ACCESS_TOKEN` or any provider credential in `.env`, shell startup files, a tmux environment, a systemd user environment, an agent prompt, or a user-owned token file.
+
+## Machine account and least privilege
+
+Create a Secrets Manager machine account, grant it access to this project, and issue an access token as documented in [[../sources/bitwarden-machine-accounts]] and [[../sources/bitwarden-access-tokens]].
+
+Grant **read** permission. The fetch path only lists secrets in the one configured project. Grant **read and write** only if you intend to use the missing-record fallback above; with all three records present, the runtime machine account stays read-only.
+
+## Linux access-token boundary
+
+On Linux, `BWS_ACCESS_TOKEN` belongs only in a temporary interactive **root shell** for the provisioning transaction. `bin/lib/vault.sh:143-147` deliberately reads the Linux token from the operator environment instead of a same-user file; on macOS the same function reads the login Keychain (`security find-generic-password -s bws_access_token`, `bin/lib/vault.sh:137-142`). Enter it from a separate terminal outside the coding-agent session:
+
+```bash
+sudo -i
+cd /path/to/the/dotfiles-checkout
+
+set +x
+read -rsp 'BWS access token: ' BWS_ACCESS_TOKEN
+printf '\n'
+export BWS_ACCESS_TOKEN
+
+status=0
+bin/vault-provision \
+  --request-user paul \
+  --operator-user root || status=$?
+
+unset BWS_ACCESS_TOKEN
+exit "$status"
+```
+
+The hidden `read` avoids echo and shell history. Elevating before entry keeps the variable out of the ordinary user's process environment. Do not pass the token through `env BWS_ACCESS_TOKEN=...` or `sudo --preserve-env`; those forms either expose it in process arguments or first place it in the agent user's environment.
+
+`--request-user` and `--operator-user` must resolve to different UIDs — `bin/vault-provision:55-58` exits 2 otherwise. The request user is the daily user whose agents get the broker socket; the operator user is the separate identity that can approve writes.
+
+This boundary assumes agents cannot become root. Unrestricted passwordless `sudo`, root-equivalent container access, or permission to inspect root processes defeats every machine-local storage boundary.
+
+## Access-token lifetime
+
+`BWS_ACCESS_TOKEN` is needed only while `vault-provision` resolves the provider and downloads the current values. The installed brokers never receive it. Bitwarden defaults token expiry to **Never**, but this workflow needs only the shortest expiry covering the maintenance transaction; alternatively revoke the token immediately after successful provisioning and create a new one for the next rotation.
+
+Revoking or expiring the BWS token blocks later Bitwarden fetches. It does not revoke provider credentials already copied into local credential files.
+
+## What provisioning installs
+
+`bin/vault-provision` writes each value to `/etc/dotfiles/agent-secret/credentials/<consumer>.credential`, root-owned mode `0600` (`bin/vault-provision:255-263`). It snapshots the selected Node runtime into a root-owned non-writable tree and pins exact MCP package versions (`bin/vault-provision:90-133,292-297`), then records non-secret provider provenance in `/etc/dotfiles/agent-secret/provider.json` (`bin/vault-provision:301-303`).
+
+`tests/vault-provision.bats:56-129` locks the credential modes, the absence of credential values in policy files, the pinned upstream argv, the per-consumer tool ceilings, and the provenance record.
+
+## Rotate a provider key
+
+There is no automatic synchronization from Bitwarden into the local credential files. Rotate a key as an explicit cutover:
+
+1. Generate the replacement at the upstream provider. Keep the old key active during the cutover when the provider supports overlap.
+2. In Secrets Manager, open the existing Secret record, replace its Value, and save it. Preserve the exact name and project assignment.
+3. In a separate root terminal, enter `BWS_ACCESS_TOKEN` with the transaction above and rerun `bin/vault-provision`.
+4. Exercise a harmless read through the affected MCP consumer. Provisioning rewrites the credential file and restarts the broker service — `bin/agent-secret-install:207-209` on Linux, `bin/agent-secret-install:230-231` on macOS.
+5. Revoke the old provider key only after the new broker path succeeds.
+6. Unset and, when using a maintenance token, revoke the BWS access token.
+
+If the provider cannot keep two keys active, steps 1–5 become a brief non-overlapping cutover. Never revoke the old key before the local smoke test when overlap is available.
+
+## Verification and failure handling
+
+`bws project list --output table` is safe for confirming project access because it does not print secret values. Run it only inside the temporary privileged token session. Avoid printing `bws secret list` output to a terminal: documented object output contains secret values. See [[../sources/bitwarden-secrets-manager-cli]].
+
+Provisioning fails before installing anything when the provider is unresolved (`bin/vault-provision:60-64`), and `bin/lib/vault.sh:196-208` names the exact cause — missing `bws`, unset `BWS_PROJECT_ID`, or an empty token. A missing Secret reports `Bitwarden secret '<KEY>' is missing` at `bin/lib/vault.sh:339-342`.
+
+After a successful provision, test the changed consumer rather than inspecting its credential file. Agents should receive MCP results, never raw secret values.
+
+_Source: Bitwarden official documentation and the PR #616 broker implementation as of `b09e39c` · Updated: 2026-08-09 · Supersedes: ad hoc `.env` credential export and undocumented key-rotation procedure_

--- a/.hallouminate/wiki/operations/index.md
+++ b/.hallouminate/wiki/operations/index.md
@@ -14,3 +14,5 @@ The repo's operational plumbing — the machinery that deploys config and the lo
 
 - [[omp-config-shape-drift]] — unknown-key gate tripping on nested `dev.autoqa.*` means a stale per-machine config serialization: normalize with an `omp config set` re-save; never fold the nested shape into the shared registry (the #487 flip-flop).
 - [[omp-fanout-worker-models]] — OMP fan-out guardrails and evidence-dated worker-model cost research: separate parent reasoning from cheap worker roles, bound task fan-out, and treat speed rankings as provisional until measured locally.
+
+- [[bitwarden-secrets-manager]] — the Bitwarden provider runbook behind `bin/vault-provision`: the exact three-Secret inventory, why records are created in the web application rather than via `bws secret create`, the single-line constraint the env-output fetch imposes, least-privilege machine account, root-shell access-token boundary, and key rotation.

--- a/.hallouminate/wiki/sources/bitwarden-access-tokens.md
+++ b/.hallouminate/wiki/sources/bitwarden-access-tokens.md
@@ -1,0 +1,18 @@
+# Access Tokens
+
+Bitwarden's Secrets Manager access-token help page, verified 2026-08-06, documents machine-account authentication, configurable expiry, one-time token display, and revocation.
+Canonical source: [Access Tokens](https://bitwarden.com/help/access-tokens/)
+
+## Supported claims
+
+A Secrets Manager access token authenticates a machine account. Operators create one from the machine account's **Access tokens** view, choose its name and expiration, and copy it when displayed. Bitwarden does not display that token again.
+
+The documented default expiration is **Never**, but tokens can be revoked from the same machine-account view. An expired or revoked token can be replaced by creating another token.
+
+## Project relevance
+
+The dotfiles Linux workflow needs `BWS_ACCESS_TOKEN` only during `vault-provision`. Bitwarden's lifecycle controls therefore permit a short-lived maintenance token or immediate post-provision revocation instead of a permanent token in user configuration.
+
+Token expiry or revocation prevents later Bitwarden fetches; it does not revoke provider credentials already copied into the local brokers.
+
+_Source: <https://bitwarden.com/help/access-tokens/> · Updated: 2026-08-06 · Supersedes: none_

--- a/.hallouminate/wiki/sources/bitwarden-machine-accounts.md
+++ b/.hallouminate/wiki/sources/bitwarden-machine-accounts.md
@@ -1,0 +1,16 @@
+# Machine Accounts
+
+Bitwarden's Secrets Manager machine-account help page, verified 2026-08-06, documents creating non-human identities and granting them project-level read or read/write access.
+Canonical source: [Machine Accounts](https://bitwarden.com/help/machine-accounts/)
+
+## Supported claims
+
+Machine accounts authenticate automated workloads rather than people. A machine account receives access to selected projects through the project's or machine account's access configuration. Permissions can allow reading secrets or reading and writing secrets.
+
+## Project relevance
+
+A dotfiles machine account needs read access when all three Secret objects are created and updated by a human in the web application. Grant write access only when `vault-provision` is intentionally allowed to create missing records.
+
+Project-scoped least privilege limits the access token to the one Secrets Manager project used by the local credential brokers.
+
+_Source: <https://bitwarden.com/help/machine-accounts/> · Updated: 2026-08-09 · Supersedes: none_

--- a/.hallouminate/wiki/sources/bitwarden-secrets-manager-cli.md
+++ b/.hallouminate/wiki/sources/bitwarden-secrets-manager-cli.md
@@ -1,0 +1,18 @@
+# Secrets Manager CLI
+
+Bitwarden's Secrets Manager CLI documentation, verified 2026-08-06, identifies `bws` as the purpose-built Secrets Manager client and documents access-token authentication plus project and secret operations.
+Canonical source: [Secrets Manager CLI](https://bitwarden.com/help/secrets-manager-cli/)
+
+## Supported claims
+
+`bws` is separate from the Password Manager CLI `bw`. The documented authentication choices include the `BWS_ACCESS_TOKEN` environment variable, recommended for most use cases, and CLI profiles. The CLI can list projects and create, edit, get, and list secrets.
+
+Secret creation and editing accept the secret value as a command-line argument. Default object output is JSON and includes secret values. Output formats include `none`, but suppressing output does not remove a positional or option value from process arguments.
+
+## Project relevance
+
+The dotfiles operator path authenticates with a temporary `BWS_ACCESS_TOKEN` environment variable. Human entry through the Bitwarden web application avoids exposing provider keys through CLI arguments.
+
+Repository code reads secrets with `bws secret list -o env` and parses that shell-oriented renderer line-by-line, which constrains managed values to a single line. Because default object output includes secret values, `bws secret get`/`list` output must never be printed to an agent-visible terminal.
+
+_Source: <https://bitwarden.com/help/secrets-manager-cli/> · Updated: 2026-08-09 · Supersedes: none_

--- a/.hallouminate/wiki/sources/bitwarden-secrets-manager-plans.md
+++ b/.hallouminate/wiki/sources/bitwarden-secrets-manager-plans.md
@@ -1,0 +1,16 @@
+# Secrets Manager Plans
+
+Bitwarden's Secrets Manager plans page, verified 2026-08-06, documents the available Secrets Manager organization tiers and their machine-account, project, and secret limits.
+Canonical source: [Secrets Manager Plans](https://bitwarden.com/help/secrets-manager-plans/)
+
+## Supported claims
+
+Secrets Manager is an organization product distinct from Password Manager. Its Free tier supports the small project and machine-account topology required by one local dotfiles installation; paid tiers raise limits and add organization features.
+
+## Project relevance
+
+A user does not need a Password Manager CLI installation to provision these MCP credentials. They need an enabled Secrets Manager organization and the separate `bws` client. The current workstation already has `bws` 2.1.0 installed.
+
+Plan details can change; verify current limits on the canonical page before relying on a specific count beyond this single-project workflow.
+
+_Source: <https://bitwarden.com/help/secrets-manager-plans/> · Updated: 2026-08-06 · Supersedes: none_

--- a/.hallouminate/wiki/sources/bitwarden-secrets-manager-quick-start.md
+++ b/.hallouminate/wiki/sources/bitwarden-secrets-manager-quick-start.md
@@ -1,0 +1,14 @@
+# Secrets Manager Quick Start
+
+Bitwarden's Secrets Manager quick start, verified 2026-08-06, documents the end-to-end product flow: open Secrets Manager, create a project, create a machine account, grant project access, issue an access token, install `bws`, and authenticate it.
+Canonical source: [Secrets Manager Quick Start](https://bitwarden.com/help/secrets-manager-quick-start/)
+
+## Supported claims
+
+Secrets Manager is opened from the Bitwarden web application's product switcher. The documented sequence creates a project and a machine account, assigns project access, creates an access token, then uses the `bws` CLI with `BWS_ACCESS_TOKEN`.
+
+## Project relevance
+
+This is the canonical onboarding sequence for the dotfiles Bitwarden provider. On a machine where `bws` is already installed, the remaining work is the web-side project, Secret objects, machine-account permission, access token, and local nonsecret project identifier.
+
+_Source: <https://bitwarden.com/help/secrets-manager-quick-start/> · Updated: 2026-08-06 · Supersedes: none_

--- a/.hallouminate/wiki/sources/bitwarden-secrets.md
+++ b/.hallouminate/wiki/sources/bitwarden-secrets.md
@@ -1,0 +1,16 @@
+# Secrets
+
+Bitwarden's Secrets Manager help page, verified 2026-08-06, defines a secret as a key/value object assigned to projects and documents creating and editing those objects in the web application.
+Canonical source: [Secrets](https://bitwarden.com/help/secrets/)
+
+## Supported claims
+
+The Bitwarden Secrets Manager web application creates a secret through **New → Secret**. A secret has a name, value, notes, and project assignment. Selecting an existing secret opens its edit surface, where the value and project assignments can be changed.
+
+This supports the dotfiles runbook's preference for entering and rotating provider credentials in the web application. The repository uses three named Secret objects; it does not model them as Password Manager login items.
+
+## Project relevance
+
+The web interface avoids placing a value in `bws secret create` process arguments. `bin/vault-provision:148-166` uses that CLI form only as a fallback when a record is missing, so creating all three records in the web application first keeps every value out of the process table.
+
+_Source: <https://bitwarden.com/help/secrets/> · Updated: 2026-08-09 · Supersedes: none_

--- a/.hallouminate/wiki/sources/bws-2-1-0-output-rendering.md
+++ b/.hallouminate/wiki/sources/bws-2-1-0-output-rendering.md
@@ -1,0 +1,20 @@
+# BWS 2.1.0 Output Rendering
+
+Bitwarden's `bws` 2.1.0 renderer source, verified 2026-08-06, establishes the exact env-output format that made line-oriented secret parsing unsafe.
+Canonical source: [bws 2.1.0 render.rs](https://raw.githubusercontent.com/bitwarden/sdk-sm/bws-v2.1.0/crates/bws/src/render.rs)
+
+## Env renderer behavior
+
+The `Output::Env` renderer emits each secret as `KEY="VALUE"`. It writes the value inside literal double quotes and does not turn a multiline value into a single independently parseable record. A Bash loop that removes only `KEY=` therefore retains the quote, and a physical-line loop truncates a multiline PEM at its first newline.
+
+## JSON renderer behavior
+
+The `Output::Json` renderer delegates serialization to `serde_json`. JSON preserves quote, backslash, equals-sign, and embedded-newline structure, allowing `jq` to select the matching `.key` and emit its `.value`.
+
+## Project relevance
+
+`bin/lib/vault.sh:_vault_fetch_bitwarden` requests env output and `vault_secret_value` parses it line-by-line, stripping one matched surrounding quote pair. This is safe only because all three managed runtime credentials — `CONTEXT7_API_KEY`, `TAVILY_API_KEY`, `TODOIST_API_KEY` — are single-line API keys. `tests/vault.bats:107-159` locks the quoted, unquoted, and interior-quote cases.
+
+The renderer's multiline behavior is therefore a live constraint, not a solved problem: adding any multiline Secret to the project would silently truncate it at the first newline. Switching `_vault_fetch_bitwarden` to `-o json` with structural `jq` selection is the fix if that need returns.
+
+_Source: <https://raw.githubusercontent.com/bitwarden/sdk-sm/bws-v2.1.0/crates/bws/src/render.rs> · Updated: 2026-08-09 · Supersedes: none_

--- a/.hallouminate/wiki/sources/index.md
+++ b/.hallouminate/wiki/sources/index.md
@@ -1,0 +1,11 @@
+# sources
+
+<!-- HALLOUMINATE:INDEX-START -->
+- [bitwarden-access-tokens](./bitwarden-access-tokens.md) — Access Tokens
+- [bitwarden-machine-accounts](./bitwarden-machine-accounts.md) — Machine Accounts
+- [bitwarden-secrets-manager-cli](./bitwarden-secrets-manager-cli.md) — Secrets Manager CLI
+- [bitwarden-secrets-manager-plans](./bitwarden-secrets-manager-plans.md) — Secrets Manager Plans
+- [bitwarden-secrets-manager-quick-start](./bitwarden-secrets-manager-quick-start.md) — Secrets Manager Quick Start
+- [bitwarden-secrets](./bitwarden-secrets.md) — Secrets
+- [bws-2-1-0-output-rendering](./bws-2-1-0-output-rendering.md) — BWS 2.1.0 Output Rendering
+<!-- HALLOUMINATE:INDEX-END -->


### PR DESCRIPTION
Documents the Bitwarden provider path behind `bin/vault-provision`, reconciled against `b09e39c` (the per-consumer broker from #616).

This content originated on `paulnsorensen/secret-manager-detection`, whose PR (#580) merged and was then superseded by #616. Rather than merge that branch (38 conflicts, including a full `agent-profile/` deletion that main has since evolved past), only the net-new wiki material is salvaged here and re-verified line by line against main.

## What's here

- `operations/bitwarden-secrets-manager.md` — the provider-side runbook: exact Secret inventory, web-application creation, machine-account least privilege, the root-shell access-token boundary, what provisioning installs, and key rotation.
- `sources/` — localized, dated vendor evidence (Bitwarden Secrets, access tokens, machine accounts, CLI, quick start, plans) plus the `bws` 2.1.0 renderer source. New wiki section, registered in `index.md`.
- Cross-link from `architecture/mcp-secret-handling.md`, an entry in `operations/index.md`, and ingest entries in `log.md`.

## Three claims corrected against main

The original draft described the abandoned branch's code, not what shipped:

1. **GitHub App consumer is gone.** The runtime set is three keys — `CONTEXT7_API_KEY`, `TAVILY_API_KEY`, `TODOIST_API_KEY` (`bin/lib/vault.sh:348-350`). `GITHUB_APP_PRIVATE_KEY` survives only as a retired name the loaders unset (`bin/lib/vault.sh:19-40`).

2. **The BWS JSON fetch never landed.** `bin/lib/vault.sh:300-302` runs `bws secret list -o env` and parses line-by-line with matched-quote stripping (`:329-342`). The `-o json` + `jq -rj` path and the terminal-newline sentinel existed only on the abandoned branch. `sources/bws-2-1-0-output-rendering.md` now records env output as shipped, with the resulting **single-line-values-only** constraint as a live gotcha and JSON noted as the fix should a multiline credential ever return. Logged `conflict-flagged`.

3. **The `bws secret create` fallback exposes values in argv.** `bin/vault-provision:148-166` prompts hidden, then passes the secret as a positional argument. The web-application-first guidance stands, now for the correct reason.

## Verification

Every code reference cites main at `b09e39c` and was read before citing. Behaviour claims are anchored to the tests that lock them (`tests/vault.bats:51-159`, `tests/vault-provision.bats:56-129`).

`hallouminate index` run — 28 files upserted, 144 chunks.

`just check`: 1357/1358. The one failure, test 349 `claude wrapper delegates to the mise shim`, is environment-dependent and unrelated — this diff is wiki markdown only. `bin/claude` blocks at ≥8 concurrent sessions and `pgrep -cx claude` reported 10; `CLAUDE_GUARD=0 bats tests/claude-wrapper.bats` passes. Worth a separate fix, since the test exercises the real launcher without disarming its guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
