### PR TITLE
chore(doc-drift): bump oh-my-pi to v17.2.12, disable agent-plugins provider

### DIFF
--- a/agents/doc-drift/sources.yaml
+++ b/agents/doc-drift/sources.yaml
@@ -69,4 +69,4 @@ sources:
     signal: { type: gh_release, ref: can1357/oh-my-pi }
     docs: https://github.com/can1357/oh-my-pi
     governs: [chezmoi/.chezmoidata/omp.yaml, chezmoi/dot_omp/private_agent/modify_config.yml, packages/sync.sh]
-    reconciled: "v17.2.10"
+    reconciled: "v17.2.12"

--- a/chezmoi/.chezmoidata/omp.yaml
+++ b/chezmoi/.chezmoidata/omp.yaml
@@ -51,6 +51,12 @@ omp:
       - github
       - opencode
       - agents-md
+      # v17.2.11 added a separate agent-plugins.org discovery provider that
+      # scans the same ~/.claude and ~/.omp plugin roots as claude-plugins
+      # and auto-imports skills/MCP for conformant plugin.json roots. Shut
+      # off per the policy above; if milknado/hallouminate later ship an
+      # agent-plugins.org plugin.json, this must be revisited deliberately.
+      - agent-plugins
     display:
       showTokenUsage: true
       cacheMissMarker: true

--- a/packages/sync.sh
+++ b/packages/sync.sh
@@ -15,7 +15,7 @@ PLATFORM="$(uname)"
 MISE_CONFIG_FILE="${MISE_CONFIG_FILE:-${XDG_CONFIG_HOME:-$HOME/.config}/mise/config.toml}"
 MISE_BOOTSTRAP_CONFIG_FILE="${MISE_BOOTSTRAP_CONFIG_FILE:-$SCRIPT_DIR/../chezmoi/dot_config/mise/config.toml}"
 # renovate: datasource=github-tags depName=can1357/oh-my-pi
-OMP_PIN="v17.2.10"
+OMP_PIN="v17.2.12"
 
 GREEN='\033[0;32m'
 BLUE='\033[0;34m'

--- a/tests/omp-config.bats
+++ b/tests/omp-config.bats
@@ -74,7 +74,7 @@ STDIN"
     [ "$(yq '.modelRoles.task' "$OUT")" = "@fast" ]
     [ "$(yq '.modelRoles.commit' "$OUT")" = "@fast" ]
     [ "$(yq '.astGrep.enabled' "$OUT")" = "true" ]
-    [ "$(yq '.disabledProviders | join(",")' "$OUT")" = "claude,codex,cursor,gemini,github,opencode,agents-md" ]
+    [ "$(yq '.disabledProviders | join(",")' "$OUT")" = "claude,codex,cursor,gemini,github,opencode,agents-md,agent-plugins" ]
     # setupVersion is machine state — never authored on a fresh machine.
     [ "$(yq 'has("setupVersion")' "$OUT")" = "false" ]
 }
@@ -95,7 +95,7 @@ setupVersion: 1'
     [ "$(yq '.symbolPreset' "$OUT")" = "nerd" ]
     [ "$(yq '.theme.dark' "$OUT")" = "chocolate-donut" ]
     [ "$(yq '.theme.light' "$OUT")" = "light" ]
-    [ "$(yq '.disabledProviders | join(",")' "$OUT")" = "claude,codex,cursor,gemini,github,opencode,agents-md" ]
+    [ "$(yq '.disabledProviders | join(",")' "$OUT")" = "claude,codex,cursor,gemini,github,opencode,agents-md,agent-plugins" ]
     [ "$(yq '.todo.enabled' "$OUT")" = "false" ]
     [ "$(yq '.todo.reminders' "$OUT")" = "false" ]
     [ "$(yq '.setupVersion' "$OUT")" = "1" ]

--- a/tests/packages.bats
+++ b/tests/packages.bats
@@ -1017,13 +1017,13 @@ MOCKBREW
 # --- Integration: native harness convergence ---
 
 @test "managed OMP and Codex pins are exact" {
-    grep -q '^OMP_PIN="v17.2.10"$' "$SYNC_SCRIPT"
+    grep -q '^OMP_PIN="v17.2.12"$' "$SYNC_SCRIPT"
     grep -q '^"aqua:openai/codex" = "rust-v0.146.0"$' \
         "$REAL_DOTFILES_DIR/chezmoi/dot_config/mise/config.toml"
 }
 @test "doc-drift records match the managed harness pins" {
     local sources="$REAL_DOTFILES_DIR/agents/doc-drift/sources.yaml"
-    [ "$(yq -r '.sources[] | select(.id == "oh-my-pi") | .reconciled' "$sources")" = "v17.2.10" ]
+    [ "$(yq -r '.sources[] | select(.id == "oh-my-pi") | .reconciled' "$sources")" = "v17.2.12" ]
     [ "$(yq -r '.sources[] | select(.id == "codex-cli") | .reconciled' "$sources")" = "0.146.0" ]
 }
 
@@ -1116,7 +1116,7 @@ YAML
     assert_success
 
     local expected_events
-    expected_events=$(printf 'sh -s -- --binary --ref v17.2.10\ncodesign --force --sign - %s' \
+    expected_events=$(printf 'sh -s -- --binary --ref v17.2.12\ncodesign --force --sign - %s' \
         "$TEST_HOME/.local/bin/omp")
     run cat "$EVENT_LOG"
     [[ "$output" == "$expected_events" ]]


### PR DESCRIPTION
## Summary

- Reconciles the doc-drift ledger's `oh-my-pi` entry from `v17.2.10` to `v17.2.12` and bumps the actual `OMP_PIN` in `packages/sync.sh` to match.
- Adds `agent-plugins` to `chezmoi/.chezmoidata/omp.yaml`'s `disabledProviders`: v17.2.11 shipped the Agent Plugins 1.0.0 discovery provider enabled by default, scanning the same `~/.claude` and `~/.omp` plugin roots as the already-disabled `claude-plugins` provider and auto-importing skills/MCP for conformant `plugin.json` roots — bypassing the "shut off external discovery" intent the existing `disabledProviders` list encodes, per Option A recommended in #653.
- Updates `tests/omp-config.bats` and `tests/packages.bats` regression assertions for the new pin and provider list, and adds a wiki note on the forward-compat trap (new OMP discovery providers ship enabled-by-default, so a version bump alone doesn't catch them) to `.hallouminate/wiki/operations/sync-and-chezmoi.md`.

v17.2.12 is pure bugfixes over v17.2.11 (per the issue's changelog review); no other config surface changed.

Closes #653

## Test plan
- [x] `just check` — exit 0 (lint-fix, lint-shell, test-python, smoke, bats all pass; 152/152 workflow unit tests, 1358/1358 bats tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)