### PR TITLE
fix(secrets): unblock Linux broker startup — symlink stat and socket mode ordering

### DIFF
--- a/bin/agent-secret-install
+++ b/bin/agent-secret-install
@@ -73,12 +73,14 @@ trusted_executable() {
     local path="$1" label="$2" owner mode
     [[ -n "$DESTDIR" ]] && return
     [[ -f "$path" && -x "$path" ]] || die "$label is not an executable file: $path"
+    # -L: judge the symlink target — /usr/bin/python3 is a symlink on Linux,
+    # and an undereferenced stat reports the link's own 0777 mode.
     if [[ "$(uname -s)" == Darwin ]]; then
-        owner="$(stat -f '%u' "$path")"
-        mode="$(stat -f '%Lp' "$path")"
+        owner="$(stat -Lf '%u' "$path")"
+        mode="$(stat -Lf '%Lp' "$path")"
     else
-        owner="$(stat -c '%u' "$path")"
-        mode="$(stat -c '%a' "$path")"
+        owner="$(stat -Lc '%u' "$path")"
+        mode="$(stat -Lc '%a' "$path")"
     fi
     if [[ "$owner" != 0 ]] || (( (8#$mode & 8#22) != 0 )); then
         die "$label must be root-owned and not group/other-writable: $path"

--- a/bin/agent-secret-install
+++ b/bin/agent-secret-install
@@ -239,6 +239,7 @@ install_consumer() {
     shift 5
     local platform service_user request_uid operator_uid policy_dir policy
     local credential_dir credential_source socket_dir request_socket control_socket home python executable
+    local state_root
     validate_consumer "$consumer"
     [[ "$credential_env" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || die "invalid credential environment name"
     ((${#READ_TOOLS[@]} + ${#WRITE_TOOLS[@]} > 0)) || die "at least one tool must be allowed"
@@ -261,15 +262,16 @@ install_consumer() {
         Linux)
             platform=linux
             socket_dir=/var/run/dotfiles-agent-secrets
-            home="/var/lib/dotfiles-agent-secrets/$consumer"
+            state_root=/var/lib/dotfiles-agent-secrets
             ;;
         Darwin)
             platform=macos
             socket_dir=/var/run/dotfiles-agent-secrets
-            home="/var/db/dotfiles-agent-secrets/$consumer"
+            state_root=/var/db/dotfiles-agent-secrets
             ;;
         *) die "unsupported platform" ;;
     esac
+    home="$state_root/$consumer"
     request_socket="$socket_dir/$consumer.sock"
     control_socket="$socket_dir/$consumer.control.sock"
     policy_dir=/etc/dotfiles/agent-secret-broker
@@ -292,7 +294,14 @@ install_consumer() {
         "$credential_env" "$credential_file" "$@"
 
     case "$platform" in
-        linux) render_systemd "$consumer" "$service_user" "$home" "$request_socket" "$control_socket" "$policy" "$python" ;;
+        # One systemd template file backs every instance, so it must be rendered
+        # instance-generic: %i resolves to the consumer at start time. Baking a
+        # single consumer's paths in makes the last install win for all of them.
+        linux)
+            render_systemd "$consumer" "agent-secret-%i" "$state_root/%i" \
+                "$socket_dir/%i.sock" "$socket_dir/%i.control.sock" \
+                "$policy_dir/%i.json" "$python"
+            ;;
         macos) render_launchd "$consumer" "$service_user" "$home" "$request_socket" "$control_socket" "$policy" "$python" ;;
     esac
 }

--- a/scripts/agent-secret-broker.py
+++ b/scripts/agent-secret-broker.py
@@ -689,14 +689,19 @@ class Broker:
         try:
             listener.bind(str(path))
             listener.listen(64)
+            # Narrow the mode before handing the socket away. chmod needs the
+            # euid to own the file or CAP_FOWNER, and the unit's bounding set
+            # is CAP_CHOWN/CAP_SETGID/CAP_SETUID only — so chowning first makes
+            # the chmod fail with EPERM. This order also never widens exposure:
+            # the socket is 0600 before any other uid can own it.
+            os.chmod(path, 0o600)
             if os.geteuid() == 0:
                 os.chown(path, owner_uid, -1)
             elif owner_uid != os.geteuid():
                 raise ConfigError("socket owner differs from broker user")
-            os.chmod(path, 0o600)
         except (ConfigError, OSError) as exc:
             listener.close()
-            raise ConfigError("socket cannot be created") from exc
+            raise ConfigError(f"socket cannot be created: {path}") from exc
         return listener
 
     def start(self) -> None:

--- a/tests/agent-secret-broker.bats
+++ b/tests/agent-secret-broker.bats
@@ -285,3 +285,47 @@ PY
     assert_failure
     [[ "$output" == *'"code":"expired"'* ]]
 }
+
+@test "socket mode is narrowed before ownership leaves the broker" {
+    run "$PYTHON" - \
+        "$REAL_DOTFILES_DIR/scripts/agent-secret-broker.py" \
+        "$TEST_ROOT/ordering.sock" <<'PY'
+import importlib.util
+import os
+import pathlib
+import sys
+
+module_path, socket_path = sys.argv[1], sys.argv[2]
+spec = importlib.util.spec_from_file_location("broker_under_test", module_path)
+module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+
+# The systemd unit grants CAP_CHOWN/CAP_SETGID/CAP_SETUID only. Without
+# CAP_FOWNER the kernel requires the caller to still own a file to chmod it,
+# so handing the socket to another uid first makes the chmod fail with EPERM.
+# Model exactly that: pretend to run as root and refuse a chmod issued after
+# ownership has already moved away.
+real_chmod = os.chmod
+owner = {"uid": 0}
+
+def guarded_chmod(path, mode):
+    if owner["uid"] != 0:
+        raise PermissionError(1, "Operation not permitted")
+    real_chmod(path, mode)
+
+def recording_chown(path, uid, gid):
+    owner["uid"] = uid
+
+os.chmod = guarded_chmod
+os.chown = recording_chown
+os.geteuid = lambda: 0
+
+listener = module.Broker._bind(pathlib.Path(socket_path), 12345)
+listener.close()
+assert owner["uid"] == 12345, "ownership was never transferred"
+print("bound")
+PY
+    assert_success
+    [[ "$output" == *bound* ]]
+}

--- a/tests/agent-secret-install.bats
+++ b/tests/agent-secret-install.bats
@@ -155,3 +155,24 @@ PY
     [[ -z "$output" ]]
     [[ -x "$INSTALL_ROOT/usr/local/libexec/dotfiles/agent-secret-broker.py" ]]
 }
+
+run_trusted_executable() {
+    bash -c 'die() { echo "$@" >&2; exit 1; }
+        eval "$(sed -n "/^trusted_executable/,/^}/p" "$1")"
+        DESTDIR= trusted_executable "$2" "python interpreter"' _ "$INSTALLER" "$1"
+}
+
+@test "trusted_executable accepts a symlink to a root-owned interpreter" {
+    ln -s /bin/sh "$TEST_HOME/python3"
+    run run_trusted_executable "$TEST_HOME/python3"
+    assert_success
+}
+
+@test "trusted_executable still rejects a symlink to a user-owned executable" {
+    printf '#!/bin/sh\n' > "$TEST_HOME/user-owned"
+    chmod 755 "$TEST_HOME/user-owned"
+    ln -s "$TEST_HOME/user-owned" "$TEST_HOME/python3"
+    run run_trusted_executable "$TEST_HOME/python3"
+    assert_failure
+    [[ "$output" == *"root-owned and not group/other-writable"* ]]
+}

--- a/tests/agent-secret-install.bats
+++ b/tests/agent-secret-install.bats
@@ -82,8 +82,10 @@ PY
         [[ "$(plist_value --control-socket)" == '/var/run/dotfiles-agent-secrets/fixture.control.sock' ]]
     else
         unit="$INSTALL_ROOT/etc/systemd/system/dotfiles-agent-secret@.service"
-        [[ "$(grep '^ExecStart=' "$unit")" == *'--run-user agent-secret-fixture --upstream-home /var/lib/dotfiles-agent-secrets/fixture'* ]]
-        [[ "$(grep '^ExecStart=' "$unit")" == *'--socket /var/run/dotfiles-agent-secrets/fixture.sock --control-socket /var/run/dotfiles-agent-secrets/fixture.control.sock'* ]]
+        exec_start="$(grep '^ExecStart=' "$unit")"
+        [[ "$exec_start" == *'--policy /etc/dotfiles/agent-secret-broker/%i.json'* ]]
+        [[ "$exec_start" == *'--socket /var/run/dotfiles-agent-secrets/%i.sock --control-socket /var/run/dotfiles-agent-secrets/%i.control.sock'* ]]
+        [[ "$exec_start" == *'--run-user agent-secret-%i --upstream-home /var/lib/dotfiles-agent-secrets/%i'* ]]
         [[ "$(grep '^CapabilityBoundingSet=' "$unit")" == 'CapabilityBoundingSet=CAP_CHOWN CAP_SETGID CAP_SETUID' ]]
     fi
     run grep -R -q 'installer-secret-sentinel' "$INSTALL_ROOT"
@@ -175,4 +177,31 @@ run_trusted_executable() {
     run run_trusted_executable "$TEST_HOME/python3"
     assert_failure
     [[ "$output" == *"root-owned and not group/other-writable"* ]]
+}
+
+@test "the shared systemd template never bakes in one consumer's paths" {
+    [[ "$(uname -s)" == Linux ]] || skip "the systemd template is Linux-only"
+    run install_fixture
+    assert_success
+    run env DESTDIR="$INSTALL_ROOT" "$INSTALLER" install second \
+        --credential-env SECOND_SECRET \
+        --credential-file "$CREDENTIAL" \
+        --request-user "$REQUEST_USER" \
+        --operator-user "$OPERATOR_USER" \
+        --read-tool read.item \
+        -- /usr/bin/tavily-mcp --stdio
+    assert_success
+
+    # Both consumers get their own policy, but a single unit file backs every
+    # instance. Installing the second must not repoint the first at it.
+    [[ -f "$INSTALL_ROOT/etc/dotfiles/agent-secret-broker/fixture.json" ]]
+    [[ -f "$INSTALL_ROOT/etc/dotfiles/agent-secret-broker/second.json" ]]
+
+    unit="$INSTALL_ROOT/etc/systemd/system/dotfiles-agent-secret@.service"
+    run grep -nE 'fixture|second' "$unit"
+    [[ "$status" -ne 0 ]]
+    # The sandbox paths must be instance-generic too, or every instance would be
+    # confined to the last-installed consumer's policy and state directory.
+    [[ "$(grep '^ReadOnlyPaths=' "$unit")" == 'ReadOnlyPaths=/etc/dotfiles/agent-secret-broker/%i.json' ]]
+    [[ "$(grep '^ReadWritePaths=' "$unit")" == 'ReadWritePaths=/var/run/dotfiles-agent-secrets /var/lib/dotfiles-agent-secrets/%i' ]]
 }


### PR DESCRIPTION
Unblocks Linux provisioning after #616. Three independent failures sat in series — no single fix gets a broker running, so they ship together.

## 1. `trusted_executable` did not dereference symlinks

`bin/agent-secret-install` died with `python interpreter must be root-owned and not group/other-writable: /usr/bin/python3`.

`trusted_executable` stats without dereferencing. `/usr/bin/python3` is a symlink on Linux distros, and GNU `stat -c` (like BSD `stat -f`) reports the link's own mode `0777` and owner — failing both halves of the check. macOS ships `/usr/bin/python3` as a regular file, so the C5 runtime smoke on Darwin could not catch it.

**Fix:** `stat -L` on both platform branches, judging the symlink target. `credential_is_private` is intentionally untouched — credential files must remain regular non-symlink files.

Verified on the affected host: `/usr/bin/python3` reports `root 777` undereferenced and `root 755` dereferenced.

**Test:** a symlink to a root-owned executable now passes; a symlink resolving to a user-owned executable is still rejected. Both exercise the real helper (extracted via `sed` + `eval` with a stubbed `die`, since the DESTDIR suite path skips validation — see #642).

## 2. Socket mode was set after ownership transferred away

With #1 fixed, provisioning completed and every broker then restart-looped, exiting 2 with `agent-secret-broker: socket cannot be created` — over 300 restarts.

The unit grants `CAP_CHOWN CAP_SETGID CAP_SETUID`. No `CAP_FOWNER`. `Broker._bind` chowned the socket to the request or operator uid and *then* chmodded it, but `chmod(2)` requires the effective uid to own the file or hold `CAP_FOWNER` — so the chmod returned EPERM and the bind was torn down.

The live sockets confirmed the diagnosis exactly: `srwx------ paul root`, i.e. mode `0700` owned by the request user — the state between the two calls.

**Fix:** narrow the mode while root still owns the socket, then transfer ownership. No additional capability, and it never widens exposure — the socket is `0600` before any other uid can own it.

The `ConfigError` now names the socket path. The previous message discarded both the path and the errno, which is why the journal was undiagnosable.

**Test:** a regression test that models the kernel rule rather than asserting call order — a fake `chmod` that refuses once ownership has moved. Red on the old ordering, green on the new.

## 3. The systemd unit was not instance-generic

With both fixes above, provisioning completed and todoist served real traffic — but context7 and tavily were still unreachable.

One template file, `/etc/systemd/system/dotfiles-agent-secret@.service`, backs every instance, and `render_systemd` substituted one consumer's literal paths into it. Each `install_consumer` call overwrote the previous one, so the last consumer installed won for all of them. On the affected host every unit — including `dotfiles-agent-secret@context7.service` — ran `--policy .../todoist.json --socket .../todoist.sock --run-user agent-secret-todoist`. Three processes raced for `todoist.sock`; `_bind` unlinks and rebinds, so one won and the others held orphaned listeners while `context7.sock` and `tavily.sock` were never bound at all.

No credential crossover, since the losing instances also dropped to `agent-secret-todoist` and loaded its credential — but two of three consumers were simply dead.

**Fix:** pass instance-generic values so `%i` resolves per consumer at start time. Path construction stays in `install_consumer`, which derives the generic forms from the same `socket_dir`, `policy_dir` and `state_root` variables, so the script remains the single source for these locations. macOS is unaffected — `render_launchd` writes a separate plist per consumer.

**Test:** installs two consumers and asserts the shared unit names neither, and that `ReadOnlyPaths` / `ReadWritePaths` are instance-generic so an instance is not confined to another consumer's sandbox. Red before, green after.

## Verification

`tests/agent-secret-broker.bats`, `agent-secret-config.bats`, `agent-secret-install.bats`: 19/19.

On the affected host, after fixes 1 and 2, the todoist broker serves a complete round trip — proxy → broker → upstream MCP → response. Fix 3 is what makes the other two consumers reachable; it is covered by the DESTDIR suite rather than re-provisioned live.

## Known gap, not addressed here

Provisioning reports success over dead brokers. With `Type=simple`, `systemctl restart` returns as soon as exec succeeds, so a broker that dies milliseconds later is never noticed — `bin/agent-secret-install` reports success and `bin/vault-provision` runs to completion. Every failure above was masked by this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
