### PR TITLE
feat(cursor): Auto-review policy for rtk and easy-cheese

### DIFF
--- a/cursor/plugins/local/cheese-grok/agent-autonomy/README.md
+++ b/cursor/plugins/local/cheese-grok/agent-autonomy/README.md
@@ -1,0 +1,22 @@
+# Cursor agent autonomy (Auto-review)
+
+Tracked source for a balanced Cursor Auto-review policy tuned for this
+dotfiles stack: `rtk`, tilth, hallouminate, milknado / easy-cheese,
+context7, and tavily.
+
+Live Cursor config under `~/.cursor/` is gitignored (that tree is the
+`cursor/` symlink target). Edit the files here, then apply:
+
+```bash
+./cursor/plugins/local/cheese-grok/agent-autonomy/apply.sh
+```
+
+Then fully quit and reopen Cursor. Keep **Settings → Agents → Approvals
+& Execution** on Auto-review (this package does not enable Run
+Everything).
+
+| File | Installs to |
+|---|---|
+| `permissions.json` | `~/.cursor/permissions.json` (Auto-review allow/block instructions) |
+| `sandbox.json` | `~/.cursor/sandbox.json` (extra paths + network default allow) |
+| `apply.sh` | also expands IDE shell + MCP allowlists in `state.vscdb` |

