### PR TITLE
fix: restore MCP broker sockets on macOS

### DIFF
--- a/.hallouminate/wiki/architecture/macos-agent-secret-socket-directory.md
+++ b/.hallouminate/wiki/architecture/macos-agent-secret-socket-directory.md
@@ -2,7 +2,7 @@
 
 `/var/run/dotfiles-agent-secrets` is volatile on macOS. LaunchDaemons therefore recreate it before the broker validates and binds its request/control sockets; otherwise launchd repeatedly exits with `socket path parent is not a directory` and Context7/Tavily MCP initialization closes.[^1]
 
-The `--ensure-socket-parent` broker mode accepts only the fixed `SOCKET_ROOT`, requires root, refuses unsafe ownership or symlinks, and restores mode `0755`. It is emitted only by the macOS launchd template; systemd already supplies the directory with `RuntimeDirectory`.[^2]
+The `--ensure-socket-parent` broker mode accepts only the fixed `SOCKET_ROOT`, requires root, refuses unsafe ownership or symlinks, assigns the requester’s primary group and restores mode `0710`. It is emitted only by the macOS launchd template; systemd already supplies the directory with `RuntimeDirectory`.[^2]
 
 After deploying a change to the root-owned broker runtime, reprovision via `bin/vault-provision --request-user <daily-user> --operator-user root` in an interactive terminal so `sudo` can authenticate. This preserves the service-owned credential boundary.[^3]
 

--- a/.hallouminate/wiki/architecture/macos-agent-secret-socket-directory.md
+++ b/.hallouminate/wiki/architecture/macos-agent-secret-socket-directory.md
@@ -1,0 +1,11 @@
+# macOS agent-secret socket directory
+
+`/var/run/dotfiles-agent-secrets` is volatile on macOS. LaunchDaemons therefore recreate it before the broker validates and binds its request/control sockets; otherwise launchd repeatedly exits with `socket path parent is not a directory` and Context7/Tavily MCP initialization closes.[^1]
+
+The `--ensure-socket-parent` broker mode accepts only the fixed `SOCKET_ROOT`, requires root, refuses unsafe ownership or symlinks, and restores mode `0755`. It is emitted only by the macOS launchd template; systemd already supplies the directory with `RuntimeDirectory`.[^2]
+
+After deploying a change to the root-owned broker runtime, reprovision via `bin/vault-provision --request-user <daily-user> --operator-user root` in an interactive terminal so `sudo` can authenticate. This preserves the service-owned credential boundary.[^3]
+
+[^1]: scripts/agent-secret-broker.py:215-234; services/agent-secret/com.dotfiles.agent-secret.plist:9-24
+[^2]: services/agent-secret/agent-secret-broker@.service:11-14
+[^3]: bin/vault-provision:72-87; architecture/mcp-secret-handling.md

