### PR TITLE
feat(hooks): detect cross-harness doom loops

### DIFF
--- a/.hallouminate/wiki/architecture/doom-loop-detection.md
+++ b/.hallouminate/wiki/architecture/doom-loop-detection.md
@@ -1,0 +1,65 @@
+---
+status: reviewed
+last_verified: 2026-08-07
+confidence: high
+sources:
+  - agents/hooks/registry.yaml
+  - chezmoi/.chezmoidata/claude.yaml
+  - agents/hooks/doom-loop-guard.sh
+  - agents/lib/doom-loop-guard.js
+  - chezmoi/dot_omp/private_agent/extensions/doom-loop-guard.ts
+  - tests/doom-loop-guard.bats
+  - tests/extensions/doom-loop-guard.test.mjs
+  - https://openrouter.ai/docs/agent-sdk/call-model/doom-loop-detection
+  - https://code.claude.com/docs/en/hooks
+  - https://learn.chatgpt.com/docs/hooks
+  - https://github.com/can1357/oh-my-pi/blob/main/docs/hooks.md
+---
+# Cross-harness doom-loop detection
+
+Claude, Codex, and OMP share one stateful detector for repeated identical local tool calls. Harness adapters translate its four verdicts—allow, observe, block, and stop—into each runtime's native hook response.[^1]
+
+## Detection contract
+
+A repeat is the same tool name plus recursively key-sorted JSON input within one user request. Request scope comes from Claude's `prompt_id`, Codex's `turn_id`, or an OMP `agent_start` generation; replayed delivery of one `tool_use_id`/`toolCallId` counts once. Counts are tracked per tool, so intervening calls to another tool do not reset the streak; changed input resets only that tool. State lives under the dotfiles cache rather than the process, preserving counts across hook subprocesses while the scope prevents carry-over into later requests.[^2]
+
+The thresholds follow OpenRouter's recommended ladder:
+
+1. First call: allow.
+2. Second identical call: observe and steer the agent.
+3. Third through fifth: block.
+4. Sixth and later: stop where the harness supports stopping.
+
+Task delegation and polling tools are exempt. They can legitimately repeat identical inputs while waiting for another worker and would otherwise produce false positives.[^3]
+
+State filenames hash the harness/session identity, state files are mode 0600, the directory is mode 0700, and retention is capped by age, session-file count, and tracked-tool count. Malformed payloads, missing identity, unavailable Node, state errors, and lock contention fail open.[^4]
+
+## Harness adapters
+
+Codex derives its catch-all PreToolUse entry from agents/hooks/registry.yaml. Claude's wholesale settings source declares the corresponding entry in chezmoi/.chezmoidata/claude.yaml. The shell bridge loads the same deployed Node module in either harness.[^5]
+
+Claude can stop execution at the sixth call with top-level continue: false. Codex does not support that field for PreToolUse, so its stop-strength verdict remains a denial whose reason identifies the stop threshold.[^6]
+
+OMP does not consume the shared hook registry. Its native tool_call extension imports the detector deployed under ~/.claude/lib, steers on observe, returns { block: true, reason } on block, and combines ctx.abort() with a block at the stop threshold.[^7]
+
+## Deliberate limits
+
+This reproduces local tool-call loop detection, not OpenRouter's text-response or server-tool repetition checks. Those events do not pass through these local PreToolUse/tool_call surfaces.
+
+Distinct calls in one parallel tool batch have distinct invocation IDs and therefore count separately. The shared local hook surfaces do not expose a uniform batch identifier, so this implementation cannot reproduce OpenRouter's batch-level deduplication across all three harnesses.[^8]
+
+## Verification
+
+The Bats suite pins thresholds, canonical inputs, per-tool reset behavior, request-scope reset, invocation replay deduplication, session isolation, exemptions, harness-specific stop responses, and fail-open behavior. The Node extension test pins OMP request reset, steering, blocking, and abort behavior.[^9]
+
+[^1]: agents/lib/doom-loop-guard.js:114-209, chezmoi/dot_omp/private_agent/extensions/doom-loop-guard.ts:18-62
+[^2]: agents/lib/doom-loop-guard.js:24-70, agents/lib/doom-loop-guard.js:147-200; [OpenRouter doom-loop detection](https://openrouter.ai/docs/agent-sdk/call-model/doom-loop-detection); [Claude prompt IDs](https://code.claude.com/docs/en/hooks); [Codex turn IDs](https://learn.chatgpt.com/docs/hooks); [OMP lifecycle events](https://github.com/can1357/oh-my-pi/blob/main/docs/hooks.md)
+[^3]: agents/lib/doom-loop-guard.js:15-40
+[^4]: agents/lib/doom-loop-guard.js:46-112, agents/lib/doom-loop-guard.js:132-190
+[^5]: agents/hooks/registry.yaml:107-119, chezmoi/.chezmoidata/claude.yaml:55-104, agents/hooks/doom-loop-guard.sh:1-14
+[^6]: [Claude hooks](https://code.claude.com/docs/en/hooks); [Codex hooks](https://learn.chatgpt.com/docs/hooks)
+[^7]: chezmoi/dot_omp/private_agent/extensions/doom-loop-guard.ts:18-62; [OMP hooks](https://github.com/can1357/oh-my-pi/blob/main/docs/hooks.md)
+[^8]: [OpenRouter doom-loop detection](https://openrouter.ai/docs/agent-sdk/call-model/doom-loop-detection); [Claude hooks](https://code.claude.com/docs/en/hooks); [Codex hooks](https://learn.chatgpt.com/docs/hooks); [OMP hooks](https://github.com/can1357/oh-my-pi/blob/main/docs/hooks.md)
+[^9]: tests/doom-loop-guard.bats:55-126, tests/extensions/doom-loop-guard.test.mjs:49-96
+
+_Source: OpenRouter detector semantics adapted to the native Claude, Codex, and OMP hook surfaces · Updated: 2026-08-07_

--- a/.hallouminate/wiki/harnesses/omp.md
+++ b/.hallouminate/wiki/harnesses/omp.md
@@ -1,11 +1,13 @@
 ---
 status: reviewed
-last_verified: 2026-08-03
+last_verified: 2026-08-07
 confidence: high
 sources:
   - chezmoi/.chezmoidata/omp.yaml
   - chezmoi/dot_omp/private_agent/APPEND_SYSTEM.md
   - chezmoi/dot_omp/private_agent/extensions/milknado-todo-guard.ts
+  - chezmoi/dot_omp/private_agent/extensions/doom-loop-guard.ts
+  - tests/extensions/doom-loop-guard.test.mjs
   - milknado.toml
   - tests/config-validation.bats
   - tests/omp-config.bats
@@ -18,7 +20,7 @@ sources:
 ---
 # OMP
 
-OMP 17.2.5 uses Milknado as its sole work tracker. Native Todo and its reminders are disabled in the repo-authoritative chezmoi data, the system prompt assigns planning to Milknado MCP, and a directly discovered input extension consumes `/todo` before OMP can create a disconnected native list.
+OMP 17.2.10 uses Milknado as its sole work tracker. Native Todo and its reminders are disabled in the repo-authoritative chezmoi data, the system prompt assigns planning to Milknado MCP, and a directly discovered input extension consumes `/todo` before OMP can create a disconnected native list.
 
 ## Ownership contract
 
@@ -49,11 +51,11 @@ Milknado task completion fails closed when the project defines no quality gates.
 
 OMP does not receive entries from `agents/hooks/registry.yaml`: the registry synchronizer implements only Claude and Codex backends and its default loop names those two targets.[^1] OMP also disables discovery of the Claude, Codex, and other external harness providers that could import their hooks.[^2]
 
-Instead OMP deploys native extensions under `~/.omp/agent/extensions/`: `cheese-flair.ts`, `rtk.ts`, `milknado-todo-guard.ts`, and `sliced-bread-audit.ts`. The flair extension intentionally runs the same deployed `~/.claude/hooks/session-start-cheese-flair.sh` script, so it shares flair output but is not a registry-hook installation.[^3]
+Instead OMP deploys native extensions under `~/.omp/agent/extensions/`: `cheese-flair.ts`, `rtk.ts`, `milknado-todo-guard.ts`, `sliced-bread-audit.ts`, and `doom-loop-guard.ts`. The flair extension runs the shared deployed session-start script. The doom-loop extension similarly imports the shared detector from `~/.claude/lib/doom-loop-guard.js`, increments a request scope on `agent_start`, and translates verdicts through OMP's native `tool_call` response surface.[^3]
 
 [^1]: `agents/hooks/sync.sh:3-18`, `agents/hooks/sync.sh:75-80`
 [^2]: `chezmoi/.chezmoidata/omp.yaml:20-24`, `chezmoi/.chezmoidata/omp.yaml:46-53`
-[^3]: `chezmoi/dot_omp/private_agent/extensions/cheese-flair.ts:1-26`, `chezmoi/dot_omp/private_agent/extensions/rtk.ts:1-84`, `chezmoi/dot_omp/private_agent/extensions/milknado-todo-guard.ts:1-15`, `chezmoi/dot_omp/private_agent/extensions/sliced-bread-audit.ts:1-94`
+[^3]: `chezmoi/dot_omp/private_agent/extensions/cheese-flair.ts:1-26`, `chezmoi/dot_omp/private_agent/extensions/rtk.ts:1-84`, `chezmoi/dot_omp/private_agent/extensions/milknado-todo-guard.ts:1-15`, `chezmoi/dot_omp/private_agent/extensions/sliced-bread-audit.ts:1-94`, `chezmoi/dot_omp/private_agent/extensions/doom-loop-guard.ts:1-62`
 
 ## `/todo` guard
 
@@ -99,11 +101,11 @@ Do not build that adapter unless native-looking Todo behavior becomes a requirem
 - Fresh renders assert `compaction.strategy: shake`, `keepRecentTokens: 20000`, no `thresholdTokens`, `task.enableLsp: true`, and `retry.modelFallback: false` (`tests/omp-config.bats:34-80`).
 - Drift repair starts with both settings true and verifies they are reset (`tests/omp-config.bats:82-102`).
 - The retired-key regression feeds the prior managed document, deletes `compaction.thresholdTokens` through wholesale rendering, and keeps genuinely unknown keys fail-closed (`tests/omp-config.bats:103-129`).
-- The managed-file test proves chezmoi deploys the four remaining extension modules and system prompt while `.chezmoiremove` owns removal of `no-fork-all.ts` (`tests/omp-config.bats:307-332`).
-- The real apply regression seeds a pre-existing retired extension, applies into an explicit temporary destination with scripts excluded, and verifies deletion plus survival of all four modules (`tests/omp-config.bats:333-359`).
-- The extension-contract test executes every remaining extension handler test (`tests/omp-config.bats:361-368`).
+- The managed-file test proves chezmoi deploys the five native extension modules and system prompt while `.chezmoiremove` owns removal of `no-fork-all.ts` (`tests/omp-config.bats:327-349`).
+- The real apply regression seeds a pre-existing retired extension, applies into an explicit temporary destination with scripts excluded, and verifies deletion plus survival of all five modules (`tests/omp-config.bats:350-376`).
+- The extension-contract test executes every native extension handler test, including doom-loop steering/blocking/abort behavior (`tests/omp-config.bats:378-383`).
 
-Root `dots sync` verifies exact live outputs `omp/17.2.5` and `codex-cli 0.146.0` after package convergence, applies the final chezmoi state under those schemas, and repeats both exact probes after a successful final apply. A failed final apply skips post-apply probes; a failed post-apply probe reports `harness-versions` while retaining upgraded binaries. The focused ordering, mismatch, absence, command-failure, and upgraded-state-retention tests live at `tests/sync-orchestrator.bats:180-548`.
+Root `dots sync` verifies exact live outputs `omp/17.2.10` and `codex-cli 0.146.0` after package convergence, applies the final chezmoi state under those schemas, and repeats both exact probes after a successful final apply. A failed final apply skips post-apply probes; a failed post-apply probe reports `harness-versions` while retaining upgraded binaries. The focused ordering, mismatch, absence, command-failure, and upgraded-state-retention tests live at `tests/sync-orchestrator.bats:180-548`.
 
 `tests/extensions/milknado-todo-guard.test.mjs:32-62` separately pins exact-command blocking, warning contents, the handled action, negative inputs, the continue action, and absence of spurious notifications. The focused OMP config suite and all remaining extension handler tests pass in the corrective gate.
 
@@ -113,4 +115,4 @@ Root `dots sync` verifies exact live outputs `omp/17.2.5` and `codex-cli 0.146.0
 
 Completed request graphs remain durable in Milknado. This cutover does not decide whether old graphs should be retained permanently, archived, or deleted; any lifecycle policy must preserve the single-owner rule and be implemented in Milknado rather than reintroducing native Todo state.
 
-_Source: OMP Todo-to-Milknado research, guarded cutover, and Codex/OMP upgrade verification · Updated: 2026-08-03 · Supersedes: native OMP Todo ownership_
+_Source: OMP Todo-to-Milknado research, guarded cutover, doom-loop adapter, and Codex/OMP upgrade verification · Updated: 2026-08-07 · Supersedes: native OMP Todo ownership_

--- a/.hallouminate/wiki/operations/sync-and-chezmoi.md
+++ b/.hallouminate/wiki/operations/sync-and-chezmoi.md
@@ -25,6 +25,12 @@ The custom backup/restore/rollback subsystem has been **deleted** (chezmoi-conso
 - **Pre-brew bootstraps on Linux** (brew isn't on PATH yet when these run): yq is downloaded as the Mike Farah Go binary into `~/.local/bin` (Ubuntu's apt `yq` is the wrong kislyuk/yq), and `uv` via the astral installer.
 - Other sources (`cargo`, `npm`, `uv`, `gh-extension`) run cross-platform unconditionally. On Linux, npm comes from the brew `node` formula (which bundles it).
 
+### Two-phase Codex version verification
+
+The pre-apply Codex probe must resolve the version from the tracked mise config by setting `MISE_OVERRIDE_CONFIG_FILENAMES` to `chezmoi/dot_config/mise/config.toml`; the live config can still name the previous version before chezmoi applies. The post-apply probe intentionally uses normal mise discovery to verify that the live config has converged.[^1]
+
+[^1]: .sync:54-67; tests/sync-orchestrator.bats:609-640
+
 ## Chezmoi-managed subset
 
 chezmoi renders the files that need per-machine templating (work vs. personal git email), per-OS branching, or secret injection — things plain symlinks can't do. Everything else stays on the symlink system.

--- a/.sync
+++ b/.sync
@@ -42,8 +42,8 @@ verify_harness_versions() {
         log_error "omp --version failed $phase"
         return 1
     fi
-    if [[ "$omp_version" != "omp/17.2.5" ]]; then
-        log_error "omp version mismatch $phase: expected omp/17.2.5, got $omp_version"
+    if [[ "$omp_version" != "omp/17.2.10" ]]; then
+        log_error "omp version mismatch $phase: expected omp/17.2.10, got $omp_version"
         return 1
     fi
 
@@ -51,7 +51,17 @@ verify_harness_versions() {
         log_error "codex unavailable $phase"
         return 1
     fi
-    if ! codex_version="$(codex --version)"; then
+    # Before chezmoi applies the new global config, make the shim resolve the
+    # tracked pin rather than the stale live config. The post-apply probe must
+    # use the live config so it still catches a failed cutover.
+    if [[ "$phase" == "after package convergence" ]]; then
+        if ! codex_version="$(
+            MISE_OVERRIDE_CONFIG_FILENAMES="$dir/chezmoi/dot_config/mise/config.toml" codex --version
+        )"; then
+            log_error "codex --version failed $phase"
+            return 1
+        fi
+    elif ! codex_version="$(codex --version)"; then
         log_error "codex --version failed $phase"
         return 1
     fi

--- a/agents/hooks/doom-loop-guard.sh
+++ b/agents/hooks/doom-loop-guard.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# PreToolUse bridge for the shared Node doom-loop detector. Fail open if the
+# deployed logic or runtime is unavailable.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HARNESS_ROOT="$(dirname "$SCRIPT_DIR")"
+LOGIC="$HARNESS_ROOT/lib/doom-loop-guard.js"
+
+[[ -f "$LOGIC" ]] || exit 0
+command -v node >/dev/null 2>&1 || exit 0
+
+exec node "$LOGIC"

--- a/agents/hooks/registry.yaml
+++ b/agents/hooks/registry.yaml
@@ -104,6 +104,20 @@ hooks:
     timeout: 5
     description: Block reads/writes of .env, private keys, and credential stores
 
+  # ─── Doom-loop detection ────────────────────────────────────────────
+  # Observe at 2 identical calls, block at 3, and stop at 6. Codex derives
+  # its registration here; Claude declares the matching hook in claude.yaml.
+  # OMP has a native adapter because it does not consume this registry.
+  doom-loop-guard:
+    event: PreToolUse
+    script: agents/hooks/doom-loop-guard.sh
+    shared_assets:
+      - agents/lib/doom-loop-guard.js
+    harnesses: [claude, codex]
+    matcher: ".*"
+    timeout: 5
+    description: Observe and block repeated identical tool calls that make no progress
+
   # ─── Tool reroute ───────────────────────────────────────────────────
   # Transparently REWRITES wrong-tool Bash/Grep/Glob calls to their tilth /
   # wt-git shell equivalent via updatedInput (grep/rg/ag/ack → tilth, cd+git →

--- a/agents/lib/doom-loop-guard.js
+++ b/agents/lib/doom-loop-guard.js
@@ -1,0 +1,246 @@
+#!/usr/bin/env node
+// PreToolUse doom-loop detector shared by Claude, Codex, and OMP.
+
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const OBSERVE_AT = 2;
+const BLOCK_AT = 3;
+const STOP_AT = 6;
+const STATE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+const MAX_STATE_FILES = 256;
+const MAX_TOOLS_PER_SESSION = 128;
+const EXEMPT_TOOLS = new Set([
+  'agent',
+  'spawn_agent',
+  'task',
+  'wait',
+  'wait_agent',
+  'write_stdin',
+]);
+
+function stableStringify(value) {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
+
+  return `{${Object.keys(value)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`)
+    .join(',')}}`;
+}
+
+function normalizedToolName(toolName) {
+  return String(toolName).split(/__|\./).pop().toLowerCase();
+}
+
+function isExempt(toolName) {
+  return EXEMPT_TOOLS.has(normalizedToolName(toolName));
+}
+
+function digest(value) {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+function stateDirectory() {
+  return process.env.DOOM_LOOP_STATE_DIR
+    || path.join(process.env.XDG_CACHE_HOME || path.join(os.homedir(), '.cache'), 'dotfiles', 'doom-loop');
+}
+
+function harnessName(event) {
+  if (event.harness) return String(event.harness);
+  return event.turn_id === undefined ? 'claude' : 'codex';
+}
+
+function sessionIdentity(event) {
+  const identity = event.agent_id || event.transcript_path || event.session_id;
+  if (!identity) return null;
+  return `${harnessName(event)}:${identity}`;
+}
+
+function scopeIdentity(event) {
+  const identity = event.scope_id ?? event.prompt_id ?? event.turn_id;
+  return identity === undefined || identity === null ? null : String(identity);
+}
+
+function invocationIdentity(event) {
+  const identity = event.invocation_id ?? event.tool_use_id;
+  return identity === undefined || identity === null ? null : String(identity);
+}
+
+function readState(statePath) {
+  try {
+    const state = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+    if (!state || typeof state !== 'object' || !state.tools || typeof state.tools !== 'object') {
+      return { tools: {} };
+    }
+    return state;
+  } catch (error) {
+    if (error.code === 'ENOENT') return { tools: {} };
+    throw error;
+  }
+}
+
+function pruneDirectory(directory, now) {
+  const files = fs.readdirSync(directory)
+    .filter((name) => name.endsWith('.json'))
+    .map((name) => {
+      const filePath = path.join(directory, name);
+      return { filePath, mtimeMs: fs.statSync(filePath).mtimeMs };
+    })
+    .sort((a, b) => b.mtimeMs - a.mtimeMs);
+
+  for (const file of files) {
+    if (file.mtimeMs < now - STATE_MAX_AGE_MS) fs.rmSync(file.filePath, { force: true });
+  }
+  for (const file of files.slice(MAX_STATE_FILES)) {
+    fs.rmSync(file.filePath, { force: true });
+  }
+}
+
+function pruneTools(state, now) {
+  const entries = Object.entries(state.tools)
+    .filter(([, entry]) => entry && entry.updatedAt >= now - STATE_MAX_AGE_MS)
+    .sort(([, a], [, b]) => b.updatedAt - a.updatedAt)
+    .slice(0, MAX_TOOLS_PER_SESSION);
+  state.tools = Object.fromEntries(entries);
+}
+
+function acquireLock(lockPath) {
+  try {
+    fs.mkdirSync(lockPath, { mode: 0o700 });
+    return true;
+  } catch (error) {
+    if (error.code !== 'EEXIST') throw error;
+    try {
+      if (fs.statSync(lockPath).mtimeMs < Date.now() - 5_000) {
+        fs.rmSync(lockPath, { recursive: true, force: true });
+        fs.mkdirSync(lockPath, { mode: 0o700 });
+        return true;
+      }
+    } catch {
+      return false;
+    }
+    return false;
+  }
+}
+
+function actionForCount(count) {
+  if (count >= STOP_AT) return 'stop';
+  if (count >= BLOCK_AT) return 'block';
+  if (count >= OBSERVE_AT) return 'observe';
+  return 'allow';
+}
+
+function messageFor(action, toolName, count) {
+  const next = 'Inspect the last result and change the input or approach; ask the user if blocked.';
+  if (action === 'stop') {
+    return `Doom-loop stop threshold reached: ${toolName} repeated identical input ${count} times. ${next}`;
+  }
+  if (action === 'block') {
+    return `Blocked ${toolName}: identical input repeated ${count} times. ${next}`;
+  }
+  return `Doom-loop warning: ${toolName} repeated identical input ${count} times. ${next}`;
+}
+
+function evaluate(event) {
+  try {
+    if (!event || typeof event !== 'object') return { action: 'allow' };
+
+    const toolName = event.tool_name;
+    const identity = sessionIdentity(event);
+    const scope = scopeIdentity(event);
+    if (!toolName || !identity || !scope || isExempt(toolName)) return { action: 'allow' };
+
+    const directory = stateDirectory();
+    fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
+    fs.chmodSync(directory, 0o700);
+
+    const statePath = path.join(directory, `${digest(identity)}.json`);
+    const lockPath = `${statePath}.lock`;
+    if (!acquireLock(lockPath)) return { action: 'allow' };
+
+    try {
+      const now = Date.now();
+      const state = readState(statePath);
+      pruneTools(state, now);
+
+      const toolKey = digest(String(toolName));
+      const signature = digest(`${toolName}\0${stableStringify(event.tool_input)}`);
+      const invocation = invocationIdentity(event);
+      const previous = state.tools[toolKey];
+      const sameInvocation = invocation
+        && previous
+        && previous.scope === scope
+        && previous.lastInvocation === invocation
+        && previous.signature === signature;
+      const count = sameInvocation
+        ? previous.count
+        : previous && previous.scope === scope && previous.signature === signature
+          ? previous.count + 1
+          : 1;
+
+      state.tools[toolKey] = {
+        signature,
+        count,
+        scope,
+        lastInvocation: invocation,
+        updatedAt: now,
+      };
+
+      const temporaryPath = `${statePath}.${process.pid}.${crypto.randomUUID()}.tmp`;
+      fs.writeFileSync(temporaryPath, JSON.stringify(state), { mode: 0o600 });
+      fs.renameSync(temporaryPath, statePath);
+      pruneDirectory(directory, now);
+
+      const action = actionForCount(count);
+      return action === 'allow'
+        ? { action }
+        : { action, message: messageFor(action, toolName, count) };
+    } finally {
+      fs.rmSync(lockPath, { recursive: true, force: true });
+    }
+  } catch {
+    return { action: 'allow' };
+  }
+}
+
+function hookResponse(event, verdict) {
+  if (verdict.action === 'allow') return null;
+
+  if (verdict.action === 'stop' && event.harness !== 'codex' && event.turn_id === undefined) {
+    return { continue: false, stopReason: verdict.message };
+  }
+
+  const hookSpecificOutput = {
+    hookEventName: 'PreToolUse',
+    permissionDecision: verdict.action === 'observe' ? undefined : 'deny',
+    permissionDecisionReason: verdict.action === 'observe' ? undefined : verdict.message,
+    additionalContext: verdict.action === 'observe' ? verdict.message : undefined,
+  };
+  for (const key of Object.keys(hookSpecificOutput)) {
+    if (hookSpecificOutput[key] === undefined) delete hookSpecificOutput[key];
+  }
+  return { hookSpecificOutput };
+}
+
+function runCli() {
+  let input = '';
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', (chunk) => { input += chunk; });
+  process.stdin.on('end', () => {
+    try {
+      const event = JSON.parse(input);
+      const response = hookResponse(event, evaluate(event));
+      if (response) process.stdout.write(`${JSON.stringify(response)}\n`);
+    } catch {
+      // Fail open: malformed hook input must not block a tool call.
+    }
+  });
+  process.stdin.on('error', () => {});
+}
+
+module.exports = { evaluate, isExempt, stableStringify };
+
+if (require.main === module) runCli();

--- a/chezmoi/.chezmoidata/claude.yaml
+++ b/chezmoi/.chezmoidata/claude.yaml
@@ -73,6 +73,11 @@ claude:
           - type: command
             command: '"$HOME/.claude/hooks/sensitive-file-guard.sh"'
             timeout: 5
+      - matcher: ".*"
+        hooks:
+          - type: command
+            command: '"$HOME/.claude/hooks/doom-loop-guard.sh"'
+            timeout: 5
       - matcher: "Bash|Grep|Glob"
         hooks:
           - type: command

--- a/chezmoi/dot_omp/private_agent/extensions/doom-loop-guard.ts
+++ b/chezmoi/dot_omp/private_agent/extensions/doom-loop-guard.ts
@@ -1,0 +1,63 @@
+// OMP adapter for the shared Claude/Codex doom-loop detector.
+
+import { createRequire } from "node:module"
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+
+type Verdict = {
+  action: "allow" | "observe" | "block" | "stop"
+  message?: string
+}
+
+type Guard = {
+  evaluate(event: Record<string, unknown>): Verdict
+}
+
+const require = createRequire(import.meta.url)
+const CORE_PATH = `${process.env.HOME}/.claude/lib/doom-loop-guard.js`
+
+export default function (pi: ExtensionAPI) {
+  let agentRun = 0
+
+  pi.on("agent_start", async () => {
+    agentRun += 1
+  })
+
+  pi.on("tool_call", async (event, ctx) => {
+    try {
+      const sessionId = ctx.sessionManager.getSessionFile()
+      if (!sessionId) return
+
+      const guard = require(CORE_PATH) as Guard
+      const verdict = guard.evaluate({
+        harness: "omp",
+        session_id: sessionId,
+        scope_id: String(agentRun),
+        invocation_id: event.toolCallId,
+        tool_name: event.toolName,
+        tool_input: event.input,
+      })
+
+      if (verdict.action === "allow") return
+      if (verdict.action === "observe") {
+        pi.sendMessage(
+          {
+            customType: "doom-loop",
+            content: verdict.message ?? "Repeated identical tool call detected.",
+            display: true,
+          },
+          { deliverAs: "steer" },
+        )
+        return
+      }
+
+      if (verdict.action === "stop") ctx.abort()
+      return {
+        block: true,
+        reason: verdict.message ?? "Repeated identical tool call blocked.",
+      }
+    } catch (err) {
+      console.warn("[doom-loop-guard] detector failed; allowing tool call", err)
+      return
+    }
+  })
+}

--- a/tests/agents-hooks-sync.bats
+++ b/tests/agents-hooks-sync.bats
@@ -97,6 +97,21 @@ teardown() {
     [[ "$(jq -r 'has("sensitive-file-guard")' <<<"$x")" == "true" ]]
 }
 
+@test "doom-loop-guard is a claude+codex catch-all PreToolUse hook" {
+    local entry c x
+    entry=$(yq -o=json '.hooks."doom-loop-guard"' "$REGISTRY_FILE")
+    [[ "$(jq -r '.event' <<<"$entry")" == "PreToolUse" ]]
+    [[ "$(jq -r '.script' <<<"$entry")" == "agents/hooks/doom-loop-guard.sh" ]]
+    [[ "$(jq -r '.shared_assets[0]' <<<"$entry")" == "agents/lib/doom-loop-guard.js" ]]
+    [[ "$(jq -r '.matcher' <<<"$entry")" == ".*" ]]
+    c=$(hook_filter_for_harness claude "$REGISTRY_JSON")
+    x=$(hook_filter_for_harness codex "$REGISTRY_JSON")
+    [[ "$(jq -r 'has("doom-loop-guard")' <<<"$c")" == "true" ]]
+    [[ "$(jq -r 'has("doom-loop-guard")' <<<"$x")" == "true" ]]
+    assert_file_exists "$REAL_DOTFILES_DIR/agents/hooks/doom-loop-guard.sh"
+    assert_file_exists "$REAL_DOTFILES_DIR/agents/lib/doom-loop-guard.js"
+}
+
 @test "registry command entries carry no machine-specific absolute paths" {
     # Issue #263: the moshi hooks hardcoded '/home/paul/.local/bin/moshi-hook',
     # so all four fired against a nonexistent path every session on macOS.

--- a/tests/claude-settings.bats
+++ b/tests/claude-settings.bats
@@ -42,6 +42,7 @@ STDIN"
     # Registry-authored keys composed in.
     jq -e '.enabledPlugins | has("plugin-dev@claude-plugins-official")' "$OUT" >/dev/null
     jq -e '.hooks.PreToolUse | length > 0' "$OUT" >/dev/null
+    [ "$(jq '[.hooks.PreToolUse[] | select(.matcher == ".*") | .hooks[] | select(.command == "\"$HOME/.claude/hooks/doom-loop-guard.sh\"" and .timeout == 5)] | length' "$OUT")" -eq 1 ]
     jq -e '.permissions.allow | length > 0' "$OUT" >/dev/null
     jq -e '.permissions.deny | index("Bash(sudo:*)")' "$OUT" >/dev/null
     # (${HOME} expansion in registry marketplace paths is covered by the

--- a/tests/doom-loop-guard.bats
+++ b/tests/doom-loop-guard.bats
@@ -1,0 +1,126 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+HOOK_SH="$REAL_DOTFILES_DIR/agents/hooks/doom-loop-guard.sh"
+HOOK_JS="$REAL_DOTFILES_DIR/agents/lib/doom-loop-guard.js"
+
+setup() {
+    setup_test_env
+    export DOOM_LOOP_STATE_DIR="$TEST_HOME/doom-loop"
+    DEPLOY="$TEST_HOME/.claude"
+    mkdir -p "$DEPLOY/hooks" "$DEPLOY/lib"
+    cp "$HOOK_SH" "$DEPLOY/hooks/doom-loop-guard.sh"
+    cp "$HOOK_JS" "$DEPLOY/lib/doom-loop-guard.js"
+    chmod +x "$DEPLOY/hooks/doom-loop-guard.sh"
+}
+
+teardown() {
+    teardown_test_env
+}
+
+event() {
+    local session="$1" tool="$2" input="$3" harness="${4:-claude}" scope="${5:-prompt-1}" invocation="${6:-}"
+    jq -nc \
+        --arg session "$session" \
+        --arg tool "$tool" \
+        --argjson input "$input" \
+        --arg harness "$harness" \
+        --arg scope "$scope" \
+        --arg invocation "$invocation" \
+        '{session_id:$session, tool_name:$tool, tool_input:$input, harness:$harness}
+         + (if $harness == "codex" then {turn_id:$scope} else {prompt_id:$scope} end)
+         + (if $invocation == "" then {} else {tool_use_id:$invocation} end)'
+}
+
+fire() {
+    local payload="$1"
+    printf '%s' "$payload" | "$DEPLOY/hooks/doom-loop-guard.sh"
+}
+
+action() {
+    local output
+    output="$(fire "$1")"
+    if [[ -z "$output" ]]; then
+        printf 'allow'
+    elif jq -e '.continue == false' >/dev/null <<<"$output"; then
+        printf 'stop'
+    elif [[ "$(jq -r '.hookSpecificOutput.permissionDecision // empty' <<<"$output")" == "deny" ]]; then
+        printf 'block'
+    else
+        printf 'observe'
+    fi
+}
+
+@test "recommended ladder observes at 2, blocks at 3, and stops Claude at 6" {
+    local payload
+    payload="$(event s1 Bash '{"command":"npm test"}')"
+
+    [[ "$(action "$payload")" == "allow" ]]
+    [[ "$(action "$payload")" == "observe" ]]
+    [[ "$(action "$payload")" == "block" ]]
+    [[ "$(action "$payload")" == "block" ]]
+    [[ "$(action "$payload")" == "block" ]]
+    [[ "$(action "$payload")" == "stop" ]]
+}
+
+@test "Codex stop-strength verdict remains a deny with stop guidance" {
+    local payload output
+    payload="$(event s2 Bash '{"command":"npm test"}' codex)"
+    for _ in 1 2 3 4 5; do fire "$payload" >/dev/null; done
+    output="$(fire "$payload")"
+
+    [[ "$(jq -r '.hookSpecificOutput.permissionDecision' <<<"$output")" == "deny" ]]
+    [[ "$(jq -r '.hookSpecificOutput.permissionDecisionReason' <<<"$output")" == *"stop threshold"* ]]
+}
+
+@test "canonical object keys identify the same call" {
+    [[ "$(action "$(event s3 mcp__x__read '{"path":"a","limit":2}')")" == "allow" ]]
+    [[ "$(action "$(event s3 mcp__x__read '{"limit":2,"path":"a"}')")" == "observe" ]]
+}
+
+@test "changing input resets only that tool while other tools do not" {
+    [[ "$(action "$(event s4 Read '{"path":"a"}')")" == "allow" ]]
+    [[ "$(action "$(event s4 Bash '{"command":"pwd"}')")" == "allow" ]]
+    [[ "$(action "$(event s4 Read '{"path":"a"}')")" == "observe" ]]
+    [[ "$(action "$(event s4 Read '{"path":"b"}')")" == "allow" ]]
+    [[ "$(action "$(event s4 Read '{"path":"b"}')")" == "observe" ]]
+}
+
+@test "replayed hook delivery counts once by tool-use id" {
+    [[ "$(action "$(event s5 Bash '{"command":"pwd"}' codex t1 call-1)")" == "allow" ]]
+    [[ "$(action "$(event s5 Bash '{"command":"pwd"}' codex t1 call-1)")" == "allow" ]]
+    [[ "$(action "$(event s5 Bash '{"command":"pwd"}' codex t1 call-2)")" == "observe" ]]
+}
+
+@test "a new user prompt resets repetition counts" {
+    [[ "$(action "$(event s9 Bash '{"command":"pwd"}' claude p1)")" == "allow" ]]
+    [[ "$(action "$(event s9 Bash '{"command":"pwd"}' claude p1)")" == "observe" ]]
+    [[ "$(action "$(event s9 Bash '{"command":"pwd"}' claude p2)")" == "allow" ]]
+    [[ "$(action "$(event s10 Bash '{"command":"pwd"}' codex t1)")" == "allow" ]]
+    [[ "$(action "$(event s10 Bash '{"command":"pwd"}' codex t2)")" == "allow" ]]
+}
+
+@test "sessions are isolated" {
+    [[ "$(action "$(event s6 Read '{"path":"a"}')")" == "allow" ]]
+    [[ "$(action "$(event s7 Read '{"path":"a"}')")" == "allow" ]]
+}
+
+@test "delegation and polling tools are exempt" {
+    local tool payload
+    for tool in Task Agent task spawn_agent write_stdin wait wait_agent functions.wait; do
+        payload="$(event "exempt-$tool" "$tool" '{}')"
+        [[ "$(action "$payload")" == "allow" ]]
+        [[ "$(action "$payload")" == "allow" ]]
+        [[ "$(action "$payload")" == "allow" ]]
+    done
+}
+
+@test "malformed input, missing identity, and unwritable state fail open" {
+    [[ -z "$(printf '{' | "$DEPLOY/hooks/doom-loop-guard.sh")" ]]
+    [[ -z "$(fire '{"tool_name":"Read","tool_input":{"path":"a"}}')" ]]
+
+    export DOOM_LOOP_STATE_DIR="$TEST_HOME/not-a-directory"
+    printf 'x' > "$DOOM_LOOP_STATE_DIR"
+    [[ "$(action "$(event s8 Read '{"path":"a"}')")" == "allow" ]]
+}

--- a/tests/extensions/doom-loop-guard.test.mjs
+++ b/tests/extensions/doom-loop-guard.test.mjs
@@ -1,0 +1,104 @@
+import assert from 'node:assert/strict'
+import { cp, mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+
+const root = await mkdtemp(join(tmpdir(), 'doom-loop-omp-'))
+const originalHome = process.env.HOME
+const originalStateDir = process.env.DOOM_LOOP_STATE_DIR
+process.env.HOME = root
+process.env.DOOM_LOOP_STATE_DIR = join(root, 'state')
+await mkdir(join(root, '.claude', 'lib'), { recursive: true })
+await cp(
+  new URL('../../agents/lib/doom-loop-guard.js', import.meta.url),
+  join(root, '.claude', 'lib', 'doom-loop-guard.js'),
+)
+const { default: doomLoopGuard } = await import(
+  '../../chezmoi/dot_omp/private_agent/extensions/doom-loop-guard.ts'
+)
+
+function loadExtension(session = 'omp-session') {
+  const handlers = new Map()
+  const messages = []
+  let aborts = 0
+
+  doomLoopGuard({
+    on(event, handler) {
+      handlers.set(event, handler)
+    },
+    sendMessage(message, options) {
+      messages.push({ message, options })
+    },
+  })
+
+  const ctx = {
+    sessionManager: {
+      getSessionFile() {
+        return session
+      },
+    },
+    abort() {
+      aborts += 1
+    },
+  }
+
+  return { handlers, messages, ctx, aborts: () => aborts }
+}
+
+test('OMP observes, blocks, and aborts within one agent run', async () => {
+  const harness = loadExtension()
+  const agentStart = harness.handlers.get('agent_start')
+  const toolCall = harness.handlers.get('tool_call')
+  assert.equal(typeof agentStart, 'function')
+  assert.equal(typeof toolCall, 'function')
+
+  await agentStart({ type: 'agent_start' }, harness.ctx)
+  const event = (toolCallId) => ({
+    type: 'tool_call',
+    toolCallId,
+    toolName: 'read',
+    input: { path: 'a' },
+  })
+  assert.equal(await toolCall(event('call-1'), harness.ctx), undefined)
+  assert.equal(await toolCall(event('call-2'), harness.ctx), undefined)
+  assert.equal(harness.messages.length, 1)
+  assert.equal(harness.messages[0].options.deliverAs, 'steer')
+  assert.match(harness.messages[0].message.content, /repeated/i)
+
+  for (let call = 3; call <= 5; call += 1) {
+    assert.equal((await toolCall(event(`call-${call}`), harness.ctx)).block, true)
+  }
+
+  assert.equal((await toolCall(event('call-6'), harness.ctx)).block, true)
+  assert.equal(harness.aborts(), 1)
+})
+
+test('OMP resets repetition counts for a new agent run', async () => {
+  const harness = loadExtension('omp-reset')
+  const agentStart = harness.handlers.get('agent_start')
+  const toolCall = harness.handlers.get('tool_call')
+  const event = (toolCallId) => ({
+    type: 'tool_call',
+    toolCallId,
+    toolName: 'read',
+    input: { path: 'a' },
+  })
+
+  await agentStart({ type: 'agent_start' }, harness.ctx)
+  assert.equal(await toolCall(event('first-1'), harness.ctx), undefined)
+  assert.equal(await toolCall(event('first-2'), harness.ctx), undefined)
+  assert.equal(harness.messages.length, 1)
+
+  await agentStart({ type: 'agent_start' }, harness.ctx)
+  assert.equal(await toolCall(event('second-1'), harness.ctx), undefined)
+  assert.equal(harness.messages.length, 1)
+})
+
+test.after(async () => {
+  if (originalHome === undefined) delete process.env.HOME
+  else process.env.HOME = originalHome
+  if (originalStateDir === undefined) delete process.env.DOOM_LOOP_STATE_DIR
+  else process.env.DOOM_LOOP_STATE_DIR = originalStateDir
+  await rm(root, { recursive: true, force: true })
+})

--- a/tests/omp-config.bats
+++ b/tests/omp-config.bats
@@ -339,6 +339,7 @@ TOML
     [[ "$output" == *".omp/agent/extensions/cheese-flair.ts"* ]]
     [[ "$output" == *".omp/agent/extensions/sliced-bread-audit.ts"* ]]
     [[ "$output" == *".omp/agent/extensions/milknado-todo-guard.ts"* ]]
+    [[ "$output" == *".omp/agent/extensions/doom-loop-guard.ts"* ]]
     [[ "$output" == *".omp/agent/APPEND_SYSTEM.md"* ]]
     [[ ! -e "$REAL_DOTFILES_DIR/chezmoi/dot_omp/private_agent/extensions/no-fork-all.ts" ]]
     grep -Fxq '.omp/agent/extensions/no-fork-all.ts' \
@@ -353,7 +354,7 @@ TOML
     local extension
     mkdir -p "$destination/.omp/agent/extensions"
     printf 'retired sentinel\n' > "$destination/.omp/agent/extensions/no-fork-all.ts"
-    for extension in rtk.ts cheese-flair.ts sliced-bread-audit.ts milknado-todo-guard.ts; do
+    for extension in rtk.ts cheese-flair.ts sliced-bread-audit.ts milknado-todo-guard.ts doom-loop-guard.ts; do
         printf 'managed sentinel\n' > "$destination/.omp/agent/extensions/$extension"
     done
     cat > "$cfg" <<TOML
@@ -369,7 +370,7 @@ TOML
     run env HOME="$TEST_HOME" chezmoi --config "$cfg" --source "$REAL_DOTFILES_DIR/chezmoi" apply --force --exclude=scripts
     [ "$status" -eq 0 ]
     [ ! -e "$destination/.omp/agent/extensions/no-fork-all.ts" ]
-    for extension in rtk.ts cheese-flair.ts sliced-bread-audit.ts milknado-todo-guard.ts; do
+    for extension in rtk.ts cheese-flair.ts sliced-bread-audit.ts milknado-todo-guard.ts doom-loop-guard.ts; do
         [ -e "$destination/.omp/agent/extensions/$extension" ]
     done
 }
@@ -380,4 +381,6 @@ TOML
     [ "$status" -eq 0 ]
     [[ "$output" == *"registers the command and dispatches the exact default workflow contract"* ]]
     [[ "$output" == *"blocks native todo commands and identifies Milknado as the owner"* ]]
+    [[ "$output" == *"OMP observes, blocks, and aborts within one agent run"* ]]
+    [[ "$output" == *"OMP resets repetition counts for a new agent run"* ]]
 }

--- a/tests/sync-orchestrator.bats
+++ b/tests/sync-orchestrator.bats
@@ -39,7 +39,7 @@ MOCK
     done
     cat > "$MOCK_BIN/omp" << 'MOCK'
 #!/bin/bash
-[[ "$1" == "--version" ]] && printf 'omp/17.2.5\n'
+[[ "$1" == "--version" ]] && printf 'omp/17.2.10\n'
 MOCK
     chmod +x "$MOCK_BIN/omp"
     cat > "$MOCK_BIN/codex" << 'MOCK'
@@ -362,7 +362,7 @@ SCRIPT
     cat > "$MOCK_BIN/omp" << 'SCRIPT'
 #!/bin/bash
 if [[ "$1" == "--version" ]]; then
-    version='omp/17.2.5'
+    version='omp/17.2.10'
     printf 'omp-version=%s\n' "$version" >> "$SYNC_EVENTS"
     printf '%s\n' "$version"
 fi
@@ -386,10 +386,10 @@ SCRIPT
     local expected_events
     expected_events='chezmoi-prepare
 packages-sync
-omp-version=omp/17.2.5
+omp-version=omp/17.2.10
 codex-version=codex-cli 0.146.0
 chezmoi-final-apply
-omp-version=omp/17.2.5
+omp-version=omp/17.2.10
 codex-version=codex-cli 0.146.0'
     [[ "$output" == "$expected_events" ]]
 }
@@ -414,7 +414,7 @@ SCRIPT
     rm -f "$FAKE_DOTFILES/packages/sync.sh"
     cat > "$FAKE_DOTFILES/packages/sync.sh" << 'SCRIPT'
 #!/bin/bash
-printf 'omp=17.2.5 codex=0.146.0\n' > "$TEST_HOME/upgraded-binaries"
+printf 'omp=17.2.10 codex=0.146.0\n' > "$TEST_HOME/upgraded-binaries"
 printf 'packages-sync\n' >> "$SYNC_EVENTS"
 SCRIPT
     chmod +x "$FAKE_DOTFILES/packages/sync.sh"
@@ -430,7 +430,7 @@ if [[ "$1" == "--version" ]]; then
     if [[ "$count" -eq 2 ]]; then
         version='omp/17.1.3'
     else
-        version='omp/17.2.5'
+        version='omp/17.2.10'
     fi
     printf 'omp-version=%s\n' "$version" >> "$SYNC_EVENTS"
     printf '%s\n' "$version"
@@ -452,8 +452,8 @@ SCRIPT
     assert_failure
     local sync_output="$output"
     run cat "$SYNC_EVENTS"
-    [[ "$output" == $'chezmoi-apply-1\npackages-sync\nomp-version=omp/17.2.5\ncodex-version=codex-cli 0.146.0\nchezmoi-final-apply-complete\nomp-version=omp/17.1.3' ]]
-    [[ "$(<"$TEST_HOME/upgraded-binaries")" == "omp=17.2.5 codex=0.146.0" ]]
+    [[ "$output" == $'chezmoi-apply-1\npackages-sync\nomp-version=omp/17.2.10\ncodex-version=codex-cli 0.146.0\nchezmoi-final-apply-complete\nomp-version=omp/17.1.3' ]]
+    [[ "$(<"$TEST_HOME/upgraded-binaries")" == "omp=17.2.10 codex=0.146.0" ]]
     [[ "$sync_output" == *"omp version mismatch after final chezmoi apply"* ]]
     [[ "$sync_output" == *"harness-versions"* ]]
 }
@@ -482,7 +482,7 @@ SCRIPT
     rm -f "$FAKE_DOTFILES/packages/sync.sh"
     cat > "$FAKE_DOTFILES/packages/sync.sh" << 'SCRIPT'
 #!/bin/bash
-printf 'omp=17.2.5 codex=0.146.0\n' > "$TEST_HOME/upgraded-binaries"
+printf 'omp=17.2.10 codex=0.146.0\n' > "$TEST_HOME/upgraded-binaries"
 printf 'packages-sync\n' >> "$SYNC_EVENTS"
 SCRIPT
     chmod +x "$FAKE_DOTFILES/packages/sync.sh"
@@ -490,8 +490,8 @@ SCRIPT
     cat > "$MOCK_BIN/omp" << 'SCRIPT'
 #!/bin/bash
 if [[ "$1" == "--version" ]]; then
-    printf 'omp-version=omp/17.2.5\n' >> "$SYNC_EVENTS"
-    printf 'omp/17.2.5\n'
+    printf 'omp-version=omp/17.2.10\n' >> "$SYNC_EVENTS"
+    printf 'omp/17.2.10\n'
 fi
 SCRIPT
     chmod +x "$MOCK_BIN/omp"
@@ -510,8 +510,8 @@ SCRIPT
     local sync_output="$output"
     local sync_stderr="$stderr"
     run cat "$SYNC_EVENTS"
-    [[ "$output" == $'chezmoi-prepare\npackages-sync\nomp-version=omp/17.2.5\ncodex-version=codex-cli 0.146.0\nchezmoi-final-apply-failed' ]]
-    [[ "$(<"$TEST_HOME/upgraded-binaries")" == "omp=17.2.5 codex=0.146.0" ]]
+    [[ "$output" == $'chezmoi-prepare\npackages-sync\nomp-version=omp/17.2.10\ncodex-version=codex-cli 0.146.0\nchezmoi-final-apply-failed' ]]
+    [[ "$(<"$TEST_HOME/upgraded-binaries")" == "omp=17.2.10 codex=0.146.0" ]]
     [[ "$sync_output" == *"Sync completed with FAILURES in: chezmoi"* ||
         "$sync_stderr" == *"Sync completed with FAILURES in: chezmoi"* ]]
 }
@@ -543,14 +543,14 @@ SCRIPT
     rm -f "$FAKE_DOTFILES/packages/sync.sh"
     cat > "$FAKE_DOTFILES/packages/sync.sh" << 'SCRIPT'
 #!/bin/bash
-printf 'omp=17.2.5 codex=0.146.0\n' > "$TEST_HOME/upgraded-binaries"
+printf 'omp=17.2.10 codex=0.146.0\n' > "$TEST_HOME/upgraded-binaries"
 printf 'packages-sync\n' >> "$SYNC_EVENTS"
 SCRIPT
     chmod +x "$FAKE_DOTFILES/packages/sync.sh"
     rm -f "$MOCK_BIN/omp"
     cat > "$MOCK_BIN/omp" << 'SCRIPT'
 #!/bin/bash
-[[ "$1" == "--version" ]] && printf 'omp/17.2.5\n'
+[[ "$1" == "--version" ]] && printf 'omp/17.2.10\n'
 SCRIPT
     chmod +x "$MOCK_BIN/omp"
     rm -f "$MOCK_BIN/codex"
@@ -565,7 +565,7 @@ SCRIPT
     local sync_output="$output"
     run cat "$SYNC_EVENTS"
     [[ "$output" == $'chezmoi-apply-1\npackages-sync' ]]
-    [[ "$(<"$TEST_HOME/upgraded-binaries")" == "omp=17.2.5 codex=0.146.0" ]]
+    [[ "$(<"$TEST_HOME/upgraded-binaries")" == "omp=17.2.10 codex=0.146.0" ]]
     [[ "$sync_output" == *"codex version mismatch"* ]]
 }
 @test "final harness verification prefers the post-package mise shim" {
@@ -606,6 +606,39 @@ SCRIPT
     [[ "$output" == "packages-sync"$'\nfinal-codex='"$TEST_HOME/.local/share/mise/shims/codex codex-cli 0.146.0" ]]
 }
 
+@test "pre-apply Codex probe uses tracked mise config before live config is applied" {
+    cd "$FAKE_DOTFILES"
+    export SYNC_EVENTS="$TEST_HOME/sync-events.log"
+    mkdir -p "$FAKE_DOTFILES/chezmoi/dot_config/mise"
+    printf '[tools]\n' > "$FAKE_DOTFILES/chezmoi/dot_config/mise/config.toml"
+    cat > "$FAKE_DOTFILES/chezmoi/.sync" << 'SCRIPT'
+#!/bin/bash
+[[ "${CHEZMOI_SYNC_PHASE:-}" == "final" ]] || exit 0
+touch "$TEST_HOME/live-mise-config"
+printf 'chezmoi-final-apply\n' >> "$SYNC_EVENTS"
+SCRIPT
+    chmod +x "$FAKE_DOTFILES/chezmoi/.sync"
+
+    rm -f "$MOCK_BIN/codex"
+    cat > "$MOCK_BIN/codex" << 'SCRIPT'
+#!/bin/bash
+[[ "$1" == "--version" ]] || exit 0
+if [[ -f "$TEST_HOME/live-mise-config" || -n "${MISE_OVERRIDE_CONFIG_FILENAMES:-}" ]]; then
+    version='codex-cli 0.146.0'
+else
+    version='codex-cli 0.145.0'
+fi
+printf 'codex-config=%s\n' "${MISE_OVERRIDE_CONFIG_FILENAMES:-live}" >> "$SYNC_EVENTS"
+printf '%s\n' "$version"
+SCRIPT
+    chmod +x "$MOCK_BIN/codex"
+
+    run bash "$SYNC_SCRIPT"
+    assert_success
+    run cat "$SYNC_EVENTS"
+    [[ "$output" == codex-config=*/chezmoi/dot_config/mise/config.toml$'\nchezmoi-final-apply\ncodex-config=live' ]]
+}
+
 @test "missing OMP after package convergence fails closed before final apply" {
     cd "$FAKE_DOTFILES"
     export SYNC_EVENTS="$TEST_HOME/sync-events.log"
@@ -618,7 +651,7 @@ SCRIPT
     rm -f "$FAKE_DOTFILES/packages/sync.sh"
     cat > "$FAKE_DOTFILES/packages/sync.sh" << 'SCRIPT'
 #!/bin/bash
-printf 'omp=17.2.5 codex=0.146.0\n' > "$TEST_HOME/upgraded-binaries"
+printf 'omp=17.2.10 codex=0.146.0\n' > "$TEST_HOME/upgraded-binaries"
 printf 'packages-sync\n' >> "$SYNC_EVENTS"
 SCRIPT
     chmod +x "$FAKE_DOTFILES/packages/sync.sh"
@@ -635,7 +668,7 @@ SCRIPT
     local sync_output="$output"
     run cat "$SYNC_EVENTS"
     [[ "$output" == $'chezmoi-apply\npackages-sync' ]]
-    [[ "$(<"$TEST_HOME/upgraded-binaries")" == "omp=17.2.5 codex=0.146.0" ]]
+    [[ "$(<"$TEST_HOME/upgraded-binaries")" == "omp=17.2.10 codex=0.146.0" ]]
     [[ "$sync_output" == *"omp unavailable after package convergence"* ]]
 }
 
@@ -651,7 +684,7 @@ SCRIPT
     rm -f "$FAKE_DOTFILES/packages/sync.sh"
     cat > "$FAKE_DOTFILES/packages/sync.sh" << 'SCRIPT'
 #!/bin/bash
-printf 'omp=17.2.5 codex=0.146.0\n' > "$TEST_HOME/upgraded-binaries"
+printf 'omp=17.2.10 codex=0.146.0\n' > "$TEST_HOME/upgraded-binaries"
 printf 'packages-sync\n' >> "$SYNC_EVENTS"
 SCRIPT
     chmod +x "$FAKE_DOTFILES/packages/sync.sh"
@@ -671,7 +704,7 @@ SCRIPT
     local sync_stderr="$stderr"
     run cat "$SYNC_EVENTS"
     [[ "$output" == $'chezmoi-apply\npackages-sync' ]]
-    [[ "$(<"$TEST_HOME/upgraded-binaries")" == "omp=17.2.5 codex=0.146.0" ]]
+    [[ "$(<"$TEST_HOME/upgraded-binaries")" == "omp=17.2.10 codex=0.146.0" ]]
     [[ "$sync_output" == *"omp --version failed after package convergence"* ]]
     [[ "$sync_stderr" == *"omp probe exploded: fixture diagnostic"* ]]
 }