--- a/cursor/plugins/local/cheese-grok/agent-autonomy/apply.sh
+++ b/cursor/plugins/local/cheese-grok/agent-autonomy/apply.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Install Cursor Auto-review + sandbox policy for the rtk/tilth/hallouminate/
+# easy-cheese stack, and expand the IDE shell/MCP allowlists.
+#
+# Source of truth (tracked):
+#   cursor/plugins/local/cheese-grok/agent-autonomy/
+# Live targets (gitignored ~/.cursor symlink tree):
+#   ~/.cursor/permissions.json
+#   ~/.cursor/sandbox.json
+#   Cursor composerState allowlists in state.vscdb
+#
+# Usage:
+#   ./cursor/plugins/local/cheese-grok/agent-autonomy/apply.sh
+#
+# Safe to re-run. Backs up state.vscdb before mutating allowlists.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+CURSOR_HOME="${CURSOR_HOME:-$HOME/.cursor}"
+DB="${CURSOR_STATE_DB:-$HOME/Library/Application Support/Cursor/User/globalStorage/state.vscdb}"
+KEY='src.vs.platform.reactivestorage.browser.reactiveStorageServiceImpl.persistentStorage.applicationUser'
+
+[[ -f "$ROOT/permissions.json" ]] || { echo "missing $ROOT/permissions.json" >&2; exit 1; }
+[[ -f "$ROOT/sandbox.json" ]] || { echo "missing $ROOT/sandbox.json" >&2; exit 1; }
+[[ -f "$DB" ]] || { echo "missing Cursor state db: $DB" >&2; exit 1; }
+
+mkdir -p "$CURSOR_HOME"
+install -m 644 "$ROOT/permissions.json" "$CURSOR_HOME/permissions.json"
+install -m 644 "$ROOT/sandbox.json" "$CURSOR_HOME/sandbox.json"
+echo "installed $CURSOR_HOME/permissions.json"
+echo "installed $CURSOR_HOME/sandbox.json"
+
+TS="$(date +%Y%m%d-%H%M%S)"
+cp "$DB" "${DB}.bak-perms-${TS}"
+echo "backed up state.vscdb -> ${DB}.bak-perms-${TS}"
+
+python3 - "$DB" "$KEY" <<'PY'
+import json, sqlite3, sys
+
+db, key = sys.argv[1], sys.argv[2]
+
+shell_allow = sorted(set([
+    "cat", "create_one", "echo", "gh", "mktemp", "set", "true", "git", "head",
+    "mkdir", "python3",
+    "rtk", "ls", "find", "rg", "fd", "jq", "yq", "node", "npm", "npx", "uv",
+    "uvx", "python", "mise", "just", "dots", "cargo", "go", "tokei", "bat",
+    "delta", "prek", "pretk", "awk", "sed", "sort", "uniq", "wc", "tr", "cut",
+    "tee", "xargs", "env", "printf", "basename", "dirname", "realpath", "touch",
+    "cp", "mv", "ln", "chmod", "tree", "file", "stat", "tail", "diff", "patch",
+    "which", "command", "type", "test", "false", "hallouminate", "tilth",
+    "serena", "brew", "curl", "wget", "bash", "zsh", "sh", "tar", "unzip",
+    "zip", "open", "pbcopy", "pbpaste", "date", "uname", "whoami", "pwd",
+]))
+
+def expand(server, tools):
+    out = []
+    for s in {server, f"user-{server}", f"plugin-{server}-{server}", f"plugin-{server}"}:
+        for t in tools:
+            out.append(f"{s}:{t}")
+        out.append(f"{s}:*")
+    return out
+
+tilth_tools = [
+    "tilth_search", "tilth_read", "tilth_list", "tilth_deps", "tilth_grok",
+    "tilth_diff", "tilth_write", "tilth_files",
+]
+hallou_tools = [
+    "add_markdown", "backlinks", "corpus_stats", "delete_markdown",
+    "get_footnote", "ground", "index", "list_corpora", "list_files",
+    "list_tree", "read_markdown",
+]
+milknado_tools = [
+    "milknado_archive_node", "milknado_unarchive_node", "milknado_delete_node",
+    "milknado_deposit_result", "milknado_deposit_review", "milknado_edit_node",
+    "milknado_get_node", "milknado_github_roadmap_bind",
+    "milknado_github_roadmap_export", "milknado_github_roadmap_import",
+    "milknado_goal_claim", "milknado_goal_release", "milknado_graph_summary",
+    "milknado_move_node", "milknado_node_verify", "milknado_plan_apply",
+    "milknado_plan_batches", "milknado_rebalance", "milknado_roadmap_export",
+    "milknado_roadmap_import", "milknado_run_cancel", "milknado_run_inline",
+    "milknado_run_inline_poll", "milknado_run_inline_start", "milknado_run_list",
+    "milknado_run_loop_poll", "milknado_run_loop_start",
+    "milknado_set_subtree_status", "milknado_todo_add", "milknado_todo_brief",
+    "milknado_todo_claim", "milknado_todo_next", "milknado_todo_set_status",
+    "milknado_todo_tree", "milknado_track_follow_up",
+]
+context7_tools = ["resolve-library-id", "query-docs"]
+tavily_tools = [
+    "tavily_search", "tavily_extract", "tavily_crawl", "tavily_map",
+    "tavily_research",
+]
+
+mcp_allow = []
+mcp_allow += expand("tilth", tilth_tools)
+mcp_allow += expand("hallouminate", hallou_tools)
+mcp_allow += [f"plugin-hallouminate-hallouminate:{t}" for t in hallou_tools]
+mcp_allow += ["plugin-hallouminate-hallouminate:*"]
+mcp_allow += expand("milknado", milknado_tools)
+mcp_allow += [f"plugin-milknado-milknado:{t}" for t in milknado_tools]
+mcp_allow += ["plugin-milknado-milknado:*"]
+mcp_allow += expand("context7", context7_tools)
+mcp_allow += expand("tavily", tavily_tools)
+mcp_allow += [
+    "code-review-graph:get_minimal_context_tool",
+    "code-review-graph:*",
+]
+mcp_allow = sorted(set(mcp_allow))
+
+con = sqlite3.connect(db)
+cur = con.cursor()
+raw = cur.execute("SELECT value FROM ItemTable WHERE key=?", (key,)).fetchone()
+if not raw:
+    raise SystemExit(f"missing reactive storage key: {key}")
+obj = json.loads(raw[0] if isinstance(raw[0], str) else raw[0].decode())
+cs = obj["composerState"]
+before_shell = len(cs.get("yoloCommandAllowlist") or [])
+before_mcp = len(cs.get("mcpAllowedTools") or [])
+cs["yoloCommandAllowlist"] = shell_allow
+cs["mcpAllowedTools"] = mcp_allow
+cs["yoloEnableRunEverything"] = False
+for mode in cs.get("modes4") or []:
+    if mode.get("id") == "agent":
+        mode["autoRun"] = True
+        mode["smartModeAutoRun"] = True
+        mode["fullAutoRun"] = False
+obj["composerState"] = cs
+cur.execute(
+    "UPDATE ItemTable SET value=? WHERE key=?",
+    (json.dumps(obj, separators=(",", ":"), ensure_ascii=False), key),
+)
+con.commit()
+con.close()
+print(f"shell allowlist: {before_shell} -> {len(shell_allow)}")
+print(f"mcp allowlist:   {before_mcp} -> {len(mcp_allow)}")
+print("Agent mode: autoRun=true, smartModeAutoRun=true, fullAutoRun=false")
+PY
+
+echo
+echo "Done. Fully quit and reopen Cursor (or reload the window) so Auto-review picks up permissions.json / sandbox.json."
+echo "Confirm under Settings → Agents → Approvals & Execution that mode is still Auto-review (not Run Everything)."