--- a/.sync
+++ b/.sync
@@ -54,8 +54,8 @@ verify_harness_versions() {
         log_error "omp --version failed $phase"
         return 1
     fi
-    if [[ "$omp_version" != "omp/17.2.5" ]]; then
-        log_error "omp version mismatch $phase: expected omp/17.2.5, got $omp_version"
+    if [[ "$omp_version" != "omp/17.2.10" ]]; then
+        log_error "omp version mismatch $phase: expected omp/17.2.10, got $omp_version"
         return 1
     fi
 

--- a/scripts/agent-secret-broker.py
+++ b/scripts/agent-secret-broker.py
@@ -212,7 +212,7 @@ def socket_path(value: str, label: str) -> pathlib.Path:
     return path
 
 
-def ensure_socket_parent(value: str) -> None:
+def ensure_socket_parent(value: str, request_gid: int) -> None:
     path = pathlib.Path(value)
     parent = path.parent
     if parent != pathlib.Path(SOCKET_ROOT):
@@ -220,18 +220,19 @@ def ensure_socket_parent(value: str) -> None:
     if os.geteuid() != 0:
         _fail("creating the managed socket parent requires root")
     try:
-        parent.mkdir(mode=0o755, parents=True, exist_ok=True)
+        parent.mkdir(mode=0o710, parents=True, exist_ok=True)
         info = parent.lstat()
     except OSError as exc:
         raise ConfigError("socket path parent cannot be created") from exc
     if stat.S_ISLNK(info.st_mode) or not stat.S_ISDIR(info.st_mode):
         _fail("socket path parent is not a directory")
-    if info.st_uid != 0 or info.st_mode & 0o022:
-        _fail("socket path parent ownership or mode is unsafe")
+    if info.st_uid != 0:
+        _fail("socket path parent must be root-owned")
     try:
-        os.chmod(parent, 0o755)
+        os.chown(parent, 0, request_gid)
+        os.chmod(parent, 0o710)
     except OSError as exc:
-        raise ConfigError("socket path parent mode cannot be set") from exc
+        raise ConfigError("socket path parent permissions cannot be set") from exc
 
 
 def default_request_socket(consumer: str) -> pathlib.Path:
@@ -1001,8 +1002,9 @@ def main(argv: list[str] | None = None) -> int:
         control_value = args.control_socket or str(default_control_socket(policy.consumer))
         run_user = _resolve_run_user(args.run_user, policy)
         if args.ensure_socket_parent:
-            ensure_socket_parent(request_value)
-            ensure_socket_parent(control_value)
+            request_gid = pwd.getpwuid(policy.request_uid).pw_gid
+            ensure_socket_parent(request_value, request_gid)
+            ensure_socket_parent(control_value, request_gid)
         upstream_home = pathlib.Path(args.upstream_home)
         if not upstream_home.is_absolute() or not upstream_home.is_dir():
             _fail("upstream home must be an existing absolute directory")

--- a/scripts/agent-secret-broker.py
+++ b/scripts/agent-secret-broker.py
@@ -212,6 +212,28 @@ def socket_path(value: str, label: str) -> pathlib.Path:
     return path
 
 
+def ensure_socket_parent(value: str) -> None:
+    path = pathlib.Path(value)
+    parent = path.parent
+    if parent != pathlib.Path(SOCKET_ROOT):
+        _fail("socket path parent is not managed")
+    if os.geteuid() != 0:
+        _fail("creating the managed socket parent requires root")
+    try:
+        parent.mkdir(mode=0o755, parents=True, exist_ok=True)
+        info = parent.lstat()
+    except OSError as exc:
+        raise ConfigError("socket path parent cannot be created") from exc
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISDIR(info.st_mode):
+        _fail("socket path parent is not a directory")
+    if info.st_uid != 0 or info.st_mode & 0o022:
+        _fail("socket path parent ownership or mode is unsafe")
+    try:
+        os.chmod(parent, 0o755)
+    except OSError as exc:
+        raise ConfigError("socket path parent mode cannot be set") from exc
+
+
 def default_request_socket(consumer: str) -> pathlib.Path:
     return pathlib.Path(SOCKET_ROOT) / f"{consumer}.sock"
 
@@ -921,6 +943,7 @@ def _build_parser(mode: str | None) -> argparse.ArgumentParser:
         parser.add_argument("--control-socket")
         parser.add_argument("--run-user")
         parser.add_argument("--upstream-home", default="/")
+        parser.add_argument("--ensure-socket-parent", action="store_true")
     if mode == "proxy":
         parser.add_argument("--socket")
         parser.add_argument("--consumer")
@@ -977,6 +1000,9 @@ def main(argv: list[str] | None = None) -> int:
         request_value = args.socket or str(default_request_socket(policy.consumer))
         control_value = args.control_socket or str(default_control_socket(policy.consumer))
         run_user = _resolve_run_user(args.run_user, policy)
+        if args.ensure_socket_parent:
+            ensure_socket_parent(request_value)
+            ensure_socket_parent(control_value)
         upstream_home = pathlib.Path(args.upstream_home)
         if not upstream_home.is_absolute() or not upstream_home.is_dir():
             _fail("upstream home must be an existing absolute directory")

--- a/services/agent-secret/com.dotfiles.agent-secret.plist
+++ b/services/agent-secret/com.dotfiles.agent-secret.plist
@@ -10,6 +10,7 @@
     <string>__LIBEXEC__/agent-secret-broker.py</string>
     <string>--mode</string>
     <string>broker</string>
+    <string>--ensure-socket-parent</string>
     <string>--policy</string>
     <string>__POLICY__</string>
     <string>--socket</string>

--- a/tests/agent-secret-install.bats
+++ b/tests/agent-secret-install.bats
@@ -80,6 +80,7 @@ PY
         [[ "$(plist_value --upstream-home)" == "$home_abs" ]]
         [[ "$(plist_value --socket)" == '/var/run/dotfiles-agent-secrets/fixture.sock' ]]
         [[ "$(plist_value --control-socket)" == '/var/run/dotfiles-agent-secrets/fixture.control.sock' ]]
+        grep -q '<string>--ensure-socket-parent</string>' "$plist"
     else
         unit="$INSTALL_ROOT/etc/systemd/system/dotfiles-agent-secret@.service"
         [[ "$(grep '^ExecStart=' "$unit")" == *'--run-user agent-secret-fixture --upstream-home /var/lib/dotfiles-agent-secrets/fixture'* ]]

--- a/tests/sync-orchestrator.bats
+++ b/tests/sync-orchestrator.bats
@@ -39,7 +39,7 @@ MOCK
     done
     cat > "$MOCK_BIN/omp" << 'MOCK'
 #!/bin/bash
-[[ "$1" == "--version" ]] && printf 'omp/17.2.5\n'
+[[ "$1" == "--version" ]] && printf 'omp/17.2.10\n'
 MOCK
     chmod +x "$MOCK_BIN/omp"
     cat > "$MOCK_BIN/codex" << 'MOCK'
@@ -351,7 +351,7 @@ SCRIPT
     cat > "$MOCK_BIN/omp" << 'SCRIPT'
 #!/bin/bash
 if [[ "$1" == "--version" ]]; then
-    version='omp/17.2.5'
+    version='omp/17.2.10'
     printf 'omp-version=%s\n' "$version" >> "$SYNC_EVENTS"
     printf '%s\n' "$version"
 fi
@@ -375,10 +375,10 @@ SCRIPT
     local expected_events
     expected_events='chezmoi-prepare
 packages-sync
-omp-version=omp/17.2.5
+omp-version=omp/17.2.10
 codex-version=codex-cli 0.146.0
 chezmoi-final-apply
-omp-version=omp/17.2.5
+omp-version=omp/17.2.10
 codex-version=codex-cli 0.146.0'
     [[ "$output" == "$expected_events" ]]
 }
