### PR TITLE
fix(packages): authenticate mise's GitHub reads via gh

### DIFF
--- a/packages/sync.sh
+++ b/packages/sync.sh
@@ -379,6 +379,19 @@ sync_mise() {
         return 0
     fi
 
+    # Authenticate mise's GitHub reads. gh stores its token in the macOS
+    # keychain, so ~/.config/gh/hosts.yml carries no `oauth_token` and mise's
+    # default gh_cli_tokens reader finds nothing — leaving the aqua release
+    # lookups anonymous against the 60/hr per-IP cap, which they exhaust and
+    # then re-request every run (a 403 caches nothing). Must be the env var:
+    # MISE_GLOBAL_CONFIG_FILE below demotes ~/.config/mise/config.toml to a
+    # non-global config, where mise ignores a `credential_command` setting and
+    # rejects the file as untrusted. zsh/core.zsh exports this for interactive
+    # shells; repeated here so bootstrap and non-interactive runs are covered.
+    if command -v gh &>/dev/null; then
+        export MISE_GITHUB_CREDENTIAL_COMMAND="gh auth token"
+    fi
+
     log_info "Converging mise-managed tool versions from $mise_config..."
     if ! MISE_GLOBAL_CONFIG_FILE="$mise_config" mise install </dev/null; then
         log_error "mise install failed"

--- a/tests/packages.bats
+++ b/tests/packages.bats
@@ -164,6 +164,20 @@ MOCKMISE
     chmod +x "$MOCK_BIN/mise"
 }
 
+# mise mock that records the GitHub credential command it was handed, so a
+# test can prove sync authenticates mise's release lookups instead of letting
+# them fall back to the anonymous 60/hr per-IP budget.
+write_mock_mise_recording_github_auth() {
+    rm -f "$MOCK_BIN/mise"
+    cat > "$MOCK_BIN/mise" << MOCKMISE
+#!/bin/bash
+echo "mise \$* config=\${MISE_GLOBAL_CONFIG_FILE:-unset}" >> "\$MISE_LOG"
+printf '%s\n' "\${MISE_GITHUB_CREDENTIAL_COMMAND-unset}" > "$TEST_HOME/mise-github-auth"
+exit 0
+MOCKMISE
+    chmod +x "$MOCK_BIN/mise"
+}
+
 # mise mock that appends a new pin to the manifest the first time it runs,
 # standing in for a concurrent `git pull` landing renovate bumps while the sync
 # is already past its install decision.
@@ -793,6 +807,20 @@ YAML
     assert_output_contains "syncing mise"
     [[ "$(<"$MISE_LOG")" == "mise install config=$MISE_CONFIG_FILE" ]]
     ! grep -Eq '^brew (install|reinstall|uninstall|upgrade)( |$)' "$BREW_LOG"
+}
+
+@test "sync hands mise a gh-backed GitHub credential command" {
+    # Regression: gh keeps its token in the macOS keychain, so hosts.yml has no
+    # oauth_token and mise's default gh_cli_tokens reader found nothing. Every
+    # aqua release lookup then went out anonymous against the 60/hr per-IP cap,
+    # and a rate-limited 403 caches nothing — so the non-semver pins re-fetched
+    # on every run and starved the rest of the sync of requests.
+    write_test_yaml
+    write_mock_mise_recording_github_auth
+
+    run_sync
+    assert_success
+    [[ "$(<"$TEST_HOME/mise-github-auth")" == "gh auth token" ]]
 }
 
 @test "cached sync fails when mise cannot restore configured tools" {

--- a/tests/zsh-config.bats
+++ b/tests/zsh-config.bats
@@ -316,6 +316,21 @@ SH
     assert_success
 }
 