--- a/cursor/plugins/local/cheese-grok/agent-autonomy/permissions.json
+++ b/cursor/plugins/local/cheese-grok/agent-autonomy/permissions.json
@@ -1,0 +1,21 @@
+{
+  "autoRun": {
+    "allow_instructions": [
+      "Allow any shell command whose first token is rtk (the required shell wrapper in this environment).",
+      "Allow routine developer shell tools: git, gh, just, dots, jq, yq, rg, fd, node, npm, npx, uv, uvx, python3, python, mise, cargo, go, rustc, tokei, bat, delta, pretk, prek, sed, awk, sort, uniq, wc, tr, cut, tee, xargs, env, printf, basename, dirname, realpath, mktemp, mkdir, touch, cp, mv, ln, chmod, ls, find, tree, file, stat, head, tail, cat, echo, true, false, test, which, command, type, diff, patch.",
+      "Allow all tilth MCP tools (tilth_list, tilth_search, tilth_read, tilth_grok, tilth_diff, tilth_deps, tilth_write) under any tilth server id (tilth, user-tilth).",
+      "Allow all hallouminate MCP tools (ground, read_markdown, add_markdown, list_tree, list_files, list_corpora, index, backlinks, corpus_stats, get_footnote, delete_markdown) under any hallouminate server id (hallouminate, user-hallouminate, plugin-hallouminate-hallouminate).",
+      "Allow all milknado MCP tools under any milknado server id (milknado, user-milknado, plugin-milknado-milknado) — required for easy-cheese /ultracook and mikado graph work.",
+      "Allow context7 MCP tools (resolve-library-id, query-docs) and tavily MCP tools used by /briesearch and easy-cheese research phases.",
+      "Allow easy-cheese phase work: reading and writing under .cheese/, ralphs/, .hallouminate/, ~/.local/share/cheese/, ~/.claude/skills/, ~/.agents/skills/, and ~/.cursor/skills*/.",
+      "Allow running easy-cheese skills and related CLIs: cheese, cook, mold, press, cure, age, melt, plate, pasteurize, wheypoint, ultracook, affinage, culture, cut, rennet, hard-cheese, and their python helpers under skills/*/scripts/.",
+      "Allow just check, just test, dots sync, dots test, dots doctor, prek, and other repo gate commands commonly used after easy-cheese edits.",
+      "Allow WebFetch to cursor.com, github.com, raw.githubusercontent.com, docs sites needed for library docs, and package registries."
+    ],
+    "block_instructions": [
+      "Ask before git push --force, git reset --hard, git clean -fd, or recursive deletes outside the workspace temp dirs.",
+      "Ask before reading or writing .env files, private keys (*.pem, id_rsa, id_ed25519), and credential stores (.netrc, .npmrc with tokens, kubeconfig, aws credentials).",
+      "Ask before installing system packages with brew/apt that modify the machine outside the project, unless the user explicitly requested setup."
+    ]
+  }
+}

--- a/cursor/plugins/local/cheese-grok/agent-autonomy/sandbox.json
+++ b/cursor/plugins/local/cheese-grok/agent-autonomy/sandbox.json
@@ -1,0 +1,20 @@
+{
+  "type": "workspace_readwrite",
+  "additionalReadonlyPaths": [
+    "/Users/paul/.claude/skills",
+    "/Users/paul/.agents/skills",
+    "/Users/paul/.cursor/skills",
+    "/Users/paul/.cursor/skills-cursor",
+    "/Users/paul/.codex/skills",
+    "/Users/paul/.local/share/mise"
+  ],
+  "additionalReadwritePaths": [
+    "/Users/paul/.local/share/cheese",
+    "/Users/paul/.cursor/projects",
+    "/tmp",
+    "/Users/paul/Dev"
+  ],
+  "networkPolicy": {
+    "default": "allow"
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a tracked Cursor Auto-review pack under `cursor/plugins/local/cheese-grok/agent-autonomy/` (`permissions.json`, `sandbox.json`, `apply.sh`, README).
- Tuned for this machine's agent stack: `rtk`, tilth, hallouminate, milknado / easy-cheese, context7, tavily — while keeping Auto-review (not Run Everything) and still asking on force-push / secrets / system package installs.
- `apply.sh` installs live `~/.cursor/permissions.json` + `sandbox.json` and expands the IDE shell/MCP allowlists in `state.vscdb` (with a backup).

## Why
Cursor Agent mode was on Auto-review with a tiny allowlist (no `rtk`, almost no MCP tools), so every normal agent turn prompted for approval and became unusable.

## Apply after merge
```bash
./cursor/plugins/local/cheese-grok/agent-autonomy/apply.sh
```
Then fully quit and reopen Cursor. Confirm **Settings → Agents → Approvals & Execution** is still Auto-review.

## Test plan
- [ ] Run `./cursor/plugins/local/cheese-grok/agent-autonomy/apply.sh` once
- [ ] Reload Cursor; confirm `~/.cursor/permissions.json` and `sandbox.json` exist
- [ ] In Agent mode, run a `rtk`-prefixed shell command — should not prompt
- [ ] Call tilth / hallouminate / milknado MCP tools — should not prompt for each call
- [ ] Confirm a destructive action (e.g. force-push shape) still asks

Made with [Cursor](https://cursor.com)