@@ -403,7 +403,7 @@ SCRIPT
     rm -f "$FAKE_DOTFILES/packages/sync.sh"
     cat > "$FAKE_DOTFILES/packages/sync.sh" << 'SCRIPT'
 #!/bin/bash
-printf 'omp=17.2.5 codex=0.146.0\n' > "$TEST_HOME/upgraded-binaries"
+printf 'omp=17.2.10 codex=0.146.0\n' > "$TEST_HOME/upgraded-binaries"
 printf 'packages-sync\n' >> "$SYNC_EVENTS"
 SCRIPT
     chmod +x "$FAKE_DOTFILES/packages/sync.sh"
@@ -419,7 +419,7 @@ if [[ "$1" == "--version" ]]; then
     if [[ "$count" -eq 2 ]]; then
         version='omp/17.1.3'
     else
-        version='omp/17.2.5'
+        version='omp/17.2.10'
     fi
     printf 'omp-version=%s\n' "$version" >> "$SYNC_EVENTS"
     printf '%s\n' "$version"
@@ -441,8 +441,8 @@ SCRIPT
     assert_failure
     local sync_output="$output"
     run cat "$SYNC_EVENTS"
-    [[ "$output" == $'chezmoi-apply-1\npackages-sync\nomp-version=omp/17.2.5\ncodex-version=codex-cli 0.146.0\nchezmoi-final-apply-complete\nomp-version=omp/17.1.3' ]]
-    [[ "$(<"$TEST_HOME/upgraded-binaries")" == "omp=17.2.5 codex=0.146.0" ]]
+    [[ "$output" == $'chezmoi-apply-1\npackages-sync\nomp-version=omp/17.2.10\ncodex-version=codex-cli 0.146.0\nchezmoi-final-apply-complete\nomp-version=omp/17.1.3' ]]
+    [[ "$(<"$TEST_HOME/upgraded-binaries")" == "omp=17.2.10 codex=0.146.0" ]]
     [[ "$sync_output" == *"omp version mismatch after final chezmoi apply"* ]]
     [[ "$sync_output" == *"harness-versions"* ]]
 }
