### PR TITLE
fix(deps): bump js-yaml to 4.3.1 for CVE-2026-59870

### DIFF
--- a/.github/lint-deps/package-lock.json
+++ b/.github/lint-deps/package-lock.json
@@ -1082,9 +1082,9 @@
       "license": "ISC"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Closes Dependabot alert [#5](https://github.com/paulnsorensen/dotfiles/security/dependabot/5) (high).

## Summary
- `js-yaml` 4.3.0 → 4.3.1 in `.github/lint-deps/package-lock.json`
- CVE-2026-59870: quadratic CPU consumption in `!!omap` resolution
- Transitive dev dependency via `eslint` 8.57.1; lockfile-only change (`npm update js-yaml --package-lock-only`)

## Test plan
- `just check` — exit 0 (1358 shell tests, 152 node tests)

Note: `npm audit` also reports a high in `brace-expansion` (GHSA-mh99-v99m-4gvg, GHSA-rgw5-rvv9-x895) that Dependabot has not opened an alert for. Left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)