### PR TITLE
fix(packages): snapshot cache inputs before installers run

### DIFF
--- a/packages/sync.sh
+++ b/packages/sync.sh
@@ -64,6 +64,13 @@ cache_hash() {
     } | shasum -a 256 | cut -d' ' -f1
 }
 
+# Composite hash of every package input, snapshotted before the first
+# installer runs. Both the cache check and the cache write read this snapshot
+# instead of re-hashing: the manifests can change mid-run (a concurrent
+# `git pull` landing renovate pins), and re-hashing at save time would record
+# inputs that were never installed, turning every later run into a false cache
+# hit that skips the new pins.
+CACHE_HASH_AT_CONVERGENCE=""
 check_cache() {
     if [[ "${FORCE_PACKAGES:-false}" == "true" || "${PACKAGES_BOOTSTRAP_ONLY:-false}" == "true" ]]; then
         log_info "Package cache bypassed"
@@ -74,12 +81,12 @@ check_cache() {
         return 1
     fi
     [[ -f "$CACHE_FILE" ]] || return 1
-    [[ "$(cache_hash)" == "$(<"$CACHE_FILE")" ]]
+    [[ "$CACHE_HASH_AT_CONVERGENCE" == "$(<"$CACHE_FILE")" ]]
 }
 
 save_cache() {
     mkdir -p "$CACHE_DIR"
-    cache_hash > "$CACHE_FILE"
+    printf '%s\n' "$CACHE_HASH_AT_CONVERGENCE" > "$CACHE_FILE"
 }
 
 ########## Query helpers
@@ -727,6 +734,9 @@ sync_native_harnesses() {
     fi
 
 }
+
+# Snapshot the inputs before the first installer runs.
+CACHE_HASH_AT_CONVERGENCE="$(cache_hash)"
 # Claude is invoked by chezmoi later in this sync, so keep its mise binary
 # present even when the package declaration cache is valid.
 if check_cache; then

--- a/tests/packages.bats
+++ b/tests/packages.bats
@@ -164,6 +164,23 @@ MOCKMISE
     chmod +x "$MOCK_BIN/mise"
 }
 
+# mise mock that appends a new pin to the manifest the first time it runs,
+# standing in for a concurrent `git pull` landing renovate bumps while the sync
+# is already past its install decision.
+write_mock_mise_landing_new_pin() {
+    rm -f "$MOCK_BIN/mise"
+    cat > "$MOCK_BIN/mise" << 'MOCKMISE'
+#!/bin/bash
+echo "mise $* config=${MISE_GLOBAL_CONFIG_FILE:-unset}" >> "$MISE_LOG"
+if [[ ! -e "$MISE_CONFIG_FILE.landed" ]]; then
+    printf 'node = "24.0.0"\n' >> "$MISE_CONFIG_FILE"
+    touch "$MISE_CONFIG_FILE.landed"
+fi
+exit 0
+MOCKMISE
+    chmod +x "$MOCK_BIN/mise"
+}
+
 teardown() {
     teardown_test_env
 }
@@ -841,6 +858,24 @@ YAML
     assert_output_contains "mise install failed"
     assert_output_contains "cache NOT saved"
     [[ ! -f "$CACHE_FILE" ]] || [[ ! -s "$CACHE_FILE" ]]
+}
+
+@test "a pin landing mid-run is never cached as converged" {
+    write_test_yaml
+    write_mock_mise_landing_new_pin
+
+    run bash "$SYNC_SCRIPT"
+    assert_success
+    [[ -s "$CACHE_FILE" ]]
+
+    # The pin arrived after mise converged, so it was never installed: the next
+    # sync has to miss the cache and reconverge instead of skipping it.
+    write_mock_mise
+    rm -f "$MISE_LOG"
+    run bash "$SYNC_SCRIPT"
+    assert_success
+    assert_output_not_contains "unchanged (cached)"
+    grep -q "mise install" "$MISE_LOG"
 }
 
 @test "mise install failure preserves stale native harness binaries" {


### PR DESCRIPTION
## What

`packages/sync.sh` recomputed its composite package-state hash inside `save_cache`, after every installer had finished. Both the cache check and the cache write now read a hash snapshotted before the first installer runs.

## Why

When a manifest changes mid-run — a `git pull` landing renovate pins while a sync is in flight — the run installs the old pins and then records the *new* manifest's hash as converged. Every later sync reports a cache hit and skips the new pins permanently, until the manifest changes again or `FORCE_PACKAGES` / `UPGRADE_MODE` bypasses the cache.

This happened live. Four aqua pins landed on 2026-08-08 (#630, #631, #629, #637) and were pulled at 01:42:35 on 08-09; `packages.hash` was written at 01:43:15 holding the post-pull hash, and `~/.local/share/mise/installs/` was never touched. Result: `fzf`, `opencode`, `crush`, and `rtk` sat declared-but-uninstalled, and `mise activate` warned about missing tools in every new shell.

## Test

`tests/packages.bats` — "a pin landing mid-run is never cached as converged". A mise mock appends a pin to the manifest on its first run (standing in for the concurrent pull), then the next sync must miss the cache and reconverge.

Fails without the fix, with exactly the production symptom:

```
not ok 1 a pin landing mid-run is never cached as converged
#   `assert_output_not_contains "unchanged (cached)"' failed
#   Actual output: [packages] Package manifests unchanged (cached), syncing Claude
```

`just check` exits 0 (1359 tests, packages.bats 79/79).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
