### PR TITLE
fix(worktrees): use generic branch prefix

### DIFF
--- a/bin/ccw-rm
+++ b/bin/ccw-rm
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # ccw-rm — tear down one worktree in a single step: remove the worktree, delete
-# its claude/<slug> branch, kill its tmux session, and drop the linked Claude
+# its checked-out branch, kill its tmux session, and drop the linked Claude
 # projects dir. Run from inside the repo (the worktree's parent).
 #
 # Usage: ccw-rm <slug> [--force]
@@ -27,10 +27,15 @@ if ! repo_root="$(git rev-parse --show-toplevel 2>/dev/null)"; then
 fi
 
 wt_dir="${repo_root}/.worktrees/${slug}"
-branch="claude/${slug}"
 
 if [[ ! -d "$wt_dir" ]]; then
     echo "ccw-rm: no worktree at ${wt_dir}" >&2
+    exit 1
+fi
+
+branch="$(git -C "$wt_dir" branch --show-current)"
+if [[ -z "$branch" ]]; then
+    echo "ccw-rm: worktree ${wt_dir} has a detached HEAD; refusing to remove an unknown branch" >&2
     exit 1
 fi
 

--- a/bin/wt
+++ b/bin/wt
@@ -37,7 +37,7 @@ fi
 
 repo_root="$(git rev-parse --show-toplevel)"
 wt_dir="${repo_root}/.worktrees/${slug}"
-branch="claude/${slug}"
+branch="worktree/${slug}"
 
 created=false
 start_point=""

--- a/tests/ccw-rm.bats
+++ b/tests/ccw-rm.bats
@@ -11,7 +11,7 @@ setup() {
     git -C "$REPO" config user.email t@t.test
     git -C "$REPO" config user.name tester
     git -C "$REPO" commit --allow-empty -q -m init
-    git -C "$REPO" worktree add -q "$REPO/.worktrees/feat" -b claude/feat
+    git -C "$REPO" worktree add -q "$REPO/.worktrees/feat" -b worktree/feat
 
     # Deterministic tmux stub: report no session so no kill is attempted.
     STUB="$TMPROOT/stub"
@@ -49,7 +49,7 @@ teardown() {
     run ccw-rm feat
     [ "$status" -eq 0 ]
     [ ! -d "$REPO/.worktrees/feat" ]
-    run git -C "$REPO" show-ref --verify --quiet refs/heads/claude/feat
+    run git -C "$REPO" show-ref --verify --quiet refs/heads/worktree/feat
     [ "$status" -ne 0 ]
 }
 

--- a/tests/wt.bats
+++ b/tests/wt.bats
@@ -1,0 +1,43 @@
+#!/usr/bin/env bats
+# Tests for bin/wt — worktree creation without a harness-specific branch name.
+
+DOTFILES_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME}")/.." && pwd)"
+
+setup() {
+    TMPROOT="$(mktemp -d)"
+    REPO="$TMPROOT/repo"
+    HOME="$TMPROOT/home"
+    export HOME DOTFILES_DIR
+    mkdir -p "$REPO" "$HOME"
+
+    git -C "$REPO" init -b main -q
+    git -C "$REPO" config user.email t@t.test
+    git -C "$REPO" config user.name tester
+    git -C "$REPO" commit --allow-empty -q -m init
+
+    local origin="$TMPROOT/origin.git"
+    git init --bare -b main -q "$origin"
+    git -C "$REPO" remote add origin "$origin"
+    git -C "$REPO" push -q origin main
+    git -C "$REPO" remote set-head origin main
+}
+
+teardown() {
+    rm -rf "$TMPROOT"
+}
+
+@test "creates a generic branch from the current branch" {
+    cd "$REPO"
+    run "$DOTFILES_DIR/bin/wt" -m feature
+    [ "$status" -eq 0 ]
+    run git -C "$REPO" show-ref --verify --quiet refs/heads/worktree/feature
+    [ "$status" -eq 0 ]
+}
+
+@test "creates a generic branch from origin's default branch" {
+    cd "$REPO"
+    run "$DOTFILES_DIR/bin/wt" -o feature
+    [ "$status" -eq 0 ]
+    run git -C "$REPO" show-ref --verify --quiet refs/heads/worktree/feature
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary
- create `worktree/<slug>` branches for `wt`, `wto`, and `wtm`
- derive the branch from the worktree HEAD when `ccw-rm` removes it
- cover current-branch and origin-default creation paths

## Verification
- `just lint-shell`
- `bats tests/wt.bats tests/ccw-rm.bats`

Semantics-altering: new worktrees no longer use the Claude-specific branch namespace. Reviewers should verify branch creation and removal preserve the selected branch name.