### PR TITLE
fix(agent-secret-broker): make approval TTL injectable to de-flake expiry test

### DIFF
--- a/scripts/agent-secret-broker.py
+++ b/scripts/agent-secret-broker.py
@@ -23,7 +23,7 @@ from dataclasses import dataclass
 from typing import Any, NoReturn
 
 SOCKET_ROOT = "/var/run/dotfiles-agent-secrets"
-APPROVAL_TTL = 60
+APPROVAL_TTL_ENV = "AGENT_SECRET_BROKER_APPROVAL_TTL"
 MAX_LINE = 1 << 20
 READ_BUFFER = 64 << 10
 RESPONSE_DRAIN_TIMEOUT = 30
@@ -81,6 +81,22 @@ class ClaimResult:
 
 def _fail(message: str) -> NoReturn:
     raise ConfigError(message)
+
+
+def _approval_ttl() -> int:
+    raw = os.environ.get(APPROVAL_TTL_ENV)
+    if raw is None:
+        return 60
+    try:
+        ttl = int(raw)
+    except ValueError:
+        _fail(f"{APPROVAL_TTL_ENV} must be a positive integer")
+    if ttl <= 0:
+        _fail(f"{APPROVAL_TTL_ENV} must be a positive integer")
+    return ttl
+
+
+APPROVAL_TTL = _approval_ttl()
 
 
 def _validate_abs_path(value: Any, label: str) -> pathlib.Path:

--- a/tests/agent-secret-broker.bats
+++ b/tests/agent-secret-broker.bats
@@ -276,12 +276,34 @@ PY
     [[ "$output" == *"$nonce"* ]]
 }
 
-@test "approval expires after the fixed sixty-second TTL" {
-    run proxy_call '{"jsonrpc":"2.0","id":8,"method":"tools/call","params":{"name":"write.item","arguments":{}}}'
+@test "approval succeeds within TTL and is rejected once the TTL elapses" {
+    local ttl_socket="$TEST_ROOT/ttl-request.sock"
+    local ttl_control="$TEST_ROOT/ttl-control.sock"
+    AGENT_SECRET_BROKER_APPROVAL_TTL=2 "$BROKER" --policy "$POLICY" --socket "$ttl_socket" --control-socket "$ttl_control" >"$TEST_ROOT/ttl-broker.log" 2>&1 &
+    local ttl_pid=$!
+    for _ in {1..50}; do
+        [[ -S "$ttl_socket" && -S "$ttl_control" ]] && break
+        sleep 0.02
+    done
+
+    run bash -c "printf '%s\n' \"\$1\" | '$PROXY' --socket '$ttl_socket'" _ '{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"write.item","arguments":{}}}'
     assert_success
-    nonce="$(printf '%s' "$output" | python3 -c 'import json,sys; print(json.load(sys.stdin)["error"]["data"]["nonce"])')"
-    sleep 61
-    run "$CTL" approve --socket "$CONTROL" --nonce "$nonce"
+    within_nonce="$(printf '%s' "$output" | python3 -c 'import json,sys; print(json.load(sys.stdin)["error"]["data"]["nonce"])')"
+    run "$CTL" approve --socket "$ttl_control" --nonce "$within_nonce"
+    assert_success
+    [[ "$output" == "{\"action\":\"approve\",\"nonce\":\"$within_nonce\",\"ok\":true}" ]]
+
+    run bash -c "printf '%s\n' \"\$1\" | '$PROXY' --socket '$ttl_socket'" _ '{"jsonrpc":"2.0","id":10,"method":"tools/call","params":{"name":"write.item","arguments":{"expiry":true}}}'
+    assert_success
+    expiring_nonce="$(printf '%s' "$output" | python3 -c 'import json,sys; print(json.load(sys.stdin)["error"]["data"]["nonce"])')"
+    for _ in {1..100}; do
+        run "$CTL" approve --socket "$ttl_control" --nonce "$expiring_nonce"
+        [[ "$output" == *'"code":"expired"'* ]] && break
+        sleep 0.05
+    done
     assert_failure
     [[ "$output" == *'"code":"expired"'* ]]
+
+    kill "$ttl_pid" 2>/dev/null || true
+    wait "$ttl_pid" 2>/dev/null || true
 }


### PR DESCRIPTION
## Summary
- The broker's approval TTL was a fixed 60s constant, and the expiry test slept a real 61s before asserting expiry — under parallel gate load, the expiry check could land before the deadline passed.
- Add `AGENT_SECRET_BROKER_APPROVAL_TTL` env override (default stays 60s) so tests can run a short TTL.
- Rewrite the expiry test to run the broker with a 2s TTL and poll for the expired state with a bounded wait, instead of a single wall-clock-raced assertion. Drops the 61s sleep from full-suite runs.

Closes #648

## Test plan
- [x] `just check` — exit 0 (all Bats, node, and shell suites pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)