### PR TITLE
fix(secrets): harden managed macOS provisioning

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,7 @@ DOTFILES_DEV=false
 # Optional Claude plugins — set to true to install during `dots sync`.
 # These are gated in claude/plugins/registry.yaml and stay out of
 # enabledPlugins / extraKnownMarketplaces unless explicitly opted in.
+# TODOIST=true also provisions the Todoist MCP credential and broker service.
 CHEESE_FLOW=false
 VAUDEVILLE=false
 TODOIST=false

--- a/.sync
+++ b/.sync
@@ -54,8 +54,8 @@ verify_harness_versions() {
         log_error "omp --version failed $phase"
         return 1
     fi
-    if [[ "$omp_version" != "omp/17.2.10" ]]; then
-        log_error "omp version mismatch $phase: expected omp/17.2.10, got $omp_version"
+    if [[ "$omp_version" != "omp/17.2.12" ]]; then
+        log_error "omp version mismatch $phase: expected omp/17.2.12, got $omp_version"
         return 1
     fi
 

--- a/bin/agent-secret-install
+++ b/bin/agent-secret-install
@@ -7,6 +7,8 @@ DESTDIR="${DESTDIR%/}"
 
 # shellcheck source=lib/agent-secret-python.sh
 source "$DOTFILES_DIR/bin/lib/agent-secret-python.sh"
+# Bash 3.2 requires the `${array[@]+"${array[@]}"}` form at use sites when
+# `set -u` is active and an array may be empty.
 READ_TOOLS=()
 WRITE_TOOLS=()
 
@@ -155,7 +157,9 @@ render_policy() {
     temporary="$(mktemp "${destination}.tmp.XXXXXX")"
     POLICY_READ_COUNT="${#READ_TOOLS[@]}" POLICY_WRITE_COUNT="${#WRITE_TOOLS[@]}" \
         "$python" - "$consumer" "$request_uid" "$operator_uid" \
-        "$credential_env" "$credential_file" "${READ_TOOLS[@]}" "${WRITE_TOOLS[@]}" "$@" \
+        "$credential_env" "$credential_file" \
+        ${READ_TOOLS[@]+"${READ_TOOLS[@]}"} \
+        ${WRITE_TOOLS[@]+"${WRITE_TOOLS[@]}"} "$@" \
         > "$temporary" <<'PY'
 import json
 import os
@@ -216,7 +220,8 @@ render_launchd() {
     local control_socket="$5" policy="$6" python="$7"
     local template="$DOTFILES_DIR/services/agent-secret/com.dotfiles.agent-secret.plist"
     local plist="$DESTDIR/Library/LaunchDaemons/com.dotfiles.agent-secret.$consumer.plist"
-    install -d -m 0755 "${plist%/*}"
+    local plist_dir="${plist%/*}"
+    [[ -d "$plist_dir" ]] || install -d -m 0755 "$plist_dir"
     sed \
         -e "s|__CONSUMER__|$consumer|g" \
         -e "s|__PYTHON__|$python|g" \
@@ -354,11 +359,13 @@ case "$action" in
             shift
         done
         [[ -n "$credential_env" && -n "$credential_file" && -n "$request_user" ]] || die "missing install option"
-        for tool in "${READ_TOOLS[@]}" "${WRITE_TOOLS[@]}"; do
+        for tool in \
+            ${READ_TOOLS[@]+"${READ_TOOLS[@]}"} \
+            ${WRITE_TOOLS[@]+"${WRITE_TOOLS[@]}"}; do
             validate_tool "$tool"
         done
-        for read_tool in "${READ_TOOLS[@]}"; do
-            for write_tool in "${WRITE_TOOLS[@]}"; do
+        for read_tool in ${READ_TOOLS[@]+"${READ_TOOLS[@]}"}; do
+            for write_tool in ${WRITE_TOOLS[@]+"${WRITE_TOOLS[@]}"}; do
                 [[ "$read_tool" != "$write_tool" ]] || die "tool cannot be both read and write: $read_tool"
             done
         done

--- a/bin/vault-provision
+++ b/bin/vault-provision
@@ -17,13 +17,14 @@ usage() {
 Usage: vault-provision [--request-user USER] [--operator-user USER]
 
 Resolve the configured vault provider and install service-owned credentials and
-policies for context7, tavily, and todoist. Secret values are never
-printed, stored in a daily-user cache, or exposed to agent processes.
+policies for context7 and tavily, plus todoist when TODOIST=true. Secret values
+are never printed, stored in a daily-user cache, or exposed to agent processes.
 EOF
 }
 
 request_user="${SUDO_USER:-${USER:-}}"
 operator_user=root
+privileged_install=false
 while (( $# > 0 )); do
     case "$1" in
         --request-user)
@@ -35,6 +36,10 @@ while (( $# > 0 )); do
             (( $# >= 2 )) || { usage; exit 2; }
             operator_user="$2"
             shift 2
+            ;;
+        --privileged-install)
+            privileged_install=true
+            shift
             ;;
         -h|--help)
             usage >&1
@@ -57,34 +62,14 @@ done
     exit 2
 }
 
-provider="$(vault_resolve)" || exit $?
-[[ "$provider" != unconfigured ]] || {
-    echo "vault-provision: no vault provider is ready; configure .env or run the provider login first." >&2
-    exit 1
-}
-
 installer="$DOTFILES_DIR/bin/agent-secret-install"
 [[ -x "$installer" ]] || {
     echo "vault-provision: missing executable $installer." >&2
     exit 1
 }
 
-if [[ -z "$DESTDIR" && $EUID -ne 0 ]]; then
-    sudo_bin="$(type -P sudo || true)"
-    [[ -n "$sudo_bin" ]] || {
-        echo "vault-provision: root or sudo is required to install service-owned credentials." >&2
-        exit 1
-    }
-else
-    sudo_bin=""
-fi
-
 run_privileged() {
-    if [[ -n "$DESTDIR" || $EUID -eq 0 ]]; then
-        "$@"
-    else
-        "$sudo_bin" "$@"
-    fi
+    "$@"
 }
 
 install_node_runtime() {
@@ -136,13 +121,8 @@ write_privileged_value() {
     local value="$1" path="$2"
     # tee receives the value on stdin; it is never an argument, log line, or
     # environment variable of the installer/broker.
-    if [[ -n "$DESTDIR" || $EUID -eq 0 ]]; then
-        printf '%s\n' "$value" | /usr/bin/tee "$path" >/dev/null
-        /bin/chmod 600 "$path"
-    else
-        printf '%s\n' "$value" | "$sudo_bin" /usr/bin/tee "$path" >/dev/null
-        "$sudo_bin" /bin/chmod 600 "$path"
-    fi
+    printf '%s\n' "$value" | /usr/bin/tee "$path" >/dev/null
+    /bin/chmod 600 "$path"
 }
 
 ensure_bitwarden_value() {
@@ -180,10 +160,9 @@ read_provider_value() {
 }
 
 install_consumer() {
-    local consumer="$1" key="$2"
-    shift 2
+    local consumer="$1" key="$2" value="$3"
+    shift 3
     local credential_path="/etc/dotfiles/agent-secret/credentials/${consumer}.credential"
-    local value
     local -a tool_flags=()
     case "$consumer" in
         context7)
@@ -252,8 +231,6 @@ install_consumer() {
         *) echo "vault-provision: unsupported consumer '$consumer'." >&2; return 2 ;;
     esac
 
-    read_provider_value "$key"
-    value="$VAULT_PROVISION_VALUE"
     if [[ -n "$DESTDIR" ]]; then
         /usr/bin/install -d -m 700 "$DESTDIR/etc/dotfiles/agent-secret/credentials"
     else
@@ -276,7 +253,75 @@ install_consumer() {
     else
         run_privileged "${command[@]}"
     fi
-    unset value VAULT_PROVISION_VALUE
+    unset value
+}
+
+read_payload_field() {
+    local name="$1"
+    IFS= read -r -d '' "$name" || {
+        echo "vault-provision: incomplete privileged payload." >&2
+        return 1
+    }
+}
+
+provision_payload() {
+    local npx_path provider_name provider_source todoist_enabled
+    local context7_value tavily_value todoist_value=""
+    [[ -n "$DESTDIR" || $EUID -eq 0 ]] || {
+        echo "vault-provision: privileged install requires root." >&2
+        return 1
+    }
+
+    read_payload_field npx_path
+    read_payload_field provider_name
+    read_payload_field provider_source
+    read_payload_field todoist_enabled
+    read_payload_field context7_value
+    read_payload_field tavily_value
+    [[ "$todoist_enabled" == false || "$todoist_enabled" == true ]] || {
+        echo "vault-provision: invalid Todoist payload state." >&2
+        return 1
+    }
+    [[ "$todoist_enabled" == false ]] || read_payload_field todoist_value
+
+    install_node_runtime "$npx_path"
+    npx_path="$NODE_RUNTIME_NPX"
+    # renovate: datasource=npm depName=@upstash/context7-mcp
+    install_consumer context7 CONTEXT7_API_KEY "$context7_value" "$npx_path" -y @upstash/context7-mcp@3.2.5
+    # renovate: datasource=npm depName=tavily-mcp
+    install_consumer tavily TAVILY_API_KEY "$tavily_value" "$npx_path" -y tavily-mcp@0.2.22
+    if [[ "$todoist_enabled" == true ]]; then
+        # renovate: datasource=npm depName=@doist/todoist-mcp
+        install_consumer todoist TODOIST_API_KEY "$todoist_value" "$npx_path" -y @doist/todoist-mcp@12.5.0
+    fi
+
+    local metadata_path="/etc/dotfiles/agent-secret/provider.json"
+    local metadata
+    metadata="$(printf '{"provider":"%s","source":"%s"}\n' \
+        "$provider_name" "$provider_source")"
+    write_privileged_value "$metadata" "$DESTDIR$metadata_path"
+}
+
+emit_payload() {
+    printf '%s\0' \
+        "$npx_path" \
+        "$provider" \
+        "$(vault_source "$provider")" \
+        "$todoist_enabled" \
+        "$context7_value" \
+        "$tavily_value"
+    [[ "$todoist_enabled" == false ]] || printf '%s\0' "$todoist_value"
+}
+
+if [[ "$privileged_install" == true ]]; then
+    provision_payload
+    exit
+fi
+
+provider="$(vault_resolve)" || exit $?
+[[ "$provider" != unconfigured ]] || {
+    echo "vault-provision: no vault provider is ready; configure .env or run the provider login first." >&2
+    exit 1
 }
 
 npx_path="$(command -v npx 2>/dev/null)" || {
@@ -287,18 +332,33 @@ npx_path="$(command -v npx 2>/dev/null)" || {
     echo "vault-provision: npx did not resolve to an absolute path." >&2
     exit 1
 }
-install_node_runtime "$npx_path"
-npx_path="$NODE_RUNTIME_NPX"
-# renovate: datasource=npm depName=@upstash/context7-mcp
-install_consumer context7 CONTEXT7_API_KEY "$npx_path" -y @upstash/context7-mcp@3.2.5
-# renovate: datasource=npm depName=tavily-mcp
-install_consumer tavily TAVILY_API_KEY "$npx_path" -y tavily-mcp@0.2.22
-# renovate: datasource=npm depName=@doist/todoist-mcp
-install_consumer todoist TODOIST_API_KEY "$npx_path" -y @doist/todoist-mcp@12.5.0
 
-# Record non-secret provider provenance for operators; policy files remain the
-# broker's exact schema and contain no provider values.
-metadata_path="/etc/dotfiles/agent-secret/provider.json"
-metadata="$(printf '{"provider":"%s","source":"%s"}\n' "$provider" "$(vault_source "$provider")")"
-write_privileged_value "$metadata" "$DESTDIR$metadata_path"
-unset metadata metadata_path provider request_user operator_user sudo_bin npx_path
+read_provider_value CONTEXT7_API_KEY
+context7_value="$VAULT_PROVISION_VALUE"
+read_provider_value TAVILY_API_KEY
+tavily_value="$VAULT_PROVISION_VALUE"
+todoist_enabled=false
+todoist_value=""
+if [[ "${TODOIST:-false}" == true ]]; then
+    todoist_enabled=true
+    read_provider_value TODOIST_API_KEY
+    todoist_value="$VAULT_PROVISION_VALUE"
+fi
+unset VAULT_PROVISION_VALUE
+
+if [[ -n "$DESTDIR" || $EUID -eq 0 ]]; then
+    emit_payload | provision_payload
+else
+    sudo_bin="$(type -P sudo || true)"
+    [[ -n "$sudo_bin" ]] || {
+        echo "vault-provision: root or sudo is required to install service-owned credentials." >&2
+        exit 1
+    }
+    emit_payload | "$sudo_bin" "$SCRIPT_DIR/vault-provision" \
+        --privileged-install \
+        --request-user "$request_user" \
+        --operator-user "$operator_user"
+fi
+
+unset context7_value npx_path operator_user privileged_install provider request_user
+unset sudo_bin tavily_value todoist_enabled todoist_value

--- a/packages/sync.sh
+++ b/packages/sync.sh
@@ -720,18 +720,31 @@ sync_native_harnesses() {
     # bun/installer incompatibility, not a bad release. --binary fetches the
     # prebuilt release asset instead, sidestepping bun entirely.
     echo "  Converging omp to $OMP_PIN (native)..."
-    if curl -fsSL https://omp.sh/install | sh -s -- --binary --ref "$OMP_PIN"; then
-        if [[ "$PLATFORM" == "Darwin" ]] && ! codesign --force --sign - "$HOME/.local/bin/omp" </dev/null; then
+    local install_status=0 omp_path="$HOME/.local/bin/omp" omp_version=""
+    curl -fsSL https://omp.sh/install | sh -s -- --binary --ref "$OMP_PIN" ||
+        install_status=$?
+    if [[ "$PLATFORM" == "Darwin" ]]; then
+        if ! codesign --force --sign - "$omp_path" </dev/null; then
             log_error "omp ad-hoc signing failed"
             FAILED+=("omp")
-        else
-            hash -r 2>/dev/null || true
-            log_success "  Converged omp to $OMP_PIN"
+            return
         fi
-    else
+        if ((install_status != 0)); then
+            omp_version="$("$omp_path" --version 2>/dev/null || true)"
+            if [[ "$omp_version" != "omp/${OMP_PIN#v}" ]]; then
+                log_error "omp native install failed"
+                FAILED+=("omp")
+                return
+            fi
+        fi
+    elif ((install_status != 0)); then
         log_error "omp native install failed"
         FAILED+=("omp")
+        return
     fi
+
+    hash -r 2>/dev/null || true
+    log_success "  Converged omp to $OMP_PIN"
 
 }
 

--- a/secrets/secrets.env.tmpl
+++ b/secrets/secrets.env.tmpl
@@ -7,4 +7,5 @@
 # gh CLI, not an MCP consumer.
 CONTEXT7_API_KEY=
 TAVILY_API_KEY=
+# Required only when TODOIST=true.
 TODOIST_API_KEY=

--- a/tests/agent-secret-install.bats
+++ b/tests/agent-secret-install.bats
@@ -93,6 +93,62 @@ PY
     [[ "$status" -ne 0 ]]
 }
 
+@test "installer renders a write-only policy with an empty read-tool array" {
+    run env DESTDIR="$INSTALL_ROOT" "$INSTALLER" install write-only \
+        --credential-env FIXTURE_SECRET \
+        --credential-file "$CREDENTIAL" \
+        --request-user "$REQUEST_USER" \
+        --operator-user "$OPERATOR_USER" \
+        --write-tool write.item \
+        -- /usr/bin/context7-mcp --stdio
+    assert_success
+    [[ -z "$output" ]]
+
+    jq -e '.tools.read == []
+        and .tools.write == ["write.item"]
+        and .upstream.argv == ["/usr/bin/context7-mcp", "--stdio"]' \
+        "$INSTALL_ROOT/etc/dotfiles/agent-secret-broker/write-only.json" >/dev/null
+}
+
+@test "installer leaves an existing LaunchDaemons directory unchanged" {
+    local fake_bin="$TEST_HOME/fake-bin"
+    local launch_daemons="$INSTALL_ROOT/Library/LaunchDaemons"
+    local real_install
+    real_install="$(command -v install)"
+    mkdir -p "$fake_bin" "$launch_daemons"
+
+    cat > "$fake_bin/uname" <<'EOF'
+#!/usr/bin/env bash
+printf 'Darwin\n'
+EOF
+    cat > "$fake_bin/install" <<'EOF'
+#!/usr/bin/env bash
+target=""
+for target; do :; done
+if [[ "${1:-}" == -d && -d "$target" ]]; then
+    printf 'install: chmod 755 %s: Operation not permitted\n' "$target" >&2
+    exit 1
+fi
+exec "$REAL_INSTALL" "$@"
+EOF
+    chmod +x "$fake_bin/uname" "$fake_bin/install"
+
+    run env \
+        PATH="$fake_bin:$PATH" \
+        REAL_INSTALL="$real_install" \
+        DESTDIR="$INSTALL_ROOT" \
+        "$INSTALLER" install launchd-existing \
+        --credential-env FIXTURE_SECRET \
+        --credential-file "$CREDENTIAL" \
+        --request-user "$REQUEST_USER" \
+        --operator-user "$OPERATOR_USER" \
+        --read-tool read.item \
+        -- /usr/bin/context7-mcp
+    assert_success
+    [[ -z "$output" ]]
+    [ -f "$launch_daemons/com.dotfiles.agent-secret.launchd-existing.plist" ]
+}
+
 @test "installer rejects empty policy, shared identities, and unsafe credentials" {
     run env DESTDIR="$INSTALL_ROOT" "$INSTALLER" install fixture \
         --credential-env FIXTURE_SECRET \

--- a/tests/claude-mcp-pins.bats
+++ b/tests/claude-mcp-pins.bats
@@ -16,7 +16,7 @@ teardown() { teardown_test_env; }
 
 broker_package() {
     local consumer=$1 line
-    line=$(grep -E "^install_consumer $consumer " "$PROVISIONER")
+    line=$(grep -E "^[[:space:]]*install_consumer $consumer " "$PROVISIONER")
     printf '%s\n' "${line##* }"
 }
 

--- a/tests/packages.bats
+++ b/tests/packages.bats
@@ -1143,6 +1143,28 @@ YAML
     [[ ! -f "$CACHE_FILE" ]] || [[ ! -s "$CACHE_FILE" ]]
 }
 
+@test "Darwin signs and validates a downloaded omp after installer smoke failure" {
+    write_mock_uname Darwin
+    write_mock_sh 1
+    mkdir -p "$TEST_HOME/.local/bin"
+    cat > "$TEST_HOME/.local/bin/omp" <<'EOF'
+#!/usr/bin/env bash
+printf 'omp/17.2.12\n'
+EOF
+    chmod +x "$TEST_HOME/.local/bin/omp"
+    write_test_yaml
+
+    run_sync
+    assert_success
+    assert_output_contains "Converged omp to v17.2.12"
+
+    local expected_events
+    expected_events=$(printf 'sh -s -- --binary --ref v17.2.12\ncodesign --force --sign - %s' \
+        "$TEST_HOME/.local/bin/omp")
+    run cat "$EVENT_LOG"
+    [[ "$output" == "$expected_events" ]]
+}
+
 @test "Darwin signs a freshly converged native omp after installation" {
     write_mock_uname Darwin
     write_test_yaml

--- a/tests/sync-orchestrator.bats
+++ b/tests/sync-orchestrator.bats
@@ -39,7 +39,7 @@ MOCK
     done
     cat > "$MOCK_BIN/omp" << 'MOCK'
 #!/bin/bash
-[[ "$1" == "--version" ]] && printf 'omp/17.2.10\n'
+[[ "$1" == "--version" ]] && printf 'omp/17.2.12\n'
 MOCK
     chmod +x "$MOCK_BIN/omp"
     cat > "$MOCK_BIN/codex" << 'MOCK'
@@ -351,7 +351,7 @@ SCRIPT
     cat > "$MOCK_BIN/omp" << 'SCRIPT'
 #!/bin/bash
 if [[ "$1" == "--version" ]]; then
-    version='omp/17.2.10'
+    version='omp/17.2.12'
     printf 'omp-version=%s\n' "$version" >> "$SYNC_EVENTS"
     printf '%s\n' "$version"
 fi
@@ -375,10 +375,10 @@ SCRIPT
     local expected_events
     expected_events='chezmoi-prepare
 packages-sync
-omp-version=omp/17.2.10
+omp-version=omp/17.2.12
 codex-version=codex-cli 0.146.0
 chezmoi-final-apply
-omp-version=omp/17.2.10
+omp-version=omp/17.2.12
 codex-version=codex-cli 0.146.0'
     [[ "$output" == "$expected_events" ]]
 }
@@ -403,7 +403,7 @@ SCRIPT
     rm -f "$FAKE_DOTFILES/packages/sync.sh"
     cat > "$FAKE_DOTFILES/packages/sync.sh" << 'SCRIPT'
 #!/bin/bash
-printf 'omp=17.2.10 codex=0.146.0\n' > "$TEST_HOME/upgraded-binaries"
+printf 'omp=17.2.12 codex=0.146.0\n' > "$TEST_HOME/upgraded-binaries"
 printf 'packages-sync\n' >> "$SYNC_EVENTS"
 SCRIPT
     chmod +x "$FAKE_DOTFILES/packages/sync.sh"
@@ -419,7 +419,7 @@ if [[ "$1" == "--version" ]]; then
     if [[ "$count" -eq 2 ]]; then
         version='omp/17.1.3'
     else
-        version='omp/17.2.10'
+        version='omp/17.2.12'
     fi
     printf 'omp-version=%s\n' "$version" >> "$SYNC_EVENTS"
     printf '%s\n' "$version"
@@ -441,8 +441,8 @@ SCRIPT
     assert_failure
     local sync_output="$output"
     run cat "$SYNC_EVENTS"
-    [[ "$output" == $'chezmoi-apply-1\npackages-sync\nomp-version=omp/17.2.10\ncodex-version=codex-cli 0.146.0\nchezmoi-final-apply-complete\nomp-version=omp/17.1.3' ]]
-    [[ "$(<"$TEST_HOME/upgraded-binaries")" == "omp=17.2.10 codex=0.146.0" ]]
+    [[ "$output" == $'chezmoi-apply-1\npackages-sync\nomp-version=omp/17.2.12\ncodex-version=codex-cli 0.146.0\nchezmoi-final-apply-complete\nomp-version=omp/17.1.3' ]]
+    [[ "$(<"$TEST_HOME/upgraded-binaries")" == "omp=17.2.12 codex=0.146.0" ]]
     [[ "$sync_output" == *"omp version mismatch after final chezmoi apply"* ]]
     [[ "$sync_output" == *"harness-versions"* ]]
 }
@@ -471,7 +471,7 @@ SCRIPT
     rm -f "$FAKE_DOTFILES/packages/sync.sh"
     cat > "$FAKE_DOTFILES/packages/sync.sh" << 'SCRIPT'
 #!/bin/bash
-printf 'omp=17.2.10 codex=0.146.0\n' > "$TEST_HOME/upgraded-binaries"
+printf 'omp=17.2.12 codex=0.146.0\n' > "$TEST_HOME/upgraded-binaries"
 printf 'packages-sync\n' >> "$SYNC_EVENTS"
 SCRIPT
     chmod +x "$FAKE_DOTFILES/packages/sync.sh"
@@ -479,8 +479,8 @@ SCRIPT
     cat > "$MOCK_BIN/omp" << 'SCRIPT'
 #!/bin/bash
 if [[ "$1" == "--version" ]]; then
-    printf 'omp-version=omp/17.2.10\n' >> "$SYNC_EVENTS"
-    printf 'omp/17.2.10\n'
+    printf 'omp-version=omp/17.2.12\n' >> "$SYNC_EVENTS"
+    printf 'omp/17.2.12\n'
 fi
 SCRIPT
     chmod +x "$MOCK_BIN/omp"
@@ -499,8 +499,8 @@ SCRIPT
     local sync_output="$output"
     local sync_stderr="$stderr"
     run cat "$SYNC_EVENTS"
-    [[ "$output" == $'chezmoi-prepare\npackages-sync\nomp-version=omp/17.2.10\ncodex-version=codex-cli 0.146.0\nchezmoi-final-apply-failed' ]]
-    [[ "$(<"$TEST_HOME/upgraded-binaries")" == "omp=17.2.10 codex=0.146.0" ]]
+    [[ "$output" == $'chezmoi-prepare\npackages-sync\nomp-version=omp/17.2.12\ncodex-version=codex-cli 0.146.0\nchezmoi-final-apply-failed' ]]
+    [[ "$(<"$TEST_HOME/upgraded-binaries")" == "omp=17.2.12 codex=0.146.0" ]]
     [[ "$sync_output" == *"Sync completed with FAILURES in: chezmoi"* ||
         "$sync_stderr" == *"Sync completed with FAILURES in: chezmoi"* ]]
 }
@@ -532,14 +532,14 @@ SCRIPT
     rm -f "$FAKE_DOTFILES/packages/sync.sh"
     cat > "$FAKE_DOTFILES/packages/sync.sh" << 'SCRIPT'
 #!/bin/bash
-printf 'omp=17.2.10 codex=0.146.0\n' > "$TEST_HOME/upgraded-binaries"
+printf 'omp=17.2.12 codex=0.146.0\n' > "$TEST_HOME/upgraded-binaries"
 printf 'packages-sync\n' >> "$SYNC_EVENTS"
 SCRIPT
     chmod +x "$FAKE_DOTFILES/packages/sync.sh"
     rm -f "$MOCK_BIN/omp"
     cat > "$MOCK_BIN/omp" << 'SCRIPT'
 #!/bin/bash
-[[ "$1" == "--version" ]] && printf 'omp/17.2.10\n'
+[[ "$1" == "--version" ]] && printf 'omp/17.2.12\n'
 SCRIPT
     chmod +x "$MOCK_BIN/omp"
     rm -f "$MOCK_BIN/codex"
@@ -554,7 +554,7 @@ SCRIPT
     local sync_output="$output"
     run cat "$SYNC_EVENTS"
     [[ "$output" == $'chezmoi-apply-1\npackages-sync' ]]
-    [[ "$(<"$TEST_HOME/upgraded-binaries")" == "omp=17.2.10 codex=0.146.0" ]]
+    [[ "$(<"$TEST_HOME/upgraded-binaries")" == "omp=17.2.12 codex=0.146.0" ]]
     [[ "$sync_output" == *"codex version mismatch"* ]]
 }
 @test "final harness verification prefers the post-package mise shim" {

--- a/tests/vault-provision.bats
+++ b/tests/vault-provision.bats
@@ -30,7 +30,10 @@ EOF
 set -euo pipefail
 case "${1:-}" in
     item) exit 0 ;;
-    read) printf 'credential-%s\n' "${2##*/}" ;;
+    read)
+        [[ "${FAIL_TODOIST_READ:-false}" != true || "${2##*/}" != TODOIST_API_KEY ]] || exit 1
+        printf 'credential-%s\n' "${2##*/}"
+        ;;
     *) exit 2 ;;
 esac
 EOF
@@ -54,6 +57,8 @@ EOF
 teardown() { teardown_test_env; }
 
 @test "vault-provision renders root-bound credentials policies and runtime" {
+    printf 'TODOIST=true\n' >> "$FIXTURE_DOTFILES/.env"
+
     export DECOY_DOTFILES="$TEST_HOME/decoy-dotfiles"
     mkdir -p "$DECOY_DOTFILES"
     run env \
@@ -126,4 +131,58 @@ teardown() { teardown_test_env; }
 
     jq -e '.provider == "onepassword" and .source == "op://fixture/Agent Secrets"' \
         "$INSTALL_ROOT/etc/dotfiles/agent-secret/provider.json" >/dev/null
+}
+
+assert_todoist_disabled() {
+    run env -u TODOIST \
+        FAIL_TODOIST_READ=true \
+        DOTFILES_DIR="$TEST_HOME/decoy-dotfiles" \
+        DESTDIR="$INSTALL_ROOT" \
+        "$FIXTURE_DOTFILES/bin/vault-provision" \
+        --request-user "$(id -un)" --operator-user root
+    assert_success
+    [ -z "$output" ]
+
+    local credentials="$INSTALL_ROOT/etc/dotfiles/agent-secret/credentials"
+    [ "$(cat "$credentials/context7.credential")" = credential-CONTEXT7_API_KEY ]
+    [ "$(cat "$credentials/tavily.credential")" = credential-TAVILY_API_KEY ]
+    [ ! -e "$credentials/todoist.credential" ]
+    [ ! -e "$INSTALL_ROOT/etc/dotfiles/agent-secret-broker/todoist.json" ]
+    [ ! -e "$INSTALL_ROOT/Library/LaunchDaemons/com.dotfiles.agent-secret.todoist.plist" ]
+
+    local service_home=/var/lib/dotfiles-agent-secrets/todoist
+    [[ "$(uname -s)" == Darwin ]] && service_home=/var/db/dotfiles-agent-secrets/todoist
+    [ ! -e "$INSTALL_ROOT$service_home" ]
+}
+
+@test "vault-provision skips Todoist when TODOIST is unset" {
+    assert_todoist_disabled
+}
+
+@test "vault-provision skips Todoist when TODOIST=false" {
+    printf 'TODOIST=false\n' >> "$FIXTURE_DOTFILES/.env"
+    assert_todoist_disabled
+}
+
+@test "vault-provision uses one sudo transaction" {
+    local sudo_log="$TEST_HOME/sudo.log"
+    cat > "$TEST_HOME/fake-bin/sudo" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$SUDO_LOG"
+[[ "$1" == */vault-provision && "${2:-}" == --privileged-install ]] || exit 97
+DESTDIR="$INSTALL_ROOT" "$@"
+EOF
+    chmod +x "$TEST_HOME/fake-bin/sudo"
+
+    run env -u DESTDIR -u TODOIST \
+        INSTALL_ROOT="$INSTALL_ROOT" \
+        SUDO_LOG="$sudo_log" \
+        "$FIXTURE_DOTFILES/bin/vault-provision" \
+        --request-user "$(id -un)" --operator-user root
+    assert_success
+    [ -z "$output" ]
+    [ "$(wc -l < "$sudo_log")" -eq 1 ]
+    [[ "$(cat "$sudo_log")" == *" --privileged-install "* ]]
+    [ -f "$INSTALL_ROOT/etc/dotfiles/agent-secret/credentials/context7.credential" ]
+    [ -f "$INSTALL_ROOT/etc/dotfiles/agent-secret/credentials/tavily.credential" ]
 }


### PR DESCRIPTION
## What changed

Provision macOS agent-secret credentials, policies, and launchd services in one privileged transaction; make Todoist provisioning opt-in through the machine-local `TODOIST` flag; and preserve valid system directories during installation. Repair native OMP convergence by ad-hoc signing and validating the downloaded binary when the installer's own smoke test is blocked by Gatekeeper, then align the orchestrator gate with the pinned `v17.2.12`.

## Why

The old provisioning path prompted once per privileged command and could fail after partially creating protected system paths. The OMP installer could also leave the correct binary installed but report failure before this repository had a chance to sign it, causing `dots sync` to fail.

## How to verify

- `./tests/run-tests.sh -v vault-provision.bats agent-secret-install.bats` — 10/10 passed
- `./tests/run-tests.sh packages.bats sync-orchestrator.bats` — 107/107 passed
- `shellcheck -x -e SC1091 -s bash bin/vault-provision bin/agent-secret-install` — passed
- `dots sync` — completed successfully end to end on macOS
- Final `just check` reached the full test leg; unrelated mise-backed tests then hit the unauthenticated GitHub API rate limit (0/60). The same full gate passed before the final OMP convergence edits, and the final changed-path suites above pass.

## Risk / rollout notes

Touches root-owned credential and launchd installation. Secret values remain stdin/environment-only inside the single privileged process and are written only to service-owned credential files. Todoist stays absent unless `TODOIST=true`. OMP fallback accepts only a binary whose exact pinned version executes after signing.

## Checklist

- [x] Conventional Commits PR title (`feat:`, `fix:`, `chore:`, `docs:`, ...)
- [x] Tests added or updated (or N/A)
- [x] Documentation updated (or N/A)
- [x] No secrets or credentials added