### PR TITLE
fix(sync): unblock dots sync convergence

### DIFF
--- a/.sync-lib.sh
+++ b/.sync-lib.sh
@@ -135,6 +135,28 @@ assemble_chezmoi_sources() {
     fi
 }
 
+# Land the tracked mise manifest before package convergence reads it.
+#
+# mise loads ~/.config/mise/config.toml *after* any --source manifest and lets
+# it win, so convergence resolves the live pins rather than the tracked ones.
+# Leaving that copy to the final apply deadlocks every pin bump: the stale file
+# pins the old version, `mise install` therefore never requests the new one,
+# and the harness-version gate — seeing the old binary — skips the very apply
+# that would refresh it. The manifest is an input to convergence, not an
+# output of it, so it has to land first.
+apply_mise_manifest() {
+    local source_dir="$1"
+    local target="${XDG_CONFIG_HOME:-$HOME/.config}/mise/config.toml"
+    command -v chezmoi &>/dev/null || return 0
+    if chezmoi --source "$source_dir" apply --force "$target"; then
+        echo "  Applied tracked mise manifest -> $target"
+    else
+        # Non-fatal: the harness-version gate stays the authority on whether
+        # convergence actually produced the pinned harnesses.
+        echo "  WARNING: could not apply $target — package convergence may read stale pins" >&2
+    fi
+}
+
 apply_chezmoi_source() {
     local source_dir="$1" chezmoi_status=0
     if command -v chezmoi &>/dev/null; then

--- a/chezmoi/.sync
+++ b/chezmoi/.sync
@@ -37,7 +37,12 @@ source "$dotfiles_dir/.sync-lib.sh"
 if ! prepare_chezmoi_wiring "$dotfiles_dir" "$source_dir"; then
     exit 1
 fi
-[[ "${CHEZMOI_SYNC_PHASE:-}" == "prepare" ]] && exit 0
+if [[ "${CHEZMOI_SYNC_PHASE:-}" == "prepare" ]]; then
+    # Package convergence runs next and resolves tool versions through the live
+    # mise config, so the tracked manifest has to be in place before it starts.
+    apply_mise_manifest "$source_dir"
+    exit 0
+fi
 "${CHEZMOI_WIRING_SKIP:-false}" && exit 0
 
 if ! assemble_chezmoi_sources "$dotfiles_dir" "$source_dir"; then

--- a/chezmoi/lib/install-external.sh
+++ b/chezmoi/lib/install-external.sh
@@ -55,9 +55,19 @@ done
 
 # Source .env for SKILL_HARNESSES
 if [[ -f "$DOTFILES_DIR/.env" ]]; then
+    env_line=0
     while IFS='=' read -r key val; do
+        env_line=$((env_line + 1))
         key="${key#export }"
-        [[ -z "$key" || "$key" =~ ^# ]] && continue
+        [[ -z "$key" || "$key" =~ ^[[:space:]]*# ]] && continue
+        # `export` aborts the script on a key that is not a shell identifier —
+        # a whitespace-only line or a `KEY = value` spacing slip is enough — so
+        # reject those here instead of letting one stray line kill the install.
+        if [[ ! "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+            [[ "$key" =~ ^[[:space:]]*$ ]] ||
+                echo -e "${YELLOW}Warning: ignoring .env line $env_line (not KEY=value)${NC}" >&2
+            continue
+        fi
         # Strip surrounding quotes from value (env loader is naive)
         val="${val%\"}"
         val="${val#\"}"

--- a/packages/sync.sh
+++ b/packages/sync.sh
@@ -713,6 +713,59 @@ migrate_omp_off_bun() {
     rm -f "$path"
 }
 
+# Install the pinned omp release into $1 and rename it over the live binary.
+#
+# The upstream installer curls the release asset directly onto its install
+# target, so pointing it at ~/.local/bin fails with ETXTBSY whenever an omp
+# session is running. Staging into a sibling directory and renaming into place
+# swaps the directory entry instead, leaving live processes on the old inode.
+#
+# --binary is required: omp.sh's installer defaults to a bun source build
+# whenever --ref is given, and that build (`bun install -g
+# packages/coding-agent` against the cloned monorepo) trips bun's
+# self-referential-workspace-loop check on the package's own dependency on
+# itself — reproduces even reinstalling an already-working pin, so it's a
+# bun/installer incompatibility, not a bad release. --binary fetches the
+# prebuilt release asset instead, sidestepping bun entirely.
+converge_omp_native() {
+    local stage_dir="$1" staged="$1/omp" install_status=0
+
+    mkdir -p "$stage_dir"
+    # The installer closes by telling the user to add its install dir to PATH
+    # unless it is already there; putting the throwaway stage dir on PATH keeps
+    # it from printing that instruction for a directory removed moments later.
+    curl -fsSL https://omp.sh/install |
+        PI_INSTALL_DIR="$stage_dir" PATH="$stage_dir:$PATH" sh -s -- --binary --ref "$OMP_PIN" ||
+        install_status=$?
+
+    if [[ ! -f "$staged" ]]; then
+        log_error "omp native install failed"
+        return 1
+    fi
+
+    if [[ "$PLATFORM" == "Darwin" ]]; then
+        if ! codesign --force --sign - "$staged" </dev/null; then
+            log_error "omp ad-hoc signing failed"
+            return 1
+        fi
+        # The installer's own smoke test fails on the still-unsigned download,
+        # so re-check the signed binary rather than trusting its exit status.
+        if ((install_status != 0)) &&
+            [[ "$("$staged" --version 2>/dev/null || true)" != "omp/${OMP_PIN#v}" ]]; then
+            log_error "omp native install failed"
+            return 1
+        fi
+    elif ((install_status != 0)); then
+        log_error "omp native install failed"
+        return 1
+    fi
+
+    if ! mv -f "$staged" "$HOME/.local/bin/omp"; then
+        log_error "omp native install failed"
+        return 1
+    fi
+}
+
 sync_native_harnesses() {
     log_info "Syncing native AI-harness CLIs..."
 
@@ -725,40 +778,16 @@ sync_native_harnesses() {
     migrate_harness_off_brew "omp"
     migrate_omp_off_bun
 
-    # --binary is required: omp.sh's installer defaults to a bun source build
-    # whenever --ref is given, and that build (`bun install -g
-    # packages/coding-agent` against the cloned monorepo) trips bun's
-    # self-referential-workspace-loop check on the package's own dependency on
-    # itself — reproduces even reinstalling an already-working pin, so it's a
-    # bun/installer incompatibility, not a bad release. --binary fetches the
-    # prebuilt release asset instead, sidestepping bun entirely.
     echo "  Converging omp to $OMP_PIN (native)..."
-    local install_status=0 omp_path="$HOME/.local/bin/omp" omp_version=""
-    curl -fsSL https://omp.sh/install | sh -s -- --binary --ref "$OMP_PIN" ||
-        install_status=$?
-    if [[ "$PLATFORM" == "Darwin" ]]; then
-        if ! codesign --force --sign - "$omp_path" </dev/null; then
-            log_error "omp ad-hoc signing failed"
-            FAILED+=("omp")
-            return
-        fi
-        if ((install_status != 0)); then
-            omp_version="$("$omp_path" --version 2>/dev/null || true)"
-            if [[ "$omp_version" != "omp/${OMP_PIN#v}" ]]; then
-                log_error "omp native install failed"
-                FAILED+=("omp")
-                return
-            fi
-        fi
-    elif ((install_status != 0)); then
-        log_error "omp native install failed"
+    local stage_dir="$HOME/.local/bin/.omp-stage"
+    rm -rf "$stage_dir"
+    if converge_omp_native "$stage_dir"; then
+        hash -r 2>/dev/null || true
+        log_success "  Converged omp to $OMP_PIN"
+    else
         FAILED+=("omp")
-        return
     fi
-
-    hash -r 2>/dev/null || true
-    log_success "  Converged omp to $OMP_PIN"
-
+    rm -rf "$stage_dir"
 }
 
 # Snapshot the inputs before the first installer runs.

--- a/tests/chezmoi-wiring.bats
+++ b/tests/chezmoi-wiring.bats
@@ -721,12 +721,15 @@ assemble_chezmoi_sources() {
 apply_chezmoi_source() {
     printf 'apply\n'
 }
+apply_mise_manifest() {
+    printf 'mise-manifest\n'
+}
 SCRIPT
 
     run env CHEZMOI_SYNC_PHASE=prepare CHEZMOI_WIRING_SKIP=false \
         bash "$fake_root/chezmoi/.sync"
     assert_success
-    [[ "$output" == "prepare" ]]
+    [[ "$output" == $'prepare\nmise-manifest' ]]
 
     run env CHEZMOI_SYNC_PHASE= CHEZMOI_WIRING_SKIP=false \
         bash "$fake_root/chezmoi/.sync"
@@ -737,6 +740,37 @@ SCRIPT
         bash "$fake_root/chezmoi/.sync"
     assert_success
     [[ "$output" == $'prepare\nassemble\napply' ]]
+}
+
+# Regression: the tracked mise manifest is an INPUT to package convergence.
+# mise lets the live ~/.config/mise/config.toml override any --source manifest,
+# so leaving it to the final apply pins the old version, starves `mise install`
+# of the new one, and lets the harness-version gate skip the apply that would
+# have fixed it — a deadlock no re-run escapes.
+@test "chezmoi prepare lands the tracked mise manifest before package convergence" {
+    command -v chezmoi >/dev/null 2>&1 || skip "chezmoi not installed"
+
+    local source_dir="$TEST_HOME/mise-src"
+    mkdir -p "$source_dir/dot_config/mise"
+    cat > "$source_dir/dot_config/mise/config.toml" <<'TOML'
+[tools]
+"aqua:openai/codex" = "rust-v9.9.9"
+TOML
+
+    local target="$TEST_HOME/.config/mise/config.toml"
+    mkdir -p "${target%/*}"
+    cat > "$target" <<'TOML'
+[tools]
+"aqua:openai/codex" = "rust-v0.0.1"
+TOML
+
+    export XDG_CONFIG_HOME="$TEST_HOME/.config"
+    run apply_mise_manifest "$source_dir"
+    assert_success
+
+    # The stale live pin must be gone before any `mise install` reads it.
+    grep -q 'rust-v9.9.9' "$target"
+    ! grep -q 'rust-v0.0.1' "$target"
 }
 
 @test "chezmoi/.sync calls chezmoi apply --force after wiring config" {

--- a/tests/packages.bats
+++ b/tests/packages.bats
@@ -109,6 +109,10 @@ MOCKCURL
     chmod +x "$MOCK_BIN/curl"
 }
 
+# Mock the piped omp.sh installer. Like the real one it truncates
+# "$PI_INSTALL_DIR/omp" in place — so aiming it at a running binary fails with
+# ETXTBSY — and it writes the binary before the exit status it is asked for,
+# modelling macOS where the download lands but the unsigned smoke test fails.
 write_mock_sh() {
     local exit_status="${1:-0}"
     rm -f "$MOCK_BIN/sh"
@@ -116,6 +120,15 @@ write_mock_sh() {
 #!/bin/bash
 echo "sh \$*" >> "\$SH_LOG"
 echo "sh \$*" >> "\$EVENT_LOG"
+ref=""
+while [ \$# -gt 0 ]; do
+    [ "\$1" = "--ref" ] && ref="\$2"
+    shift
+done
+dir="\${PI_INSTALL_DIR:-\$HOME/.local/bin}"
+mkdir -p "\$dir"
+printf '#!/bin/bash\nprintf "omp/%s\\\\n"\n' "\${ref#v}" > "\$dir/omp" || exit 1
+chmod +x "\$dir/omp"
 exit $exit_status
 MOCKSH
     chmod +x "$MOCK_BIN/sh"
@@ -580,7 +593,7 @@ path_without_buildtools() {
     local stub="$TEST_HOME/nobuild-stub"
     mkdir -p "$stub"
     local -a needed=(bash sh env uname id yq jq shasum sha256sum curl git \
-        awk sed grep cut sort tr head tail cat chmod mkdir rm ln mktemp \
+        awk sed grep cut sort tr head tail cat chmod mkdir rm mv ln mktemp \
         dirname basename tee wc printf find xargs sleep)
     local tool src
     for tool in "${needed[@]}"; do
@@ -1170,6 +1183,34 @@ YAML
     [[ ! -f "$OMP_LOG" ]] || ! grep -q "omp update" "$OMP_LOG"
 }
 
+# The upstream installer truncates its target in place, so a live omp session
+# makes the kernel refuse the write with ETXTBSY. A real ELF is required to
+# reproduce it: an interpreted script is only held open for reading.
+@test "package sync converges omp while a running omp holds the live binary" {
+    local omp_path="$TEST_HOME/.local/bin/omp"
+    mkdir -p "$TEST_HOME/.local/bin"
+    cp "$(command -v bash)" "$omp_path"
+    "$omp_path" -c 'sleep 300' &
+    local holder=$! waited=0
+    # Wait for the exec to land, else the install races past the busy window.
+    # A read-write open never truncates, so probing is safe.
+    until ! (exec 3<>"$omp_path") 2>/dev/null; do
+        kill -0 "$holder" 2>/dev/null && ((waited++ < 100)) ||
+            { kill "$holder" 2>/dev/null; fail "held omp binary never became busy"; }
+        sleep 0.05
+    done
+    write_test_yaml
+
+    run_sync
+    local sync_status="$status"
+    kill "$holder" 2>/dev/null || true
+    wait "$holder" 2>/dev/null || true
+
+    [[ "$sync_status" -eq 0 ]]
+    assert_output_contains "Converged omp to v17.2.12"
+    [[ "$("$omp_path")" == "omp/17.2.12" ]]
+}
+
 @test "omp installer failure fails loudly and does not save cache" {
     write_test_yaml
     write_mock_sh 1
@@ -1185,21 +1226,16 @@ YAML
 @test "Darwin signs and validates a downloaded omp after installer smoke failure" {
     write_mock_uname Darwin
     write_mock_sh 1
-    mkdir -p "$TEST_HOME/.local/bin"
-    cat > "$TEST_HOME/.local/bin/omp" <<'EOF'
-#!/usr/bin/env bash
-printf 'omp/17.2.12\n'
-EOF
-    chmod +x "$TEST_HOME/.local/bin/omp"
     write_test_yaml
 
     run_sync
     assert_success
     assert_output_contains "Converged omp to v17.2.12"
+    [[ "$("$TEST_HOME/.local/bin/omp")" == "omp/17.2.12" ]]
 
     local expected_events
     expected_events=$(printf 'sh -s -- --binary --ref v17.2.12\ncodesign --force --sign - %s' \
-        "$TEST_HOME/.local/bin/omp")
+        "$TEST_HOME/.local/bin/.omp-stage/omp")
     run cat "$EVENT_LOG"
     [[ "$output" == "$expected_events" ]]
 }
@@ -1213,7 +1249,7 @@ EOF
 
     local expected_events
     expected_events=$(printf 'sh -s -- --binary --ref v17.2.12\ncodesign --force --sign - %s' \
-        "$TEST_HOME/.local/bin/omp")
+        "$TEST_HOME/.local/bin/.omp-stage/omp")
     run cat "$EVENT_LOG"
     [[ "$output" == "$expected_events" ]]
 }


### PR DESCRIPTION
`dots sync` failed on this machine. It turned out to be three separate defects stacked behind each other, each hidden by the one before it. All three are fixed; `dots sync` and `just check` both exit 0.

## 1. omp install died on ETXTBSY

`curl: (23) client returned ERROR on write` reads like a network or disk fault, but it was neither. The omp.sh installer curls the release asset straight onto `~/.local/bin/omp`, and any running omp session makes the kernel refuse that write. Confirmed with `os.open(..., O_WRONLY)` returning `[Errno 26] Text file busy` and `fuser` naming three holders.

`packages/sync.sh` now stages the download in a sibling directory and renames it into place — `rename(2)` swaps the directory entry and leaves running processes on the old inode. Verified against the real installer with three live omp sessions: inode `2886064 → 3151370`, all three kept running.

## 2. A codex pin deadlock, 8 days old

With omp fixed, sync got further and hit this. mise loads `~/.config/mise/config.toml` *after* any `--source` manifest and lets it win, so convergence resolved the live pins, not the tracked ones. Leaving that file to the final apply deadlocked every pin bump:

- the stale live file pinned `rust-v0.145.0`, so `mise install` never requested `rust-v0.146.0`
- the harness-version gate saw the old binary and skipped the final chezmoi apply
- that apply was the only step that would have refreshed the live file

No re-run escaped it. The pin landed Aug 3 (#589); the live config was still dated Aug 1.

The manifest is an *input* to package convergence, not an output of it, so the prepare phase now lands it before convergence reads it. A failed apply warns rather than aborts — the harness-version gate stays the authority on whether convergence actually produced the pinned harnesses.

## 3. A stray environment-file line aborted the skills installer

This was the last thing holding `dots sync` at exit 1 after the sync itself reported success, and it was also failing the `install-external.sh` regression test. The loader exported every parsed key unvalidated, so one whitespace-only line produced `export: not a valid identifier` and killed the script under `set -e`.

Keys are now validated as shell identifiers before export: blanks and comments skip silently, anything else warns with a line number — never the contents — so a real setting cannot be dropped without a trace.

## Testing

- Regression test for the busy-binary case. It needs a **real ELF** to reproduce ETXTBSY — an interpreted script is only held open for reading — and the mock installer now truncates its target in place like the real one. Confirmed the test fails without the staging fix and passes with it.
- `mv` was missing from the stripped-PATH whitelist that lists the tools `sync.sh` relies on; the staging fix exposed that. Added.
- New prepare-phase ordering test plus a manifest-application test.
- `just check`: exit 0, 1383 tests pass. `dots sync`: exit 0.

## Note for the reviewer

`mise install aqua:openai/codex@rust-v0.146.0` was run by hand while diagnosing whether that version was installable at all. It is the pinned version sync installs anyway, and the final sync converged it properly, so local state is consistent — but that is why the "before" state in this description already has 0.146.0 on disk.

The mise config-precedence deadlock is worth a wiki page under the AGENTS.md "record durable gotchas" rule; that is not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
