### PR TITLE
fix(packages): heal missing mise tools on cache hits

### DIFF
--- a/packages/sync.sh
+++ b/packages/sync.sh
@@ -380,7 +380,7 @@ sync_mise() {
     fi
 
     log_info "Converging mise-managed tool versions from $mise_config..."
-    if ! MISE_GLOBAL_CONFIG_FILE="$mise_config" mise install "$@" </dev/null; then
+    if ! MISE_GLOBAL_CONFIG_FILE="$mise_config" mise install </dev/null; then
         log_error "mise install failed"
         FAILED+=("mise-install")
         return 0
@@ -750,16 +750,16 @@ sync_native_harnesses() {
 
 # Snapshot the inputs before the first installer runs.
 CACHE_HASH_AT_CONVERGENCE="$(cache_hash)"
-# Claude is invoked by chezmoi later in this sync, so keep its mise binary
-# present even when the package declaration cache is valid.
+# Even with an unchanged manifest, reconcile every mise tool so a deleted or
+# previously failed install cannot leave the active config unresolved.
 if check_cache; then
-    log_success "Package manifests unchanged (cached), syncing Claude"
+    log_success "Package manifests unchanged (cached), syncing mise"
     heal_missing_cask_apps
+    sync_mise
     if ((${#FAILED[@]})); then
         log_error "failed to heal ${#FAILED[@]} package(s): ${FAILED[*]}"
         exit 1
     fi
-    sync_mise "aqua:anthropics/claude-code@v2.1.219"
     exit 0
 fi
 ########## Main

--- a/tests/packages.bats
+++ b/tests/packages.bats
@@ -768,7 +768,7 @@ YAML
     [[ -s "$CACHE_FILE" ]]
 }
 
-@test "sync skips all installers when package inputs and pins match the cache" {
+@test "sync skips non-mise installers when package inputs and pins match the cache" {
     write_test_yaml
     run_sync
     assert_success
@@ -776,13 +776,13 @@ YAML
 
     run bash "$SYNC_SCRIPT"
     assert_success
-    assert_output_contains "unchanged (cached), syncing Claude"
+    assert_output_contains "unchanged (cached), syncing mise"
 
     ! grep -Eq '^brew (install|reinstall|uninstall|upgrade)( |$)' "$BREW_LOG"
     [[ ! -f "$CURL_LOG" ]]
 }
 
-@test "sync cache restores the Claude mise package" {
+@test "sync cache restores every configured mise package" {
     write_test_yaml
     run_sync
     assert_success
@@ -790,9 +790,20 @@ YAML
 
     run bash "$SYNC_SCRIPT"
     assert_success
-    assert_output_contains "syncing Claude"
-    grep -q "mise install aqua:anthropics/claude-code@v2.1.219" "$MISE_LOG"
+    assert_output_contains "syncing mise"
+    [[ "$(<"$MISE_LOG")" == "mise install config=$MISE_CONFIG_FILE" ]]
     ! grep -Eq '^brew (install|reinstall|uninstall|upgrade)( |$)' "$BREW_LOG"
+}
+
+@test "cached sync fails when mise cannot restore configured tools" {
+    write_test_yaml
+    run_sync
+    assert_success
+    write_mock_mise 1
+
+    run bash "$SYNC_SCRIPT"
+    assert_failure
+    assert_output_contains "failed to heal 1 package(s): mise-install"
 }
 
 @test "a mise config-only change invalidates the package cache and reconverges" {
@@ -1097,7 +1108,7 @@ MOCKBREW
 
     run bash "$SYNC_SCRIPT"
     assert_success
-    assert_output_contains "unchanged (cached), syncing Claude"
+    assert_output_contains "unchanged (cached), syncing mise"
     [[ "$(wc -l < "$SH_LOG")" -eq "$before" ]]
 }
 


### PR DESCRIPTION
## What changed

Make the cached package-sync path reconcile every configured mise tool instead of only Claude, and fail the cached sync when mise restoration fails.

## Why

The active mise config requested `fzf@v0.74.2`, `opencode@v1.18.11`, `crush@v0.88.0`, and `rtk@v0.44.2`, but only their previous versions were installed. A valid manifest cache skipped the full mise reconciliation, so `dots sync` reported success while later shells emitted `mise WARN missing` for all four tools.

## How to verify

- `mise doctor` reproduced the missing-tool failure 5/5 times before the fix
- `./tests/run-tests.sh -v packages.bats` — 81/81 passed
- `shellcheck -x -e SC1091 -s bash packages/sync.sh` — passed
- `dots sync` — installed all four missing Aqua versions and completed successfully
- `mise ls --missing` — empty
- `mise doctor` — `No problems found`

## Risk / rollout notes

Cache hits now run `mise install` across the configured toolset. This is a fast no-op when the toolset is complete, but intentionally performs downloads when installed state has drifted. Non-mise package installers remain skipped.

## Checklist

- [x] Conventional Commits PR title (`feat:`, `fix:`, `chore:`, `docs:`, ...)
- [x] Tests added or updated (or N/A)
- [x] Documentation updated (N/A)
- [x] No secrets or credentials added