@@ -719,7 +752,7 @@ SCRIPT
     rm -f "$FAKE_DOTFILES/packages/sync.sh"
     cat > "$FAKE_DOTFILES/packages/sync.sh" << 'SCRIPT'
 #!/bin/bash
-printf 'omp=17.2.5 codex=0.146.0\n' > "$TEST_HOME/upgraded-binaries"
+printf 'omp=17.2.10 codex=0.146.0\n' > "$TEST_HOME/upgraded-binaries"
 printf 'packages-sync\n' >> "$SYNC_EVENTS"
 SCRIPT
     chmod +x "$FAKE_DOTFILES/packages/sync.sh"
@@ -736,7 +769,7 @@ SCRIPT
     local sync_output="$output"
     run cat "$SYNC_EVENTS"
     [[ "$output" == $'chezmoi-apply\npackages-sync' ]]
-    [[ "$(<"$TEST_HOME/upgraded-binaries")" == "omp=17.2.5 codex=0.146.0" ]]
+    [[ "$(<"$TEST_HOME/upgraded-binaries")" == "omp=17.2.10 codex=0.146.0" ]]
     [[ "$sync_output" == *"codex unavailable after package convergence"* ]]
 }
 
@@ -752,7 +785,7 @@ SCRIPT
     rm -f "$FAKE_DOTFILES/packages/sync.sh"
     cat > "$FAKE_DOTFILES/packages/sync.sh" << 'SCRIPT'
 #!/bin/bash