+@test "core.zsh hands mise a gh-backed GitHub credential command" {
+    command -v zsh &>/dev/null || skip "zsh not installed"
+    command -v gh &>/dev/null || skip "gh not installed"
+    # Regression: gh keeps its token in the macOS keychain, so hosts.yml has no
+    # oauth_token and mise's default gh_cli_tokens reader found nothing —
+    # leaving every aqua release lookup anonymous against the 60/hr per-IP cap.
+    #
+    # Only the gh-present branch is asserted. core.zsh unconditionally prepends
+    # /opt/homebrew/bin (which carries both gh and mise) before reaching the
+    # guard, so a no-gh shell cannot be simulated by controlling PATH here.
+    run zsh --no-rcs -c "source '$REAL_DOTFILES_DIR/zsh/core.zsh'; printf 'CRED=[%s]' \"\$MISE_GITHUB_CREDENTIAL_COMMAND\""
+    assert_success
+    [[ "$output" == *"CRED=[gh auth token]"* ]]
+}
+
 @test "zshenv prepends the mise shims dir ahead of stale PATH entries" {
     local zshenv_file="$REAL_DOTFILES_DIR/zshenv"
 

--- a/zsh/core.zsh
+++ b/zsh/core.zsh
@@ -89,6 +89,16 @@ fi
 # copies so a mise-managed tool (e.g. claude, codex) resolves before any
 # stale native/brew install still on PATH from before migration.
 if command -v mise 1>/dev/null 2>&1; then
+  # gh keeps its token in the macOS keychain, so ~/.config/gh/hosts.yml has no
+  # `oauth_token` and mise's default gh_cli_tokens reader finds nothing —
+  # leaving every aqua release lookup anonymous against the 60/hr per-IP cap.
+  # This has to be the env var, not a [settings] block: packages/sync.sh runs
+  # `mise install` with MISE_GLOBAL_CONFIG_FILE aimed at the repo source, which
+  # demotes ~/.config/mise/config.toml to a non-global config where mise
+  # ignores credential_command and demands `mise trust`.
+  if command -v gh 1>/dev/null 2>&1; then
+    export MISE_GITHUB_CREDENTIAL_COMMAND="gh auth token"
+  fi
   eval "$(mise activate zsh)"
 fi
 


### PR DESCRIPTION
## Problem

`dots sync` failed at the omp install:

```
curl: (56) The requested URL returned error: 403
Release tag not found: v17.2.12
[packages] omp native install failed
```

The anonymous GitHub budget was exhausted (`0/60`), and it kept re-exhausting within minutes of each hourly reset.

## Root cause

`gh` stores its token in the **macOS keychain**, so `~/.config/gh/hosts.yml` carries no `oauth_token` field. mise's default `github.gh_cli_tokens` reader parses that file, finds nothing, and falls back to unauthenticated requests:

```
$ mise token github
github.com: (none)          # despite gh being logged in
```

That interacts badly with the non-semver pins. `tmux-builds`, `protobuf/protoc`, `rust-analyzer`, and `nextest/cargo-nextest` can't be resolved from the local install alone, so mise fetches each one's release list. The cache tells the story:

```
2026-08-08  aqua-protocolbuffers-protobuf-protoc/remote_versions-*.msgpack.z
2026-08-08  aqua-rust-lang-rust-analyzer/remote_versions-*.msgpack.z
2026-08-08  aqua-tmux-tmux-builds/remote_versions-*.msgpack.z
            aqua-nextest-rs-nextest-cargo-nextest/   <- no remote_versions file
```

The first three cached successfully in August. nextest never did, because a rate-limited 403 caches nothing — so it re-fetched **8 times per `mise install`, every run**, forever, starving the omp installer of the requests it needed.

## Fix

Point mise at `gh auth token`, which reaches the keychain and lifts it to the authenticated 5000/hr budget.

This has to be the **env var**, not a `[settings]` block in `~/.config/mise/config.toml` — I tried that first and it broke the sync harder:

```
mise WARN  github.credential_command in non-global config ~/.config/mise/config.toml is ignored for security reasons
mise ERROR Config files in ~/.config/mise/config.toml are not trusted.
```

`sync_mise` runs `mise install` with `MISE_GLOBAL_CONFIG_FILE` aimed at the repo source manifest, which demotes the deployed config to a *non-global* config. There mise ignores `credential_command` and demands `mise trust`. A `settings.toml` doesn't work either — mise 2026.7.14 doesn't read one (`mise doctor` lists only `config.toml` under `config_files`).

Wired in both places a sync can start from:
- `zsh/core.zsh` — interactive shells
- `packages/sync.sh` (`sync_mise`) — bootstrap and non-interactive runs

Both guarded on `gh` being present.

## Verification

| Check | Before | After |
|---|---|---|
| nextest release fetch | `403 Forbidden` | `200 OK` |
| GitHub API calls per repeat `mise install` | 8 | **0** |
| `mise token github` | `(none)` | `gho_…wyVH (source: credential_command)` |
| `omp --version` | `omp/17.2.10` (pin `v17.2.12`) | `omp/17.2.12` |
| `dots sync` | fails, cache not saved | exit 0, `packages.hash` written |
| Anonymous budget | pinned at `0/60` | holding at `33/60` |

`just check` green — 1381 tests, all passed.

## Tests

Two regression tests, both **mutation-checked** (each fails when its export is removed, passes when restored):

- `tests/packages.bats` — sync hands mise a gh-backed credential command
- `tests/zsh-config.bats` — `core.zsh` exports it on shell startup

The zsh test asserts only the gh-present branch. `core.zsh` unconditionally prepends `/opt/homebrew/bin` (carrying both `gh` and `mise`) before reaching the guard, so a no-gh shell can't be simulated by controlling PATH — the comment records that rather than shipping a vacuous assertion.

## Note

A pre-existing flake surfaced during this work: `agent-secret-broker.bats` "approval succeeds within TTL and is rejected once the TTL elapses" failed once under full-suite load and passed in isolation, then passed on two subsequent full runs. Untouched by this PR, but worth a look separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)