### PR TITLE
chore(doc-drift): bump context7-mcp to 4.0.0 (no-op)

### DIFF
--- a/agents/doc-drift/sources.yaml
+++ b/agents/doc-drift/sources.yaml
@@ -49,7 +49,7 @@ sources:
     signal: { type: npm, ref: "@upstash/context7-mcp" }
     docs: https://github.com/upstash/context7
     governs: [chezmoi/.chezmoidata/claude.yaml, agents/mcp/registry.yaml]
-    reconciled: "3.2.5"
+    reconciled: "4.0.0"
 
   - id: tavily-mcp
     signal: { type: npm, ref: tavily-mcp }


### PR DESCRIPTION
## What
Bumps the `reconciled` marker for `context7-mcp` in `agents/doc-drift/sources.yaml` from `3.2.5` to `4.0.0`.

## Why no-op

This is a MAJOR version bump (`3.2.5` → `4.0.0`), so I read every intervening changelog entry, not just the top one:

- **3.2.5** — bumped `undici` to 7 / require Node >= 20.18.1 (fixes `HTTPS_PROXY`/custom-CA being silently ignored); tweaked `query-docs` prompt wording.
- **3.2.4** — bumped `jose` 6.1.3 → 6.2.3.
- **3.2.3** — hardened client-IP extraction from `X-Forwarded-For` (skip loopback/link-local/CGNAT/etc.); clarified `query-docs` description.
- **3.2.2** — added Enterprise-Managed Auth (id-jag) token validation for enterprise IdP (Okta) sign-in.
- **3.2.1** — restored Node 18 support by pinning `undici`/`commander`.
- **3.2.0** — replaced the in-result sign-in nudge with an MCP `elicitation/create` form prompt; bumped `@modelcontextprotocol/sdk`, `undici`, `zod`; advertised empty `prompts`/`resources` capabilities.
- **3.1.0** — added multi-tenant Microsoft Entra ID validation for MCP tokens.
- **4.0.0 (major)** — migrated the server to the v2 MCP SDK (`@modelcontextprotocol/{node,server,client}` 2.0.0) and the 2026-07-28 protocol revision; **HTTP serving is now stateless, and Redis-backed sessions are removed**.

The 4.0.0 breaking change is scoped to the server's **stateful HTTP transport mode** (session persistence via Redis). Our config (`chezmoi/.chezmoidata/claude.yaml`'s `context7` mcp entry, `agents/mcp/registry.yaml`'s `context7` entry) invokes the server exclusively over **stdio** — `agent-secret-proxy` spawns `npx -y @upstash/context7-mcp@<pin>` (pin owned by Renovate in `bin/vault-provision`) with no `--transport`/`--port` flags and only `CONTEXT7_API_KEY` set. Stdio is the CLI's default transport and is untouched by the 4.0.0 changes. Tool names (`resolve-library-id`, `query-docs`) and the `CONTEXT7_API_KEY` env var are also unchanged across the whole delta.

Nothing in our mirrored surface needs edits.

Note: the version literal pinned in `bin/vault-provision` (`@upstash/context7-mcp@3.2.5`) carries a `# renovate:` marker, so bumping that pin is Renovate's job, not this doc-drift routine's — consistent with treating this as no-op (same pattern as #565, #472, #417).

Part of the weekly doc-drift routine (`agents/doc-drift/routine.md`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01FDmy6p93tSwv7XiLm3uLVm)_