### PR TITLE
chore(doc-drift): bump opencode to 1.18.15 (no-op)

### DIFF
--- a/agents/doc-drift/sources.yaml
+++ b/agents/doc-drift/sources.yaml
@@ -37,7 +37,7 @@ sources:
     signal: { type: npm, ref: opencode-ai }
     docs: https://opencode.ai/docs
     governs: [harnesses/opencode.md]
-    reconciled: "1.18.14"
+    reconciled: "1.18.15"
 
   - id: copilot-cli
     signal: { type: npm, ref: "@github/copilot" }


### PR DESCRIPTION
## Doc-drift: opencode 1.18.14 → 1.18.15 — no-op

**Signal:** npm `opencode-ai` 1.18.14 → 1.18.15
**Docs:** https://opencode.ai/docs
**Governs:** `harnesses/opencode.md`

### Delta researched (GitHub release notes for v1.18.15, released 2026-08-07)

**Core (bugfixes):**
- Chronological message ordering fixed for imported/legacy message IDs
- Revert/fork now use real message chronology instead of ID ordering
- Truncation cleanup removes stale files by timestamp more reliably
- Repeated compaction keeps earlier tool-call history in summaries
- Blob-based attachments render correctly in the web UI

**Desktop app:**
- Broader locale coverage, native language names in locale picker, translation fill-ins
- Full session transcript export as JSON
- Timeline/session-list ordering and sort-stability fixes

### Why this is a no-op

None of these changes touch the config surface `harnesses/opencode.md` mirrors: no changes to hooks/plugin-API lifecycle events, sub-agent rendering, MCP config, system prompt / `AGENTS.md` rules / `instructions` key, `opencode.json` schema or settings keys, skills loading, the local-LLM provider integration, isolated-settings env vars (`OPENCODE_CONFIG_CONTENT`, `OPENCODE_PERMISSION`, `OPENCODE_DISABLE_PROJECT_CONFIG`), or any CLI flag. This release is entirely internal bugfixes (message-ordering/compaction/truncation) plus desktop-app-only UI/locale work.

Classified **no-op** per `agents/doc-drift/routine.md`. This PR only bumps the `reconciled` marker for `opencode` in `agents/doc-drift/sources.yaml`; no other files touched.

---
🤖 Generated by the doc-drift routine subagent.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FDmy6p93tSwv7XiLm3uLVm)_