@@ -471,7 +471,7 @@ SCRIPT
     rm -f "$FAKE_DOTFILES/packages/sync.sh"
     cat > "$FAKE_DOTFILES/packages/sync.sh" << 'SCRIPT'
 #!/bin/bash
-printf 'omp=17.2.5 codex=0.146.0\n' > "$TEST_HOME/upgraded-binaries"
+printf 'omp=17.2.10 codex=0.146.0\n' > "$TEST_HOME/upgraded-binaries"
 printf 'packages-sync\n' >> "$SYNC_EVENTS"
 SCRIPT
     chmod +x "$FAKE_DOTFILES/packages/sync.sh"
@@ -479,8 +479,8 @@ SCRIPT
     cat > "$MOCK_BIN/omp" << 'SCRIPT'
 #!/bin/bash
 if [[ "$1" == "--version" ]]; then
-    printf 'omp-version=omp/17.2.5\n' >> "$SYNC_EVENTS"
-    printf 'omp/17.2.5\n'
+    printf 'omp-version=omp/17.2.10\n' >> "$SYNC_EVENTS"
+    printf 'omp/17.2.10\n'
 fi
 SCRIPT
     chmod +x "$MOCK_BIN/omp"
@@ -499,8 +499,8 @@ SCRIPT
     local sync_output="$output"
     local sync_stderr="$stderr"
     run cat "$SYNC_EVENTS"
-    [[ "$output" == $'chezmoi-prepare\npackages-sync\nomp-version=omp/17.2.5\ncodex-version=codex-cli 0.146.0\nchezmoi-final-apply-failed' ]]
-    [[ "$(<"$TEST_HOME/upgraded-binaries")" == "omp=17.2.5 codex=0.146.0" ]]
+    [[ "$output" == $'chezmoi-prepare\npackages-sync\nomp-version=omp/17.2.10\ncodex-version=codex-cli 0.146.0\nchezmoi-final-apply-failed' ]]
+    [[ "$(<"$TEST_HOME/upgraded-binaries")" == "omp=17.2.10 codex=0.146.0" ]]
     [[ "$sync_output" == *"Sync completed with FAILURES in: chezmoi"* ||
         "$sync_stderr" == *"Sync completed with FAILURES in: chezmoi"* ]]
 }
@@ -532,14 +532,14 @@ SCRIPT
     rm -f "$FAKE_DOTFILES/packages/sync.sh"
     cat > "$FAKE_DOTFILES/packages/sync.sh" << 'SCRIPT'
 #!/bin/bash
-printf 'omp=17.2.5 codex=0.146.0\n' > "$TEST_HOME/upgraded-binaries"
+printf 'omp=17.2.10 codex=0.146.0\n' > "$TEST_HOME/upgraded-binaries"
 printf 'packages-sync\n' >> "$SYNC_EVENTS"
 SCRIPT
     chmod +x "$FAKE_DOTFILES/packages/sync.sh"
     rm -f "$MOCK_BIN/omp"
     cat > "$MOCK_BIN/omp" << 'SCRIPT'
 #!/bin/bash
-[[ "$1" == "--version" ]] && printf 'omp/17.2.5\n'
+[[ "$1" == "--version" ]] && printf 'omp/17.2.10\n'
 SCRIPT
     chmod +x "$MOCK_BIN/omp"
     rm -f "$MOCK_BIN/codex"
@@ -554,7 +554,7 @@ SCRIPT
     local sync_output="$output"
     run cat "$SYNC_EVENTS"
     [[ "$output" == $'chezmoi-apply-1\npackages-sync' ]]
-    [[ "$(<"$TEST_HOME/upgraded-binaries")" == "omp=17.2.5 codex=0.146.0" ]]
+    [[ "$(<"$TEST_HOME/upgraded-binaries")" == "omp=17.2.10 codex=0.146.0" ]]
     [[ "$sync_output" == *"codex version mismatch"* ]]
 }
 @test "final harness verification prefers the post-package mise shim" {


### PR DESCRIPTION
## Summary
- recreate the volatile macOS broker socket directory at daemon startup
- align dots sync's OMP version gate with the managed 17.2.10 pin
- cover both regressions and document the macOS deployment requirement

## Verification
- rtk bats tests/sync-orchestrator.bats tests/agent-secret-install.bats
- rtk dots sync
- rtk just check