### PR TITLE
test(claude): disarm the launcher guard in the delegation test

### DIFF
--- a/tests/claude-wrapper.bats
+++ b/tests/claude-wrapper.bats
@@ -4,6 +4,11 @@ load test_helper
 
 setup() {
     setup_test_env
+    # The guard reads live machine state — pgrep -cx claude and /proc/meminfo —
+    # so leaving it armed makes this fail whenever the host happens to sit at the
+    # 8-session ceiling or under 15% free RAM. Delegation is what's under test, so
+    # disarm the guard rather than depend on ambient load.
+    export CLAUDE_GUARD=0
     export XDG_DATA_HOME="$TEST_HOME/.local/share"
     mkdir -p "$XDG_DATA_HOME/mise/shims"
     cat > "$XDG_DATA_HOME/mise/shims/claude" <<'SH'


### PR DESCRIPTION
`tests/claude-wrapper.bats` invoked the real `bin/claude` with its guard armed, so the test's result depended on ambient machine state rather than on the code under test.

`bin/claude` blocks when `pgrep -cx claude` reaches 8, or when MemAvailable drops below 15%. Running `just check` from inside a Claude Code session reliably trips the session ceiling, failing test 349 — "claude wrapper delegates to the mise shim" — with no relation to the diff being checked. That reads as a regression during a completion gate and invites a pointless bisect.

Delegation to the mise shim is what this file covers, so `setup()` now sets `CLAUDE_GUARD=0` rather than depending on host load.

## Verification

Verified passing with 10 concurrent claude sessions live — the exact condition that previously failed it. Full `just check`: 1358/1358.

## Known gap

The guard's own thresholds have no direct coverage; this test was only exercising them by accident. Testing them properly means controlling both `pgrep` output and `/proc/meminfo` reads, which needs more than a PATH mock, so it is left as follow-up rather than bolted on here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