-printf 'omp=17.2.5 codex=0.146.0\n' > "$TEST_HOME/upgraded-binaries"
+printf 'omp=17.2.10 codex=0.146.0\n' > "$TEST_HOME/upgraded-binaries"
 printf 'packages-sync\n' >> "$SYNC_EVENTS"
 SCRIPT
     chmod +x "$FAKE_DOTFILES/packages/sync.sh"
@@ -772,7 +805,7 @@ SCRIPT
     local sync_stderr="$stderr"
     run cat "$SYNC_EVENTS"
     [[ "$output" == $'chezmoi-apply\npackages-sync' ]]
-    [[ "$(<"$TEST_HOME/upgraded-binaries")" == "omp=17.2.5 codex=0.146.0" ]]
+    [[ "$(<"$TEST_HOME/upgraded-binaries")" == "omp=17.2.10 codex=0.146.0" ]]
     [[ "$sync_output" == *"codex --version failed after package convergence"* ]]
     [[ "$sync_stderr" == *"codex probe exploded: fixture diagnostic"* ]]
 }


### PR DESCRIPTION
## Summary

- add a shared, stateful detector for repeated identical tool calls
- wire escalating warnings, blocking, and stop behavior into Claude, Codex, and OMP
- scope counters to the active user request and deduplicate replayed hook deliveries by invocation ID
- exempt delegation and polling tools, bound persisted state, and fail open on detector errors
- repair the OMP version assertion and pre-apply Codex mise probe uncovered during deployment

## Verification

- `just check` — 1,427 Bats tests, 917 Python tests with 2 skips, workflow tests, markdownlint, and ShellCheck
- focused detector suite — 9 Bats cases
- focused OMP adapter suite — 2 Node test cases
- severity review — no remaining findings after request-scope corrections
- `dots sync` — hook apply and live deployment completed; the command reported only the unrelated locked-1Password `vault-secrets` failure

## Durable artifacts

| Artifact | Status |
| --- | --- |
| Cross-harness detector architecture wiki | Complete |
| OMP harness inventory and lifecycle notes | Updated |
| Two-phase Codex sync gotcha | Recorded |

## Known limits

- distinct calls in one parallel tool batch count separately because the three hook surfaces expose no uniform batch identifier
- Codex maps the stop threshold to a denial because `PreToolUse` does not support the hard-stop response used by Claude
