### PR TITLE
fix(macos): persist keyboard settings

### DIFF
--- a/.hallouminate/wiki/operations/macos-modifier-keys.md
+++ b/.hallouminate/wiki/operations/macos-modifier-keys.md
@@ -1,0 +1,27 @@
+# macOS modifier-key remapping
+
+Keep the `hidutil` LaunchAgent for Caps Lock → Left Control. Apple documents the mapping as a supported Modifier Keys setting, but the checked Apple sources expose no supported CLI for writing the native per-keyboard preference. The LaunchAgent reapplies `hidutil`'s transient mapping at login.[^1][^2]
+
+## Managed mapping
+
+`macos/com.local.KeyRemapping.plist` runs `hidutil property --set` with Caps Lock (`30064771129`) as the source and Left Control (`30064771296`) as the destination. `macos/.sync` installs and bootstraps that LaunchAgent.[^3]
+
+Do not infer absence from `hidutil property --get UserKeyMapping` alone. On macOS 26.5.1, that global read returned `(null)` while the built-in keyboard driver held the exact requested per-device map. Inspect the driver state instead:
+
+```sh
+ioreg -a -r -c AppleHIDKeyboardEventDriverV2 \
+  | plutil -extract 0.HIDEventServiceProperties.UserKeyMapping json -o - -
+```
+
+The verified result was:
+
+```json
+[{"HIDKeyboardModifierMappingDst":30064771296,"HIDKeyboardModifierMappingSrc":30064771129}]
+```
+
+`tests/macos.bats` protects the static contract: the real sync entry point installs and bootstraps the plist, whose mapping must remain exact. Runtime verification remains an IORegistry check because the test suite does not mutate the operator's keyboard.[^4]
+
+[^1]: <https://support.apple.com/en-us/guide/mac-help/mchlp1011/mac>
+[^2]: <https://developer.apple.com/library/archive/technotes/tn2450/_index.html>
+[^3]: macos/com.local.KeyRemapping.plist:1-18; macos/.sync:57-73
+[^4]: tests/macos.bats:78-110

--- a/.hallouminate/wiki/operations/macos-symbolic-hotkeys.md
+++ b/.hallouminate/wiki/operations/macos-symbolic-hotkeys.md
@@ -1,0 +1,24 @@
+# macOS symbolic-hotkey preference typing
+
+Never pass nested symbolic-hotkey dictionaries to `defaults write ... -dict-add` as OpenStep text. The leaf values serialize as strings, so `enabled = 0` becomes `"0"`; macOS Tahoe treats that non-empty string as enabled and re-checks the Input Sources shortcut.[^1]
+
+## Managed write path
+
+`macos/.sync` delegates symbolic-hotkey changes to `macos_write_symbolic_hotkeys`.[^2] The helper exports the complete `com.apple.symbolichotkeys` domain, uses `plutil` for typed edits, then imports the domain. This preserves unknown hotkeys and the existing payloads for IDs 60 and 61.
+
+The managed bindings are:
+
+- ID 60 (Control-Space): boolean `false`, existing `value` preserved.
+- ID 61 (Control-Option-Space): boolean `false`, existing `value` preserved.
+- ID 160 (Launchpad): boolean `true`; parameters `[32, 49, 1179648]` are integers.
+
+Apple documents Control-Space and Control-Option-Space as the previous/next input-source shortcuts.[^3]
+
+## Regression seam
+
+`tests/macos.bats` runs the real `macos/.sync` entry point against an isolated preference domain. It asserts boolean enabled flags, integer Launchpad parameters, and preservation of the input-source binding payloads.[^4]
+
+[^1]: Reproduced on macOS 26.5.1 with `defaults write /tmp/prefs AppleSymbolicHotKeys -dict-add 60 '{enabled = 0;}'`; `plutil -type AppleSymbolicHotKeys.60.enabled` returned `string`.
+[^2]: macos/.sync:35-55; macos/lib.sh:4-27
+[^3]: <https://support.apple.com/en-us/102650>
+[^4]: tests/macos.bats:46-76

--- a/justfile
+++ b/justfile
@@ -12,7 +12,7 @@ lint-shell:
     shellcheck -x -e SC1091 $(find bin -type f) .sync
     shellcheck -x -e SC1091 -s bash agents/mcp/sync.sh agents/hooks/sync.sh agents/hooks/lib.sh claude/plugins/sync.sh claude/lib/sync-common.sh agents/lib/cheese-flair.sh chezmoi/lib/claude-mcp-reconcile.sh chezmoi/lib/claude-plugin-reconcile.sh chezmoi/lib/install-agents-doc.sh chezmoi/lib/install-shared-assets.sh
     shellcheck -x -s sh chezmoi/private_dot_codex/modify_private_config.toml
