### PR TITLE
docs(wiki): agent-secret broker ADRs + landing gotchas

### DIFF
--- a/.hallouminate/wiki/adr/index.md
+++ b/.hallouminate/wiki/adr/index.md
@@ -5,6 +5,7 @@
 - [codex-omp-harness-upgrade-001](./codex-omp-harness-upgrade-001.md) — ADR-001 — Use model-relative snapcompact compaction
 - [codex-omp-harness-upgrade-002](./codex-omp-harness-upgrade-002.md) — ADR-002 — Cut over to OMP's native Task schema
 - [codex-omp-harness-upgrade-003](./codex-omp-harness-upgrade-003.md) — ADR-003 — Activate the dual-harness upgrade dependency-first
+- [land-agent-secret-broker](./land-agent-secret-broker.md) — ADRs — land the agent-secret broker (PR #616)
 - [machine-aware-vault-selection-001](./machine-aware-vault-selection-001.md) — ADR-001 — Resolve vault providers by explicit intent or unique readiness
 - [machine-aware-vault-selection-002](./machine-aware-vault-selection-002.md) — ADR-002 — Tag vault cache provenance and invalidate source changes
 - [manifest-pinned-packages](./manifest-pinned-packages.md) — ADRs — manifest-pinned packages (supply-chain redesign)

--- a/.hallouminate/wiki/adr/land-agent-secret-broker.md
+++ b/.hallouminate/wiki/adr/land-agent-secret-broker.md
@@ -1,0 +1,40 @@
+# ADRs — land the agent-secret broker (PR #616)
+
+Rationale record for the land-agent-secret-broker spec (durable spec:
+~/.local/share/cheese/paulnsorensen-dotfiles/specs/land-agent-secret-broker.md;
+research slugs bws-token-storage-fork and harness-bws-runtime-injection under
+the same corpus). Session date: 2026-08-08. Related:
+[[architecture/agent-secret-isolation-001]] (lands with the PR),
+[[architecture/mcp-secret-handling]].
+
+## ADRs
+
+### ADR-001: Land the existing broker rather than re-scope it or switch to bws-run wrappers  [status: accepted]
+
+- **Context:** The user's requirement is that a same-user coding agent cannot read secret values ("isolation", not "hygiene"). Research showed: `pass`/gpg on headless Linux degrades to same-user-readable state (agent cache TTL or loopback passphrase file); the macOS `security` CLI cannot enforce user presence (no ACL/partition-list mechanism gates a live check — only a compiled Data-Protection-Keychain binary can); `bws run` wrappers leave the machine token invocable by any same-user process. A root-ownership boundary is the only mechanism that meets the bar on both platforms, and PR #616 already implements it.
+- **Decision:** Land PR #616 with a fix list (rebase, #598 rename port, verification sweep, deny-block fold) rather than re-scoping the broker or replacing it with `bws run` command wrappers.
+- **Rejected:** `bws run --` wrapper redesign (hygiene, not isolation — recorded in .cheese/.out-of-scope/land-agent-secret-broker-001.md); re-scoping the broker down before landing (grill found the surface justified: 100% stdlib, real behavior tests, clean rebase).
+
+### ADR-002: Keep the write-nonce machinery although the chosen bar doesn't require it  [status: accepted]
+
+- **Context:** The user chose bar 2 (root-boundary isolation); the shipped broker also implements bar 3 (one-shot 60s operator nonces on write tools). The grill found the nonce machinery cleanly separable (~20% of the daemon behind a single read/write gate at scripts/agent-secret-broker.py:588-591), so stripping was a real option.
+- **Decision:** Keep as shipped. Nonces fire only on todoist/github write tools (context7/tavily are read-only), so day-to-day friction is near zero, and deleting working, tested security code to match a bar exactly is its own risk. Revisit if friction materializes.
+- **Rejected:** Stripping to bar 2 (mechanical but unnecessary churn); policy-level relaxation (moving write tools to the pass-through list — subverts the policy vocabulary).
+
+### ADR-003: Close PR #598; port only its Keychain service rename  [status: accepted]
+
+- **Context:** #598 (green, unreviewed) renames the macOS Keychain service to `bws_access_token` and exports the token into every interactive zsh. #616 still uses the old service name (branch vault.sh:139-140) — a real semantic conflict — and its scrub model makes the zsh export a regression, not a fix.
+- **Decision:** Port the `bws_access_token` rename into #616 (curd C2); close #598 with a supersession comment explaining the split verdict on its two halves.
+- **Rejected:** Landing #598 first (churn: immediate rebase + deletion of its zsh-export half); keeping the old `BWS_ACCESS_TOKEN` service name (perpetuates the name collision between env var and Keychain service that #598 existed to fix).
+
+### ADR-004: Harness deny rules are a friction layer, never the boundary  [status: accepted]
+
+- **Context:** An uncommitted claude.yaml `permissions.deny` block (bws, security) predated this session. Vendor docs for both Claude Code and Codex state their command/path rules are bypassable via `sh -c`-class indirection, and Codex permission profiles explicitly do not govern MCP subprocesses.
+- **Decision:** Fold the deny block into the landing (curd C3) documented as friction-not-boundary, layered on the root boundary. A codex `.rules` mirror is follow-up F004.
+- **Rejected:** Dropping the block as redundant (cheap friction still raises the bypass cost); treating deny rules as the primary control (documented-bypassable — the failure mode this whole spec exists to close).
+
+### ADR-005: Remove the github MCP consumer from the branch  [status: accepted]
+
+- **Context:** The broker commit (725b4fd5) introduced a github consumer, but main never had a github MCP (no `github` entry in main's `claude.yaml`), and `gh` CLI already covers GitHub operations. Shipping the consumer would add a GitHub App requirement as net-new scope beyond what the broker needed to land.
+- **Decision:** Operator-directed removal (bce694c8) of the github consumer: `install_github_runtime`, `GITHUB_APP_*` settings, and the github entries in `claude.yaml`/`codex.yaml` and downstream registries/profiles/tests.
+- **Rejected:** Keeping the github consumer and its GitHub App provisioning (scope the landing didn't need and main never carried).

--- a/.hallouminate/wiki/architecture/mcp-secret-handling.md
+++ b/.hallouminate/wiki/architecture/mcp-secret-handling.md
@@ -20,6 +20,12 @@ different owners. The broker binds both sockets as root, then permanently drops
 to the service identity before accepting traffic
 (`scripts/agent-secret-broker.py`, `Broker.start`).
 
+CPython's `socket` module has no `getpeereid()` and exposes neither the
+constant nor a helper for macOS peer-credential lookup. On Darwin the broker
+reads peer UID via `getsockopt(SOL_LOCAL, LOCAL_PEERCRED)` into a
+`struct xucred` (`scripts/agent-secret-broker.py:30-33`); missing this dropped
+every client connection until fixed.
+
 ## Credential lifecycle
 
 `bin/vault-provision` is the only vault-reading operator path. It resolves the
@@ -38,13 +44,24 @@ executable after provisioning.
 launching a child. They also remove the obsolete
 `$XDG_CACHE_HOME/dotfiles/secrets.env` file.
 
+`bws -o env` output quotes values. The legacy shell-sourcing flow stripped
+those quotes for free; the broker path reads the raw bytes, so
+`vault_secret_value` must strip the matched surrounding quote pair itself or
+every credential file ends up quote-wrapped and rejected by the upstream API.
+
 ## Operator workflow
 
 1. Install packages with `dots sync`. Put the three provider API keys in the
    selected vault source.
 2. Run `bin/vault-provision --request-user <daily-user> --operator-user
-   <separate-operator>` from an authenticated operator session. Reprovisioning
-   replaces the root-owned snapshots and restarts every Linux or macOS broker.
+   <separate-operator>` from an authenticated operator session, as the user and
+   not under `sudo` — the script sudos internally, and readiness needs the
+   user's own Keychain session. A `sudo`'d run also leaves a root-owned
+   `~/.cache/dotfiles/vault-resolution.lock` that blocks later user runs.
+   `DOTFILES_DIR` resolves script-relative rather than from the environment, so
+   an inherited `DOTFILES_DIR` pointing at another clone can no longer anchor
+   the install elsewhere. Reprovisioning replaces the root-owned snapshots and
+   restarts every Linux or macOS broker.
 3. When an agent receives a pending write, inspect it as the operator with
    `/usr/local/libexec/dotfiles/agent-secretctl --consumer <name> pending`.
 4. Approve only the matching request with


### PR DESCRIPTION
## Summary

Harvests durable wiki knowledge from the session that landed PR #616 (agent-secret broker, merged as b09e39ca) but never made it into the tracked wiki.

- `.hallouminate/wiki/adr/land-agent-secret-broker.md`: adds ADR-005 recording the operator-directed removal of the github MCP consumer (bce694c8) — main never had a github MCP, `gh` CLI covers GitHub operations, the GitHub App requirement was net-new scope introduced by the broker commit (725b4fd5).
- `.hallouminate/wiki/adr/index.md`: link-tree entry for the new ADR file.
- `.hallouminate/wiki/architecture/mcp-secret-handling.md`: three gotcha notes pulled from `.cheese/cook/land-agent-secret-broker.md`'s `durable_flags` and open-decision lines —
  - Darwin has no `socket.getpeereid()` in CPython; the broker reads peer UID via `LOCAL_PEERCRED`/`struct xucred` (fixed in 2714a65c after the daemon dropped every client connection).
  - `bws -o env` quotes values; `vault_secret_value` must strip the matched surrounding quote pair or every credential file ends up quote-wrapped and rejected upstream (defect c1f0ead0, masked previously by legacy shell-sourcing).
  - Provisioning must run as the user, not `sudo` (readiness needs the user Keychain; a `sudo`'d run leaves a root-owned `vault-resolution.lock`), and `DOTFILES_DIR` resolves script-relative now (3705e2ec) rather than from an inherited env var.

Source: session `land-agent-secret-broker` (spec + cook handoff under `.cheese/cook/land-agent-secret-broker.md` in the main clone).

## Gates run

- `hallouminate index` (CLI) from the worktree root — reindexed `repo:dotfiles:wiki`, 72 files.
- `just check` from the worktree — 1358 tests, exit 0.
- `dots sync` — **skipped**. `bin/dots:8` hardcodes `DOTFILES_DIR="${DOTFILES_DIR:-${HOME}/Dev/dotfiles}"`, so running it from this worktree would silently operate on the main clone (which carries unrelated dirty WIP) rather than validating anything in this branch. This change touches only tracked wiki markdown — no registry/skill/agent/plugin/chezmoi-template surface — so the docs-source sync gate's rendered-target purpose doesn't apply here.

## Test plan

- [x] `just check` green in the worktree (1358/1358)
- [x] `hallouminate index` ran clean, no warnings for the dotfiles corpus
- [ ] `dots sync` — intentionally not run (see Gates above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)