### PR TITLE
fix(secrets): resolve agent-secret-proxy via absolute libexec path

### DIFF
--- a/bin/agent-secret-broker
+++ b/bin/agent-secret-broker
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 BIN_DIR="$(cd -- "${BASH_SOURCE[0]%/*}" && pwd)"
+LIB="$BIN_DIR/agent-secret-python.sh"
+[[ -f "$LIB" ]] || LIB="$BIN_DIR/lib/agent-secret-python.sh"
+# shellcheck source=lib/agent-secret-python.sh
+source "$LIB"
+PYTHON_BIN="$(agent_secret_python_path)" || { echo "agent-secret-broker: python3 not found" >&2; exit 1; }
 PYTHON="$BIN_DIR/agent-secret-broker.py"
 [[ -f "$PYTHON" ]] || PYTHON="${BIN_DIR%/*}/scripts/agent-secret-broker.py"
-exec python3 "$PYTHON" --mode broker "$@"
+exec "$PYTHON_BIN" "$PYTHON" --mode broker "$@"

--- a/bin/agent-secret-install
+++ b/bin/agent-secret-install
@@ -4,6 +4,9 @@ set -euo pipefail
 DOTFILES_DIR="$(cd -- "${BASH_SOURCE[0]%/*}/.." && pwd)"
 DESTDIR="${DESTDIR:-}"
 DESTDIR="${DESTDIR%/}"
+
+# shellcheck source=lib/agent-secret-python.sh
+source "$DOTFILES_DIR/bin/lib/agent-secret-python.sh"
 READ_TOOLS=()
 WRITE_TOOLS=()
 
@@ -48,11 +51,7 @@ resolve_gid() {
 
 
 python_path() {
-    if [[ -x /usr/bin/python3 ]]; then
-        printf '%s\n' /usr/bin/python3
-        return
-    fi
-    command -v python3 2>/dev/null || die "python3 not found"
+    agent_secret_python_path || die "python3 not found"
 }
 
 credential_is_private() {
@@ -141,6 +140,7 @@ copy_runtime_tools() {
     install -m 0755 "$DOTFILES_DIR/bin/agent-secret-broker" "$libexec/agent-secret-broker"
     install -m 0755 "$DOTFILES_DIR/bin/agent-secret-proxy" "$libexec/agent-secret-proxy"
     install -m 0755 "$DOTFILES_DIR/bin/agent-secretctl" "$libexec/agent-secretctl"
+    install -m 0644 "$DOTFILES_DIR/bin/lib/agent-secret-python.sh" "$libexec/agent-secret-python.sh"
     install -m 0755 "$DOTFILES_DIR/scripts/agent-secret-broker.py" "$libexec/agent-secret-broker.py"
 }
 

--- a/bin/agent-secret-proxy
+++ b/bin/agent-secret-proxy
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 BIN_DIR="$(cd -- "${BASH_SOURCE[0]%/*}" && pwd)"
+LIB="$BIN_DIR/agent-secret-python.sh"
+[[ -f "$LIB" ]] || LIB="$BIN_DIR/lib/agent-secret-python.sh"
+# shellcheck source=lib/agent-secret-python.sh
+source "$LIB"
+PYTHON_BIN="$(agent_secret_python_path)" || { echo "agent-secret-proxy: python3 not found" >&2; exit 1; }
 PYTHON="$BIN_DIR/agent-secret-broker.py"
 [[ -f "$PYTHON" ]] || PYTHON="${BIN_DIR%/*}/scripts/agent-secret-broker.py"
-exec python3 "$PYTHON" --mode proxy "$@"
+exec "$PYTHON_BIN" "$PYTHON" --mode proxy "$@"

--- a/bin/agent-secretctl
+++ b/bin/agent-secretctl
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 BIN_DIR="$(cd -- "${BASH_SOURCE[0]%/*}" && pwd)"
+LIB="$BIN_DIR/agent-secret-python.sh"
+[[ -f "$LIB" ]] || LIB="$BIN_DIR/lib/agent-secret-python.sh"
+# shellcheck source=lib/agent-secret-python.sh
+source "$LIB"
+PYTHON_BIN="$(agent_secret_python_path)" || { echo "agent-secretctl: python3 not found" >&2; exit 1; }
 PYTHON="$BIN_DIR/agent-secret-broker.py"
 [[ -f "$PYTHON" ]] || PYTHON="${BIN_DIR%/*}/scripts/agent-secret-broker.py"
-exec python3 "$PYTHON" --mode control "$@"
+exec "$PYTHON_BIN" "$PYTHON" --mode control "$@"

--- a/bin/lib/agent-secret-python.sh
+++ b/bin/lib/agent-secret-python.sh
@@ -1,0 +1,17 @@
+# shellcheck shell=bash
+# agent-secret-python.sh — shared python3 interpreter resolution for the
+# agent-secret broker toolchain. Sourced by agent-secret-install and the
+# installed agent-secret-{broker,proxy,ctl} wrappers so every consumer pins
+# to the same interpreter agent-secret-install's services run under, instead
+# of a bare PATH-resolved python3.
+
+# agent_secret_python_path — print the resolved python3 interpreter path.
+# Prefers /usr/bin/python3, falling back to the first python3 on PATH.
+# Returns non-zero with no output if neither is found.
+agent_secret_python_path() {
+    if [[ -x /usr/bin/python3 ]]; then
+        printf '%s\n' /usr/bin/python3
+        return 0
+    fi
+    command -v python3 2>/dev/null
+}

--- a/chezmoi/.chezmoidata/claude.yaml
+++ b/chezmoi/.chezmoidata/claude.yaml
@@ -40,10 +40,10 @@ claude:
       env:
         TILTH_MCP_CWD_HOOK_INJECTED: "1"
     context7:
-      command: agent-secret-proxy
+      command: /usr/local/libexec/dotfiles/agent-secret-proxy
       args: ["--socket", "/var/run/dotfiles-agent-secrets/context7.sock"]
     tavily:
-      command: agent-secret-proxy
+      command: /usr/local/libexec/dotfiles/agent-secret-proxy
       args: ["--socket", "/var/run/dotfiles-agent-secrets/tavily.sock"]
 
   # ── settings.json `hooks` key (authored wholesale) ─────────────────────────

--- a/chezmoi/.chezmoidata/codex.yaml
+++ b/chezmoi/.chezmoidata/codex.yaml
@@ -53,10 +53,10 @@ codex:
         tilth_write:
           approval_mode: approve
     context7:
-      command: agent-secret-proxy
+      command: /usr/local/libexec/dotfiles/agent-secret-proxy
       args: ["--socket", "/var/run/dotfiles-agent-secrets/context7.sock"]
     tavily:
-      command: agent-secret-proxy
+      command: /usr/local/libexec/dotfiles/agent-secret-proxy
       args: ["--socket", "/var/run/dotfiles-agent-secrets/tavily.sock"]
     milknado:
       command: uvx

--- a/chezmoi/dot_omp/private_agent/mcp.json
+++ b/chezmoi/dot_omp/private_agent/mcp.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/can1357/oh-my-pi/main/packages/coding-agent/src/config/mcp-schema.json",
   "mcpServers": {
     "context7": {
-      "command": "agent-secret-proxy",
+      "command": "/usr/local/libexec/dotfiles/agent-secret-proxy",
       "args": [
         "--socket",
         "/var/run/dotfiles-agent-secrets/context7.sock"

--- a/chezmoi/private_dot_copilot/mcp-config.json.tmpl
+++ b/chezmoi/private_dot_copilot/mcp-config.json.tmpl
@@ -8,7 +8,7 @@ reads or emits API-key, PAT, env, or envFile values.
   "mcpServers": {
     "context7": {
       "type": "local",
-      "command": "agent-secret-proxy",
+      "command": "/usr/local/libexec/dotfiles/agent-secret-proxy",
       "args": [
         "--socket",
         "/var/run/dotfiles-agent-secrets/context7.sock"
@@ -20,7 +20,7 @@ reads or emits API-key, PAT, env, or envFile values.
 
     "tavily": {
       "type": "local",
-      "command": "agent-secret-proxy",
+      "command": "/usr/local/libexec/dotfiles/agent-secret-proxy",
       "args": [
         "--socket",
         "/var/run/dotfiles-agent-secrets/tavily.sock"

--- a/tests/agent-secret-config.bats
+++ b/tests/agent-secret-config.bats
@@ -10,16 +10,16 @@ setup() {
 teardown() { teardown_test_env; }
 
 assert_yaml_proxy() {
-    local file=$1 query=$2 consumer=$3
-    [[ "$(yq -r "$query.command" "$file")" == "agent-secret-proxy" ]]
+    local file=$1 query=$2 consumer=$3 command=${4:-agent-secret-proxy}
+    [[ "$(yq -r "$query.command" "$file")" == "$command" ]]
     [[ "$(yq -r "$query.args | @json" "$file")" == "[\"--socket\",\"/var/run/dotfiles-agent-secrets/$consumer.sock\"]" ]]
     [[ "$(yq -r "$query | has(\"env\")" "$file")" == false ]]
     [[ "$(yq -r "$query | has(\"envFile\")" "$file")" == false ]]
 }
 
 assert_json_proxy() {
-    local file=$1 query=$2 consumer=$3
-    jq -e "$query.command == \"agent-secret-proxy\"" "$file" >/dev/null
+    local file=$1 query=$2 consumer=$3 command=${4:-agent-secret-proxy}
+    jq -e "$query.command == \"$command\"" "$file" >/dev/null
     jq -e "$query.args == [\"--socket\", \"/var/run/dotfiles-agent-secrets/$consumer.sock\"]" "$file" >/dev/null
     jq -e "$query | has(\"env\") | not" "$file" >/dev/null
     jq -e "$query | has(\"envFile\") | not" "$file" >/dev/null
@@ -45,17 +45,19 @@ assert_json_proxy() {
             "$file" ".mcps[] | select(.name == \"$consumer\")" "$consumer"
     done
 
+    local libexec_proxy=/usr/local/libexec/dotfiles/agent-secret-proxy
+
     local claude="$REAL_DOTFILES_DIR/chezmoi/.chezmoidata/claude.yaml"
-    assert_yaml_proxy "$claude" '.claude.mcps.context7' context7
-    assert_yaml_proxy "$claude" '.claude.mcps.tavily' tavily
+    assert_yaml_proxy "$claude" '.claude.mcps.context7' context7 "$libexec_proxy"
+    assert_yaml_proxy "$claude" '.claude.mcps.tavily' tavily "$libexec_proxy"
 
     local codex="$REAL_DOTFILES_DIR/chezmoi/.chezmoidata/codex.yaml"
-    assert_yaml_proxy "$codex" '.codex.mcps.context7' context7
-    assert_yaml_proxy "$codex" '.codex.mcps.tavily' tavily
+    assert_yaml_proxy "$codex" '.codex.mcps.context7' context7 "$libexec_proxy"
+    assert_yaml_proxy "$codex" '.codex.mcps.tavily' tavily "$libexec_proxy"
 
     assert_json_proxy \
         "$REAL_DOTFILES_DIR/chezmoi/dot_omp/private_agent/mcp.json" \
-        '.mcpServers.context7' context7
+        '.mcpServers.context7' context7 "$libexec_proxy"
 }
 
 @test "rendered Copilot MCP config contains no credential delivery channel" {
@@ -69,8 +71,9 @@ assert_json_proxy() {
         chezmoi --source "$REAL_DOTFILES_DIR/chezmoi" execute-template \
         < "$template" > "$rendered"
 
-    assert_json_proxy "$rendered" '.mcpServers.context7' context7
-    assert_json_proxy "$rendered" '.mcpServers.tavily' tavily
+    local libexec_proxy=/usr/local/libexec/dotfiles/agent-secret-proxy
+    assert_json_proxy "$rendered" '.mcpServers.context7' context7 "$libexec_proxy"
+    assert_json_proxy "$rendered" '.mcpServers.tavily' tavily "$libexec_proxy"
 
     local retired
     for retired in \

--- a/tests/agent-secret-python.bats
+++ b/tests/agent-secret-python.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() { setup_test_env; }
+teardown() { teardown_test_env; }
+
+@test "prefers /usr/bin/python3 over a PATH-resolved interpreter" {
+    [[ -x /usr/bin/python3 ]] || skip "/usr/bin/python3 is required"
+    run bash -c 'source "$0/bin/lib/agent-secret-python.sh"; agent_secret_python_path' "$REAL_DOTFILES_DIR"
+    assert_success
+    [[ "$output" == /usr/bin/python3 ]]
+}
+
+@test "falls back to PATH python3 when /usr/bin/python3 is absent" {
+    [[ ! -x /usr/bin/python3 ]] || skip "/usr/bin/python3 present; fallback branch not exercised"
+    local fake_root="$TEST_HOME/fake-bin"
+    mkdir -p "$fake_root"
+    cat > "$fake_root/python3" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    chmod +x "$fake_root/python3"
+    # shellcheck disable=SC2016  # literal $0 form for bash -c positional arg, not for expansion
+    run env PATH="$fake_root:$PATH" bash -c 'source "$0/bin/lib/agent-secret-python.sh"; agent_secret_python_path' "$REAL_DOTFILES_DIR"
+    assert_success
+    [[ "$output" == "$fake_root/python3" ]]
+}
+
+@test "every agent-secret wrapper resolves its interpreter through the shared library, never bare python3" {
+    local wrapper
+    for wrapper in agent-secret-broker agent-secret-proxy agent-secretctl; do
+        run grep -n 'exec python3 ' "$REAL_DOTFILES_DIR/bin/$wrapper"
+        assert_failure
+        run grep -q 'agent_secret_python_path' "$REAL_DOTFILES_DIR/bin/$wrapper"
+        assert_success
+    done
+}
+
+@test "agent-secret-install reuses the shared python resolution library" {
+    # shellcheck disable=SC2016  # literal string to match in the file, not for expansion
+    run grep -q 'source "$DOTFILES_DIR/bin/lib/agent-secret-python.sh"' "$REAL_DOTFILES_DIR/bin/agent-secret-install"
+    assert_success
+}

--- a/tests/chezmoi-wiring.bats
+++ b/tests/chezmoi-wiring.bats
@@ -354,7 +354,7 @@ EOF
     # credential placeholders or envFile entries.
     local consumer
     for consumer in context7 tavily; do
-        [[ "$(yq -r ".claude.mcps.$consumer.command" "$reg")" == "agent-secret-proxy" ]] \
+        [[ "$(yq -r ".claude.mcps.$consumer.command" "$reg")" == "/usr/local/libexec/dotfiles/agent-secret-proxy" ]] \
             || { echo "claude MCP $consumer is not proxy-backed" >&2; return 1; }
         [[ "$(yq -r ".claude.mcps.$consumer.args | join(\" \")" "$reg")" == "--socket /var/run/dotfiles-agent-secrets/$consumer.sock" ]] \
             || { echo "claude MCP $consumer has the wrong proxy socket" >&2; return 1; }
@@ -651,7 +651,7 @@ YAML
         chezmoi --source "$REAL_DOTFILES_DIR/chezmoi" execute-template < "$tmpl")"
     jq -e . <<<"$rendered" >/dev/null
     for consumer in context7 tavily; do
-        jq -e ".mcpServers.$consumer.command == \"agent-secret-proxy\"" <<<"$rendered"
+        jq -e ".mcpServers.$consumer.command == \"/usr/local/libexec/dotfiles/agent-secret-proxy\"" <<<"$rendered"
         jq -e ".mcpServers.$consumer.args == [\"--socket\", \"/var/run/dotfiles-agent-secrets/$consumer.sock\"]" <<<"$rendered"
         jq -e "(.mcpServers.$consumer | has(\"env\") | not)" <<<"$rendered"
         jq -e "(.mcpServers.$consumer | has(\"envFile\") | not)" <<<"$rendered"
@@ -875,7 +875,7 @@ TOML
     # Fixed proxy arguments are the only secret-bearing MCP configuration.
     assert_file_exists "$HOME/.copilot/mcp-config.json"
     for consumer in context7 tavily; do
-        jq -e ".mcpServers.$consumer.command == \"agent-secret-proxy\"" \
+        jq -e ".mcpServers.$consumer.command == \"/usr/local/libexec/dotfiles/agent-secret-proxy\"" \
             "$HOME/.copilot/mcp-config.json"
         jq -e ".mcpServers.$consumer.args == [\"--socket\", \"/var/run/dotfiles-agent-secrets/$consumer.sock\"]" \
             "$HOME/.copilot/mcp-config.json"
@@ -908,7 +908,7 @@ TOML
         chezmoi --source "$REAL_DOTFILES_DIR/chezmoi" execute-template < "$tmpl")"
     jq -e . <<<"$rendered" >/dev/null
     for consumer in context7 tavily; do
-        jq -e ".mcpServers.$consumer.command == \"agent-secret-proxy\"" <<<"$rendered"
+        jq -e ".mcpServers.$consumer.command == \"/usr/local/libexec/dotfiles/agent-secret-proxy\"" <<<"$rendered"
         jq -e ".mcpServers.$consumer.args == [\"--socket\", \"/var/run/dotfiles-agent-secrets/$consumer.sock\"]" <<<"$rendered"
         jq -e "(.mcpServers.$consumer | has(\"env\") | not)" <<<"$rendered"
         jq -e "(.mcpServers.$consumer | has(\"envFile\") | not)" <<<"$rendered"

--- a/tests/omp-config.bats
+++ b/tests/omp-config.bats
@@ -202,7 +202,7 @@ STDIN"
 @test "omp-mcp: native user config keeps brokered context7 only; wiki/planner are plugins" {
     local cfg="$REAL_DOTFILES_DIR/chezmoi/dot_omp/private_agent/mcp.json"
     local omp_reg="$REAL_DOTFILES_DIR/chezmoi/.chezmoidata/omp.yaml"
-    jq -e '.mcpServers.context7.command == "agent-secret-proxy"' "$cfg"
+    jq -e '.mcpServers.context7.command == "/usr/local/libexec/dotfiles/agent-secret-proxy"' "$cfg"
     jq -e '.mcpServers.context7.args == ["--socket", "/var/run/dotfiles-agent-secrets/context7.sock"]' "$cfg"
     jq -e '(.mcpServers.context7 | has("env") | not)' "$cfg"
     jq -e '(.mcpServers.context7 | has("envFile") | not)' "$cfg"


### PR DESCRIPTION
## Summary
- MCP configs invoked `agent-secret-proxy` by bare name, unreachable outside an interactive zsh session with the shim on `PATH`. Point the four rendered configs (`claude.yaml`, `codex.yaml`, omp `mcp.json`, copilot `mcp-config.json.tmpl`) at the installed `/usr/local/libexec/dotfiles/agent-secret-proxy`.
- `agent-secret-broker`, `agent-secret-proxy`, and `agent-secretctl` exec'd bare-PATH `python3` while the installer pins `/usr/bin/python3`. Extract shared `agent_secret_python_path()` resolution into `bin/lib/agent-secret-python.sh` so the wrappers and `agent-secret-install` agree on interpreter.
- Update the checked-in-config assertions in `tests/agent-secret-config.bats`, `tests/chezmoi-wiring.bats`, and `tests/omp-config.bats` (previously untouched, silently broken by the config change) to expect the absolute proxy path.

Closes #641

## Test plan
- [x] `just check` — exit 0 (bats unit suite, workflows-test.sh, run-tests.sh 1362/1362 passing)
- [x] `shellcheck` clean on all touched shell files

🤖 Generated with [Claude Code](https://claude.com/claude-code)