-    shellcheck -x -e SC1091 -s bash agents/hooks/session-start-cheese-flair.sh
+    shellcheck -x -e SC1091 -s bash agents/hooks/session-start-cheese-flair.sh macos/.sync macos/lib.sh
     shellcheck -x -e SC1091 -s bash tests/run-tests.sh tests/install-bats.sh
     shellcheck -x -e SC1091 -s bash tests/workflows-test.sh
     @echo "shellcheck: ok"

--- a/macos/.sync
+++ b/macos/.sync
@@ -9,8 +9,12 @@ if [[ "$(uname -s)" != "Darwin" ]]; then
     exit 0
 fi
 
-readonly SCRIPT_DIR="$(cd "${BASH_SOURCE%/*}" && pwd)"
-readonly LAUNCH_AGENTS_DIR="$HOME/Library/LaunchAgents"
+SCRIPT_DIR="$(cd "${BASH_SOURCE%/*}" && pwd)"
+readonly SCRIPT_DIR
+LAUNCH_AGENTS_DIR="$HOME/Library/LaunchAgents"
+readonly LAUNCH_AGENTS_DIR
+# shellcheck source=macos/lib.sh
+source "$SCRIPT_DIR/lib.sh"
 
 mkdir -p "$LAUNCH_AGENTS_DIR"
 
@@ -29,21 +33,16 @@ defaults write com.apple.AppleMultitouchMouse mouseButtonMode -string TwoButton
 defaults write com.cmuxterm.app browserOpenTerminalLinksInCmuxBrowser -bool false
 
 # Disable the input-source switching shortcuts so they free up Control+Space
-# for the tmux prefix. ID 60 = "Select the previous input source" (⌃Space),
+# for the tmux prefix. ID 60 = "Select the previous input source" (⌃Space);
 # ID 61 = "Select next source in Input menu" (⌃⌥Space, the reverse).
 #
-# CAVEAT (macOS 26 Tahoe): writing enabled=0 here sets the *preference*, which a
-# fresh login reads — but it does NOT disable the shortcut on an already-running
-# session (activateSettings no longer flushes it). To take effect now without a
-# logout, also uncheck it in:
-#   System Settings > Keyboard > Keyboard Shortcuts… > Input Sources >
-#   "Select the previous input source".
-defaults write com.apple.symbolichotkeys AppleSymbolicHotKeys -dict-add 60 "{enabled = 0;}"
-defaults write com.apple.symbolichotkeys AppleSymbolicHotKeys -dict-add 61 "{enabled = 0;}"
-
-# Show Launchpad on ⌘⇧Space (ID 160): parameters = (32 = space char, 49 = space
-# keycode, 1179648 = ⌘+⇧). Verified working on macOS 26 (Tahoe).
-defaults write com.apple.symbolichotkeys AppleSymbolicHotKeys -dict-add 160 "{enabled = 1; value = { parameters = (32, 49, 1179648); type = standard; }; }"
+# Export/edit/import preserves the existing binding payloads and writes actual
+# plist booleans/integers. An ASCII dictionary passed to defaults serializes
+# these leaves as strings, which Tahoe treats as enabled.
+#
+# ID 160 shows Launchpad on ⌘⇧Space: parameters = (32 = space char,
+# 49 = space keycode, 1179648 = ⌘+⇧).
+macos_write_symbolic_hotkeys
 
 # NOT scriptable here (managed elsewhere, left untouched by this script):
 #   - Spotlight's ⌘Space (Tahoe "Super Spotlight") lives in an opaque
@@ -52,9 +51,7 @@ defaults write com.apple.symbolichotkeys AppleSymbolicHotKeys -dict-add 160 "{en
 #   - Alfred's launcher hotkey (⌘Space) is set in the Alfred app; to version it,
 #     point Alfred's sync folder at $DOTFILES/alfred/ (see alfred/.sync).
 
-# Reload symbolic-hotkey prefs. On Tahoe this reliably applies additive bindings
-# (e.g. ID 160) but may NOT disable a reserved system shortcut on a live session
-# (see ID 60 caveat above) — a logout or the System Settings toggle is the sure fix.
+# Reload the symbolic-hotkey preferences into the current session.
 /System/Library/PrivateFrameworks/SystemAdministration.framework/Resources/activateSettings -u || true
 
 for plist in "$SCRIPT_DIR"/*.plist; do

--- a/macos/lib.sh
+++ b/macos/lib.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Typed preference updates used by macos/.sync.
+
+macos_write_symbolic_hotkeys() {
+    local domain="${1:-com.apple.symbolichotkeys}"
+    local plist rc=0
+    local launchpad='{"enabled":true,"value":{"parameters":[32,49,1179648],"type":"standard"}}'
+
+    plist="$(mktemp "${TMPDIR:-/tmp}/dotfiles-symbolichotkeys.XXXXXX")"
+    defaults export "$domain" "$plist" >/dev/null || rc=$?
+
+    if (( rc == 0 )); then
+        plutil -replace AppleSymbolicHotKeys.60.enabled -bool false "$plist" || rc=$?
+    fi
+    if (( rc == 0 )); then
+        plutil -replace AppleSymbolicHotKeys.61.enabled -bool false "$plist" || rc=$?
+    fi
+    if (( rc == 0 )) &&
+        ! plutil -replace AppleSymbolicHotKeys.160 -json "$launchpad" "$plist" 2>/dev/null; then
+        plutil -insert AppleSymbolicHotKeys.160 -json "$launchpad" "$plist" || rc=$?
+    fi
+    if (( rc == 0 )); then
+        defaults import "$domain" "$plist" >/dev/null || rc=$?
+    fi
+
+    rm -f "$plist"
+    return "$rc"
+}

--- a/tests/macos.bats
+++ b/tests/macos.bats
@@ -1,0 +1,147 @@
+#!/usr/bin/env bats
+# shellcheck disable=SC2016  # Mock scripts expand variables when they run.
+load test_helper
+
+SYNC_SCRIPT="$REAL_DOTFILES_DIR/macos/.sync"
+
+setup() {
+    setup_test_env
+    [[ "$(uname -s)" == "Darwin" ]] || skip "macOS defaults/plutil required"
+
+    export MOCK_BIN="$TEST_HOME/bin"
+    export HOTKEY_DOMAIN="$TEST_HOME/com.apple.symbolichotkeys"
+    export COMMAND_LOG="$TEST_HOME/commands.log"
+    export LAUNCH_AGENTS_DIR="$HOME/Library/LaunchAgents"
+    mkdir -p "$MOCK_BIN"
+
+    /usr/bin/plutil -create xml1 "$HOTKEY_DOMAIN.plist"
+    /usr/bin/plutil -insert AppleSymbolicHotKeys -json '{
+      "60": {"enabled": true, "value": {"parameters": [32, 49, 262144], "type": "standard"}},
+      "61": {"enabled": true, "value": {"parameters": [32, 49, 786432], "type": "standard"}}
+    }' "$HOTKEY_DOMAIN.plist"
+
+    cat > "$MOCK_BIN/defaults" <<'MOCK'
+#!/bin/bash
+command="$1"
+domain="$2"
+printf '%s\n' "$*" >> "$COMMAND_LOG"
+if [[ "$command" == "export" || "$command" == "import" ]]; then
+    shift 2
+    exec /usr/bin/defaults "$command" "$HOTKEY_DOMAIN" "$@"
+fi
+exit 0
+MOCK
+    cat > "$MOCK_BIN/launchctl" <<'MOCK'
+#!/bin/bash
+printf '%s\n' "$*" >> "$COMMAND_LOG"
+exit 0
+MOCK
+    printf '#!/bin/bash\nprintf "Darwin\\n"\n' > "$MOCK_BIN/uname"
+    chmod +x "$MOCK_BIN/defaults" "$MOCK_BIN/launchctl" "$MOCK_BIN/uname"
+    export PATH="$MOCK_BIN:$PATH"
+}
+
+teardown() { teardown_test_env; }
+
+@test "macos sync writes typed symbolic-hotkey values and preserves input-source bindings" {
+    run bash "$SYNC_SCRIPT"
+    assert_success
+
+    local prefs="$HOTKEY_DOMAIN.plist"
+    run /usr/bin/plutil -extract AppleSymbolicHotKeys.60.enabled raw -expect bool "$prefs"
+    assert_success
+    [ "$output" = "false" ]
+    run /usr/bin/plutil -extract AppleSymbolicHotKeys.61.enabled raw -expect bool "$prefs"
+    assert_success
+    [ "$output" = "false" ]
+    run /usr/bin/plutil -extract AppleSymbolicHotKeys.60.value.parameters.2 raw -expect integer "$prefs"
+    assert_success
+    [ "$output" = "262144" ]
+    run /usr/bin/plutil -extract AppleSymbolicHotKeys.61.value.parameters.2 raw -expect integer "$prefs"
+    assert_success
+    [ "$output" = "786432" ]
+    run /usr/bin/plutil -extract AppleSymbolicHotKeys.160.enabled raw -expect bool "$prefs"
+    assert_success
+    [ "$output" = "true" ]
+    for index in 0 1 2; do
+        run /usr/bin/plutil -extract "AppleSymbolicHotKeys.160.value.parameters.$index" raw -expect integer "$prefs"
+        assert_success
+    done
+    [ "$( /usr/bin/plutil -extract AppleSymbolicHotKeys.160.value.parameters.0 raw -expect integer "$prefs" )" = "32" ]
+    [ "$( /usr/bin/plutil -extract AppleSymbolicHotKeys.160.value.parameters.1 raw -expect integer "$prefs" )" = "49" ]
+    [ "$( /usr/bin/plutil -extract AppleSymbolicHotKeys.160.value.parameters.2 raw -expect integer "$prefs" )" = "1179648" ]
+    run /usr/bin/plutil -extract AppleSymbolicHotKeys.160.value.type raw -expect string "$prefs"
+    assert_success
+    [ "$output" = "standard" ]
+}
+
+@test "macos sync installs and bootstraps the Caps Lock to Control LaunchAgent" {
+    run bash "$SYNC_SCRIPT"
+    assert_success
+
+    local plist="$REAL_DOTFILES_DIR/macos/com.local.KeyRemapping.plist"
+    local target="$HOME/Library/LaunchAgents/com.local.KeyRemapping.plist"
+    assert_symlink "$target" "$plist"
+
+    for index in 0 1 2; do
+        run /usr/bin/plutil -extract "ProgramArguments.$index" raw -expect string "$plist"
+        assert_success
+    done
+    run /usr/bin/plutil -extract ProgramArguments.0 raw -expect string "$plist"
+    assert_success
+    [ "$output" = "/usr/bin/hidutil" ]
+    run /usr/bin/plutil -extract ProgramArguments.1 raw -expect string "$plist"
+    assert_success
+    [ "$output" = "property" ]
+    run /usr/bin/plutil -extract ProgramArguments.2 raw -expect string "$plist"
+    assert_success
+    [ "$output" = "--set" ]
+    run /usr/bin/plutil -extract ProgramArguments.3 raw -expect string "$plist"
+    assert_success
+    [ "$output" = '{"UserKeyMapping":[{"HIDKeyboardModifierMappingSrc":0x700000039,"HIDKeyboardModifierMappingDst":0x7000000E0}]}' ]
+    run /usr/bin/plutil -extract RunAtLoad raw -expect bool "$plist"
+    assert_success
+    [ "$output" = "true" ]
+    run /usr/bin/plutil -extract ProgramArguments.4 raw -expect string "$plist"
+    assert_failure
+
+    run /usr/bin/grep -Fx -- "bootstrap gui/$(id -u) $target" "$COMMAND_LOG"
+    assert_success
+}
+
+@test "macos sync writes the declared typed device defaults" {
+    run bash "$SYNC_SCRIPT"
+    assert_success
+
+    local expected
+    for expected in \
+        "write com.apple.driver.AppleMultitouchTrackpad TrackpadRightClick -bool true" \
+        "write com.apple.driver.AppleBluetoothMultitouch.trackpad TrackpadRightClick -bool true" \
+        "write NSGlobalDomain com.apple.trackpad.enableSecondaryClick -bool true" \
+        "write com.apple.driver.AppleBluetoothMultitouch.mouse MouseButtonMode -string TwoButton" \
+        "write com.apple.AppleMultitouchMouse mouseButtonMode -string TwoButton" \
+        "write com.cmuxterm.app browserOpenTerminalLinksInCmuxBrowser -bool false"; do
+        run /usr/bin/grep -Fx -- "$expected" "$COMMAND_LOG"
+        assert_success
+    done
+}
+
+@test "macos sync stops before agents when symbolic-hotkey export fails" {
+    cat > "$MOCK_BIN/defaults" <<'MOCK'
+#!/bin/bash
+if [[ "$1" == "export" ]]; then
+    exit 42
+fi
+printf '%s\n' "$*" >> "$COMMAND_LOG"
+exit 0
+MOCK
+    chmod +x "$MOCK_BIN/defaults"
+
+    run bash "$SYNC_SCRIPT"
+    assert_failure
+    [ "$status" -eq 42 ]
+    local target="$HOME/Library/LaunchAgents/com.local.KeyRemapping.plist"
+    run /usr/bin/grep -Fx -- "bootstrap gui/$(id -u) $target" "$COMMAND_LOG"
+    assert_failure
+    [ ! -e "$target" ]
+}


### PR DESCRIPTION
## Summary

- preserve plist boolean/integer types when managing macOS symbolic hotkeys
- keep Control-Space input-source shortcuts disabled without replacing their payloads
- retain and regression-cover the Caps Lock to Left Control LaunchAgent and every other declared macOS default
- document the correct per-device runtime check for modifier mappings

## Root cause

The prior defaults -dict-add values serialized nested leaves as strings. Tahoe interpreted the non-empty "0" string as enabled and re-checked the input-source shortcuts.

## Verification

- just check
- tests/macos.bats: 5 consecutive passes, 4 tests per run
- live macos/.sync: hotkeys 60/61 false booleans; hotkey 160 true with integer parameters
- live IORegistry: Caps Lock 30064771129 maps to Left Control 30064771296
- live trackpad, Magic Mouse, and cmux defaults match the declarations
